### PR TITLE
fix: use PyInfo from rules_python

### DIFF
--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -1,5 +1,6 @@
 """Implementation for the py_binary and py_test rules."""
 
+load("@rules_python//python:defs.bzl", "PyInfo")
 load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@aspect_bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -1,5 +1,6 @@
 """Implementation for the py_library rule"""
 
+load("@rules_python//python:defs.bzl", "PyInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("//py/private:providers.bzl", "PyVirtualInfo")

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -1,5 +1,6 @@
 """Unpacks a Python wheel into a directory and returns a PyInfo provider that represents that wheel"""
 
+load("@rules_python//python:defs.bzl", "PyInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "UNPACK_TOOLCHAIN")

--- a/py/private/py_venv.bzl
+++ b/py/private/py_venv.bzl
@@ -1,5 +1,6 @@
 """Implementation for the py_binary and py_test rules."""
 
+load("@rules_python//python:defs.bzl", "PyInfo")
 load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//py/private:providers.bzl", "PyVirtualInfo")

--- a/py/tests/import-pathing/BUILD.bazel
+++ b/py/tests/import-pathing/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_library")
 load(":tests.bzl", "py_library_import_pathing_test_suite")
 
 # This is used in the py_library import pathing tests

--- a/py/tests/internal-deps/BUILD.bazel
+++ b/py/tests/internal-deps/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_library")
 load("//py:defs.bzl", "py_binary", "py_test", rules_py_py_library = "py_library")
 
 rules_py_py_library(


### PR DESCRIPTION
Switches to using `PyInfo` from rules_python, rather than relying on the builtin one from Java.

Note that this doesn't add any interoperability between the **native** `py_*` rules (java based) and the exports from rules_python. As such, using rules_python with the native java based rules and providers is no longer supported after this commit.

If we want, we could support it, but being able to consume and return both providers.

---

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
- Suggested release notes are provided below:

Use `PyInfo` provider as loaded from rules_python, and drop support for dependency edges from native `py_*` rules.

### Test plan

- Covered by existing test cases