### PR TITLE
feat: add autodetecting toolchain compatible with rules_py venvs

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -8,6 +8,7 @@ bzl_library(
     srcs = ["repositories.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//py/private/toolchain:autodetecting",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],

--- a/py/private/toolchain/BUILD.bazel
+++ b/py/private/toolchain/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+exports_files(
+    ["python.sh"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "autodetecting",
+    srcs = ["autodetecting.bzl"],
+    visibility = ["//py:__subpackages__"],
+)

--- a/py/private/toolchain/autodetecting.bzl
+++ b/py/private/toolchain/autodetecting.bzl
@@ -1,0 +1,62 @@
+def _autodetecting_py_wrapper_impl(rctx):
+    which_python = rctx.which("python3")
+    if which_python == None:
+        fail("Unable to locate 'python3' on the path")
+
+    rctx.template(
+        "python.sh",
+        rctx.attr._python_wrapper_tmpl,
+        substitutions = {
+            "{{PYTHON_BIN}}": str(which_python),
+        },
+        executable = True,
+    )
+
+    build_content = """\
+load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
+
+py_runtime(
+    name = "autodecting_python3_runtime",
+    interpreter = "@{name}//:python.sh",
+    python_version = "PY3",
+)
+
+py_runtime_pair(
+    name = "autodetecting_py_runtime_pair",
+    py2_runtime = None,
+    py3_runtime = ":autodecting_python3_runtime",
+)
+
+toolchain(
+    name = "py_toolchain",
+    toolchain = ":autodetecting_py_runtime_pair",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+""".format(
+        name = rctx.attr.name,
+    )
+    rctx.file("BUILD.bazel", content = build_content)
+
+_autodetecting_py_toolchain = repository_rule(
+    implementation = _autodetecting_py_wrapper_impl,
+    attrs = {
+        "_python_wrapper_tmpl": attr.label(
+            default = "@rules_py//py/private/toolchain:python.sh",
+        ),
+    },
+)
+
+def register_autodetecting_python_toolchain(name):
+    """Registers a Python toolchain that will auto detect the location of Python that can be used with rules_py.
+
+    The autodetecting Python toolchain replaces the automatically registered one under bazel, and correctly handles the
+    Python virtual environment indirection created by rules_py. However it is recommended to instead use one of the prebuilt
+    Python interpreter toolchains from rules_python, rather than rely on the the correct Python binary being present on the host.
+    """
+    _autodetecting_py_toolchain(
+        name = name,
+    )
+
+    native.register_toolchains(
+        "@%s//:py_toolchain" % name,
+    )

--- a/py/private/toolchain/python.sh
+++ b/py/private/toolchain/python.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -o errexit -o nounset
+
+PYTHON_BIN="{{PYTHON_BIN}}"
+
+# We need to ensure that we exec Python from within the venv path if set so that the correct
+# exec and base prefixes are set.
+if [ -z "${VIRTUAL_ENV:-}" ]; then
+  exec "${PYTHON_BIN}" "$@"
+else
+  PYTHON_REAL="${VIRTUAL_ENV}/bin/python_real"
+  ln -snf "${PYTHON_BIN}" "${PYTHON_REAL}"
+  exec "${PYTHON_REAL}" "$@"
+fi

--- a/py/repositories.bzl
+++ b/py/repositories.bzl
@@ -6,6 +6,9 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//py/private/toolchain:autodetecting.bzl", _register_autodetecting_python_toolchain = "register_autodetecting_python_toolchain")
+
+register_autodetecting_python_toolchain = _register_autodetecting_python_toolchain
 
 # WARNING: any changes in this function may be BREAKING CHANGES for users
 # because we'll fetch a dependency which may be different from one that


### PR DESCRIPTION
Fixes #21 

```
$ which python3
/opt/homebrew/bin/python3

$ python3 --version
Python 3.9.10

$ bazel run --override_repository rules_py=/Users/matt/Documents/workspace/rules_py ipython
INFO: Analyzed target //:ipython (26 packages loaded, 95 targets configured).
INFO: Found 1 target...
Target //:ipython up-to-date:
  bazel-bin/ipython
INFO: Elapsed time: 1.458s, Critical Path: 1.33s
INFO: 3 processes: 2 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 3 total actions
INFO: Build completed successfully, 3 total actions

Python: /private/var/tmp/_bazel_matt/b28310042610550fd4cf1ffc282c1f7a/execroot/rules_py_example/bazel-out/darwin_arm64-fastbuild/bin/ipython.runfiles/ipython.venv/bin/python_real
version: 3.9.10 (main, Jan 15 2022, 11:40:53)
[Clang 13.0.0 (clang-1300.0.29.3)]
version info: sys.version_info(major=3, minor=9, micro=10, releaselevel='final', serial=0)
cwd: /private/var/tmp/_bazel_matt/b28310042610550fd4cf1ffc282c1f7a/execroot/rules_py_example/bazel-out/darwin_arm64-fastbuild/bin/ipython.runfiles/rules_py_example
site-packages folder: ['/private/var/tmp/_bazel_matt/b28310042610550fd4cf1ffc282c1f7a/execroot/rules_py_example/bazel-out/darwin_arm64-fastbuild/bin/ipython.runfiles/ipython.venv/lib/python3.9/site-packages']
VIRTUAL_ENV=/private/var/tmp/_bazel_matt/b28310042610550fd4cf1ffc282c1f7a/execroot/rules_py_example/bazel-out/darwin_arm64-fastbuild/bin/ipython.runfiles/ipython.venv
Python 3.9.10 (main, Jan 15 2022, 11:40:53)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]:
```