### PR TITLE
refactor: remove use of maybe() helper

### DIFF
--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -4,13 +4,15 @@ Users should *not* need to install these. If users see a load()
 statement from these, that's a bug in our distribution.
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def http_archive(name, **kwargs):
+    maybe(_http_archive, name = name, **kwargs)
 
 def rules_py_internal_deps():
     "Fetch deps needed for local development"
-    maybe(
-        http_archive,
+    http_archive(
         name = "build_bazel_integration_testing",
         urls = [
             "https://github.com/bazelbuild/bazel-integration-testing/archive/165440b2dbda885f8d1ccb8d0f417e6cf8c54f17.zip",
@@ -19,8 +21,7 @@ def rules_py_internal_deps():
         sha256 = "2401b1369ef44cc42f91dc94443ef491208dbd06da1e1e10b702d8c189f098e3",
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "io_bazel_rules_go",
         sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
         urls = [
@@ -29,8 +30,7 @@ def rules_py_internal_deps():
         ],
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "bazel_gazelle",
         sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
         urls = [
@@ -42,8 +42,7 @@ def rules_py_internal_deps():
     # Override bazel_skylib distribution to fetch sources instead
     # so that the gazelle extension is included
     # see https://github.com/bazelbuild/bazel-skylib/issues/250
-    maybe(
-        http_archive,
+    http_archive(
         name = "bazel_skylib",
         sha256 = "07b4117379dde7ab382345c3b0f5edfc6b7cff6c93756eac63da121e0bbcc5de",
         strip_prefix = "bazel-skylib-1.1.1",
@@ -53,8 +52,7 @@ def rules_py_internal_deps():
         ],
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "io_bazel_stardoc",
         sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
         urls = [
@@ -64,8 +62,7 @@ def rules_py_internal_deps():
     )
 
     # Aspect gcc toolchain for RBE
-    maybe(
-        http_archive,
+    http_archive(
         name = "aspect_gcc_toolchain",
         sha256 = "2610f573f62031c381814ed6dc9f21bf7338b6615ba53d5fe2b4e028a0d0cf2a",
         urls = [
@@ -74,8 +71,7 @@ def rules_py_internal_deps():
         strip_prefix = "gcc-toolchain-9128134f01cc5e77f8394414ba76293ed22ffc77",
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "io_bazel_rules_docker",
         sha256 = "bb4b7defb8e39e3fda5ca5b1535c9885a68d7dc22e48653baa8956fb101cba04",
         strip_prefix = "rules_docker-7281c051b7071c065b8ac5b6210301c5f5504663",

--- a/py/repositories.bzl
+++ b/py/repositories.bzl
@@ -4,9 +4,12 @@ These are needed for local dev, and users must install them as well.
 See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//py/private/toolchain:autodetecting.bzl", _register_autodetecting_python_toolchain = "register_autodetecting_python_toolchain")
+
+def http_archive(name, **kwargs):
+    maybe(_http_archive, name = name, **kwargs)
 
 register_autodetecting_python_toolchain = _register_autodetecting_python_toolchain
 
@@ -16,10 +19,10 @@ register_autodetecting_python_toolchain = _register_autodetecting_python_toolcha
 # ours took precedence. Such breakages are challenging for users, so any
 # changes in this function should be marked as BREAKING in the commit message
 # and released only in semver majors.
+# buildifier: disable=function-docstring
 def rules_py_dependencies():
     # The minimal version of bazel_skylib we require
-    maybe(
-        http_archive,
+    http_archive(
         name = "bazel_skylib",
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
         urls = [
@@ -28,16 +31,14 @@ def rules_py_dependencies():
         ],
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "aspect_bazel_lib",
         sha256 = "b381ac4dca544ecc5515916f38066e9793628477e2577edb7b2ab04e8c210738",
         strip_prefix = "bazel-lib-1.0.0",
         url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.0.0.tar.gz",
     )
 
-    maybe(
-        http_archive,
+    http_archive(
         name = "rules_python",
         sha256 = "cdf6b84084aad8f10bf20b46b77cb48d83c319ebe6458a18e9d2cebf57807cdd",
         strip_prefix = "rules_python-0.8.1",


### PR DESCRIPTION
It's no fewer lines than inlining that function, and as a result renovate will understand our dependencies

Alternative to getting support for this pattern in renovate itself