### PR TITLE
fix: py_library add srcs to its runfiles

### DIFF
--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -123,7 +123,7 @@ def _py_library_impl(ctx):
     imports = _make_imports_depset(ctx)
     virtuals = _make_virtual_depset(ctx)
     resolutions = _make_virtual_resolutions_depset(ctx)
-    runfiles = _make_merged_runfiles(ctx)
+    runfiles = _make_merged_runfiles(ctx, extra_runfiles = ctx.files.srcs)
     instrumented_files_info = _make_instrumented_files_info(ctx)
     py_wheel_info = py_wheel.make_py_wheel_info(ctx, ctx.attr.deps)
 


### PR DESCRIPTION
At the client where I'm installing rules_py, this absence caused a test failure in //bazel/examples/proto:test_my_service

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Client build passes now. I can make a regression test in this repo if you like.