### PR TITLE
feat: GHA release automation for rust bins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,14 @@ concurrency:
 
 jobs:
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@ca6324c506371e708095b42e24d6f34030753de6
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
     with:
       folders: '[".", "e2e/smoke"]'
       # TODO: Build Windows tools and add to toolchain
       # TODO(alex): switch the root folder to bzlmod
-      exclude: '[{"os": "windows-latest"}, {"folder": ".", "bazelversion": "6.4.0"}, {"folder": ".", "bzlmodEnabled": true}]'
+      exclude: |
+        [
+          {"os": "windows-latest"},
+          {"folder": ".", "bazelversion": "6.4.0"},
+          {"folder": ".", "bzlmodEnabled": true}
+        ]

--- a/.github/workflows/integrity.jq
+++ b/.github/workflows/integrity.jq
@@ -1,0 +1,21 @@
+# JQ filter to transform sha256 files to a value we can read from starlark.
+# NB: the sha256 files are expected to be newline-terminated.
+# 
+# Input looks like
+# 48552e399a1f2ab97e62ca7fce5783b6214e284330c7555383f43acf82446636 unpack-linux-aarch64\nfd265552bfd236efef519f81ce783322a50d8d7ab5af5d08a713e519cedff87f unpack-linux-x86_64\n
+#
+# Output should look like
+# {
+#  "unpack-linux-aarch64": "48552e399a1f2ab97e62ca7fce5783b6214e284330c7555383f43acf82446636",
+#  "unpack-linux-x86_64": "fd265552bfd236efef519f81ce783322a50d8d7ab5af5d08a713e519cedff87f"
+# }
+
+.
+# Don't end with an empty object
+| rtrimstr("\n")
+| split("\n")
+| map(
+    split(" ")
+    | {"key": .[1], "value": .[0]}
+  )
+| from_entries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Build Rust Binaries
         env:
+          # NB: this variable is read by tools/release/copy_release_artifacts.sh
           DEST: artifacts
         run: |
           rm -rf ${{ env.DEST }}
           mkdir -p ${{ env.DEST }}
           bazel --bazelrc=.github/workflows/ci.bazelrc \
             run --config=release //tools/release:copy_release_artifacts
+
       - uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ matrix.os }}
@@ -38,9 +41,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Fetch the built artifacts from build jobs above and extract into
+      # ${GITHUB_WORKSPACE}/artifacts-macos-latest/*
+      # ${GITHUB_WORKSPACE}/artifacts-ubuntu-latest/*
       - uses: actions/download-artifact@v4
+
       - name: Prepare release
         run: .github/workflows/release_prep.sh > release_notes.txt
+
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ jobs:
     # So just spin up a runner on each OS to build its binaries.
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # Pin to runner releases since our Rust compile is fiddly with system libs
+        os: [ubuntu-20.04, macos-12]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,25 +10,37 @@ on:
 
 jobs:
   build:
+    # We don't attempt to cross-compile rust binaries from one OS to another.
+    # So just spin up a runner on each OS to build its binaries.
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Rust Binaries
+        env:
+          DEST: artifacts
+        run: |
+          rm -rf ${{ env.DEST }}
+          mkdir -p ${{ env.DEST }}
+          bazel --bazelrc=.github/workflows/ci.bazelrc \
+            run --config=release //tools/release:copy_release_artifacts
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.os }}
+          path: artifacts/
+          retention-days: 1
+
+  release:
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Mount bazel caches
-        uses: actions/cache@v3
-        with:
-          path: |
-            "~/.cache/bazel"
-            "~/.cache/bazel-repo"
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
-          restore-keys: bazel-cache-
-      - name: bazel test //...
-        env:
-          # Bazelisk will download bazel to here
-          XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
       - name: Prepare release
-        run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
+        run: .github/workflows/release_prep.sh > release_notes.txt
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
@@ -36,5 +48,7 @@ jobs:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt
-          files: rules_py-*.tar.gz
+          files: |
+            artifacts-*/*
+            rules_py-*.tar.gz
           fail_on_unmatched_files: true

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -8,9 +8,42 @@ TAG=${GITHUB_REF_NAME}
 # The prefix is chosen to match what GitHub generates for source archives
 PREFIX="rules_py-${TAG:1}"
 ARCHIVE="rules_py-$TAG.tar.gz"
+ARCHIVE_TMP=$(mktemp)
 
 # NB: configuration for 'git archive' is in /.gitattributes
-git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} > $ARCHIVE_TMP
+
+############
+# Patch up the archive to have integrity hashes for built binaries that we downloaded in the GHA workflow.
+# Now that we've run `git archive` we are free to pollute the working directory.
+
+# Delete the placeholder file
+tar --file $ARCHIVE_TMP --delete ${PREFIX}/tools/integrity.bzl
+
+# Add trailing newlines to sha256 files. They were built with
+# https://github.com/aspect-build/bazel-lib/blob/main/tools/release/hashes.bzl
+for sha in $(ls artifacts-*/*.sha256); do
+  echo "" >> $sha
+done
+
+mkdir -p ${PREFIX}/tools
+cat >${PREFIX}/tools/integrity.bzl <<EOF
+"Generated during release by release_prep.sh, using integrity.jq"
+
+RELEASED_BINARY_INTEGRITY = $(jq \
+  --from-file .github/workflows/integrity.jq \
+  --slurp \
+  --raw-input artifacts-*/*.sha256 \
+)
+EOF
+
+# Append that generated file back into the archive
+tar --file $ARCHIVE_TMP --append ${PREFIX}/tools/integrity.bzl
+
+# END patch up the archive
+############
+
+gzip < $ARCHIVE_TMP > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat << EOF

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -1,0 +1,7 @@
+"""Release binary integrity hashes.
+
+This file contents are entirely replaced during release publishing.
+The checked in content is only here to allow load() statements in the sources to resolve.
+"""
+
+RELEASED_BINARY_INTEGRITY = {}


### PR DESCRIPTION
Demo:

https://github.com/alexeagle/rules_py/releases/tag/v0.100.8

the `rules_py-v0.100.8.tar.gz` artifact has the following content in `tools/integrity.bzl`

```
"Generated during release by release_prep.sh, using integrity.jq"

RELEASED_BINARY_INTEGRITY = {
  "unpack-macos-aarch64": "f97a503e2fb2614ca27355c03bb7b743092e91efab15f5eee139aff9cb41c915",
  "unpack-macos-x86_64": "6af1d8466a40d0a18b7802642a5ff477b82f9008d5fc6678113b422d2d33bed0",
  "venv-macos-aarch64": "3b37f326418e4e77426b9c9a05eb958e29fd0045435624611c3571e77730612a",
  "venv-macos-x86_64": "f0f8a5e9484bb2ff98e788ebea87b3e960b5745ece837e68e5d2732985a84e32",
  "unpack-linux-aarch64": "48552e399a1f2ab97e62ca7fce5783b6214e284330c7555383f43acf82446636",
  "unpack-linux-x86_64": "fd265552bfd236efef519f81ce783322a50d8d7ab5af5d08a713e519cedff87f",
  "venv-linux-aarch64": "b05d6cbe485e8ed1872f330012929126778744208e47485d7e2be285a027c7ca",
  "venv-linux-x86_64": "61f53fe45da5f2f160907c87c1a2d663bc57eee667520a46490a837825be61c9"
}
```

and omits the `examples/` folder and stamps the `tools/version.bzl` as expected per `.gitattributes`
