### PR TITLE
Fix PTH generation for standalone virtualenvs

### DIFF
--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -51,8 +51,8 @@ bzl_library(
 bzl_library(
     name = "py_pytest_main",
     srcs = ["py_pytest_main.bzl"],
-    deps = ["@rules_python//python:defs"],
     visibility = ["//py:__subpackages__"],
+    deps = ["@rules_python//python:defs"],
 )
 
 bzl_library(

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -15,7 +15,6 @@ def _py_binary_rule_imp(ctx):
     venv_info = _py_venv.make_venv(
         ctx,
         name = "%s.venv" % ctx.attr.name,
-        strip_pth_workspace_root = False,
     )
 
     env = dict({

--- a/py/tests/external-deps/BUILD.bazel
+++ b/py/tests/external-deps/BUILD.bazel
@@ -28,6 +28,7 @@ genrule(
         """sed "s#$$(pwd)#(pwd)#" """,
         "sed 's#^.*execroot/aspect_rules_py/external/python_toolchain_%s#(py_toolchain)#'" % host_platform,
         "sed 's#(main, .*)#(main, REDACTED)#'",
+        "sed 's#bazel-out/.*/bin/py#bazel-out/(platform)/bin/py#'",
     ]) + "> $@",
     tools = ["pathing"],
 )

--- a/py/tests/external-deps/expected_pathing
+++ b/py/tests/external-deps/expected_pathing
@@ -1,23 +1,23 @@
-Python: (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/bin/python
+Python: (pwd)/bazel-out/(platform)/bin/python
 version: 3.9.15 (main, REDACTED) 
 [Clang 14.0.3 ]
 version info: sys.version_info(major=3, minor=9, micro=15, releaselevel='final', serial=0)
 cwd: (pwd)
-site-packages folder: ['(pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages']
+site-packages folder: ['(pwd)/bazel-out/(platform)/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages']
 
 sys path:
 (py_toolchain)/lib/python39.zip
 (py_toolchain)/lib/python3.9
 (py_toolchain)/lib/python3.9/lib-dynload
-(pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages
-(pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles
-(pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps
-(pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py
+(pwd)/bazel-out/(platform)/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages
+(pwd)/bazel-out/(platform)/bin/py/tests/external-deps/pathing.runfiles
+(pwd)/bazel-out/(platform)/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps
+(pwd)/bazel-out/(platform)/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py
 
-Entrypoint Path: (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/pathing.py
+Entrypoint Path: (pwd)/bazel-out/(platform)/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/pathing.py
 
-Django location: (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages/django/__init__.py
+Django location: (pwd)/bazel-out/(platform)/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages/django/__init__.py
 Django version: 4.0.9
 
 From lib with wheel dependency: [32mHello Matt[0m
-lib filepath: (pwd)/bazel-out/host/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/lib.py
+lib filepath: (pwd)/bazel-out/(platform)/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/lib.py

--- a/py/tests/py-test/test_env_vars.py
+++ b/py/tests/py-test/test_env_vars.py
@@ -12,6 +12,11 @@ test_env('ONE', 'un')
 test_env('TWO', 'deux')
 test_env('LOCATION', "py/tests/py-test/test_env_vars.py")
 test_env('DEFINE', "SOME_VALUE")
-test_env('BAZEL_TARGET', "//py/tests/py-test:test_env_vars")
+try:
+    test_env('BAZEL_TARGET', "@//py/tests/py-test:test_env_vars")
+except AssertionError:
+    # This behavior changes with bazel 6, it now inserts the @ symbol to ctx.label
+    # Use this assertion so that either test form will pass
+    test_env('BAZEL_TARGET', "//py/tests/py-test:test_env_vars")
 test_env('BAZEL_WORKSPACE', "aspect_rules_py")
 test_env('BAZEL_TARGET_NAME', "test_env_vars")


### PR DESCRIPTION
Virtualenvs created in the runfiles tree can safely assume where they live- as such, they can happily use relative paths to find the correct location of whatever py_library targets they need to link in. However, using 'bazel run :sometarget.venv' is expected to create a virtualenv in the root source directory, presumably for user IDE integration. The existing code creates a broken one however- basically every path is changed to ../../../.. . Since this virtualenv doesn't live in a runfiles tree, it cannot find packages that way- but since it is running in 'bazel run' instead of during execution, we can use runfiles to find the correct absolute paths. I could not figure out a use case for strip_pth_workspace_root, or any uses of it that didn't result in a broken virtualenv, so I removed it.