### PR TITLE
chore: bump rust to 1.77.2

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,12 +1,12 @@
 {
-  "checksum": "4a44eff98611bff4403fb96e71ce5359782946583f1b5973c1b7baed7bf4d7b8",
+  "checksum": "32b494853fa6e3f2c2ea61a76720e873e7384da14889aadcba90bfcd4f1916e3",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
       "version": "0.21.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/addr2line/0.21.0/download",
+          "url": "https://static.crates.io/crates/addr2line/0.21.0/download",
           "sha256": "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
         }
       },
@@ -45,7 +45,7 @@
       "version": "1.0.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/adler/1.0.2/download",
+          "url": "https://static.crates.io/crates/adler/1.0.2/download",
           "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
         }
       },
@@ -75,7 +75,7 @@
       "version": "0.8.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/aes/0.8.3/download",
+          "url": "https://static.crates.io/crates/aes/0.8.3/download",
           "sha256": "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
         }
       },
@@ -125,7 +125,7 @@
       "version": "1.1.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/aho-corasick/1.1.2/download",
+          "url": "https://static.crates.io/crates/aho-corasick/1.1.2/download",
           "sha256": "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
         }
       },
@@ -171,7 +171,7 @@
       "version": "0.1.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/android-tzdata/0.1.1/download",
+          "url": "https://static.crates.io/crates/android-tzdata/0.1.1/download",
           "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
         }
       },
@@ -201,7 +201,7 @@
       "version": "0.1.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/android_system_properties/0.1.5/download",
+          "url": "https://static.crates.io/crates/android_system_properties/0.1.5/download",
           "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
         }
       },
@@ -240,7 +240,7 @@
       "version": "0.6.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstream/0.6.11/download",
+          "url": "https://static.crates.io/crates/anstream/0.6.11/download",
           "sha256": "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
         }
       },
@@ -310,7 +310,7 @@
       "version": "1.0.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstyle/1.0.6/download",
+          "url": "https://static.crates.io/crates/anstyle/1.0.6/download",
           "sha256": "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
         }
       },
@@ -347,7 +347,7 @@
       "version": "0.2.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstyle-parse/0.2.3/download",
+          "url": "https://static.crates.io/crates/anstyle-parse/0.2.3/download",
           "sha256": "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
         }
       },
@@ -393,7 +393,7 @@
       "version": "1.0.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstyle-query/1.0.2/download",
+          "url": "https://static.crates.io/crates/anstyle-query/1.0.2/download",
           "sha256": "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
         }
       },
@@ -434,7 +434,7 @@
       "version": "3.0.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstyle-wincon/3.0.2/download",
+          "url": "https://static.crates.io/crates/anstyle-wincon/3.0.2/download",
           "sha256": "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
         }
       },
@@ -480,7 +480,7 @@
       "version": "1.0.79",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.79/download",
+          "url": "https://static.crates.io/crates/anyhow/1.0.79/download",
           "sha256": "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
         }
       },
@@ -540,7 +540,7 @@
       "version": "0.3.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-compression/0.3.15/download",
+          "url": "https://static.crates.io/crates/async-compression/0.3.15/download",
           "sha256": "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
         }
       },
@@ -603,7 +603,7 @@
       "version": "0.5.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-once-cell/0.5.3/download",
+          "url": "https://static.crates.io/crates/async-once-cell/0.5.3/download",
           "sha256": "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
         }
       },
@@ -633,7 +633,7 @@
       "version": "1.0.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-recursion/1.0.5/download",
+          "url": "https://static.crates.io/crates/async-recursion/1.0.5/download",
           "sha256": "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
         }
       },
@@ -680,7 +680,7 @@
       "version": "0.1.77",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-trait/0.1.77/download",
+          "url": "https://static.crates.io/crates/async-trait/0.1.77/download",
           "sha256": "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
         }
       },
@@ -745,7 +745,7 @@
       "version": "0.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async_http_range_reader/0.6.0/download",
+          "url": "https://static.crates.io/crates/async_http_range_reader/0.6.0/download",
           "sha256": "809a79b508f86b02136fc5aab935ef777d03e5d377dda04e6736a081add9287c"
         }
       },
@@ -828,7 +828,7 @@
       "version": "0.0.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async_zip/0.0.15/download",
+          "url": "https://static.crates.io/crates/async_zip/0.0.15/download",
           "sha256": "795310de3218cde15219fc98c1cf7d8fe9db4865aab27fcf1d535d6cb61c6b54"
         }
       },
@@ -904,7 +904,7 @@
       "version": "1.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/autocfg/1.1.0/download",
+          "url": "https://static.crates.io/crates/autocfg/1.1.0/download",
           "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
         }
       },
@@ -934,7 +934,7 @@
       "version": "0.3.69",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/backtrace/0.3.69/download",
+          "url": "https://static.crates.io/crates/backtrace/0.3.69/download",
           "sha256": "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
         }
       },
@@ -1030,7 +1030,7 @@
       "version": "0.2.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/backtrace-ext/0.2.1/download",
+          "url": "https://static.crates.io/crates/backtrace-ext/0.2.1/download",
           "sha256": "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
         }
       },
@@ -1069,7 +1069,7 @@
       "version": "0.21.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/base64/0.21.7/download",
+          "url": "https://static.crates.io/crates/base64/0.21.7/download",
           "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
         }
       },
@@ -1107,7 +1107,7 @@
       "version": "1.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/base64ct/1.6.0/download",
+          "url": "https://static.crates.io/crates/base64ct/1.6.0/download",
           "sha256": "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
         }
       },
@@ -1137,7 +1137,7 @@
       "version": "0.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bisection/0.1.0/download",
+          "url": "https://static.crates.io/crates/bisection/0.1.0/download",
           "sha256": "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
         }
       },
@@ -1167,7 +1167,7 @@
       "version": "1.3.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bitflags/1.3.2/download",
+          "url": "https://static.crates.io/crates/bitflags/1.3.2/download",
           "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
         }
       },
@@ -1203,7 +1203,7 @@
       "version": "2.4.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bitflags/2.4.2/download",
+          "url": "https://static.crates.io/crates/bitflags/2.4.2/download",
           "sha256": "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
         }
       },
@@ -1239,7 +1239,7 @@
       "version": "1.0.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bitvec/1.0.1/download",
+          "url": "https://static.crates.io/crates/bitvec/1.0.1/download",
           "sha256": "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
         }
       },
@@ -1299,7 +1299,7 @@
       "version": "0.10.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/blake2/0.10.6/download",
+          "url": "https://static.crates.io/crates/blake2/0.10.6/download",
           "sha256": "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
         }
       },
@@ -1345,7 +1345,7 @@
       "version": "0.10.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.4/download",
+          "url": "https://static.crates.io/crates/block-buffer/0.10.4/download",
           "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
         }
       },
@@ -1384,7 +1384,7 @@
       "version": "3.14.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bumpalo/3.14.0/download",
+          "url": "https://static.crates.io/crates/bumpalo/3.14.0/download",
           "sha256": "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
         }
       },
@@ -1420,7 +1420,7 @@
       "version": "1.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/byteorder/1.5.0/download",
+          "url": "https://static.crates.io/crates/byteorder/1.5.0/download",
           "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
         }
       },
@@ -1457,7 +1457,7 @@
       "version": "1.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytes/1.5.0/download",
+          "url": "https://static.crates.io/crates/bytes/1.5.0/download",
           "sha256": "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
         }
       },
@@ -1494,7 +1494,7 @@
       "version": "0.4.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bzip2/0.4.4/download",
+          "url": "https://static.crates.io/crates/bzip2/0.4.4/download",
           "sha256": "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
         }
       },
@@ -1537,7 +1537,7 @@
       "version": "0.1.11+1.0.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bzip2-sys/0.1.11+1.0.8/download",
+          "url": "https://static.crates.io/crates/bzip2-sys/0.1.11+1.0.8/download",
           "sha256": "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
         }
       },
@@ -1608,7 +1608,7 @@
       "version": "12.0.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cacache/12.0.0/download",
+          "url": "https://static.crates.io/crates/cacache/12.0.0/download",
           "sha256": "142316461ed3a3dfcba10417317472da5bfd0461e4d276bf7c07b330766d9490"
         }
       },
@@ -1739,7 +1739,7 @@
       "version": "1.0.83",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.83/download",
+          "url": "https://static.crates.io/crates/cc/1.0.83/download",
           "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
         }
       },
@@ -1792,7 +1792,7 @@
       "version": "1.0.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cfg-if/1.0.0/download",
+          "url": "https://static.crates.io/crates/cfg-if/1.0.0/download",
           "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
         }
       },
@@ -1822,7 +1822,7 @@
       "version": "0.4.33",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/chrono/0.4.33/download",
+          "url": "https://static.crates.io/crates/chrono/0.4.33/download",
           "sha256": "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
         }
       },
@@ -1884,7 +1884,7 @@
       "version": "0.2.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ciborium/0.2.2/download",
+          "url": "https://static.crates.io/crates/ciborium/0.2.2/download",
           "sha256": "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
         }
       },
@@ -1938,7 +1938,7 @@
       "version": "0.2.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ciborium-io/0.2.2/download",
+          "url": "https://static.crates.io/crates/ciborium-io/0.2.2/download",
           "sha256": "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
         }
       },
@@ -1975,7 +1975,7 @@
       "version": "0.2.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ciborium-ll/0.2.2/download",
+          "url": "https://static.crates.io/crates/ciborium-ll/0.2.2/download",
           "sha256": "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
         }
       },
@@ -2018,7 +2018,7 @@
       "version": "0.4.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cipher/0.4.4/download",
+          "url": "https://static.crates.io/crates/cipher/0.4.4/download",
           "sha256": "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
         }
       },
@@ -2061,7 +2061,7 @@
       "version": "4.4.18",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/4.4.18/download",
+          "url": "https://static.crates.io/crates/clap/4.4.18/download",
           "sha256": "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
         }
       },
@@ -2122,7 +2122,7 @@
       "version": "4.4.18",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_builder/4.4.18/download",
+          "url": "https://static.crates.io/crates/clap_builder/4.4.18/download",
           "sha256": "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
         }
       },
@@ -2184,7 +2184,7 @@
       "version": "4.4.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_derive/4.4.7/download",
+          "url": "https://static.crates.io/crates/clap_derive/4.4.7/download",
           "sha256": "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
         }
       },
@@ -2241,7 +2241,7 @@
       "version": "0.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_lex/0.6.0/download",
+          "url": "https://static.crates.io/crates/clap_lex/0.6.0/download",
           "sha256": "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
         }
       },
@@ -2271,7 +2271,7 @@
       "version": "1.0.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/colorchoice/1.0.0/download",
+          "url": "https://static.crates.io/crates/colorchoice/1.0.0/download",
           "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
         }
       },
@@ -2301,7 +2301,7 @@
       "version": "3.0.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/configparser/3.0.4/download",
+          "url": "https://static.crates.io/crates/configparser/3.0.4/download",
           "sha256": "4ec6d3da8e550377a85339063af6e3735f4b1d9392108da4e083a1b3b9820288"
         }
       },
@@ -2331,7 +2331,7 @@
       "version": "0.1.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/constant_time_eq/0.1.5/download",
+          "url": "https://static.crates.io/crates/constant_time_eq/0.1.5/download",
           "sha256": "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
         }
       },
@@ -2361,7 +2361,7 @@
       "version": "0.9.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/core-foundation/0.9.4/download",
+          "url": "https://static.crates.io/crates/core-foundation/0.9.4/download",
           "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
         }
       },
@@ -2411,7 +2411,7 @@
       "version": "0.8.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/core-foundation-sys/0.8.6/download",
+          "url": "https://static.crates.io/crates/core-foundation-sys/0.8.6/download",
           "sha256": "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
         }
       },
@@ -2448,7 +2448,7 @@
       "version": "0.2.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cpufeatures/0.2.12/download",
+          "url": "https://static.crates.io/crates/cpufeatures/0.2.12/download",
           "sha256": "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
         }
       },
@@ -2507,7 +2507,7 @@
       "version": "1.3.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crc32fast/1.3.2/download",
+          "url": "https://static.crates.io/crates/crc32fast/1.3.2/download",
           "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
         }
       },
@@ -2571,7 +2571,7 @@
       "version": "0.8.19",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.19/download",
+          "url": "https://static.crates.io/crates/crossbeam-utils/0.8.19/download",
           "sha256": "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
         }
       },
@@ -2631,7 +2631,7 @@
       "version": "0.2.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crunchy/0.2.2/download",
+          "url": "https://static.crates.io/crates/crunchy/0.2.2/download",
           "sha256": "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
         }
       },
@@ -2684,7 +2684,7 @@
       "version": "0.1.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crypto-common/0.1.6/download",
+          "url": "https://static.crates.io/crates/crypto-common/0.1.6/download",
           "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
         }
       },
@@ -2733,7 +2733,7 @@
       "version": "1.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/csv/1.3.0/download",
+          "url": "https://static.crates.io/crates/csv/1.3.0/download",
           "sha256": "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
         }
       },
@@ -2784,7 +2784,7 @@
       "version": "0.1.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/csv-core/0.1.11/download",
+          "url": "https://static.crates.io/crates/csv-core/0.1.11/download",
           "sha256": "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
         }
       },
@@ -2829,7 +2829,7 @@
       "version": "0.20.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling/0.20.5/download",
+          "url": "https://static.crates.io/crates/darling/0.20.5/download",
           "sha256": "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
         }
       },
@@ -2884,7 +2884,7 @@
       "version": "0.20.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling_core/0.20.5/download",
+          "url": "https://static.crates.io/crates/darling_core/0.20.5/download",
           "sha256": "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
         }
       },
@@ -2950,7 +2950,7 @@
       "version": "0.20.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/darling_macro/0.20.5/download",
+          "url": "https://static.crates.io/crates/darling_macro/0.20.5/download",
           "sha256": "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
         }
       },
@@ -2997,7 +2997,7 @@
       "version": "2.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/data-encoding/2.5.0/download",
+          "url": "https://static.crates.io/crates/data-encoding/2.5.0/download",
           "sha256": "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
         }
       },
@@ -3035,7 +3035,7 @@
       "version": "0.3.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/deranged/0.3.11/download",
+          "url": "https://static.crates.io/crates/deranged/0.3.11/download",
           "sha256": "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
         }
       },
@@ -3086,7 +3086,7 @@
       "version": "0.10.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/digest/0.10.7/download",
+          "url": "https://static.crates.io/crates/digest/0.10.7/download",
           "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
         }
       },
@@ -3145,7 +3145,7 @@
       "version": "1.0.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/dunce/1.0.4/download",
+          "url": "https://static.crates.io/crates/dunce/1.0.4/download",
           "sha256": "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
         }
       },
@@ -3175,7 +3175,7 @@
       "version": "1.9.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/either/1.9.0/download",
+          "url": "https://static.crates.io/crates/either/1.9.0/download",
           "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
         }
       },
@@ -3212,7 +3212,7 @@
       "version": "1.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/elsa/1.10.0/download",
+          "url": "https://static.crates.io/crates/elsa/1.10.0/download",
           "sha256": "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
         }
       },
@@ -3257,7 +3257,7 @@
       "version": "0.8.33",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/encoding_rs/0.8.33/download",
+          "url": "https://static.crates.io/crates/encoding_rs/0.8.33/download",
           "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
         }
       },
@@ -3303,7 +3303,7 @@
       "version": "1.0.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/equivalent/1.0.1/download",
+          "url": "https://static.crates.io/crates/equivalent/1.0.1/download",
           "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
         }
       },
@@ -3333,7 +3333,7 @@
       "version": "0.3.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/errno/0.3.8/download",
+          "url": "https://static.crates.io/crates/errno/0.3.8/download",
           "sha256": "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
         }
       },
@@ -3398,7 +3398,7 @@
       "version": "2.0.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fastrand/2.0.1/download",
+          "url": "https://static.crates.io/crates/fastrand/2.0.1/download",
           "sha256": "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
         }
       },
@@ -3436,7 +3436,7 @@
       "version": "0.2.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/filetime/0.2.23/download",
+          "url": "https://static.crates.io/crates/filetime/0.2.23/download",
           "sha256": "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
         }
       },
@@ -3494,7 +3494,7 @@
       "version": "0.4.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fixedbitset/0.4.2/download",
+          "url": "https://static.crates.io/crates/fixedbitset/0.4.2/download",
           "sha256": "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
         }
       },
@@ -3524,7 +3524,7 @@
       "version": "1.0.28",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/flate2/1.0.28/download",
+          "url": "https://static.crates.io/crates/flate2/1.0.28/download",
           "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
         }
       },
@@ -3576,7 +3576,7 @@
       "version": "1.0.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fnv/1.0.7/download",
+          "url": "https://static.crates.io/crates/fnv/1.0.7/download",
           "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
         }
       },
@@ -3613,7 +3613,7 @@
       "version": "1.2.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/form_urlencoded/1.2.1/download",
+          "url": "https://static.crates.io/crates/form_urlencoded/1.2.1/download",
           "sha256": "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
         }
       },
@@ -3660,7 +3660,7 @@
       "version": "2.11.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fs-err/2.11.0/download",
+          "url": "https://static.crates.io/crates/fs-err/2.11.0/download",
           "sha256": "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
         }
       },
@@ -3722,7 +3722,7 @@
       "version": "0.6.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fs4/0.6.6/download",
+          "url": "https://static.crates.io/crates/fs4/0.6.6/download",
           "sha256": "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
         }
       },
@@ -3776,7 +3776,7 @@
       "version": "1.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/fs_extra/1.3.0/download",
+          "url": "https://static.crates.io/crates/fs_extra/1.3.0/download",
           "sha256": "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
         }
       },
@@ -3806,7 +3806,7 @@
       "version": "2.0.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/funty/2.0.0/download",
+          "url": "https://static.crates.io/crates/funty/2.0.0/download",
           "sha256": "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
         }
       },
@@ -3836,7 +3836,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures/0.3.30/download",
           "sha256": "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
         }
       },
@@ -3910,7 +3910,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-channel/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures-channel/0.3.30/download",
           "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
         }
       },
@@ -4059,7 +4059,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-core/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures-core/0.3.30/download",
           "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
         }
       },
@@ -4097,7 +4097,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-executor/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures-executor/0.3.30/download",
           "sha256": "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
         }
       },
@@ -4150,7 +4150,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-io/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures-io/0.3.30/download",
           "sha256": "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
         }
       },
@@ -4187,7 +4187,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-macro/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures-macro/0.3.30/download",
           "sha256": "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
         }
       },
@@ -4234,7 +4234,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-sink/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures-sink/0.3.30/download",
           "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
         }
       },
@@ -4272,7 +4272,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-task/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures-task/0.3.30/download",
           "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
         }
       },
@@ -4309,7 +4309,7 @@
       "version": "0.3.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/futures-util/0.3.30/download",
+          "url": "https://static.crates.io/crates/futures-util/0.3.30/download",
           "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
         }
       },
@@ -4408,7 +4408,7 @@
       "version": "0.14.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/generic-array/0.14.7/download",
+          "url": "https://static.crates.io/crates/generic-array/0.14.7/download",
           "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
         }
       },
@@ -4480,7 +4480,7 @@
       "version": "0.2.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/getrandom/0.2.12/download",
+          "url": "https://static.crates.io/crates/getrandom/0.2.12/download",
           "sha256": "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
         }
       },
@@ -4532,7 +4532,7 @@
       "version": "0.28.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gimli/0.28.1/download",
+          "url": "https://static.crates.io/crates/gimli/0.28.1/download",
           "sha256": "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
         }
       },
@@ -4569,7 +4569,7 @@
       "version": "0.3.24",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/h2/0.3.24/download",
+          "url": "https://static.crates.io/crates/h2/0.3.24/download",
           "sha256": "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
         }
       },
@@ -4648,7 +4648,7 @@
       "version": "2.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/half/2.3.1/download",
+          "url": "https://static.crates.io/crates/half/2.3.1/download",
           "sha256": "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
         }
       },
@@ -4694,7 +4694,7 @@
       "version": "0.12.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hashbrown/0.12.3/download",
+          "url": "https://static.crates.io/crates/hashbrown/0.12.3/download",
           "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
         }
       },
@@ -4724,7 +4724,7 @@
       "version": "0.14.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hashbrown/0.14.3/download",
+          "url": "https://static.crates.io/crates/hashbrown/0.14.3/download",
           "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
         }
       },
@@ -4760,7 +4760,7 @@
       "version": "0.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/heck/0.4.1/download",
+          "url": "https://static.crates.io/crates/heck/0.4.1/download",
           "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
         }
       },
@@ -4796,7 +4796,7 @@
       "version": "0.3.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hermit-abi/0.3.5/download",
+          "url": "https://static.crates.io/crates/hermit-abi/0.3.5/download",
           "sha256": "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
         }
       },
@@ -4826,7 +4826,7 @@
       "version": "0.4.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hex/0.4.3/download",
+          "url": "https://static.crates.io/crates/hex/0.4.3/download",
           "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
         }
       },
@@ -4864,7 +4864,7 @@
       "version": "0.12.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hmac/0.12.1/download",
+          "url": "https://static.crates.io/crates/hmac/0.12.1/download",
           "sha256": "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
         }
       },
@@ -4909,7 +4909,7 @@
       "version": "0.2.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/html-escape/0.2.13/download",
+          "url": "https://static.crates.io/crates/html-escape/0.2.13/download",
           "sha256": "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
         }
       },
@@ -4955,7 +4955,7 @@
       "version": "0.2.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/http/0.2.11/download",
+          "url": "https://static.crates.io/crates/http/0.2.11/download",
           "sha256": "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
         }
       },
@@ -5002,7 +5002,7 @@
       "version": "0.4.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/http-body/0.4.6/download",
+          "url": "https://static.crates.io/crates/http-body/0.4.6/download",
           "sha256": "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
         }
       },
@@ -5049,7 +5049,7 @@
       "version": "1.0.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/http-cache-semantics/1.0.2/download",
+          "url": "https://static.crates.io/crates/http-cache-semantics/1.0.2/download",
           "sha256": "7aec9f678bca3f4a15194b980f20ed9bfe0dd38e8d298c65c559a93dfbd6380a"
         }
       },
@@ -5111,7 +5111,7 @@
       "version": "0.1.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/http-content-range/0.1.2/download",
+          "url": "https://static.crates.io/crates/http-content-range/0.1.2/download",
           "sha256": "9f0d1a8ef218a86416107794b34cc446958d9203556c312bb41eab4c924c1d2e"
         }
       },
@@ -5141,7 +5141,7 @@
       "version": "1.1.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/http-serde/1.1.3/download",
+          "url": "https://static.crates.io/crates/http-serde/1.1.3/download",
           "sha256": "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
         }
       },
@@ -5184,7 +5184,7 @@
       "version": "1.8.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/httparse/1.8.0/download",
+          "url": "https://static.crates.io/crates/httparse/1.8.0/download",
           "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
         }
       },
@@ -5244,7 +5244,7 @@
       "version": "1.0.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/httpdate/1.0.3/download",
+          "url": "https://static.crates.io/crates/httpdate/1.0.3/download",
           "sha256": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
         }
       },
@@ -5274,7 +5274,7 @@
       "version": "0.14.28",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hyper/0.14.28/download",
+          "url": "https://static.crates.io/crates/hyper/0.14.28/download",
           "sha256": "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
         }
       },
@@ -5385,7 +5385,7 @@
       "version": "0.24.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hyper-rustls/0.24.2/download",
+          "url": "https://static.crates.io/crates/hyper-rustls/0.24.2/download",
           "sha256": "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
         }
       },
@@ -5444,7 +5444,7 @@
       "version": "0.1.60",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/iana-time-zone/0.1.60/download",
+          "url": "https://static.crates.io/crates/iana-time-zone/0.1.60/download",
           "sha256": "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
         }
       },
@@ -5513,7 +5513,7 @@
       "version": "0.1.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/iana-time-zone-haiku/0.1.2/download",
+          "url": "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download",
           "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
         }
       },
@@ -5575,7 +5575,7 @@
       "version": "1.0.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ident_case/1.0.1/download",
+          "url": "https://static.crates.io/crates/ident_case/1.0.1/download",
           "sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
         }
       },
@@ -5605,7 +5605,7 @@
       "version": "0.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/idna/0.5.0/download",
+          "url": "https://static.crates.io/crates/idna/0.5.0/download",
           "sha256": "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
         }
       },
@@ -5656,7 +5656,7 @@
       "version": "0.7.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/include_dir/0.7.3/download",
+          "url": "https://static.crates.io/crates/include_dir/0.7.3/download",
           "sha256": "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
         }
       },
@@ -5701,7 +5701,7 @@
       "version": "0.7.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/include_dir_macros/0.7.3/download",
+          "url": "https://static.crates.io/crates/include_dir_macros/0.7.3/download",
           "sha256": "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
         }
       },
@@ -5744,7 +5744,7 @@
       "version": "1.9.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/indexmap/1.9.3/download",
+          "url": "https://static.crates.io/crates/indexmap/1.9.3/download",
           "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
         }
       },
@@ -5814,7 +5814,7 @@
       "version": "2.2.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/indexmap/2.2.2/download",
+          "url": "https://static.crates.io/crates/indexmap/2.2.2/download",
           "sha256": "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
         }
       },
@@ -5869,7 +5869,7 @@
       "version": "0.1.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/inout/0.1.3/download",
+          "url": "https://static.crates.io/crates/inout/0.1.3/download",
           "sha256": "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
         }
       },
@@ -5908,7 +5908,7 @@
       "version": "2.9.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ipnet/2.9.0/download",
+          "url": "https://static.crates.io/crates/ipnet/2.9.0/download",
           "sha256": "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
         }
       },
@@ -5945,7 +5945,7 @@
       "version": "0.4.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/is-terminal/0.4.10/download",
+          "url": "https://static.crates.io/crates/is-terminal/0.4.10/download",
           "sha256": "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
         }
       },
@@ -5998,7 +5998,7 @@
       "version": "1.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/is_ci/1.2.0/download",
+          "url": "https://static.crates.io/crates/is_ci/1.2.0/download",
           "sha256": "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
         }
       },
@@ -6028,7 +6028,7 @@
       "version": "0.11.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/itertools/0.11.0/download",
+          "url": "https://static.crates.io/crates/itertools/0.11.0/download",
           "sha256": "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
         }
       },
@@ -6075,7 +6075,7 @@
       "version": "0.12.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/itertools/0.12.1/download",
+          "url": "https://static.crates.io/crates/itertools/0.12.1/download",
           "sha256": "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
         }
       },
@@ -6122,7 +6122,7 @@
       "version": "1.0.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/itoa/1.0.10/download",
+          "url": "https://static.crates.io/crates/itoa/1.0.10/download",
           "sha256": "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
         }
       },
@@ -6152,7 +6152,7 @@
       "version": "0.1.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/jobserver/0.1.27/download",
+          "url": "https://static.crates.io/crates/jobserver/0.1.27/download",
           "sha256": "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
         }
       },
@@ -6193,7 +6193,7 @@
       "version": "0.3.68",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/js-sys/0.3.68/download",
+          "url": "https://static.crates.io/crates/js-sys/0.3.68/download",
           "sha256": "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
         }
       },
@@ -6232,7 +6232,7 @@
       "version": "0.2.153",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.153/download",
+          "url": "https://static.crates.io/crates/libc/0.2.153/download",
           "sha256": "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
         }
       },
@@ -6365,7 +6365,7 @@
       "version": "0.4.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/linux-raw-sys/0.4.13/download",
+          "url": "https://static.crates.io/crates/linux-raw-sys/0.4.13/download",
           "sha256": "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
         }
       },
@@ -6445,7 +6445,7 @@
       "version": "0.4.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/lock_api/0.4.11/download",
+          "url": "https://static.crates.io/crates/lock_api/0.4.11/download",
           "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
         }
       },
@@ -6518,7 +6518,7 @@
       "version": "0.4.20",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/log/0.4.20/download",
+          "url": "https://static.crates.io/crates/log/0.4.20/download",
           "sha256": "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
         }
       },
@@ -6548,7 +6548,7 @@
       "version": "0.10.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/md-5/0.10.6/download",
+          "url": "https://static.crates.io/crates/md-5/0.10.6/download",
           "sha256": "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
         }
       },
@@ -6598,7 +6598,7 @@
       "version": "2.7.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/memchr/2.7.1/download",
+          "url": "https://static.crates.io/crates/memchr/2.7.1/download",
           "sha256": "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
         }
       },
@@ -6636,7 +6636,7 @@
       "version": "0.5.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/memmap2/0.5.10/download",
+          "url": "https://static.crates.io/crates/memmap2/0.5.10/download",
           "sha256": "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
         }
       },
@@ -6677,7 +6677,7 @@
       "version": "0.9.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/memmap2/0.9.4/download",
+          "url": "https://static.crates.io/crates/memmap2/0.9.4/download",
           "sha256": "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
         }
       },
@@ -6718,7 +6718,7 @@
       "version": "5.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/miette/5.10.0/download",
+          "url": "https://static.crates.io/crates/miette/5.10.0/download",
           "sha256": "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
         }
       },
@@ -6827,7 +6827,7 @@
       "version": "5.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/miette-derive/5.10.0/download",
+          "url": "https://static.crates.io/crates/miette-derive/5.10.0/download",
           "sha256": "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
         }
       },
@@ -6874,7 +6874,7 @@
       "version": "0.3.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/mime/0.3.17/download",
+          "url": "https://static.crates.io/crates/mime/0.3.17/download",
           "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
         }
       },
@@ -6904,7 +6904,7 @@
       "version": "2.0.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/mime_guess/2.0.4/download",
+          "url": "https://static.crates.io/crates/mime_guess/2.0.4/download",
           "sha256": "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
         }
       },
@@ -6974,7 +6974,7 @@
       "version": "0.7.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/miniz_oxide/0.7.2/download",
+          "url": "https://static.crates.io/crates/miniz_oxide/0.7.2/download",
           "sha256": "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
         }
       },
@@ -7019,7 +7019,7 @@
       "version": "0.8.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/mio/0.8.10/download",
+          "url": "https://static.crates.io/crates/mio/0.8.10/download",
           "sha256": "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
         }
       },
@@ -7084,7 +7084,7 @@
       "version": "0.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num-conv/0.1.0/download",
+          "url": "https://static.crates.io/crates/num-conv/0.1.0/download",
           "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
         }
       },
@@ -7114,7 +7114,7 @@
       "version": "0.2.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num-traits/0.2.17/download",
+          "url": "https://static.crates.io/crates/num-traits/0.2.17/download",
           "sha256": "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
         }
       },
@@ -7176,7 +7176,7 @@
       "version": "1.16.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num_cpus/1.16.0/download",
+          "url": "https://static.crates.io/crates/num_cpus/1.16.0/download",
           "sha256": "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
         }
       },
@@ -7223,7 +7223,7 @@
       "version": "0.32.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/object/0.32.2/download",
+          "url": "https://static.crates.io/crates/object/0.32.2/download",
           "sha256": "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
         }
       },
@@ -7274,7 +7274,7 @@
       "version": "1.19.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/once_cell/1.19.0/download",
+          "url": "https://static.crates.io/crates/once_cell/1.19.0/download",
           "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
         }
       },
@@ -7313,7 +7313,7 @@
       "version": "3.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/owo-colors/3.5.0/download",
+          "url": "https://static.crates.io/crates/owo-colors/3.5.0/download",
           "sha256": "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
         }
       },
@@ -7343,7 +7343,7 @@
       "version": "0.12.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/parking_lot/0.12.1/download",
+          "url": "https://static.crates.io/crates/parking_lot/0.12.1/download",
           "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
         }
       },
@@ -7392,7 +7392,7 @@
       "version": "0.9.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.9/download",
+          "url": "https://static.crates.io/crates/parking_lot_core/0.9.9/download",
           "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
         }
       },
@@ -7472,7 +7472,7 @@
       "version": "0.4.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/password-hash/0.4.2/download",
+          "url": "https://static.crates.io/crates/password-hash/0.4.2/download",
           "sha256": "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
         }
       },
@@ -7525,7 +7525,7 @@
       "version": "0.2.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pathdiff/0.2.1/download",
+          "url": "https://static.crates.io/crates/pathdiff/0.2.1/download",
           "sha256": "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
         }
       },
@@ -7555,7 +7555,7 @@
       "version": "0.11.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pbkdf2/0.11.0/download",
+          "url": "https://static.crates.io/crates/pbkdf2/0.11.0/download",
           "sha256": "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
         }
       },
@@ -7616,7 +7616,7 @@
       "version": "0.8.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/peg/0.8.2/download",
+          "url": "https://static.crates.io/crates/peg/0.8.2/download",
           "sha256": "400bcab7d219c38abf8bd7cc2054eb9bbbd4312d66f6a5557d572a203f646f61"
         }
       },
@@ -7671,7 +7671,7 @@
       "version": "0.8.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/peg-macros/0.8.2/download",
+          "url": "https://static.crates.io/crates/peg-macros/0.8.2/download",
           "sha256": "46e61cce859b76d19090f62da50a9fe92bab7c2a5f09e183763559a2ac392c90"
         }
       },
@@ -7718,7 +7718,7 @@
       "version": "0.8.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/peg-runtime/0.8.2/download",
+          "url": "https://static.crates.io/crates/peg-runtime/0.8.2/download",
           "sha256": "36bae92c60fa2398ce4678b98b2c4b5a7c61099961ca1fa305aec04a9ad28922"
         }
       },
@@ -7754,7 +7754,7 @@
       "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pep440_rs/0.4.0/download",
+          "url": "https://static.crates.io/crates/pep440_rs/0.4.0/download",
           "sha256": "e0c29f9c43de378b4e4e0cd7dbcce0e5cfb80443de8c05620368b2948bc936a1"
         }
       },
@@ -7811,7 +7811,7 @@
       "version": "0.2.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pep508_rs/0.2.4/download",
+          "url": "https://static.crates.io/crates/pep508_rs/0.2.4/download",
           "sha256": "aa9d1320b78f4a5715b3ec914f32b5e85a50287ad923730e3cbf0255259432eb"
         }
       },
@@ -7885,7 +7885,7 @@
       "version": "2.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/percent-encoding/2.3.1/download",
+          "url": "https://static.crates.io/crates/percent-encoding/2.3.1/download",
           "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
         }
       },
@@ -7923,7 +7923,7 @@
       "version": "0.6.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/petgraph/0.6.4/download",
+          "url": "https://static.crates.io/crates/petgraph/0.6.4/download",
           "sha256": "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
         }
       },
@@ -7975,7 +7975,7 @@
       "version": "1.1.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project/1.1.4/download",
+          "url": "https://static.crates.io/crates/pin-project/1.1.4/download",
           "sha256": "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
         }
       },
@@ -8014,7 +8014,7 @@
       "version": "1.1.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project-internal/1.1.4/download",
+          "url": "https://static.crates.io/crates/pin-project-internal/1.1.4/download",
           "sha256": "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
         }
       },
@@ -8061,7 +8061,7 @@
       "version": "0.2.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project-lite/0.2.13/download",
+          "url": "https://static.crates.io/crates/pin-project-lite/0.2.13/download",
           "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
         }
       },
@@ -8091,7 +8091,7 @@
       "version": "0.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-utils/0.1.0/download",
+          "url": "https://static.crates.io/crates/pin-utils/0.1.0/download",
           "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
         }
       },
@@ -8121,7 +8121,7 @@
       "version": "0.3.29",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pkg-config/0.3.29/download",
+          "url": "https://static.crates.io/crates/pkg-config/0.3.29/download",
           "sha256": "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
         }
       },
@@ -8151,7 +8151,7 @@
       "version": "0.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/powerfmt/0.2.0/download",
+          "url": "https://static.crates.io/crates/powerfmt/0.2.0/download",
           "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
         }
       },
@@ -8181,7 +8181,7 @@
       "version": "1.0.78",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.78/download",
+          "url": "https://static.crates.io/crates/proc-macro2/1.0.78/download",
           "sha256": "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
         }
       },
@@ -8283,7 +8283,7 @@
       "version": "0.8.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pyproject-toml/0.8.2/download",
+          "url": "https://static.crates.io/crates/pyproject-toml/0.8.2/download",
           "sha256": "ef61ae096a2f8c8b49eca360679dbc25f57c99145f6634b6bc18fedb1f9c6c30"
         }
       },
@@ -8338,7 +8338,7 @@
       "version": "1.0.35",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.35/download",
+          "url": "https://static.crates.io/crates/quote/1.0.35/download",
           "sha256": "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
         }
       },
@@ -8384,7 +8384,7 @@
       "version": "0.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/radium/0.7.0/download",
+          "url": "https://static.crates.io/crates/radium/0.7.0/download",
           "sha256": "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
         }
       },
@@ -8437,7 +8437,7 @@
       "version": "0.6.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rand_core/0.6.4/download",
+          "url": "https://static.crates.io/crates/rand_core/0.6.4/download",
           "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
         }
       },
@@ -8467,7 +8467,7 @@
       "version": "0.9.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rattler_digest/0.9.0/download",
+          "url": "https://static.crates.io/crates/rattler_digest/0.9.0/download",
           "sha256": "881d6040b07c00070386bc7d98f21b71474a0b7847fa5b32a7c5a0a01d028f8f"
         }
       },
@@ -8793,7 +8793,7 @@
       "version": "0.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/redox_syscall/0.4.1/download",
+          "url": "https://static.crates.io/crates/redox_syscall/0.4.1/download",
           "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
         }
       },
@@ -8832,7 +8832,7 @@
       "version": "0.1.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/reflink-copy/0.1.14/download",
+          "url": "https://static.crates.io/crates/reflink-copy/0.1.14/download",
           "sha256": "767be24c0da52e7448d495b8d162506a9aa125426651d547d545d6c2b4b65b62"
         }
       },
@@ -8884,7 +8884,7 @@
       "version": "1.10.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex/1.10.3/download",
+          "url": "https://static.crates.io/crates/regex/1.10.3/download",
           "sha256": "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
         }
       },
@@ -8957,7 +8957,7 @@
       "version": "0.4.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex-automata/0.4.5/download",
+          "url": "https://static.crates.io/crates/regex-automata/0.4.5/download",
           "sha256": "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
         }
       },
@@ -9031,7 +9031,7 @@
       "version": "0.8.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex-syntax/0.8.2/download",
+          "url": "https://static.crates.io/crates/regex-syntax/0.8.2/download",
           "sha256": "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
         }
       },
@@ -9076,7 +9076,7 @@
       "version": "0.11.24",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/reqwest/0.11.24/download",
+          "url": "https://static.crates.io/crates/reqwest/0.11.24/download",
           "sha256": "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
         }
       },
@@ -9284,7 +9284,7 @@
       "version": "0.2.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/reqwest-middleware/0.2.4/download",
+          "url": "https://static.crates.io/crates/reqwest-middleware/0.2.4/download",
           "sha256": "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
         }
       },
@@ -9352,7 +9352,7 @@
       "version": "0.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/resolvo/0.3.0/download",
+          "url": "https://static.crates.io/crates/resolvo/0.3.0/download",
           "sha256": "acd163bc7df01195423c83a7a391fecf319ff41d3de899694a9ccb698e790b29"
         }
       },
@@ -9407,7 +9407,7 @@
       "version": "0.17.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ring/0.17.7/download",
+          "url": "https://static.crates.io/crates/ring/0.17.7/download",
           "sha256": "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
         }
       },
@@ -9505,7 +9505,7 @@
       "version": "0.1.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustc-demangle/0.1.23/download",
+          "url": "https://static.crates.io/crates/rustc-demangle/0.1.23/download",
           "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
         }
       },
@@ -9535,7 +9535,7 @@
       "version": "0.38.31",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustix/0.38.31/download",
+          "url": "https://static.crates.io/crates/rustix/0.38.31/download",
           "sha256": "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
         }
       },
@@ -9728,7 +9728,7 @@
       "version": "0.21.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustls/0.21.10/download",
+          "url": "https://static.crates.io/crates/rustls/0.21.10/download",
           "sha256": "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
         }
       },
@@ -9816,7 +9816,7 @@
       "version": "1.0.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustls-pemfile/1.0.4/download",
+          "url": "https://static.crates.io/crates/rustls-pemfile/1.0.4/download",
           "sha256": "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
         }
       },
@@ -9855,7 +9855,7 @@
       "version": "0.101.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustls-webpki/0.101.7/download",
+          "url": "https://static.crates.io/crates/rustls-webpki/0.101.7/download",
           "sha256": "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
         }
       },
@@ -9906,7 +9906,7 @@
       "version": "1.0.16",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ryu/1.0.16/download",
+          "url": "https://static.crates.io/crates/ryu/1.0.16/download",
           "sha256": "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
         }
       },
@@ -9936,7 +9936,7 @@
       "version": "1.0.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/same-file/1.0.6/download",
+          "url": "https://static.crates.io/crates/same-file/1.0.6/download",
           "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
         }
       },
@@ -9977,7 +9977,7 @@
       "version": "1.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/scopeguard/1.2.0/download",
+          "url": "https://static.crates.io/crates/scopeguard/1.2.0/download",
           "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
         }
       },
@@ -10007,7 +10007,7 @@
       "version": "0.7.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sct/0.7.1/download",
+          "url": "https://static.crates.io/crates/sct/0.7.1/download",
           "sha256": "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
         }
       },
@@ -10050,7 +10050,7 @@
       "version": "1.0.196",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.196/download",
+          "url": "https://static.crates.io/crates/serde/1.0.196/download",
           "sha256": "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
         }
       },
@@ -10122,7 +10122,7 @@
       "version": "1.0.196",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.196/download",
+          "url": "https://static.crates.io/crates/serde_derive/1.0.196/download",
           "sha256": "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
         }
       },
@@ -10175,7 +10175,7 @@
       "version": "1.0.113",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_json/1.0.113/download",
+          "url": "https://static.crates.io/crates/serde_json/1.0.113/download",
           "sha256": "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
         }
       },
@@ -10247,7 +10247,7 @@
       "version": "0.6.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_spanned/0.6.5/download",
+          "url": "https://static.crates.io/crates/serde_spanned/0.6.5/download",
           "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
         }
       },
@@ -10292,7 +10292,7 @@
       "version": "0.7.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_urlencoded/0.7.1/download",
+          "url": "https://static.crates.io/crates/serde_urlencoded/0.7.1/download",
           "sha256": "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
         }
       },
@@ -10343,7 +10343,7 @@
       "version": "3.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_with/3.6.0/download",
+          "url": "https://static.crates.io/crates/serde_with/3.6.0/download",
           "sha256": "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
         }
       },
@@ -10400,7 +10400,7 @@
       "version": "3.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_with_macros/3.6.0/download",
+          "url": "https://static.crates.io/crates/serde_with_macros/3.6.0/download",
           "sha256": "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
         }
       },
@@ -10451,7 +10451,7 @@
       "version": "0.10.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sha-1/0.10.1/download",
+          "url": "https://static.crates.io/crates/sha-1/0.10.1/download",
           "sha256": "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
         }
       },
@@ -10508,7 +10508,7 @@
       "version": "0.10.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sha1/0.10.6/download",
+          "url": "https://static.crates.io/crates/sha1/0.10.6/download",
           "sha256": "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
         }
       },
@@ -10565,7 +10565,7 @@
       "version": "0.10.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sha2/0.10.8/download",
+          "url": "https://static.crates.io/crates/sha2/0.10.8/download",
           "sha256": "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
         }
       },
@@ -10622,7 +10622,7 @@
       "version": "1.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/signal-hook-registry/1.4.1/download",
+          "url": "https://static.crates.io/crates/signal-hook-registry/1.4.1/download",
           "sha256": "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
         }
       },
@@ -10661,7 +10661,7 @@
       "version": "0.4.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/slab/0.4.9/download",
+          "url": "https://static.crates.io/crates/slab/0.4.9/download",
           "sha256": "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
         }
       },
@@ -10730,7 +10730,7 @@
       "version": "1.13.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/smallvec/1.13.1/download",
+          "url": "https://static.crates.io/crates/smallvec/1.13.1/download",
           "sha256": "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
         }
       },
@@ -10767,7 +10767,7 @@
       "version": "0.3.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/smawk/0.3.2/download",
+          "url": "https://static.crates.io/crates/smawk/0.3.2/download",
           "sha256": "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
         }
       },
@@ -10797,7 +10797,7 @@
       "version": "0.5.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/socket2/0.5.5/download",
+          "url": "https://static.crates.io/crates/socket2/0.5.5/download",
           "sha256": "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
         }
       },
@@ -10850,7 +10850,7 @@
       "version": "0.9.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/spin/0.9.8/download",
+          "url": "https://static.crates.io/crates/spin/0.9.8/download",
           "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
         }
       },
@@ -10886,7 +10886,7 @@
       "version": "9.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ssri/9.2.0/download",
+          "url": "https://static.crates.io/crates/ssri/9.2.0/download",
           "sha256": "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
         }
       },
@@ -10964,7 +10964,7 @@
       "version": "1.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/stable_deref_trait/1.2.0/download",
+          "url": "https://static.crates.io/crates/stable_deref_trait/1.2.0/download",
           "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
         }
       },
@@ -11002,7 +11002,7 @@
       "version": "0.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/strsim/0.10.0/download",
+          "url": "https://static.crates.io/crates/strsim/0.10.0/download",
           "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
         }
       },
@@ -11032,7 +11032,7 @@
       "version": "2.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/subtle/2.5.0/download",
+          "url": "https://static.crates.io/crates/subtle/2.5.0/download",
           "sha256": "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
         }
       },
@@ -11062,7 +11062,7 @@
       "version": "2.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/supports-color/2.1.0/download",
+          "url": "https://static.crates.io/crates/supports-color/2.1.0/download",
           "sha256": "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
         }
       },
@@ -11105,7 +11105,7 @@
       "version": "2.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/supports-hyperlinks/2.1.0/download",
+          "url": "https://static.crates.io/crates/supports-hyperlinks/2.1.0/download",
           "sha256": "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
         }
       },
@@ -11144,7 +11144,7 @@
       "version": "2.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/supports-unicode/2.1.0/download",
+          "url": "https://static.crates.io/crates/supports-unicode/2.1.0/download",
           "sha256": "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
         }
       },
@@ -11183,7 +11183,7 @@
       "version": "2.0.48",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/2.0.48/download",
+          "url": "https://static.crates.io/crates/syn/2.0.48/download",
           "sha256": "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
         }
       },
@@ -11252,7 +11252,7 @@
       "version": "0.1.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/sync_wrapper/0.1.2/download",
+          "url": "https://static.crates.io/crates/sync_wrapper/0.1.2/download",
           "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
         }
       },
@@ -11282,7 +11282,7 @@
       "version": "0.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/system-configuration/0.5.1/download",
+          "url": "https://static.crates.io/crates/system-configuration/0.5.1/download",
           "sha256": "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
         }
       },
@@ -11329,7 +11329,7 @@
       "version": "0.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/system-configuration-sys/0.5.0/download",
+          "url": "https://static.crates.io/crates/system-configuration-sys/0.5.0/download",
           "sha256": "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
         }
       },
@@ -11390,7 +11390,7 @@
       "version": "1.0.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tap/1.0.1/download",
+          "url": "https://static.crates.io/crates/tap/1.0.1/download",
           "sha256": "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
         }
       },
@@ -11420,7 +11420,7 @@
       "version": "0.4.40",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tar/0.4.40/download",
+          "url": "https://static.crates.io/crates/tar/0.4.40/download",
           "sha256": "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
         }
       },
@@ -11477,7 +11477,7 @@
       "version": "0.1.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/task-local-extensions/0.1.4/download",
+          "url": "https://static.crates.io/crates/task-local-extensions/0.1.4/download",
           "sha256": "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
         }
       },
@@ -11516,7 +11516,7 @@
       "version": "3.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tempfile/3.10.0/download",
+          "url": "https://static.crates.io/crates/tempfile/3.10.0/download",
           "sha256": "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
         }
       },
@@ -11572,7 +11572,7 @@
       "version": "0.1.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/terminal_size/0.1.17/download",
+          "url": "https://static.crates.io/crates/terminal_size/0.1.17/download",
           "sha256": "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
         }
       },
@@ -11619,7 +11619,7 @@
       "version": "0.15.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/textwrap/0.15.2/download",
+          "url": "https://static.crates.io/crates/textwrap/0.15.2/download",
           "sha256": "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
         }
       },
@@ -11675,7 +11675,7 @@
       "version": "1.0.56",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror/1.0.56/download",
+          "url": "https://static.crates.io/crates/thiserror/1.0.56/download",
           "sha256": "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
         }
       },
@@ -11737,7 +11737,7 @@
       "version": "1.0.56",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.56/download",
+          "url": "https://static.crates.io/crates/thiserror-impl/1.0.56/download",
           "sha256": "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
         }
       },
@@ -11784,7 +11784,7 @@
       "version": "0.3.34",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time/0.3.34/download",
+          "url": "https://static.crates.io/crates/time/0.3.34/download",
           "sha256": "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
         }
       },
@@ -11853,7 +11853,7 @@
       "version": "0.1.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time-core/0.1.2/download",
+          "url": "https://static.crates.io/crates/time-core/0.1.2/download",
           "sha256": "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
         }
       },
@@ -11883,7 +11883,7 @@
       "version": "0.2.17",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time-macros/0.2.17/download",
+          "url": "https://static.crates.io/crates/time-macros/0.2.17/download",
           "sha256": "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
         }
       },
@@ -11926,7 +11926,7 @@
       "version": "1.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tinyvec/1.6.0/download",
+          "url": "https://static.crates.io/crates/tinyvec/1.6.0/download",
           "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
         }
       },
@@ -11973,7 +11973,7 @@
       "version": "0.1.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tinyvec_macros/0.1.1/download",
+          "url": "https://static.crates.io/crates/tinyvec_macros/0.1.1/download",
           "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
         }
       },
@@ -12003,7 +12003,7 @@
       "version": "0.7.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tl/0.7.8/download",
+          "url": "https://static.crates.io/crates/tl/0.7.8/download",
           "sha256": "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
         }
       },
@@ -12033,7 +12033,7 @@
       "version": "1.36.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.36.0/download",
+          "url": "https://static.crates.io/crates/tokio/1.36.0/download",
           "sha256": "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
         }
       },
@@ -12274,7 +12274,7 @@
       "version": "2.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-macros/2.2.0/download",
+          "url": "https://static.crates.io/crates/tokio-macros/2.2.0/download",
           "sha256": "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
         }
       },
@@ -12321,7 +12321,7 @@
       "version": "0.24.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-rustls/0.24.1/download",
+          "url": "https://static.crates.io/crates/tokio-rustls/0.24.1/download",
           "sha256": "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
         }
       },
@@ -12372,7 +12372,7 @@
       "version": "0.1.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-stream/0.1.14/download",
+          "url": "https://static.crates.io/crates/tokio-stream/0.1.14/download",
           "sha256": "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
         }
       },
@@ -12433,7 +12433,7 @@
       "version": "0.7.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-util/0.7.10/download",
+          "url": "https://static.crates.io/crates/tokio-util/0.7.10/download",
           "sha256": "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
         }
       },
@@ -12665,7 +12665,7 @@
       "version": "0.8.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/toml/0.8.10/download",
+          "url": "https://static.crates.io/crates/toml/0.8.10/download",
           "sha256": "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
         }
       },
@@ -12722,7 +12722,7 @@
       "version": "0.6.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/toml_datetime/0.6.5/download",
+          "url": "https://static.crates.io/crates/toml_datetime/0.6.5/download",
           "sha256": "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
         }
       },
@@ -12767,7 +12767,7 @@
       "version": "0.22.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/toml_edit/0.22.4/download",
+          "url": "https://static.crates.io/crates/toml_edit/0.22.4/download",
           "sha256": "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
         }
       },
@@ -12829,7 +12829,7 @@
       "version": "0.3.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tower-service/0.3.2/download",
+          "url": "https://static.crates.io/crates/tower-service/0.3.2/download",
           "sha256": "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
         }
       },
@@ -12859,7 +12859,7 @@
       "version": "0.1.40",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing/0.1.40/download",
+          "url": "https://static.crates.io/crates/tracing/0.1.40/download",
           "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
         }
       },
@@ -12925,7 +12925,7 @@
       "version": "0.1.27",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.27/download",
+          "url": "https://static.crates.io/crates/tracing-attributes/0.1.27/download",
           "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
         }
       },
@@ -12972,7 +12972,7 @@
       "version": "0.1.32",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.32/download",
+          "url": "https://static.crates.io/crates/tracing-core/0.1.32/download",
           "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
         }
       },
@@ -13018,7 +13018,7 @@
       "version": "0.2.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/try-lock/0.2.5/download",
+          "url": "https://static.crates.io/crates/try-lock/0.2.5/download",
           "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
         }
       },
@@ -13048,7 +13048,7 @@
       "version": "1.17.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/typenum/1.17.0/download",
+          "url": "https://static.crates.io/crates/typenum/1.17.0/download",
           "sha256": "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
         }
       },
@@ -13101,7 +13101,7 @@
       "version": "2.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicase/2.7.0/download",
+          "url": "https://static.crates.io/crates/unicase/2.7.0/download",
           "sha256": "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
         }
       },
@@ -13163,7 +13163,7 @@
       "version": "0.3.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-bidi/0.3.15/download",
+          "url": "https://static.crates.io/crates/unicode-bidi/0.3.15/download",
           "sha256": "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
         }
       },
@@ -13200,7 +13200,7 @@
       "version": "1.0.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.12/download",
+          "url": "https://static.crates.io/crates/unicode-ident/1.0.12/download",
           "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
         }
       },
@@ -13230,7 +13230,7 @@
       "version": "0.1.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-linebreak/0.1.5/download",
+          "url": "https://static.crates.io/crates/unicode-linebreak/0.1.5/download",
           "sha256": "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
         }
       },
@@ -13260,7 +13260,7 @@
       "version": "0.1.22",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-normalization/0.1.22/download",
+          "url": "https://static.crates.io/crates/unicode-normalization/0.1.22/download",
           "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
         }
       },
@@ -13305,7 +13305,7 @@
       "version": "0.1.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-width/0.1.11/download",
+          "url": "https://static.crates.io/crates/unicode-width/0.1.11/download",
           "sha256": "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
         }
       },
@@ -13369,7 +13369,7 @@
       "version": "0.9.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/untrusted/0.9.0/download",
+          "url": "https://static.crates.io/crates/untrusted/0.9.0/download",
           "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
         }
       },
@@ -13399,7 +13399,7 @@
       "version": "2.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/url/2.5.0/download",
+          "url": "https://static.crates.io/crates/url/2.5.0/download",
           "sha256": "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
         }
       },
@@ -13457,7 +13457,7 @@
       "version": "0.1.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/utf8-width/0.1.7/download",
+          "url": "https://static.crates.io/crates/utf8-width/0.1.7/download",
           "sha256": "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
         }
       },
@@ -13487,7 +13487,7 @@
       "version": "0.2.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/utf8parse/0.2.1/download",
+          "url": "https://static.crates.io/crates/utf8parse/0.2.1/download",
           "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
         }
       },
@@ -13551,7 +13551,7 @@
       "version": "0.9.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/version_check/0.9.4/download",
+          "url": "https://static.crates.io/crates/version_check/0.9.4/download",
           "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
         }
       },
@@ -13581,7 +13581,7 @@
       "version": "2.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/walkdir/2.4.0/download",
+          "url": "https://static.crates.io/crates/walkdir/2.4.0/download",
           "sha256": "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
         }
       },
@@ -13627,7 +13627,7 @@
       "version": "0.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/want/0.3.1/download",
+          "url": "https://static.crates.io/crates/want/0.3.1/download",
           "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
         }
       },
@@ -13666,7 +13666,7 @@
       "version": "0.11.0+wasi-snapshot-preview1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasi/0.11.0+wasi-snapshot-preview1/download",
+          "url": "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download",
           "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
         }
       },
@@ -13703,7 +13703,7 @@
       "version": "0.2.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen/0.2.91/download",
+          "url": "https://static.crates.io/crates/wasm-bindgen/0.2.91/download",
           "sha256": "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
         }
       },
@@ -13777,7 +13777,7 @@
       "version": "0.2.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.91/download",
+          "url": "https://static.crates.io/crates/wasm-bindgen-backend/0.2.91/download",
           "sha256": "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
         }
       },
@@ -13846,7 +13846,7 @@
       "version": "0.4.41",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-futures/0.4.41/download",
+          "url": "https://static.crates.io/crates/wasm-bindgen-futures/0.4.41/download",
           "sha256": "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
         }
       },
@@ -13900,7 +13900,7 @@
       "version": "0.2.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.91/download",
+          "url": "https://static.crates.io/crates/wasm-bindgen-macro/0.2.91/download",
           "sha256": "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
         }
       },
@@ -13949,7 +13949,7 @@
       "version": "0.2.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.91/download",
+          "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.91/download",
           "sha256": "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
         }
       },
@@ -14010,7 +14010,7 @@
       "version": "0.2.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.91/download",
+          "url": "https://static.crates.io/crates/wasm-bindgen-shared/0.2.91/download",
           "sha256": "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
         }
       },
@@ -14064,7 +14064,7 @@
       "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-streams/0.4.0/download",
+          "url": "https://static.crates.io/crates/wasm-streams/0.4.0/download",
           "sha256": "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
         }
       },
@@ -14119,7 +14119,7 @@
       "version": "0.3.68",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/web-sys/0.3.68/download",
+          "url": "https://static.crates.io/crates/web-sys/0.3.68/download",
           "sha256": "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
         }
       },
@@ -14204,7 +14204,7 @@
       "version": "0.25.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/webpki-roots/0.25.4/download",
+          "url": "https://static.crates.io/crates/webpki-roots/0.25.4/download",
           "sha256": "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
         }
       },
@@ -14234,7 +14234,7 @@
       "version": "0.3.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/winapi/0.3.9/download",
+          "url": "https://static.crates.io/crates/winapi/0.3.9/download",
           "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
         }
       },
@@ -14317,7 +14317,7 @@
       "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
+          "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
           "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
         }
       },
@@ -14370,7 +14370,7 @@
       "version": "0.1.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/winapi-util/0.1.6/download",
+          "url": "https://static.crates.io/crates/winapi-util/0.1.6/download",
           "sha256": "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
         }
       },
@@ -14411,7 +14411,7 @@
       "version": "0.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
+          "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
           "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
         }
       },
@@ -14464,7 +14464,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows/0.52.0/download",
           "sha256": "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
         }
       },
@@ -14521,7 +14521,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows-core/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows-core/0.52.0/download",
           "sha256": "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
         }
       },
@@ -14566,7 +14566,7 @@
       "version": "0.48.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows-sys/0.48.0/download",
+          "url": "https://static.crates.io/crates/windows-sys/0.48.0/download",
           "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
         }
       },
@@ -14628,7 +14628,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows-sys/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows-sys/0.52.0/download",
           "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
         }
       },
@@ -14679,7 +14679,7 @@
       "version": "0.48.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows-targets/0.48.5/download",
+          "url": "https://static.crates.io/crates/windows-targets/0.48.5/download",
           "sha256": "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
         }
       },
@@ -14756,7 +14756,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows-targets/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows-targets/0.52.0/download",
           "sha256": "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
         }
       },
@@ -14833,7 +14833,7 @@
       "version": "0.48.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.48.5/download",
+          "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.5/download",
           "sha256": "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
         }
       },
@@ -14886,7 +14886,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.0/download",
           "sha256": "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
         }
       },
@@ -14939,7 +14939,7 @@
       "version": "0.48.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.48.5/download",
+          "url": "https://static.crates.io/crates/windows_aarch64_msvc/0.48.5/download",
           "sha256": "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
         }
       },
@@ -14992,7 +14992,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows_aarch64_msvc/0.52.0/download",
           "sha256": "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
         }
       },
@@ -15045,7 +15045,7 @@
       "version": "0.48.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.48.5/download",
+          "url": "https://static.crates.io/crates/windows_i686_gnu/0.48.5/download",
           "sha256": "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
         }
       },
@@ -15098,7 +15098,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_i686_gnu/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows_i686_gnu/0.52.0/download",
           "sha256": "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
         }
       },
@@ -15151,7 +15151,7 @@
       "version": "0.48.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.48.5/download",
+          "url": "https://static.crates.io/crates/windows_i686_msvc/0.48.5/download",
           "sha256": "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
         }
       },
@@ -15204,7 +15204,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_i686_msvc/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows_i686_msvc/0.52.0/download",
           "sha256": "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
         }
       },
@@ -15257,7 +15257,7 @@
       "version": "0.48.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.48.5/download",
+          "url": "https://static.crates.io/crates/windows_x86_64_gnu/0.48.5/download",
           "sha256": "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
         }
       },
@@ -15310,7 +15310,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows_x86_64_gnu/0.52.0/download",
           "sha256": "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
         }
       },
@@ -15363,7 +15363,7 @@
       "version": "0.48.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.48.5/download",
+          "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.5/download",
           "sha256": "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
         }
       },
@@ -15416,7 +15416,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.0/download",
           "sha256": "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
         }
       },
@@ -15469,7 +15469,7 @@
       "version": "0.48.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.48.5/download",
+          "url": "https://static.crates.io/crates/windows_x86_64_msvc/0.48.5/download",
           "sha256": "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
         }
       },
@@ -15522,7 +15522,7 @@
       "version": "0.52.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.52.0/download",
+          "url": "https://static.crates.io/crates/windows_x86_64_msvc/0.52.0/download",
           "sha256": "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
         }
       },
@@ -15575,7 +15575,7 @@
       "version": "0.5.39",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/winnow/0.5.39/download",
+          "url": "https://static.crates.io/crates/winnow/0.5.39/download",
           "sha256": "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
         }
       },
@@ -15613,7 +15613,7 @@
       "version": "0.50.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/winreg/0.50.0/download",
+          "url": "https://static.crates.io/crates/winreg/0.50.0/download",
           "sha256": "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
         }
       },
@@ -15656,7 +15656,7 @@
       "version": "0.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wyz/0.5.1/download",
+          "url": "https://static.crates.io/crates/wyz/0.5.1/download",
           "sha256": "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
         }
       },
@@ -15695,7 +15695,7 @@
       "version": "1.3.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/xattr/1.3.1/download",
+          "url": "https://static.crates.io/crates/xattr/1.3.1/download",
           "sha256": "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
         }
       },
@@ -15754,7 +15754,7 @@
       "version": "0.8.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/xxhash-rust/0.8.8/download",
+          "url": "https://static.crates.io/crates/xxhash-rust/0.8.8/download",
           "sha256": "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
         }
       },
@@ -15790,7 +15790,7 @@
       "version": "0.6.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/zip/0.6.6/download",
+          "url": "https://static.crates.io/crates/zip/0.6.6/download",
           "sha256": "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
         }
       },
@@ -15893,7 +15893,7 @@
       "version": "0.11.2+zstd.1.5.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/zstd/0.11.2+zstd.1.5.2/download",
+          "url": "https://static.crates.io/crates/zstd/0.11.2+zstd.1.5.2/download",
           "sha256": "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
         }
       },
@@ -15941,7 +15941,7 @@
       "version": "5.0.2+zstd.1.5.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/zstd-safe/5.0.2+zstd.1.5.2/download",
+          "url": "https://static.crates.io/crates/zstd-safe/5.0.2+zstd.1.5.2/download",
           "sha256": "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
         }
       },
@@ -16020,7 +16020,7 @@
       "version": "2.0.9+zstd.1.5.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/zstd-sys/2.0.9+zstd.1.5.5/download",
+          "url": "https://static.crates.io/crates/zstd-sys/2.0.9+zstd.1.5.5/download",
           "sha256": "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
         }
       },

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -140,37 +140,39 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
+RUST_EDITION = "2021"
+
+RUST_VERSION = "1.77.2"
+
 rust_register_toolchains(
-    edition = "2021",
+    edition = RUST_EDITION,
     extra_target_triples = [
         "x86_64-apple-darwin",
     ],
-    versions = [
-        "1.74.1",
-    ],
+    versions = [RUST_VERSION],
 )
 
 # Declare cross-compilation toolchains
 rust_repository_set(
     name = "apple_darwin_86_64",
-    edition = "2021",
+    edition = RUST_EDITION,
     exec_triple = "x86_64-apple-darwin",
     # and cross-compile to these platforms:
     extra_target_triples = [
         "aarch64-apple-darwin",
     ],
-    versions = ["1.74.1"],
+    versions = [RUST_VERSION],
 )
 
 rust_repository_set(
     name = "linux_x86_64",
-    edition = "2021",
+    edition = RUST_EDITION,
     exec_triple = "x86_64-unknown-linux-gnu",
     # and cross-compile to these platforms:
     extra_target_triples = [
         "aarch64-unknown-linux-gnu",
     ],
-    versions = ["1.74.1"],
+    versions = [RUST_VERSION],
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")


### PR DESCRIPTION
Bump rust version to 1.77.2

---

### Test plan

- Covered by existing test cases