### PR TITLE
fix: symlink to python3 instead of python_real

### DIFF
--- a/py/private/entry.tmpl.sh
+++ b/py/private/entry.tmpl.sh
@@ -81,7 +81,7 @@ ENTRYPOINT="$(rlocation {{BINARY_ENTRY_POINT}})"
 VENV_SOURCE="$(alocation $(rlocation {{VENV_SOURCE}}))"
 VENV_LOCATION="$(alocation ${RUNFILES_DIR}/{{VENV_NAME}})"
 VBIN_LOCATION="${VENV_LOCATION}/bin"
-VPYTHON="${VBIN_LOCATION}/python3 {{INTERPRETER_FLAGS}}"
+VPYTHON="${VBIN_LOCATION}/python {{INTERPRETER_FLAGS}}"
 
 mkdir "${VENV_LOCATION}" 2>/dev/null || true
 ln -snf "${VENV_SOURCE}/include" "${VENV_LOCATION}/include"
@@ -89,8 +89,7 @@ ln -snf "${VENV_SOURCE}/lib" "${VENV_LOCATION}/lib"
 
 mkdir "${VBIN_LOCATION}" 2>/dev/null || true
 ln -snf ${VENV_SOURCE}/bin/* "${VBIN_LOCATION}/"
-ln -snf "${PYTHON_LOCATION}" "${VBIN_LOCATION}/python3"
-ln -snf "${VBIN_LOCATION}/python3" "${VBIN_LOCATION}/python"
+ln -snf "${PYTHON_LOCATION}" "${VBIN_LOCATION}/python"
 
 echo "home = ${VBIN_LOCATION}" > "${VENV_LOCATION}/pyvenv.cfg"
 echo "include-system-site-packages = false" >> "${VENV_LOCATION}/pyvenv.cfg"

--- a/py/private/toolchain/python.sh
+++ b/py/private/toolchain/python.sh
@@ -9,7 +9,7 @@ PYTHON_BIN="{{PYTHON_BIN}}"
 if [ -z "${VIRTUAL_ENV:-}" ]; then
   exec "${PYTHON_BIN}" "$@"
 else
-  PYTHON_REAL="${VIRTUAL_ENV}/bin/python_real"
+  PYTHON_REAL="${VIRTUAL_ENV}/bin/python3"
   ln -snf "${PYTHON_BIN}" "${PYTHON_REAL}"
   exec "${PYTHON_REAL}" "$@"
 fi

--- a/py/private/utils.bzl
+++ b/py/private/utils.bzl
@@ -1,6 +1,8 @@
 PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
 SH_TOOLCHAIN = "@bazel_tools//tools/sh:toolchain_type"
 
+INTERPRETER_FLAGS = ["-B", "-s", "-I"]
+
 def dict_to_exports(env):
     return [
         "export %s=\"%s\"" % (k, v)
@@ -35,5 +37,5 @@ def resolve_toolchain(ctx):
         files = files,
         python = interpreter,
         uses_interpreter_path = uses_interpreter_path,
-        flags = ["-B", "-s", "-I"],
+        flags = INTERPRETER_FLAGS,
     )

--- a/py/tests/external-deps/expected_pathing
+++ b/py/tests/external-deps/expected_pathing
@@ -1,4 +1,4 @@
-Python: (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/bin/python3
+Python: (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/bin/python
 version: 3.9.10 (main, REDACTED) 
 [Clang 13.0.1 ]
 version info: sys.version_info(major=3, minor=9, micro=10, releaselevel='final', serial=0)


### PR DESCRIPTION
On MacOS (or at least what I'm running), it has some odd semantics around how `/usr/bin/python` behaves which appear to depend on the **name** of the binary itself 🙄 

If the autodetecting toolchain links `/usr/bin/python`, then the shim will call `python_real`, which in turn gets called by whatever the binary at `/usr/bin/python` is, and as `python_real` isn't a binary it can call, it decides it needs to install Xcodes command line utilities. This of course doesn't help, and the cycle continues.

Instead, link to `python3`, and only link in `python` into the venv/bin as the others were kinda extraneous anyway.