### PR TITLE
refactor: don't default imports to current folder

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -28,12 +28,12 @@ Run a Python program under Bazel. Most users should use the [py_binary macro](#p
 | <a id="py_binary_rule-srcs"></a>srcs |  Python source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 
-<a id="py_library_rule"></a>
+<a id="py_library"></a>
 
-## py_library_rule
+## py_library
 
 <pre>
-py_library_rule(<a href="#py_library_rule-name">name</a>, <a href="#py_library_rule-data">data</a>, <a href="#py_library_rule-deps">deps</a>, <a href="#py_library_rule-imports">imports</a>, <a href="#py_library_rule-resolutions">resolutions</a>, <a href="#py_library_rule-srcs">srcs</a>, <a href="#py_library_rule-virtual_deps">virtual_deps</a>)
+py_library(<a href="#py_library-name">name</a>, <a href="#py_library-data">data</a>, <a href="#py_library-deps">deps</a>, <a href="#py_library-imports">imports</a>, <a href="#py_library-resolutions">resolutions</a>, <a href="#py_library-srcs">srcs</a>, <a href="#py_library-virtual_deps">virtual_deps</a>)
 </pre>
 
 
@@ -43,13 +43,13 @@ py_library_rule(<a href="#py_library_rule-name">name</a>, <a href="#py_library_r
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="py_library_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="py_library_rule-data"></a>data |  Runtime dependencies of the program.<br><br>        The transitive closure of the <code>data</code> dependencies will be available in the <code>.runfiles</code>         folder for this binary/test. The program may optionally use the Runfiles lookup library to         locate the data files, see https://pypi.org/project/bazel-runfiles/.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_library_rule-deps"></a>deps |  Targets that produce Python code, commonly <code>py_library</code> rules.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_library_rule-imports"></a>imports |  List of import directories to be added to the PYTHONPATH.   | List of strings | optional | <code>[]</code> |
-| <a id="py_library_rule-resolutions"></a>resolutions |  FIXME   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional | <code>{}</code> |
-| <a id="py_library_rule-srcs"></a>srcs |  Python source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_library_rule-virtual_deps"></a>virtual_deps |  -   | List of strings | optional | <code>[]</code> |
+| <a id="py_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_library-data"></a>data |  Runtime dependencies of the program.<br><br>        The transitive closure of the <code>data</code> dependencies will be available in the <code>.runfiles</code>         folder for this binary/test. The program may optionally use the Runfiles lookup library to         locate the data files, see https://pypi.org/project/bazel-runfiles/.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="py_library-deps"></a>deps |  Targets that produce Python code, commonly <code>py_library</code> rules.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="py_library-imports"></a>imports |  List of import directories to be added to the PYTHONPATH.   | List of strings | optional | <code>[]</code> |
+| <a id="py_library-resolutions"></a>resolutions |  FIXME   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional | <code>{}</code> |
+| <a id="py_library-srcs"></a>srcs |  Python source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="py_library-virtual_deps"></a>virtual_deps |  -   | List of strings | optional | <code>[]</code> |
 
 
 <a id="py_test_rule"></a>
@@ -78,12 +78,12 @@ Run a Python program under Bazel. Most users should use the [py_test macro](#py_
 | <a id="py_test_rule-srcs"></a>srcs |  Python source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 
-<a id="py_unpacked_wheel_rule"></a>
+<a id="py_unpacked_wheel"></a>
 
-## py_unpacked_wheel_rule
+## py_unpacked_wheel
 
 <pre>
-py_unpacked_wheel_rule(<a href="#py_unpacked_wheel_rule-name">name</a>, <a href="#py_unpacked_wheel_rule-py_package_name">py_package_name</a>, <a href="#py_unpacked_wheel_rule-src">src</a>)
+py_unpacked_wheel(<a href="#py_unpacked_wheel-name">name</a>, <a href="#py_unpacked_wheel-py_package_name">py_package_name</a>, <a href="#py_unpacked_wheel-src">src</a>)
 </pre>
 
 
@@ -93,9 +93,9 @@ py_unpacked_wheel_rule(<a href="#py_unpacked_wheel_rule-name">name</a>, <a href=
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="py_unpacked_wheel_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="py_unpacked_wheel_rule-py_package_name"></a>py_package_name |  -   | String | required |  |
-| <a id="py_unpacked_wheel_rule-src"></a>src |  The Wheel file, as defined by https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="py_unpacked_wheel-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_unpacked_wheel-py_package_name"></a>py_package_name |  -   | String | required |  |
+| <a id="py_unpacked_wheel-src"></a>src |  The Wheel file, as defined by https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
 <a id="py_binary"></a>
@@ -103,13 +103,13 @@ py_unpacked_wheel_rule(<a href="#py_unpacked_wheel_rule-name">name</a>, <a href=
 ## py_binary
 
 <pre>
-py_binary(<a href="#py_binary-name">name</a>, <a href="#py_binary-srcs">srcs</a>, <a href="#py_binary-main">main</a>, <a href="#py_binary-imports">imports</a>, <a href="#py_binary-kwargs">kwargs</a>)
+py_binary(<a href="#py_binary-name">name</a>, <a href="#py_binary-srcs">srcs</a>, <a href="#py_binary-main">main</a>, <a href="#py_binary-kwargs">kwargs</a>)
 </pre>
 
-Wrapper macro for [`py_binary_rule`](#py_binary_rule), setting a default for imports.
+Wrapper macro for [`py_binary_rule`](#py_binary_rule).
 
-It also creates a virtualenv to constrain the interpreter and packages used at runtime,
-you can `bazel run [name].venv` to produce this, then use it in the editor.
+Creates a virtualenv to constrain the interpreter and packages used at runtime.
+Users can `bazel run [name].venv` to produce this, then use it in the editor.
 
 
 **PARAMETERS**
@@ -120,28 +120,7 @@ you can `bazel run [name].venv` to produce this, then use it in the editor.
 | <a id="py_binary-name"></a>name |  Name of the rule.   |  none |
 | <a id="py_binary-srcs"></a>srcs |  Python source files.   |  <code>[]</code> |
 | <a id="py_binary-main"></a>main |  Entry point. Like rules_python, this is treated as a suffix of a file that should appear among the srcs. If absent, then "[name].py" is tried. As a final fallback, if the srcs has a single file, that is used as the main.   |  <code>None</code> |
-| <a id="py_binary-imports"></a>imports |  List of import paths to add for this binary.   |  <code>["."]</code> |
 | <a id="py_binary-kwargs"></a>kwargs |  additional named parameters to the py_binary_rule.   |  none |
-
-
-<a id="py_library"></a>
-
-## py_library
-
-<pre>
-py_library(<a href="#py_library-name">name</a>, <a href="#py_library-imports">imports</a>, <a href="#py_library-kwargs">kwargs</a>)
-</pre>
-
-Wrapper macro for the [py_library_rule](./py_library_rule), supporting virtual deps.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="py_library-name"></a>name |  Name for this rule.   |  none |
-| <a id="py_library-imports"></a>imports |  List of import paths to add for this library.   |  <code>["."]</code> |
-| <a id="py_library-kwargs"></a>kwargs |  Additional named parameters to py_library_rule.   |  none |
 
 
 <a id="py_pytest_main"></a>
@@ -172,7 +151,7 @@ py_pytest_main wraps the template rendering target and the final py_library.
 ## py_test
 
 <pre>
-py_test(<a href="#py_test-name">name</a>, <a href="#py_test-main">main</a>, <a href="#py_test-srcs">srcs</a>, <a href="#py_test-imports">imports</a>, <a href="#py_test-kwargs">kwargs</a>)
+py_test(<a href="#py_test-name">name</a>, <a href="#py_test-main">main</a>, <a href="#py_test-srcs">srcs</a>, <a href="#py_test-kwargs">kwargs</a>)
 </pre>
 
 Identical to py_binary, but produces a target that can be used with `bazel test`.
@@ -185,27 +164,7 @@ Identical to py_binary, but produces a target that can be used with `bazel test`
 | <a id="py_test-name"></a>name |  <p align="center"> - </p>   |  none |
 | <a id="py_test-main"></a>main |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="py_test-srcs"></a>srcs |  <p align="center"> - </p>   |  <code>[]</code> |
-| <a id="py_test-imports"></a>imports |  <p align="center"> - </p>   |  <code>["."]</code> |
 | <a id="py_test-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
-
-
-<a id="py_unpacked_wheel"></a>
-
-## py_unpacked_wheel
-
-<pre>
-py_unpacked_wheel(<a href="#py_unpacked_wheel-name">name</a>, <a href="#py_unpacked_wheel-kwargs">kwargs</a>)
-</pre>
-
-Wrapper macro for the [py_unpacked_wheel_rule](#py_unpacked_wheel_rule), setting a defaults.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="py_unpacked_wheel-name"></a>name |  Name of this rule.   |  none |
-| <a id="py_unpacked_wheel-kwargs"></a>kwargs |  Additional named parameters to py_unpacked_wheel_rule.   |  none |
 
 
 <a id="py_venv"></a>

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -14,12 +14,12 @@ py_pytest_main = _py_pytest_main
 py_venv = _py_venv
 py_binary_rule = _py_binary
 py_test_rule = _py_test
-py_library_rule = _py_library
-py_unpacked_wheel_rule = _py_unpacked_wheel
+py_library = _py_library
+py_unpacked_wheel = _py_unpacked_wheel
 
 resolutions = _resolutions
 
-def _py_binary_or_test(name, rule, srcs, main, imports, deps = [], resolutions = {}, **kwargs):
+def _py_binary_or_test(name, rule, srcs, main, deps = [], resolutions = {}, **kwargs):
     # Compatibility with rules_python, see docs in py_executable.bzl
     main_target = "_{}.find_main".format(name)
     determine_main(
@@ -34,7 +34,6 @@ def _py_binary_or_test(name, rule, srcs, main, imports, deps = [], resolutions =
         name = name,
         srcs = srcs,
         main = main_target,
-        imports = imports,
         deps = deps,
         resolutions = resolutions,
         **kwargs
@@ -43,16 +42,16 @@ def _py_binary_or_test(name, rule, srcs, main, imports, deps = [], resolutions =
     _py_venv(
         name = "{}.venv".format(name),
         deps = deps,
-        imports = imports,
+        imports = kwargs.get("imports"),
         resolutions = resolutions,
         tags = ["manual"],
     )
 
-def py_binary(name, srcs = [], main = None, imports = [], **kwargs):
-    """Wrapper macro for [`py_binary_rule`](#py_binary_rule), setting a default for imports.
+def py_binary(name, srcs = [], main = None, **kwargs):
+    """Wrapper macro for [`py_binary_rule`](#py_binary_rule).
 
-    It also creates a virtualenv to constrain the interpreter and packages used at runtime,
-    you can `bazel run [name].venv` to produce this, then use it in the editor.
+    Creates a virtualenv to constrain the interpreter and packages used at runtime.
+    Users can `bazel run [name].venv` to produce this, then use it in the editor.
 
     Args:
         name: Name of the rule.
@@ -61,7 +60,6 @@ def py_binary(name, srcs = [], main = None, imports = [], **kwargs):
             Like rules_python, this is treated as a suffix of a file that should appear among the srcs.
             If absent, then "[name].py" is tried. As a final fallback, if the srcs has a single file,
             that is used as the main.
-        imports: List of import paths to add for this binary.
         **kwargs: additional named parameters to the py_binary_rule.
     """
 
@@ -71,32 +69,11 @@ def py_binary(name, srcs = [], main = None, imports = [], **kwargs):
     if resolutions:
         resolutions = resolutions.to_label_keyed_dict()
 
-    _py_binary_or_test(name = name, rule = _py_binary, srcs = srcs, main = main, imports = imports, resolutions = resolutions, **kwargs)
+    _py_binary_or_test(name = name, rule = _py_binary, srcs = srcs, main = main, resolutions = resolutions, **kwargs)
 
-def py_test(name, main = None, srcs = [], imports = [], **kwargs):
+def py_test(name, main = None, srcs = [], **kwargs):
     "Identical to py_binary, but produces a target that can be used with `bazel test`."
 
     # Ensure that any other targets we write will be testonly like the py_test target
     kwargs["testonly"] = True
-    _py_binary_or_test(name = name, rule = _py_test, srcs = srcs, main = main, imports = imports, **kwargs)
-
-def py_library(name, imports = [], **kwargs):
-    """Wrapper macro for the [py_library_rule](./py_library_rule), supporting virtual deps.
-
-    Args:
-        name: Name for this rule.
-        imports: List of import paths to add for this library.
-        **kwargs: Additional named parameters to py_library_rule.
-    """
-
-    _py_library(name = name, imports = imports, **kwargs)
-
-def py_unpacked_wheel(name, **kwargs):
-    """Wrapper macro for the [py_unpacked_wheel_rule](#py_unpacked_wheel_rule), setting a defaults.
-
-    Args:
-        name: Name of this rule.
-        **kwargs: Additional named parameters to py_unpacked_wheel_rule.
-    """
-
-    _py_unpacked_wheel(name = name, **kwargs)
+    _py_binary_or_test(name = name, rule = _py_test, srcs = srcs, main = main, **kwargs)

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -48,7 +48,7 @@ def _py_binary_or_test(name, rule, srcs, main, imports, deps = [], resolutions =
         tags = ["manual"],
     )
 
-def py_binary(name, srcs = [], main = None, imports = ["."], **kwargs):
+def py_binary(name, srcs = [], main = None, imports = [], **kwargs):
     """Wrapper macro for [`py_binary_rule`](#py_binary_rule), setting a default for imports.
 
     It also creates a virtualenv to constrain the interpreter and packages used at runtime,
@@ -73,14 +73,14 @@ def py_binary(name, srcs = [], main = None, imports = ["."], **kwargs):
 
     _py_binary_or_test(name = name, rule = _py_binary, srcs = srcs, main = main, imports = imports, resolutions = resolutions, **kwargs)
 
-def py_test(name, main = None, srcs = [], imports = ["."], **kwargs):
+def py_test(name, main = None, srcs = [], imports = [], **kwargs):
     "Identical to py_binary, but produces a target that can be used with `bazel test`."
 
     # Ensure that any other targets we write will be testonly like the py_test target
     kwargs["testonly"] = True
     _py_binary_or_test(name = name, rule = _py_test, srcs = srcs, main = main, imports = imports, **kwargs)
 
-def py_library(name, imports = ["."], **kwargs):
+def py_library(name, imports = [], **kwargs):
     """Wrapper macro for the [py_library_rule](./py_library_rule), supporting virtual deps.
 
     Args:

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -214,6 +214,7 @@ _attrs = dict({
     ),
     "imports": attr.string_list(
         doc = "List of import directories to be added to the PYTHONPATH.",
+        default = [],
     ),
     "resolutions": attr.label_keyed_string_dict(
         doc = "FIXME",


### PR DESCRIPTION
This causes errors for one of our clients. @dizzy57 is planning to file a corresponding issue.

Fixes #368 

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

`py_library` no longer defaults to `imports=["."]`. we recommend using longer-form import statements to import first-party libraries. You can manually restore this value on the `imports` attribute of your libraries if you still want to import them with shorthand.

### Test plan

- Covered by existing test cases
