### PR TITLE
fix: move toolchain registration to different package

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,7 +6,6 @@ test --test_output=errors
 
 # TODO(alex): enable
 common --noenable_bzlmod
-common --lockfile_mode=off
 
 # Define value used by tests
 build --define=SOME_VAR=SOME_VALUE

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,3 +21,4 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@e76b9e5a1d91256e06b097c4470a22263969600b
     with:
       folders: '[".", "e2e/smoke"]'
+      exclude: '[{"bazelversion": "6.4.0"}]'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,4 +21,6 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@e76b9e5a1d91256e06b097c4470a22263969600b
     with:
       folders: '[".", "e2e/smoke"]'
-      exclude: '[{"bazelversion": "6.4.0"}]'
+      # TODO: make the root folder work with bzlmod
+      # MAYBE: allow usage from Bazel 6 as well
+      exclude: '[{"bazelversion": "6.4.0"}, {"folder": ".", "bzlmodEnabled": true}]'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,34 +18,6 @@ concurrency:
 
 jobs:
   test:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-      # Cache build and external artifacts so that the next ci build is incremental.
-      # Because github action caches cannot be updated after a build, we need to
-      # store the contents of each build in a unique cache key, then fall back to loading
-      # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
-      # the prefix to load the most recent cache for the branch on a cache miss. You
-      # should customize the contents of hashFiles to capture any bazel input sources,
-      # although this doesn't need to be perfect. If none of the input sources change
-      # then a cache hit will load an existing cache and bazel won't have to do any work.
-      # In the case of a cache miss, you want the fallback cache to contain most of the
-      # previously built artifacts to minimize build time. The more precise you are with
-      # hashFiles sources the less work bazel will have to do.
-      - name: Mount bazel caches
-        uses: actions/cache@v3
-        with:
-          path: |
-            "~/.cache/bazel"
-            "~/.cache/bazel-repo"
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
-          restore-keys: bazel-cache-
-      - name: bazel test //...
-        env:
-          # Bazelisk will download bazel to here, ensure it is cached between runs.
-          XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@e76b9e5a1d91256e06b097c4470a22263969600b
+    with:
+      folders: '[".", "e2e/smoke"]'

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 **/target/
 **/*.whl
 .venv/
+
+# TODO: enable when it is more stable, maybe Bazel 7.1
+MODULE.bazel.lock

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,5 +21,6 @@ archive_override(
 )
 
 register_toolchains(
-    "@aspect_rules_py//py/tools/...",
+    "@aspect_rules_py//py/private/toolchain/venv/...",
+    "@aspect_rules_py//py/private/toolchain/unpack/...",
 )

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -12,3 +12,13 @@ local_repository(
 # already fetched all the dependencies.
 load("@aspect_rules_py//py:repositories.bzl", "rules_py_dependencies")
 rules_py_dependencies()
+
+# "Installation" for rules_python
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+
+python_register_toolchains(
+    name = "python_toolchain",
+    python_version = "3.9",
+)
+
+py_repositories()

--- a/py/private/toolchain/tools.bzl
+++ b/py/private/toolchain/tools.bzl
@@ -82,19 +82,20 @@ def make_toolchain(name, toolchain_type, tools, cfg = "exec"):
         cfg: Generate a toolchain for the target or exec config.
     """
 
-    if IS_PRERELEASE:
-        toolchain_rule = "{}_toolchain_source".format(name)
-        _toolchain(
-            name = toolchain_rule,
-            bin = tools["from-source"],
-            template_var = "{}_BIN".format(name.upper()),
-        )
-        native.toolchain(
-            name = _make_toolchain_name(name, "source"),
-            toolchain = toolchain_rule,
-            toolchain_type = toolchain_type,
-        )
-        return
+    # TODO(alex): setup prerelease toolchain when we have rust binaries shipped to GH releases
+    # if IS_PRERELEASE:
+    #     toolchain_rule = "{}_toolchain_source".format(name)
+    #     _toolchain(
+    #         name = toolchain_rule,
+    #         bin = tools["from-source"],
+    #         template_var = "{}_BIN".format(name.upper()),
+    #     )
+    #     native.toolchain(
+    #         name = _make_toolchain_name(name, "source"),
+    #         toolchain = toolchain_rule,
+    #         toolchain_type = toolchain_type,
+    #     )
+    #     return
 
     for [platform, meta] in TOOLCHAIN_PLATFORMS.items():
         toolchain_rule = "{}_toolchain_{}".format(name, platform)

--- a/py/private/toolchain/types.bzl
+++ b/py/private/toolchain/types.bzl
@@ -4,5 +4,5 @@ PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
 SH_TOOLCHAIN = "@bazel_tools//tools/sh:toolchain_type"
 
 # Toolchain type for the virtual env creation tools.
-VENV_TOOLCHAIN = "@aspect_rules_py//py/tools/venv_bin:toolchain_type"
-UNPACK_TOOLCHAIN = "@aspect_rules_py//py/tools/unpack_bin:toolchain_type"
+VENV_TOOLCHAIN = "@aspect_rules_py//py/private/toolchain/venv:toolchain_type"
+UNPACK_TOOLCHAIN = "@aspect_rules_py//py/private/toolchain/unpack:toolchain_type"

--- a/py/private/toolchain/unpack/BUILD.bazel
+++ b/py/private/toolchain/unpack/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//py/private/toolchain:tools.bzl", "make_toolchain")
+
+toolchain_type(
+    name = "toolchain_type",
+)
+
+make_toolchain(
+    name = "unpack",
+    toolchain_type = ":toolchain_type",
+    tools = {
+        "from-source": "//py/tools/unpack_bin",
+        "macos-amd64": "@aspect_rules_py//py/tools/unpack_bin/bins:unpack-x86_64-apple-darwin",
+        "macos-arm64": "@aspect_rules_py//py/tools/unpack_bin/bins:unpack-aarch64-apple-darwin",
+        "linux-amd64": "@aspect_rules_py//py/tools/unpack_bin/bins:unpack-x86_64-unknown-linux-musl",
+        "linux-arm64": "@aspect_rules_py//py/tools/unpack_bin/bins:unpack-aarch64-unknown-linux-musl",
+    },
+)

--- a/py/private/toolchain/venv/BUILD.bazel
+++ b/py/private/toolchain/venv/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//py/private/toolchain:tools.bzl", "make_toolchain")
+
+toolchain_type(
+    name = "toolchain_type",
+)
+
+make_toolchain(
+    name = "venv",
+    cfg = "target",
+    toolchain_type = ":toolchain_type",
+    tools = {
+        "from-source": "//py/tools/venv_bin",
+        "macos-amd64": "@aspect_rules_py//py/tools/venv_bin/bins:venv-x86_64-apple-darwin",
+        "macos-arm64": "@aspect_rules_py//py/tools/venv_bin/bins:venv-aarch64-apple-darwin",
+        "linux-amd64": "@aspect_rules_py//py/tools/venv_bin/bins:venv-x86_64-unknown-linux-musl",
+        "linux-arm64": "@aspect_rules_py//py/tools/venv_bin/bins:venv-aarch64-unknown-linux-musl",
+    },
+)

--- a/py/repositories.bzl
+++ b/py/repositories.bzl
@@ -52,4 +52,7 @@ def rules_py_dependencies(register_py_toolchains = True):
     )
 
     if register_py_toolchains:
-        native.register_toolchains("@aspect_rules_py//py/tools/...")
+        native.register_toolchains(
+            "@aspect_rules_py//py/private/toolchain/venv/...",
+            "@aspect_rules_py//py/private/toolchain/unpack/...",
+        )

--- a/py/tools/unpack_bin/BUILD.bazel
+++ b/py/tools/unpack_bin/BUILD.bazel
@@ -1,26 +1,12 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//py/private/toolchain:tools.bzl", "make_toolchain")
-
-toolchain_type(
-    name = "toolchain_type",
-)
-
-make_toolchain(
-    name = "unpack",
-    toolchain_type = ":toolchain_type",
-    tools = {
-        "from-source": ":unpack_bin",
-        "macos-amd64": "@aspect_rules_py//py/tools/unpack_bin/bins:unpack-x86_64-apple-darwin",
-        "macos-arm64": "@aspect_rules_py//py/tools/unpack_bin/bins:unpack-aarch64-apple-darwin",
-        "linux-amd64": "@aspect_rules_py//py/tools/unpack_bin/bins:unpack-x86_64-unknown-linux-musl",
-        "linux-arm64": "@aspect_rules_py//py/tools/unpack_bin/bins:unpack-aarch64-unknown-linux-musl",
-    },
-)
 
 rust_binary(
     name = "unpack_bin",
     srcs = [
         "src/main.rs",
+    ],
+    visibility = [
+        "//visibility:public",
     ],
     deps = [
         "//py/tools/py",

--- a/py/tools/venv_bin/BUILD.bazel
+++ b/py/tools/venv_bin/BUILD.bazel
@@ -1,27 +1,12 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//py/private/toolchain:tools.bzl", "make_toolchain")
-
-toolchain_type(
-    name = "toolchain_type",
-)
-
-make_toolchain(
-    name = "venv",
-    cfg = "target",
-    toolchain_type = ":toolchain_type",
-    tools = {
-        "from-source": ":venv_bin",
-        "macos-amd64": "@aspect_rules_py//py/tools/venv_bin/bins:venv-x86_64-apple-darwin",
-        "macos-arm64": "@aspect_rules_py//py/tools/venv_bin/bins:venv-aarch64-apple-darwin",
-        "linux-amd64": "@aspect_rules_py//py/tools/venv_bin/bins:venv-x86_64-unknown-linux-musl",
-        "linux-arm64": "@aspect_rules_py//py/tools/venv_bin/bins:venv-aarch64-unknown-linux-musl",
-    },
-)
 
 rust_binary(
     name = "venv_bin",
     srcs = [
         "src/main.rs",
+    ],
+    visibility = [
+        "//visibility:public",
     ],
     deps = [
         "//py/tools/py",


### PR DESCRIPTION
We must take care that `rules_rust` load statements don't appear in public API packages.