### PR TITLE
Add `testonly` and `data` parameters to `py_pytest_main` rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -108,7 +108,7 @@ py_pytest_main wraps the template rendering target and the final py_library.
 | <a id="py_pytest_main-py_library"></a>py_library |  Use this attribute to override the default py_library rule.   |  <code>&lt;function py_library&gt;</code> |
 | <a id="py_pytest_main-deps"></a>deps |  A list containing the pytest library target, e.g., @pypi_pytest//:pkg.   |  <code>[]</code> |
 | <a id="py_pytest_main-data"></a>data |  A list of data dependencies to pass to the py_library target.   |  <code>[]</code> |
-| <a id="py_pytest_main-testonly"></a>testonly |  A boolean indicating if the py_library target is testonly.   |  <code>False</code> |
+| <a id="py_pytest_main-testonly"></a>testonly |  A boolean indicating if the py_library target is testonly.   |  <code>True</code> |
 | <a id="py_pytest_main-kwargs"></a>kwargs |  The extra arguments passed to the template rendering target.   |  none |
 
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -94,7 +94,7 @@ Wrapper macro for the py_library rule, setting a default for imports
 ## py_pytest_main
 
 <pre>
-py_pytest_main(<a href="#py_pytest_main-name">name</a>, <a href="#py_pytest_main-py_library">py_library</a>, <a href="#py_pytest_main-deps">deps</a>, <a href="#py_pytest_main-kwargs">kwargs</a>)
+py_pytest_main(<a href="#py_pytest_main-name">name</a>, <a href="#py_pytest_main-py_library">py_library</a>, <a href="#py_pytest_main-deps">deps</a>, <a href="#py_pytest_main-data">data</a>, <a href="#py_pytest_main-testonly">testonly</a>, <a href="#py_pytest_main-kwargs">kwargs</a>)
 </pre>
 
 py_pytest_main wraps the template rendering target and the final py_library.
@@ -107,6 +107,8 @@ py_pytest_main wraps the template rendering target and the final py_library.
 | <a id="py_pytest_main-name"></a>name |  The name of the runable target that updates the test entry file.   |  none |
 | <a id="py_pytest_main-py_library"></a>py_library |  Use this attribute to override the default py_library rule.   |  <code>&lt;function py_library&gt;</code> |
 | <a id="py_pytest_main-deps"></a>deps |  A list containing the pytest library target, e.g., @pypi_pytest//:pkg.   |  <code>[]</code> |
+| <a id="py_pytest_main-data"></a>data |  A list of data dependencies to pass to the py_library target.   |  <code>[]</code> |
+| <a id="py_pytest_main-testonly"></a>testonly |  A boolean indicating if the py_library target is testonly.   |  <code>False</code> |
 | <a id="py_pytest_main-kwargs"></a>kwargs |  The extra arguments passed to the template rendering target.   |  none |
 
 

--- a/py/private/py_pytest_main.bzl
+++ b/py/private/py_pytest_main.bzl
@@ -53,13 +53,15 @@ _py_pytest_main = rule(
     },
 )
 
-def py_pytest_main(name, py_library = default_py_library, deps = [], **kwargs):
+def py_pytest_main(name, py_library = default_py_library, deps = [], data = [], testonly = False, **kwargs):
     """py_pytest_main wraps the template rendering target and the final py_library.
 
     Args:
         name: The name of the runable target that updates the test entry file.
         py_library: Use this attribute to override the default py_library rule.
         deps: A list containing the pytest library target, e.g., @pypi_pytest//:pkg.
+        data: A list of data dependencies to pass to the py_library target.
+        testonly: A boolean indicating if the py_library target is testonly.
         **kwargs: The extra arguments passed to the template rendering target.
     """
 
@@ -77,8 +79,10 @@ def py_pytest_main(name, py_library = default_py_library, deps = [], **kwargs):
 
     py_library(
         name = name,
+        testonly = testonly,
         srcs = [test_main],
         tags = tags,
         visibility = visibility,
         deps = deps,
+        data = data,
     )

--- a/py/private/py_pytest_main.bzl
+++ b/py/private/py_pytest_main.bzl
@@ -53,7 +53,7 @@ _py_pytest_main = rule(
     },
 )
 
-def py_pytest_main(name, py_library = default_py_library, deps = [], data = [], testonly = False, **kwargs):
+def py_pytest_main(name, py_library = default_py_library, deps = [], data = [], testonly = True, **kwargs):
     """py_pytest_main wraps the template rendering target and the final py_library.
 
     Args:


### PR DESCRIPTION
### Type of change

- New feature or functionality (change which adds functionality)

Adds 2 new **optional** parameters to `py_pytest_main(...)` rule: `data` and `testonly`. These are standard arguments to the `py_library`. This change simply exposes the arguments to the `py_pytest_main` rule

closes: #189 

### Test plan

- Covered by existing test cases
