### PR TITLE
fix: don't allow files in deps attr

### DIFF
--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -201,7 +201,6 @@ _attrs = dict({
     ),
     "deps": attr.label_list(
         doc = "Targets that produce Python code, commonly `py_library` rules.",
-        allow_files = True,
         providers = [[PyInfo], [PyVirtualInfo]],
     ),
     "data": attr.label_list(


### PR DESCRIPTION
Remove the `allow_files = True` from the `deps` attr of `py_libaray` (they are inherited by `py_binary`). This allowed users to place non-existent targets into `deps`.

Closes #316 