### PR TITLE
chore: update presubmit.yml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,8 @@ bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
     bazel: ["7.x", "6.x"]
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    # TODO(#9): add windows to this list
+    platform: ["debian10", "macos", "ubuntu2004"]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Turn off Windows testing. It's red on BCR. We don't publish windows binaries for our Rust tools yet.

Upstreaming https://github.com/bazelbuild/bazel-central-registry/pull/1572/commits/9a64dd61504a046b76043055f5adae4c3fc67669