### PR TITLE
chore: bump bazel version to 6.3.1

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.2.0
+6.3.1
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.


### PR DESCRIPTION
Bumps the bazel version to 6.3.1

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases