### PR TITLE
chore: flip no legacy external runfiles

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,9 @@ common --incompatible_enable_cc_toolchain_resolution
 # Use local rules_python
 # Enable with --config=dev
 common:dev --override_repository=rules_python=~/workspace/rules_python
+# No external runfiles
+common --nolegacy_external_runfiles
+
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members

--- a/examples/py_binary/BUILD.bazel
+++ b/examples/py_binary/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//py:defs.bzl", "py_binary")
+
+py_binary(
+    name = "py_binary",
+    srcs = ["say.py"],
+    deps = [
+        "@pypi_cowsay//:pkg",
+    ],
+)

--- a/examples/py_binary/say.py
+++ b/examples/py_binary/say.py
@@ -1,0 +1,3 @@
+import cowsay
+
+cowsay.cow('hello py_binary!')

--- a/gazelle_python.yaml
+++ b/gazelle_python.yaml
@@ -40,6 +40,13 @@ manifest:
     colorama.tests.winterm_test: colorama
     colorama.win32: colorama
     colorama.winterm: colorama
+    cowsay: cowsay
+    cowsay.characters: cowsay
+    cowsay.main: cowsay
+    cowsay.tests: cowsay
+    cowsay.tests.solutions: cowsay
+    cowsay.tests.test_api: cowsay
+    cowsay.tests.test_output: cowsay
     django: Django
     django.apps: Django
     django.apps.config: Django
@@ -946,4 +953,4 @@ manifest:
     typing_extensions: typing_extensions
   pip_repository:
     name: pypi
-integrity: f553566eaf30557a41499dc599ab31526aa68e77f5cee73ed0da29d6c02bedfd
+integrity: bda699f1c32ae76fb0df4861571379f69bfd240f131217fc47553f0af4e6d085

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ django~=4.2.7
 colorama~=0.4.0
 click
 pytest
+cowsay

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,9 @@ colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via -r requirements.in
+cowsay==6.1 \
+    --hash=sha256:274b1e6fc1b966d53976333eb90ac94cb07a450a700b455af9fbdf882244b30a
+    # via -r requirements.in
 django==4.2.10 \
     --hash=sha256:a2d4c4d4ea0b6f0895acde632071aff6400bfc331228fc978b05452a0ff3e9f1 \
     --hash=sha256:b1260ed381b10a11753c73444408e19869f3241fc45c985cd55a30177c789d13


### PR DESCRIPTION
### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- New test cases added

It seems like this issue has already been fixed, I flipped the flag for future cases. 

closes #152 
