### PR TITLE
chore: add smoke test to e2e/use_release

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -9,5 +9,8 @@ bcr_test_module:
       name: "Run test module"
       bazel: ${{ bazel }}
       platform: ${{ platform }}
+      test_flags:
+        # Bazel 6.x requires this flag set.
+        - --@aspect_rules_py//py:interpreter_version=3.8.12
       test_targets:
         - "//..."

--- a/e2e/use_release/BUILD.bazel
+++ b/e2e/use_release/BUILD.bazel
@@ -1,6 +1,18 @@
-load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_test")
 
 py_binary(
     name = "main",
-    srcs = ["__main__.py"],
+    srcs = [
+        "__init__.py",
+        "__main__.py",
+    ],
+    main = "__main__.py",
+)
+
+py_test(
+    name = "test",
+    srcs = ["test.py"],
+    deps = [
+        ":main",
+    ],
 )

--- a/e2e/use_release/__init__.py
+++ b/e2e/use_release/__init__.py
@@ -1,0 +1,2 @@
+def welcome(name):
+    return "hello %s" % name

--- a/e2e/use_release/__main__.py
+++ b/e2e/use_release/__main__.py
@@ -1,1 +1,4 @@
-print("hello world")
+from __init__ import welcome
+
+if __name__ == "__main__":
+    print(welcome("world"))

--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -11,7 +11,7 @@ fi
 
 # This test references pre-built artifacts from a prior release.
 # Will need to bump this version in the future when there are breaking changes.
-export RULES_PY_RELEASE_VERSION=0.7.3
+export RULES_PY_RELEASE_VERSION=0.7.4
 
 #############
 # Test bzlmod
@@ -59,3 +59,13 @@ then
     >&2 echo "ERROR: we fetched a rust repository"
     exit 1
 fi
+
+#############
+# Smoke test
+bazel test --test_output=streamed //...
+
+(
+    cd ../..
+    rm MODULE.bazel
+    mv MODULE.bazel.orig MODULE.bazel
+)

--- a/e2e/use_release/test.py
+++ b/e2e/use_release/test.py
@@ -1,0 +1,5 @@
+from __init__ import welcome
+
+def test_welcome():
+    greeting = welcome("world")
+    assert greeting == "Hello world"

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -4,14 +4,14 @@ This file contents are entirely replaced during release publishing.
 The checked in content is only here to allow load() statements in the sources to resolve.
 """
 
-# TEST DATA extracted from tools/integrity.bzl file within https://github.com/aspect-build/rules_py/releases/download/v0.7.3/rules_py-v0.7.3.tar.gz
+# TEST DATA extracted from tools/integrity.bzl file within https://github.com/aspect-build/rules_py/releases/download/v0.7.4/rules_py-v0.7.4.tar.gz
 RELEASED_BINARY_INTEGRITY = {
-    "unpack-aarch64-apple-darwin": "7b707566f3d47faae3f27715fb1ae1689d3d1003c21b60d344c644fdee54aef9",
-    "unpack-x86_64-apple-darwin": "6e10eb9c8a336adf2c091fd0de73a0e6a2e9ff104829a2516f1283b1429deaea",
-    "venv-aarch64-apple-darwin": "cda216aed9cb6c6a9d9d5627f5d109139536d94e206e5248b1027bd0fbc42342",
-    "venv-x86_64-apple-darwin": "12ea7c3e0a660322059610aac6ce05c93667a17cfa3f3585d442e9e4815edef0",
-    "unpack-aarch64-unknown-linux-gnu": "e6da0ffc82b462ec14e6e660c396bc9530d7f1588729e3dd6500508c661e1819",
-    "unpack-x86_64-unknown-linux-gnu": "35fc4335877a852a6fa1bd3ac2f99d756376ef8540d1bfa36ac7abf9c4fcc8f8",
-    "venv-aarch64-unknown-linux-gnu": "b51756d0d66a0defcc176c2363f649a698e235f56f6d6cbc3bc2142fb99b0240",
-    "venv-x86_64-unknown-linux-gnu": "79e753c51d51c37d77151e2c36df52d5f0eb9b301e6001274a92ce9d0cdf67cd",
+    "unpack-aarch64-apple-darwin": "791c711bba95829118920553489537d156c320163876f2435e017c07bfcbd30a",
+    "unpack-x86_64-apple-darwin": "2a060c679e376e951877c4179824fa3bb8edd8674b7ec430585a4f83650ad910",
+    "venv-aarch64-apple-darwin": "a355e4338e7c2312d8366386ad981ed6864a65214d38ed6bd756ba19b532aa05",
+    "venv-x86_64-apple-darwin": "af56a742e79d64a30bae422c46a9d6c7edc77df107a8bb96f826967059eff96b",
+    "unpack-aarch64-unknown-linux-gnu": "84a2603b5c521346c22431f73af54c54ebed50ddcb19740fa958c8ad870723dc",
+    "unpack-x86_64-unknown-linux-gnu": "4e21607baa25108b7ca322b57dcf5fd94545e0960e8d7f2b449e84c5e68ec9cc",
+    "venv-aarch64-unknown-linux-gnu": "56be3172bbb95007120a2183dff0dcb204b7e0464bd0197397bb86198bb5d7ba",
+    "venv-x86_64-unknown-linux-gnu": "c09b7f8d0af9cde213f658e9b43444709f687e4d7e1d67941c661525432092a4",
 }


### PR DESCRIPTION
The BCR presubmit runs `bazel test` in the `e2e/use_release` directory, and requires an actual test, else bazel fails with the "no tests found" error. This diff adds a simple test, and bumps the tested binaries to 0.7.4.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added