### PR TITLE
fix: skylib download warning

### DIFF
--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -46,10 +46,7 @@ def rules_py_internal_deps():
         name = "bazel_skylib",
         sha256 = "3b620033ca48fcd6f5ef2ac85e0f6ec5639605fa2f627968490e52fc91a9932f",
         strip_prefix = "bazel-skylib-1.3.0",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.3.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.3.0.tar.gz",
-        ],
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.3.0.tar.gz",
     )
 
     http_archive(

--- a/py/repositories.bzl
+++ b/py/repositories.bzl
@@ -24,11 +24,9 @@ def rules_py_dependencies():
     # The minimal version of bazel_skylib we require
     http_archive(
         name = "bazel_skylib",
-        sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-        ],
+        sha256 = "3b620033ca48fcd6f5ef2ac85e0f6ec5639605fa2f627968490e52fc91a9932f",
+        strip_prefix = "bazel-skylib-1.3.0",
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.3.0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
This commit gets the two imports in sync and fixes the missing archive on mirror.bazel.build.