### PR TITLE
chore(BCR): drop Bazel 6 testing

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "e2e/use_release"
   matrix:
-    bazel: ["7.x", "6.x"]
+    bazel: ["7.x"]
     # TODO(#9): add windows to this list
     platform: ["debian10", "macos", "ubuntu2004"]
   tasks:


### PR DESCRIPTION
it's red for the last couple releases, and Bazel 8 RC will come out next week so we should switch to testing that.
