### PR TITLE
fix: don't add source files to requirements files from transitive native py_library rules

### DIFF
--- a/py/private/py_wheel.bzl
+++ b/py/private/py_wheel.bzl
@@ -24,7 +24,11 @@ def _make_py_wheel_info(ctx, wheel_filegroups):
         if PyWheelInfo in filegroup:
             files_depsets.append(filegroup[PyWheelInfo].files)
             runfiles.append(filegroup[PyWheelInfo].default_runfiles)
-        elif DefaultInfo in filegroup:
+        elif DefaultInfo in filegroup and not PyInfo in filegroup:
+            # This is slightly incorrect, but we don't yet have a better way of knowing if the dependency is a filegroup
+            # that we should consume a wheel from.
+            # What we do know though is we must ignore other py_library dependencies from rules_python, so exclude anything
+            # that provides the PyInfo provider.
             files_depsets.append(filegroup[DefaultInfo].files)
             files_depsets.append(filegroup[DefaultInfo].default_runfiles.files)
             runfiles.append(filegroup[DefaultInfo].default_runfiles)


### PR DESCRIPTION
Only take the `DefaultInfo` when there is no `PyInfo`. This stops us adding the source files from a rules_python / native py_library to the requirements file when installing wheels.

This is kinda a workaround that the upstream rules_python doesn't have a provider that can give a reference to the wheel, and we must get it from the `DefaultInfo` of a filegroup.