### PR TITLE
fix: install transitive wheels reachable through resolutions

### DIFF
--- a/py/private/venv/venv.bzl
+++ b/py/private/venv/venv.bzl
@@ -47,6 +47,7 @@ def _make_venv(ctx, name = None, strip_pth_workspace_root = None):
             fail("Conflict in virtual dependency resolutions while resolving '{}'. Dependency is resolved by {} and {}".format(resolution.virtual, str(resolution.target), str(conflicts_with)))
         seen.update([[resolution.virtual, i]])
         wheels.append(resolution.target[DefaultInfo].files)
+        wheels_depsets.append(resolution.target[DefaultInfo].default_runfiles.files)
 
         if PyWheelInfo in resolution.target:
             wheels.append(resolution.target[PyWheelInfo].files)

--- a/py/tests/virtual/django/BUILD.bazel
+++ b/py/tests/virtual/django/BUILD.bazel
@@ -20,11 +20,17 @@ py_library(
 
 py_binary(
     name = "manage",
-    srcs = [
-        "proj/manage.py",
-    ],
+    srcs = ["proj/manage.py"],
+    # Resolve django to the "standard" one from our requirements.txt
+    resolutions = {"django": "@django//django:whl"},
+    deps = [":proj"],
+)
+
+py_binary(
+    name = "manage.override_django",
+    srcs = ["proj/manage.py"],
     resolutions = resolutions(
-        # Use the wheels that the pip_parse rule defined as defaults...
+        # Install ALL the wheels that the pip_parse rule defined as defaults...
         django_resolutions,
         # ...but replace the resolution of django with a specific wheel fetched by http_file.
         {"django": "@django_4_2_4//file"},


### PR DESCRIPTION
This allows users to provide a resolution for the direct dependency they see, ensuring that the venv will be created with its dependencies installed as well.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
The new py_binary can run successfully; without this change it couldn't import `asgiref`