### PR TITLE
fix: add toolchain setup to bzlmod release snippet

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 bcr_test_module:
-  module_path: "e2e/smoke"
+  module_path: "e2e/use_release"
   matrix:
     bazel: ["7.x", "6.x"]
     # TODO(#9): add windows to this list

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,13 @@ jobs:
   test:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
     with:
-      folders: '[".", "e2e/smoke", "e2e/repository-rule-deps", "e2e/system-interpreter"]'
+      folders: |
+        [
+          ".",
+          "e2e/repository-rule-deps", 
+          "e2e/system-interpreter",
+          "e2e/use_release"
+        ]
       # TODO: Build Windows tools and add to toolchain
       # TODO(alex): switch the root folder to bzlmod
       exclude: |

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -53,6 +53,13 @@ Add to your \`MODULE.bazel\` file:
 
 \`\`\`starlark
 bazel_dep(name = "aspect_rules_py", version = "${TAG:1}")
+
+EOF
+
+# Collect the tools snippet from the use_release module file.
+awk 'f;/--SNIP--/{f=1}' e2e/use_release/MODULE.bazel
+
+cat << EOF
 \`\`\`
 
 And also register a Python toolchain, see rules_python. For example:

--- a/e2e/use_release/MODULE.bazel
+++ b/e2e/use_release/MODULE.bazel
@@ -5,6 +5,7 @@ local_path_override(
     path = "../..",
 )
 
+#---SNIP--- Below here is re-used in the snippet published on releases
 tools = use_extension("@aspect_rules_py//py:extensions.bzl", "py_tools")
 tools.rules_py_tools(is_prerelease = False)
 use_repo(tools, "rules_py_tools")

--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -11,7 +11,7 @@ fi
 
 # This test references pre-built artifacts from a prior release.
 # Will need to bump this version in the future when there are breaking changes.
-export RULES_PY_RELEASE_VERSION=0.7.0
+export RULES_PY_RELEASE_VERSION=0.7.1
 
 #############
 # Test bzlmod
@@ -37,6 +37,8 @@ then
     >&2 echo "ERROR: we fetched a rust repository"
     exit 1
 fi
+
+bazel "--output_base=$OUTPUT_BASE" test --enable_bzlmod //...
 
 #############
 # Test WORKSPACE


### PR DESCRIPTION
Adds the bzlmod `use_extension` to the release instructions snippet. Will look something like:

## Using [Bzlmod] with Bazel 6:

Add to your `MODULE.bazel` file:

```starlark
bazel_dep(name = "aspect_rules_py", version = "")

tools = use_extension("@aspect_rules_py//py:extensions.bzl", "py_tools")
tools.rules_py_tools()
use_repo(tools, "rules_py_tools")
```

And also register a Python toolchain, see rules_python. For example:

```starlark
# Minimum version needs:
# feat: add interpreter_version_info to py_runtime by @mattem in #1671
bazel_dep(name = "rules_python", dev_dependency = True, version = "0.29.0")

python = use_extension("@rules_python//python/extensions:python.bzl", "python")
python.toolchain(
    configure_coverage_tool = True,
    python_version = "3.11",
)
```

[Bzlmod]: https://bazel.build/build/bzlmod