### PR TITLE
fix: use rlocation for interpreter location

### DIFF
--- a/py/private/venv/venv.bzl
+++ b/py/private/venv/venv.bzl
@@ -128,6 +128,7 @@ def _make_venv(ctx, name = None, main = None, strip_pth_workspace_root = None):
         substitutions = dict(
             common_substitutions,
             **{
+                "{{PYTHON_INTERPRETER_PATH}}": to_manifest_path(ctx, interpreter.python),
                 "{{WHL_REQUIREMENTS_FILE}}": to_manifest_path(ctx, whl_requirements),
                 "{{PTH_FILE}}": to_manifest_path(ctx, pth),
                 "{{VENV_LOCATION}}": "${BUILD_WORKSPACE_DIRECTORY}/.%s" % name,

--- a/py/private/venv/venv.tmpl.sh
+++ b/py/private/venv/venv.tmpl.sh
@@ -23,7 +23,7 @@ function maybe_rlocation() {
 }
 
 # Resolved from the py_interpreter via PyInterpreterInfo.
-PYTHON_LOCATION="{{PYTHON_INTERPRETER_PATH}}"
+PYTHON_LOCATION="$(maybe_rlocation "{{PYTHON_INTERPRETER_PATH}}")"
 PYTHON="${PYTHON_LOCATION} {{INTERPRETER_FLAGS}}"
 REAL_PYTHON_LOCATION=$(${PYTHON} -c 'import sys; import os; print(os.path.realpath(sys.executable))')
 PYTHON_SITE_PACKAGES=$(${PYTHON} -c 'import site; print(site.getsitepackages()[0])')


### PR DESCRIPTION
If an in-build interpreter is used for venv creation, then the script needs to resolve the path to the interpreter via the runfiles library.

---

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below:

Ensure in-build interpreters are resolved when creating venvs.

### Test plan

- Manual testing
