### PR TITLE
chore: show errors by default for failed tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@
 # Take care to document any settings that you expect users to apply.
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
+test --test_output=errors
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members


### PR DESCRIPTION
I like seeing the errors rather than having to manually cat the file