### PR TITLE
fix: mark a 'testing only' python toolchain as dev_dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,9 +13,8 @@ bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_python", version = "0.29.0")
 bazel_dep(name = "platforms", version = "0.0.7")
 
-
 # Custom python version for testing only
-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
 python.toolchain(
     is_default = False,
     python_version = "3.8.12",


### PR DESCRIPTION

---

### Changes are visible to end-users: no

### Test plan
None