### PR TITLE
fix: use original interpreter path as 'home' value in pyvenv.cfg

### DIFF
--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -11,12 +11,12 @@ bazel_dep(name = "rules_python", dev_dependency = True, version = "0.22.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
-    name = "python3_9",
+    name = "python3",
     configure_coverage_tool = True,
-    python_version = "3.9",
+    python_version = "3.11",
 )
-use_repo(python, "python3_9_toolchains")
+use_repo(python, "python3_toolchains")
 
 register_toolchains(
-    "@python3_9_toolchains//:all",
+    "@python3_toolchains//:all",
 )

--- a/py/private/entry.tmpl.sh
+++ b/py/private/entry.tmpl.sh
@@ -91,7 +91,7 @@ mkdir "${VBIN_LOCATION}" 2>/dev/null || true
 ln -snf ${VENV_SOURCE}/bin/* "${VBIN_LOCATION}/"
 ln -snf "${PYTHON_LOCATION}" "${VBIN_LOCATION}/python"
 
-echo "home = ${VBIN_LOCATION}" > "${VENV_LOCATION}/pyvenv.cfg"
+echo "home = ${PYTHON_BIN_DIR}" > "${VENV_LOCATION}/pyvenv.cfg"
 echo "include-system-site-packages = false" >> "${VENV_LOCATION}/pyvenv.cfg"
 echo "version = ${PYTHON_VERSION}" >> "${VENV_LOCATION}/pyvenv.cfg"
 


### PR DESCRIPTION
Use the original (source) interpreters bin path as the 'home' value in the generated `pyvenv.cfg` file.

Closes #159 

---

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below:

Ensure correct `home` pathing is used when generating the venv.

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:

Updated e2e smoke to use py3.11