### PR TITLE
Fix for external deps that use repo root relative imports

### DIFF
--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -135,7 +135,11 @@ def _make_imports_depset(ctx, imports = [], extra_imports_depsets = []):
     ] + [
         # Add the workspace name in the imports such that repo-relative imports work.
         ctx.workspace_name,
+        ctx.label.workspace_name,
     ]
+
+    # Filter out any empty strings
+    import_paths = [x for x in import_paths if x]
 
     return depset(
         direct = import_paths,

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -135,11 +135,11 @@ def _make_imports_depset(ctx, imports = [], extra_imports_depsets = []):
     ] + [
         # Add the workspace name in the imports such that repo-relative imports work.
         ctx.workspace_name,
-        ctx.label.workspace_name,
     ]
 
-    # Filter out any empty strings
-    import_paths = [x for x in import_paths if x]
+    # Handle the case where its a target from an external workspace that uses repo-relative imports
+    if ctx.label.workspace_name:
+        import_paths.append(ctx.label.workspace_name)
 
     return depset(
         direct = import_paths,


### PR DESCRIPTION
---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases

### Details

As a follow-up to https://github.com/aspect-build/rules_py/pull/299 , this PR enables the use of external dependencies that use workspace root relative imports.

This just expands current functionality to also cover the case where the dependency is from an external workspace.
