### PR TITLE
refactor: put 'git archive' config in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 docs/*.md linguist-generated=true
+
+# Configuration for 'git archive'
+# see https://git-scm.com/docs/git-archive/2.40.0#ATTRIBUTES
+# Don't include examples in the distribution artifact, just to reduce size
+examples export-ignore

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,15 +2,14 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Don't include examples in the distribution artifact, just to reduce size
-echo >.git/info/attributes "examples export-ignore"
-
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
 # The prefix is chosen to match what GitHub generates for source archives
 PREFIX="rules_py-${TAG:1}"
 ARCHIVE="rules_py-$TAG.tar.gz"
+
+# NB: configuration for 'git archive' is in /.gitattributes
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 


### PR DESCRIPTION
Makes it match bazelbuild/rules_proto#189

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
I made a clean git repo and verified the export-* settings work in .gitattributes