### PR TITLE
chore: minimal changes required to upgrade to Bazel 7 and bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,10 +7,6 @@ test --test_output=errors
 # Define value used by tests
 build --define=SOME_VAR=SOME_VALUE
 
-# Use local rules_python
-# Enable with --config=dev
-common:dev --override_repository=rules_python=~/workspace/rules_python
-
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.3.2
+7.0.0
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,4 +10,13 @@ module(
 # When bumping, add a comment explaining what's required from the newer release.
 bazel_dep(name = "aspect_bazel_lib", version = "1.38.1")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
-bazel_dep(name = "rules_python", version = "0.19.0")
+# This is the minimum version that includes
+# feat(pip): provide pypi -> whl target mapping in requirements.bzl by @alexeagle in #1532
+bazel_dep(name = "rules_python", version = "0.27.0")
+
+bazel_dep(name = "rules_testing", version = "0.5.0", dev_dependency = True)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+python.toolchain(
+    python_version = "3.9",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,4 @@
-# Declare the local Bazel workspace.
-workspace(name = "aspect_rules_py")
+# Marker that this folder is the root of a Bazel workspace.
 
 load(":internal_deps.bzl", "rules_py_internal_deps")
 

--- a/py/tests/external-deps/BUILD.bazel
+++ b/py/tests/external-deps/BUILD.bazel
@@ -26,8 +26,10 @@ genrule(
     cmd = "|".join([
         "$(execpath pathing)",
         """sed "s#$$(pwd)#(pwd)#" """,
-        "sed 's#^.*execroot/aspect_rules_py/external/python_toolchain_%s#(py_toolchain)#'" % host_platform,
-        "sed 's#bazel-out/[_a-z0-9-]*-exec-[A-Z0-9]*/bin/#bazel-out/[exec]/bin/#'",
+        # scrub various platform-specific paths, so our expected_pathing file is portable
+        "sed 's#^.*execroot/_main/external/rules_python~[0-9.]*~python~python_3_9_%s#(py_toolchain)#'" % host_platform,
+        "sed 's#^/tmp/bazel-source-roots/[0-9]#(py_toolchain)#'",
+        "sed 's#bazel-out/[_a-z0-9-]*-exec-[A-Za-f0-9-]*/bin/#bazel-out/[exec]/bin/#'",
         "sed 's#(main, .*)#(main, REDACTED)#'",
     ]) + "> $@",
     tools = ["pathing"],

--- a/py/tests/external-deps/expected_pathing
+++ b/py/tests/external-deps/expected_pathing
@@ -11,13 +11,13 @@ sys path:
 (py_toolchain)/lib/python3.9/lib-dynload
 (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages
 (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles
-(pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps
-(pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py
+(pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/_main/py/tests/external-deps
+(pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/_main
 
-Entrypoint Path: (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/pathing.py
+Entrypoint Path: (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/_main/py/tests/external-deps/pathing.py
 
 Django location: (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/pathing.venv/lib/python3.9/site-packages/django/__init__.py
 Django version: 4.2.7
 
 From lib with wheel dependency: [32mHello Matt[0m
-lib filepath: (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/aspect_rules_py/py/tests/external-deps/lib.py
+lib filepath: (pwd)/bazel-out/[exec]/bin/py/tests/external-deps/pathing.runfiles/_main/py/tests/external-deps/lib.py

--- a/py/tests/import-pathing/tests.bzl
+++ b/py/tests/import-pathing/tests.bzl
@@ -66,7 +66,7 @@ def _can_resolve_path_in_workspace_test_impl(ctx):
     # Transitive imports are included in depset
     fake_ctx = _ctx_with_imports([".."], [ctx.attr.import_dep])
     imports = py_library.make_imports_depset(fake_ctx).to_list()
-    asserts.equals(env, "aspect_rules_py/py/tests/import-pathing/baz", imports[0])
+    asserts.equals(env, "_main/py/tests/import-pathing/baz", imports[0])
     asserts.equals(env, "aspect_rules_py/foo", imports[1])
 
     return unittest.end(env)

--- a/py/tests/py-test/test_env_vars.py
+++ b/py/tests/py-test/test_env_vars.py
@@ -13,5 +13,12 @@ test_env('TWO', 'deux')
 test_env('LOCATION', "py/tests/py-test/test_env_vars.py")
 test_env('DEFINE', "SOME_VALUE")
 test_env('BAZEL_TARGET', "//py/tests/py-test:test_env_vars")
-test_env('BAZEL_WORKSPACE', "aspect_rules_py")
+# With bzlmod enabled, the main workspace has this hard-coded name.
+# See https://bazelbuild.slack.com/archives/C014RARENH0/p1702318129963129?thread_ts=1702288944.560349&cid=C014RARENH0
+# Xudong Yang:
+# the 'workspace name' is an unfortunate concept laden with historical baggage.
+# The better question here might be -- what do you intend to do with the 'workspace name'?
+# the name of the execution root directory will always be _main when Bzlmod is enabled.
+# similarly, the runfiles dir prefix for the main repo will always be _main.
+test_env('BAZEL_WORKSPACE', "_main")
 test_env('BAZEL_TARGET_NAME', "test_env_vars")


### PR DESCRIPTION
In a follow-up change I'll try to empty out the WORKSPACE file.
Also we need another change to add CI testing for other Bazel versions, assuming we decide to continue supporting Bazel 6 and have tests for it.

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

**For changes visible to end-users**

This shouldn't be user-visible, it's only applicable when building within rules_py.

### Test plan

- Covered by existing test cases