### PR TITLE
chore: use modern helper from bazel-lib

### DIFF
--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -1,6 +1,6 @@
 "Implementation for the py_binary and py_test rules."
 
-load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_manifest_path")
+load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@aspect_bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:providers.bzl", "PyWheelInfo")
@@ -32,16 +32,16 @@ def _py_binary_rule_imp(ctx):
             attribute_name = "env",
         )
 
-    python_interpreter_path = interpreter.python.path if interpreter.uses_interpreter_path else to_manifest_path(ctx, interpreter.python)
+    python_interpreter_path = interpreter.python.path if interpreter.uses_interpreter_path else to_rlocation_path(ctx, interpreter.python)
 
     common_substitutions = {
         "{{BASH_BIN}}": bash_bin,
         "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION,
-        "{{BINARY_ENTRY_POINT}}": to_manifest_path(ctx, main),
+        "{{BINARY_ENTRY_POINT}}": to_rlocation_path(ctx, main),
         "{{INTERPRETER_FLAGS}}": " ".join(interpreter.flags),
         "{{PYTHON_INTERPRETER_PATH}}": python_interpreter_path,
         "{{RUN_BINARY_ENTRY_POINT}}": "true",
-        "{{VENV_SOURCE}}": to_manifest_path(ctx, venv_info.venv_directory),
+        "{{VENV_SOURCE}}": to_rlocation_path(ctx, venv_info.venv_directory),
         "{{VENV_NAME}}": "%s.venv" % ctx.attr.name,
         "{{PYTHON_ENV}}": "\n".join(dict_to_exports(env)).strip(),
         "{{PYTHON_ENV_UNSET}}": "\n".join(["unset %s" % k for k in env.keys()]).strip(),

--- a/py/private/venv/venv.bzl
+++ b/py/private/venv/venv.bzl
@@ -1,6 +1,6 @@
 "Implementations for the py_venv rule."
 
-load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_manifest_path")
+load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("//py/private:providers.bzl", "PyWheelInfo")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:utils.bzl", "PY_TOOLCHAIN", "SH_TOOLCHAIN", "resolve_toolchain")
@@ -130,9 +130,9 @@ def _make_venv(ctx, name = None, strip_pth_workspace_root = None):
         substitutions = dict(
             common_substitutions,
             **{
-                "{{PYTHON_INTERPRETER_PATH}}": to_manifest_path(ctx, interpreter.python),
-                "{{WHL_REQUIREMENTS_FILE}}": to_manifest_path(ctx, whl_requirements),
-                "{{PTH_FILE}}": to_manifest_path(ctx, pth),
+                "{{PYTHON_INTERPRETER_PATH}}": to_rlocation_path(ctx, interpreter.python),
+                "{{WHL_REQUIREMENTS_FILE}}": to_rlocation_path(ctx, whl_requirements),
+                "{{PTH_FILE}}": to_rlocation_path(ctx, pth),
                 "{{VENV_LOCATION}}": "${BUILD_WORKSPACE_DIRECTORY}/.%s" % name,
                 "{{USE_MANIFEST_PATH}}": "true",
             }


### PR DESCRIPTION
The to_manifest_path is removed on the 2.x branch

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
