### PR TITLE
s/external/../ if the python interpreter cannot be found in the resolved venv creation script.

### DIFF
--- a/py/private/venv/venv.tmpl.sh
+++ b/py/private/venv/venv.tmpl.sh
@@ -24,6 +24,9 @@ function maybe_rlocation() {
 
 # Resolved from the py_interpreter via PyInterpreterInfo.
 PYTHON_LOCATION="{{PYTHON_INTERPRETER_PATH}}"
+if [[ ! -f "${PYTHON_LOCATION}" ]]; then
+  PYTHON_LOCATION="${PYTHON_LOCATION/external/..}"
+fi
 PYTHON="${PYTHON_LOCATION} {{INTERPRETER_FLAGS}}"
 REAL_PYTHON_LOCATION=$(${PYTHON} -c 'import sys; import os; print(os.path.realpath(sys.executable))')
 PYTHON_SITE_PACKAGES=$(${PYTHON} -c 'import site; print(site.getsitepackages()[0])')


### PR DESCRIPTION
s/external/../ if the python interpreter cannot be  found in the resolved venv creation script.

In my environment the python interpreter is up a level and doesn't have 'external/' as a prefix. Not really sure why. This works for my environment, but not certain that it's the correct change to make. Let me know what you think.
