### PR TITLE
Fix/repo relative imports

### DIFF
--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -55,6 +55,9 @@ def _make_imports_depset(ctx):
     import_paths = [
         _make_import_path(ctx.label, ctx.workspace_name, base, im)
         for im in ctx.attr.imports
+    ] + [
+        # Add the workspace name in the imports such that repo-relative imports work.
+        ctx.workspace_name
     ]
 
     return depset(

--- a/py/private/venv/venv.bzl
+++ b/py/private/venv/venv.bzl
@@ -56,6 +56,11 @@ def _make_venv(ctx, name = None, main = None, strip_pth_workspace_root = None):
     # We also need to collect our own "imports" attr.
     # Can reuse the helper from py_library, as it's the same process
     imports_depset = _py_library.make_imports_depset(ctx)
+    # Add the workspace name in the imports such that repo-relative imports work.
+    imports_depset = depset(
+        direct = [ctx.workspace_name],
+        transitive = [imports_depset],
+    )
 
     pth = ctx.actions.declare_file("%s.pth" % name)
 

--- a/py/private/venv/venv.bzl
+++ b/py/private/venv/venv.bzl
@@ -56,11 +56,6 @@ def _make_venv(ctx, name = None, main = None, strip_pth_workspace_root = None):
     # We also need to collect our own "imports" attr.
     # Can reuse the helper from py_library, as it's the same process
     imports_depset = _py_library.make_imports_depset(ctx)
-    # Add the workspace name in the imports such that repo-relative imports work.
-    imports_depset = depset(
-        direct = [ctx.workspace_name],
-        transitive = [imports_depset],
-    )
 
     pth = ctx.actions.declare_file("%s.pth" % name)
 

--- a/py/tests/external-deps/expected_pathing
+++ b/py/tests/external-deps/expected_pathing
@@ -12,6 +12,7 @@ sys path:
 (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages
 (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles
 (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps
+(pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py
 
 Entrypoint Path: (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/pathing.py
 

--- a/py/tests/import-pathing/tests.bzl
+++ b/py/tests/import-pathing/tests.bzl
@@ -25,10 +25,11 @@ def _can_resolve_path_in_workspace_test_impl(ctx):
     imports = py_library.make_imports_depset(fake_ctx).to_list()
     asserts.equals(env, "aspect_rules_py/foo/bar", imports[0])
 
-    # Empty imports array results in no imports
+    # Empty imports array results in just the workspace root import
     fake_ctx = _ctx_with_imports([])
     imports = py_library.make_imports_depset(fake_ctx).to_list()
-    asserts.equals(env, 0, len(imports))
+    asserts.equals(env, 1, len(imports))
+    asserts.equals(env, "aspect_rules_py", imports[0])
 
     # The import path is the parent package
     fake_ctx = _ctx_with_imports([".."])

--- a/py/tests/repo_relative_imports/lib/BUILD.bazel
+++ b/py/tests/repo_relative_imports/lib/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//py:defs.bzl", "py_library")
+
+py_library(
+    name = "lib",
+    srcs = ["adder.py"],
+    visibility = ["//visibility:public"],
+)

--- a/py/tests/repo_relative_imports/lib/adder.py
+++ b/py/tests/repo_relative_imports/lib/adder.py
@@ -1,0 +1,2 @@
+def add(a, b):
+    return a + b

--- a/py/tests/repo_relative_imports/test/BUILD.bazel
+++ b/py/tests/repo_relative_imports/test/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//py:defs.bzl", "py_test")
+
+py_test(
+    name = "test",
+    srcs = ["test.py"],
+    deps = ["//py/tests/repo_relative_imports/lib"],
+)

--- a/py/tests/repo_relative_imports/test/test.py
+++ b/py/tests/repo_relative_imports/test/test.py
@@ -1,0 +1,3 @@
+from py.tests.repo_relative_imports.lib import adder
+
+assert adder.add(2, 3) == 5


### PR DESCRIPTION
Fixes #94 . The extra import path is routed via the .pth file.