### PR TITLE
fix black and flake8 errors in generated pytest runner.

### DIFF
--- a/py/private/py_pytest_main.bzl
+++ b/py/private/py_pytest_main.bzl
@@ -20,7 +20,9 @@ load("@rules_python//python:defs.bzl", default_py_library = "py_library")
 def _py_pytest_main_impl(ctx):
     substitutions = {
         "$$FLAGS$$": ", ".join(['"{}"'.format(f) for f in ctx.attr.args]).strip(),
-        "$$CHDIR$$": "os.chdir('{}')".format(ctx.attr.chdir) if ctx.attr.chdir else "",
+        # Leaving CHDIR empty results in potentially user facing issues w/
+        # black and flake8, so we'll just assign something trivial as a no-op.
+        "$$CHDIR$$": "os.chdir('{}')".format(ctx.attr.chdir) if ctx.attr.chdir else "_ = 0",
     }
 
     ctx.actions.expand_template(

--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -18,6 +18,7 @@ import os
 import pytest
 
 if __name__ == "__main__":
+    # Change to the directory where we need to run the test or execute a no-op
     $$CHDIR$$
 
     os.environ["ENV"] = "testing"


### PR DESCRIPTION
Fix flake8 and black formatting issues in generated pytest driver by adding a no-op statement instead of an empty string. The previous version resulted in a file with 2 blank lines if chdir was undefined, resulting in the following issues being raised:

```
bazel-out/k8-fastbuild/bin/REDACTED/__test__.py:21:1: BLK100 Black would make changes.
bazel-out/k8-fastbuild/bin/REDACTED/__test__.py:21:1: W293 blank line contains whitespace
bazel-out/k8-fastbuild/bin/REDACTED/__test__.py:23:5: E303 too many blank lines (2)
```