### PR TITLE
feat: expose py_venv rule, allowing creation of virtual envs from multiple targets

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,6 +2,29 @@
 
 Public API re-exports
 
+<a id="py_venv"></a>
+
+## py_venv
+
+<pre>
+py_venv(<a href="#py_venv-name">name</a>, <a href="#py_venv-data">data</a>, <a href="#py_venv-deps">deps</a>, <a href="#py_venv-imports">imports</a>, <a href="#py_venv-srcs">srcs</a>, <a href="#py_venv-strip_pth_workspace_root">strip_pth_workspace_root</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="py_venv-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_venv-data"></a>data |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="py_venv-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="py_venv-imports"></a>imports |  -   | List of strings | optional | <code>[]</code> |
+| <a id="py_venv-srcs"></a>srcs |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="py_venv-strip_pth_workspace_root"></a>strip_pth_workspace_root |  -   | Boolean | optional | <code>True</code> |
+
+
 <a id="py_wheel"></a>
 
 ## py_wheel
@@ -43,7 +66,7 @@ you can `bazel run [name].venv` to produce this, then use it in the editor.
 | <a id="py_binary-name"></a>name |  name of the rule   |  none |
 | <a id="py_binary-srcs"></a>srcs |  python source files   |  <code>[]</code> |
 | <a id="py_binary-main"></a>main |  the entry point. If absent, then the first entry in srcs is used.   |  <code>None</code> |
-| <a id="py_binary-imports"></a>imports |  <p align="center"> - </p>   |  <code>["."]</code> |
+| <a id="py_binary-imports"></a>imports |  List of import paths to add for this binary.   |  <code>["."]</code> |
 | <a id="py_binary-kwargs"></a>kwargs |  see [py_binary attributes](./py_binary)   |  none |
 
 
@@ -52,7 +75,7 @@ you can `bazel run [name].venv` to produce this, then use it in the editor.
 ## py_library
 
 <pre>
-py_library(<a href="#py_library-name">name</a>, <a href="#py_library-imports">imports</a>, <a href="#py_library-kwargs">kwargs</a>)
+py_library(<a href="#py_library-name">name</a>, <a href="#py_library-kwargs">kwargs</a>)
 </pre>
 
 Wrapper macro for the py_library rule, setting a default for imports
@@ -63,7 +86,6 @@ Wrapper macro for the py_library rule, setting a default for imports
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="py_library-name"></a>name |  name of the rule   |  none |
-| <a id="py_library-imports"></a>imports |  <p align="center"> - </p>   |  <code>["."]</code> |
 | <a id="py_library-kwargs"></a>kwargs |  see [py_library attributes](./py_library)   |  none |
 
 

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -6,16 +6,16 @@ load("//py/private:py_pytest_main.bzl", _py_pytest_main = "py_pytest_main")
 load("//py/private:py_wheel.bzl", "py_wheel_lib")
 load("//py/private/venv:venv.bzl", _py_venv = "py_venv")
 
-def py_library(name, imports = ["."], **kwargs):
+def py_library(name, **kwargs):
     """Wrapper macro for the py_library rule, setting a default for imports
 
     Args:
         name: name of the rule
         **kwargs: see [py_library attributes](./py_library)
     """
+
     _py_library(
         name = name,
-        imports = imports,
         **kwargs
     )
 
@@ -29,8 +29,10 @@ def py_binary(name, srcs = [], main = None, imports = ["."], **kwargs):
         name: name of the rule
         srcs: python source files
         main: the entry point. If absent, then the first entry in srcs is used.
+        imports: List of import paths to add for this binary.
         **kwargs: see [py_binary attributes](./py_binary)
     """
+
     if not main and not len(srcs):
         fail("When 'main' is not specified, 'srcs' must be non-empty")
     _py_binary(
@@ -51,6 +53,7 @@ def py_binary(name, srcs = [], main = None, imports = ["."], **kwargs):
 
 def py_test(name, main = None, srcs = [], imports = ["."], **kwargs):
     "Identical to py_binary, but produces a target that can be used with `bazel test`."
+
     _py_test(
         name = name,
         srcs = srcs,
@@ -74,3 +77,4 @@ py_wheel = rule(
 )
 
 py_pytest_main = _py_pytest_main
+py_venv = _py_venv

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -4,6 +4,7 @@ load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_manifest
 load("@aspect_bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:providers.bzl", "PyWheelInfo")
+load("//py/private:py_wheel.bzl", py_wheel = "py_wheel_lib")
 load("//py/private:utils.bzl", "PY_TOOLCHAIN", "SH_TOOLCHAIN", "dict_to_exports", "resolve_toolchain")
 load("//py/private/venv:venv.bzl", _py_venv = "py_venv_utils")
 
@@ -78,6 +79,7 @@ def _py_binary_rule_imp(ctx):
         ctx, 
         extra_source_attributes = ["main"]
     )
+    py_wheel_info = py_wheel.make_py_wheel_info(ctx, ctx.attr.deps)
 
     return [
         DefaultInfo(
@@ -93,6 +95,7 @@ def _py_binary_rule_imp(ctx):
             uses_shared_libraries = False,
         ),
         instrumented_files_info,
+        py_wheel_info,
     ]
 
 _attrs = dict({

--- a/py/private/venv/venv.bzl
+++ b/py/private/venv/venv.bzl
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_manifest_path")
 load("//py/private:providers.bzl", "PyWheelInfo")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
-load("//py/private:utils.bzl", "PY_TOOLCHAIN", "SH_TOOLCHAIN", "dict_to_exports", "resolve_toolchain")
+load("//py/private:utils.bzl", "PY_TOOLCHAIN", "SH_TOOLCHAIN", "resolve_toolchain")
 
 def _wheel_path_map(file):
     return file.path
@@ -16,7 +16,7 @@ def _get_attr(ctx, attr, override):
     else:
         return override
 
-def _make_venv(ctx, name = None, main = None, strip_pth_workspace_root = None):
+def _make_venv(ctx, name = None, strip_pth_workspace_root = None):
     bash_bin = ctx.toolchains[SH_TOOLCHAIN].path
     interpreter = resolve_toolchain(ctx)
 

--- a/py/tests/external-deps/expected_pathing
+++ b/py/tests/external-deps/expected_pathing
@@ -11,8 +11,8 @@ sys path:
 (py_toolchain)/lib/python3.9/lib-dynload
 (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages
 (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles
-(pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps
 (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py
+(pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps
 
 Entrypoint Path: (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/pathing.py
 


### PR DESCRIPTION
Exposes the `py_venv` rule, which can create a Python virtual environment from a set of targets.
This allows for easier creation of environments for IDE use, as they can contain dependencies from multiple targets, such as tests.

The virtual environment that is created uses paths for first party libraries that resolve into the source tree. While this allows for a nicer user experience within the IDE, such as editing files being "live", it is less "correct" as the Bazel target may reflect a different state.