### PR TITLE
fix: remove check on missing interpreter or interpreter_path on the toolchain

### DIFF
--- a/py/private/utils.bzl
+++ b/py/private/utils.bzl
@@ -30,9 +30,6 @@ def resolve_toolchain(ctx):
         files = depset([])
         uses_interpreter_path = True
 
-    if interpreter == None:
-        fail("Unable to resolve interpreter to a path or file. Ensure `interpreter` or `interpreter_file` is defined on the py3_runtime")
-
     return struct(
         toolchain = py3_toolchain,
         files = files,


### PR DESCRIPTION
@JesseTatasciore was right, this is a pointless check as it's already validated by bazel on the `py_runtime` rule:

```
ERROR: /private/var/tmp/_bazel_matt/b28310042610550fd4cf1ffc282c1f7a/external/host_python_autodecting_toolchain/BUILD.bazel:3:11: in py_runtime rule @host_python_autodecting_toolchain//:autodecting_python3_runtime: exactly one of the 'interpreter' or 'interpreter_path' attributes must be specified
```