### PR TITLE
chore: add --check_direct_dependencies to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,10 @@ common:dev --override_repository=rules_python=~/workspace/rules_python
 # No external runfiles
 common --nolegacy_external_runfiles
 
+# Don’t want to push a rules author to update their deps if not needed.
+# https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies
+# https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
+common --check_direct_dependencies=off
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members


### PR DESCRIPTION
Setting this flag in our the rule sets we maintain. Don’t want to push a rules author to update their deps if not needed.

https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies

https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0

