### PR TITLE
fix: add the runfiles root as a python package

### DIFF
--- a/py/tests/external-deps/BUILD.bazel
+++ b/py/tests/external-deps/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//py:defs.bzl", "py_binary", "py_library")
+load("//py:defs.bzl", "py_binary", "py_library", "py_test")
 load("@python_toolchain//:defs.bzl", "host_platform")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 
@@ -53,4 +53,12 @@ write_source_files(
         "expected_pathing": "pathing_out",
         "expected_click": "click_out",
     },
+)
+
+py_test(
+    name = "test_can_import_runfiles_helper",
+    srcs = ["test_can_import_runfiles_helper.py"],
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+    ],
 )

--- a/py/tests/external-deps/expected_pathing
+++ b/py/tests/external-deps/expected_pathing
@@ -10,6 +10,7 @@ sys path:
 (py_toolchain)/lib/python3.9
 (py_toolchain)/lib/python3.9/lib-dynload
 (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages
+(pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles
 (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps
 
 Entrypoint Path: (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/pathing.py

--- a/py/tests/external-deps/test_can_import_runfiles_helper.py
+++ b/py/tests/external-deps/test_can_import_runfiles_helper.py
@@ -1,0 +1,4 @@
+try:
+    from bazel_tools.tools.python.runfiles import runfiles
+except ModuleNotFoundError as err:
+    assert False, "Expected to be able to import runfiles helper"

--- a/py/tests/import-pathing/tests.bzl
+++ b/py/tests/import-pathing/tests.bzl
@@ -20,6 +20,16 @@ def _can_resolve_path_in_workspace_test_impl(ctx):
     imports = py_library.make_imports_depset(fake_ctx).to_list()
     asserts.equals(env, "aspect_rules_py/foo/bar", imports[0])
 
+    # Empty string import is semantically equal to "."
+    fake_ctx = _ctx_with_imports([""])
+    imports = py_library.make_imports_depset(fake_ctx).to_list()
+    asserts.equals(env, "aspect_rules_py/foo/bar", imports[0])
+
+    # Empty imports array results in no imports
+    fake_ctx = _ctx_with_imports([])
+    imports = py_library.make_imports_depset(fake_ctx).to_list()
+    asserts.equals(env, 0, len(imports))
+
     # The import path is the parent package
     fake_ctx = _ctx_with_imports([".."])
     imports = py_library.make_imports_depset(fake_ctx).to_list()


### PR DESCRIPTION
A few imports rely on being able to reference the root of the runfiles tree as a Python module, the common case here being the `@rules_python//python/runfiles` or `@bazel_tools//tools/python/runfiles` targets that adds the runfiles helper, which ends up in `bazel_tools/tools/python/runfiles/runfiles.py` (or the rules_python equiv path), but there are no imports attrs that hint we should be adding the root to the `PYTHONPATH`.