### PR TITLE
refactor: py_venv macro improved defaults for usability

### DIFF
--- a/py/private/py_venv.bzl
+++ b/py/private/py_venv.bzl
@@ -140,9 +140,12 @@ A collision can occour when multiple packages providing the same file are instal
 )
 
 def py_venv(name, **kwargs):
+    # By default, support VSCode (and other tools) by creating virtualenv's in the root of the workspace.
+    # Editors expect to locate them here, and provide a nice name to see "which one is open".
+    # See https://github.com/aspect-build/rules_py/issues/395
+    default_venv_name = ".{}".format(paths.join(native.package_name(), name).replace("/", "+"))
     _py_venv(
         name = name,
-        location = kwargs.pop("location", native.package_name()),
-        venv_name = kwargs.pop("venv_name", ".{}".format(name)),
+        venv_name = kwargs.pop("venv_name", default_venv_name),
         **kwargs
     )

--- a/py/private/py_venv.bzl
+++ b/py/private/py_venv.bzl
@@ -140,8 +140,8 @@ A collision can occour when multiple packages providing the same file are instal
 )
 
 def py_venv(name, **kwargs):
-    # By default, support VSCode (and other tools) by creating virtualenv's in the root of the workspace.
-    # Editors expect to locate them here, and provide a nice name to see "which one is open".
+    # By default, VSCode (and likely other tools) expect to find virtualenv's in the root of the project opened in the editor.
+    # They also provide a nice name to see "which one is open" when discovered this way.
     # See https://github.com/aspect-build/rules_py/issues/395
     default_venv_name = ".{}".format(paths.join(native.package_name(), name).replace("/", "+"))
     _py_venv(

--- a/py/private/venv.tmpl.sh
+++ b/py/private/venv.tmpl.sh
@@ -21,7 +21,7 @@ function alocation {
 }
 
 VENV_TOOL="$(rlocation {{VENV_TOOL}})"
-VENV_ROOT="${BUILD_WORKSPACE_DIRECTORY}"
+VENV_ROOT="${BUILD_WORKING_DIRECTORY}"
 VIRTUAL_ENV="$(alocation "${VENV_ROOT}/{{ARG_VENV_LOCATION}}")"
 
 "${VENV_TOOL}" \
@@ -31,3 +31,5 @@ VIRTUAL_ENV="$(alocation "${VENV_ROOT}/{{ARG_VENV_LOCATION}}")"
     --pth-file "$(rlocation {{ARG_PTH_FILE}})" \
     --pth-entry-prefix "${RUNFILES_DIR}" \
     --collision-strategy "{{ARG_COLLISION_STRATEGY}}"
+
+echo "Created virtualenv in ${VIRTUAL_ENV}"


### PR DESCRIPTION
After testing real developer workflows in vscode, this way works correctly and is much more practical.

Fixes #395
<img width="750" alt="Screenshot 2024-10-01 at 2 55 13 PM" src="https://github.com/user-attachments/assets/20a57379-8828-4a87-a7b9-6ab4feba2684">


---

### Changes are visible to end-users: no

### Test plan

Try a few things in VScode:

1. in the root, run `bazel run app:app_bin.venv` and see VSCode offers to open the resulting virtual env, labels it well
2. open the app folder in the editor, then run `bazel run app_bin.venv` which also is detected
3. run `bazel run app_test.venv` and the editor offers to switch
4. open a terminal in vscode and run `python -m pytest` and the tests run correctly, meaning they should also be debuggable