### PR TITLE
example: Add example for pybind11

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,6 @@ bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_python", version = "0.29.0")
 bazel_dep(name = "platforms", version = "0.0.7")
 
-
 # Custom python version for testing only
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
@@ -81,3 +80,5 @@ crate.from_cargo(
 )
 
 use_repo(crate, "crate_index")
+
+bazel_dep(name = "pybind11_bazel", version = "2.12.0", dev_dependency = True)

--- a/examples/pybind11/BUILD.bazel
+++ b/examples/pybind11/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library", "py_test")
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
+
+pybind_extension(
+    name = "basic",
+    srcs = ["basic.cpp"],
+)
+
+py_library(
+    name = "basic_lib",
+    data = [":basic"],
+    imports = ["."],
+)
+
+py_test(
+    name = "basic_test",
+    srcs = ["basic_test.py"],
+    deps = [":basic_lib"],
+)

--- a/examples/pybind11/MODULE.bazel
+++ b/examples/pybind11/MODULE.bazel
@@ -1,8 +1,0 @@
-bazel_dep(name = "pybind11_bazel", version = "2.12.0")
-bazel_dep(name = "rules_python", version = "0.34.0")
-bazel_dep(name = "aspect_rules_py", version = "0.7.4", dev_dependency = True)
-
-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.8.10")
-
-use_repo(python, "python_3_8_10")

--- a/examples/pybind11/MODULE.bazel
+++ b/examples/pybind11/MODULE.bazel
@@ -1,0 +1,8 @@
+bazel_dep(name = "pybind11_bazel", version = "2.12.0")
+bazel_dep(name = "rules_python", version = "0.34.0")
+bazel_dep(name = "aspect_rules_py", version = "0.7.4", dev_dependency = True)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.8.10")
+
+use_repo(python, "python_3_8_10")

--- a/examples/pybind11/basic.cpp
+++ b/examples/pybind11/basic.cpp
@@ -1,0 +1,10 @@
+#include <pybind11/pybind11.h>
+
+int add(int i, int j) {
+  return i + j;
+}
+
+PYBIND11_MODULE(basic, module) {
+  module.doc() = "A basic pybind11 extension";
+  module.def("add", &add, "A function that adds two numbers");
+}

--- a/examples/pybind11/basic_test.py
+++ b/examples/pybind11/basic_test.py
@@ -1,0 +1,14 @@
+import unittest
+
+import basic
+
+
+class TestBasic(unittest.TestCase):
+
+  def test_add(self):
+    self.assertEqual(basic.add(1, 2), 3)
+    self.assertEqual(basic.add(2, 2), 4)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Add an example for pybind11 with rules_py which is a modified version of https://github.com/pybind/pybind11_bazel/tree/master/examples/basic.

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- New test cases added
