### PR TITLE
feat: return PyInfo provider from py_binary rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_python//python/pip_install:requirements.bzl", "compile_pip_requirements")
+load("@rules_python//python:defs.bzl", "py_runtime", "py_runtime_pair")
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 
 # gazelle:exclude internal_python_deps.bzl
@@ -20,4 +21,25 @@ compile_pip_requirements(
     extra_args = ["--allow-unsafe"],
     requirements_in = "requirements.in",
     requirements_txt = "requirements.txt",
+)
+
+py_runtime(
+    name = "container_py3_runtime",
+    interpreter_path = "/usr/bin/python",
+    python_version = "PY3",
+)
+
+py_runtime_pair(
+    name = "container_py_runtime_pair",
+    py2_runtime = None,
+    py3_runtime = ":container_py3_runtime",
+)
+
+toolchain(
+    name = "container_py_toolchain",
+    exec_compatible_with = [
+        "@io_bazel_rules_docker//platforms:run_in_container",
+    ],
+    toolchain = ":container_py_runtime_pair",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,9 @@ load("//py:repositories.bzl", "rules_py_dependencies")
 # Fetch dependencies which users need as well
 rules_py_dependencies()
 
+# Load the Python toolchain for rules_docker
+register_toolchains("//:container_py_toolchain")
+
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(
@@ -59,3 +62,19 @@ go_rules_dependencies()
 go_register_toolchains(version = "1.17.2")
 
 gazelle_dependencies()
+
+############################################
+# rules_docker dependencies for containers
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+load(
+    "@io_bazel_rules_docker//python3:image.bzl",
+    _py_image_repos = "repositories",
+)
+
+_py_image_repos()

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -73,3 +73,11 @@ def rules_py_internal_deps():
         ],
         strip_prefix = "gcc-toolchain-9128134f01cc5e77f8394414ba76293ed22ffc77",
     )
+
+    maybe(
+        http_archive,
+        name = "io_bazel_rules_docker",
+        sha256 = "bb4b7defb8e39e3fda5ca5b1535c9885a68d7dc22e48653baa8956fb101cba04",
+        strip_prefix = "rules_docker-7281c051b7071c065b8ac5b6210301c5f5504663",
+        urls = ["https://github.com/bazelbuild/rules_docker/archive/7281c051b7071c065b8ac5b6210301c5f5504663.zip"],
+    )

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -73,13 +73,21 @@ def _py_binary_rule_imp(ctx):
         ],
     )
 
+    imports = _py_library.make_imports_depset(ctx)
+
     return [
         DefaultInfo(
             files = depset([entry, main]),
             runfiles = runfiles,
             executable = entry,
         ),
-        # Return PyInfo?
+        PyInfo(
+            imports = imports,
+            transitive_sources = srcs_depset,
+            has_py2_only_sources = False,
+            has_py3_only_sources = True,
+            uses_shared_libraries = False,
+        ),
     ]
 
 _attrs = dict({

--- a/py/tests/containers/BUILD.bazel
+++ b/py/tests/containers/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@io_bazel_rules_docker//python3:image.bzl", "py3_image")
+load("//py:defs.bzl", "py_binary")
+
+py_binary(
+    name = "main_bin",
+    srcs = ["__main__.py"],
+    deps = [
+        "@pypi_colorama//:pkg",
+    ],
+)
+
+py3_image(
+    name = "py_image",
+    srcs = ["__main__.py"],
+    main = "__main__.py",
+    deps = [":main_bin"],
+)
+
+container_test(
+    name = "py_image_test",
+    configs = ["py_image_test.yaml"],
+    image = ":py_image",
+)

--- a/py/tests/containers/__main__.py
+++ b/py/tests/containers/__main__.py
@@ -1,0 +1,4 @@
+from colorama import Fore, Style
+
+if __name__ == "__main__":
+    print(f"{Fore.GREEN}Hello rules_py{Style.RESET_ALL}")

--- a/py/tests/containers/py_image_test.yaml
+++ b/py/tests/containers/py_image_test.yaml
@@ -1,0 +1,14 @@
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: __main__ is present
+    path: /app/py/tests/containers/py_image.binary.runfiles/aspect_rules_py/py/tests/containers/__main__.py
+  - name: runfiles dependencies are present
+    path: /app/py/tests/containers/py_image.binary.runfiles/pypi_colorama/colorama/__init__.py
+commandTests:
+  - name: can run binary
+    exitCode: 0
+    command: /usr/bin/python
+    args:
+      - /app/py/tests/containers/py_image.binary
+    expectedOutput: ["Hello rules_py"]


### PR DESCRIPTION
Return a `PyInfo` provider from the `py_binary` (and, `py_test` for that matter) rules. This allows them to be plugged into the `py*_image` rules from rules_docker. 

There is a slight caveat here - if the user is using the wheel approach then the `PyInfo` provider is not sufficient in providing all the required files to put into the container. Will circle back and think about that one.