### PR TITLE
fix: (follow-up) use original interpreter path as 'home' value in pyv…

### DIFF
--- a/py/private/venv/venv.tmpl.sh
+++ b/py/private/venv/venv.tmpl.sh
@@ -139,7 +139,7 @@ if [ "$USE_MANIFEST_PATH" = true ]; then
   ln -snf "${VBIN_LOCATION}/python" "${VBIN_LOCATION}/python${PYTHON_SYMLINK_VERSION_SUFFIX}"
 
   PYTHON_VERSION=$(${PYTHON} -c 'import platform; print(platform.python_version())')
-  echo "home = ${VBIN_LOCATION}" > "${PYVENV_CFG}"
+  echo "home = ${PYTHON_BIN_DIR}" > "${PYVENV_CFG}"
   echo "include-system-site-packages = false" >> "${PYVENV_CFG}"
   echo "version = ${PYTHON_VERSION}" >> "${PYVENV_CFG}"
 


### PR DESCRIPTION
…env.cfg

This is a follow-up of #226 to fix another place.

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below:

Ensure correct home pathing is used when generating the venv.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

As described by https://github.com/aspect-build/rules_py/pull/226#issuecomment-1833958996