### PR TITLE
fix: BCR presubmit should test the release path

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 bcr_test_module:
-  module_path: "e2e/smoke"
+  module_path: "e2e/use_release"
   matrix:
     bazel: ["7.x", "6.x"]
     platform: ["debian10", "macos", "ubuntu2004", "windows"]

--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -11,7 +11,7 @@ fi
 
 # This test references pre-built artifacts from a prior release.
 # Will need to bump this version in the future when there are breaking changes.
-export RULES_PY_RELEASE_VERSION=0.7.0
+export RULES_PY_RELEASE_VERSION=0.7.1
 
 #############
 # Test bzlmod
@@ -37,6 +37,8 @@ then
     >&2 echo "ERROR: we fetched a rust repository"
     exit 1
 fi
+
+bazel "--output_base=$OUTPUT_BASE" test --enable_bzlmod //...
 
 #############
 # Test WORKSPACE

--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -11,7 +11,7 @@ fi
 
 # This test references pre-built artifacts from a prior release.
 # Will need to bump this version in the future when there are breaking changes.
-export RULES_PY_RELEASE_VERSION=0.7.1
+export RULES_PY_RELEASE_VERSION=0.7.3
 
 #############
 # Test bzlmod

--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -38,8 +38,6 @@ then
     exit 1
 fi
 
-bazel "--output_base=$OUTPUT_BASE" test --enable_bzlmod //...
-
 #############
 # Test WORKSPACE
 OUTPUT_BASE=$(mktemp -d)


### PR DESCRIPTION
Because bzlmod users get a module that doesn't have a rules_rust dep


---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
