### PR TITLE
feat: port pytest_test macro

### DIFF
--- a/docs/py_test.md
+++ b/docs/py_test.md
@@ -95,7 +95,7 @@ py_pytest_main wraps the template rendering target and the final py_library.
 ## py_test
 
 <pre>
-py_test(<a href="#py_test-name">name</a>, <a href="#py_test-srcs">srcs</a>, <a href="#py_test-main">main</a>, <a href="#py_test-kwargs">kwargs</a>)
+py_test(<a href="#py_test-name">name</a>, <a href="#py_test-srcs">srcs</a>, <a href="#py_test-main">main</a>, <a href="#py_test-pytest_main">pytest_main</a>, <a href="#py_test-kwargs">kwargs</a>)
 </pre>
 
 Identical to [py_binary](./py_binary.md), but produces a target that can be used with `bazel test`.
@@ -108,6 +108,7 @@ Identical to [py_binary](./py_binary.md), but produces a target that can be used
 | <a id="py_test-name"></a>name |  Name of the rule.   |  none |
 | <a id="py_test-srcs"></a>srcs |  Python source files.   |  <code>[]</code> |
 | <a id="py_test-main"></a>main |  Entry point. Like rules_python, this is treated as a suffix of a file that should appear among the srcs. If absent, then <code>[name].py</code> is tried. As a final fallback, if the srcs has a single file, that is used as the main.   |  <code>None</code> |
+| <a id="py_test-pytest_main"></a>pytest_main |  If set, generate a [py_pytest_main](#py_pytest_main) script and use it as the main. The deps should include the pytest package (as well as the coverage package if desired).   |  <code>False</code> |
 | <a id="py_test-kwargs"></a>kwargs |  additional named parameters to <code>py_binary_rule</code>.   |  none |
 
 

--- a/e2e/use_release/src/BUILD.bazel
+++ b/e2e/use_release/src/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_pytest_main", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_test")
 
 py_binary(
     name = "main",
@@ -9,25 +9,14 @@ py_binary(
     main = "__main__.py",
 )
 
-# TODO(alex): land https://github.com/aspect-build/rules_py/pull/401 and shorten this
-py_pytest_main(
-    name = "__test__",
-    data = ["//:.coveragerc"],
-    deps = [
-        "@pip//coverage",
-        "@pip//pytest",
-    ],
-)
-
 py_test(
     name = "test",
-    srcs = [
-        "my_test.py",
-        ":__test__",
-    ],
-    main = ":__test__.py",
+    srcs = ["my_test.py"],
+    data = ["//:.coveragerc"],
+    pytest_main = True,
     deps = [
-        ":__test__",
         ":main",
+        "@pip//coverage",  # keep
+        "@pip//pytest",  # keep
     ],
 )

--- a/examples/pytest/BUILD.bazel
+++ b/examples/pytest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_library", "py_pytest_main", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_library", "py_test")
 
 py_library(
     name = "lib",
@@ -6,31 +6,19 @@ py_library(
     imports = ["../.."],
 )
 
-py_pytest_main(
-    name = "__test__",
-    chdir = package_name(),  # So that test fixtures are available at the correct path
-    deps = [
-        "@pypi_coverage//:pkg",
-        "@pypi_pytest//:pkg",
-    ],
-)
-
 py_test(
     name = "pytest_test",
-    srcs = [
-        "foo_test.py",
-        ":__test__",
-    ],
+    srcs = ["foo_test.py"],
     data = glob([
         "fixtures/*.json",
     ]),
     env_inherit = ["FOO"],
     imports = ["../.."],
-    main = ":__test__.py",
     package_collisions = "warning",
+    pytest_main = True,
     deps = [
-        ":__test__",
         ":lib",
+        "@pypi_coverage//:pkg",
         "@pypi_ftfy//:pkg",
         "@pypi_neptune//:pkg",
         "@pypi_pytest//:pkg",
@@ -38,38 +26,12 @@ py_test(
 )
 
 py_test(
-    name = "nested/pytest",
-    srcs = [
-        "foo_test.py",
-        ":__test__",
-    ],
-    data = glob([
-        "fixtures/*.json",
-    ]),
-    env_inherit = ["FOO"],
+    # NB: name contains a slash as regression test for #483
+    name = "sharded/test",
+    srcs = ["sharding_test.py"],
     imports = ["../.."],
-    main = ":__test__.py",
     package_collisions = "warning",
-    deps = [
-        ":__test__",
-        ":lib",
-        "@pypi_ftfy//:pkg",
-        "@pypi_neptune//:pkg",
-        "@pypi_pytest//:pkg",
-    ],
-)
-
-py_test(
-    name = "sharding_test",
-    srcs = [
-        "__test__.py",
-        "sharding_test.py",
-    ],
-    imports = ["../.."],
-    main = "__test__.py",
-    package_collisions = "warning",
+    pytest_main = True,
     shard_count = 2,
-    deps = [
-        "__test__",
-    ],
+    deps = ["@pypi_pytest//:pkg"],
 )

--- a/examples/pytest/foo_test.py
+++ b/examples/pytest/foo_test.py
@@ -1,5 +1,6 @@
-import pytest
 import json
+
+import os
 
 from examples.pytest.foo import add
 
@@ -7,6 +8,7 @@ def test_add():
     assert add(1, 1) == 2, "Expected 1 + 1 to equal 2"
 
 def test_hello_json():
-    content = open('fixtures/hello.json', 'r').read()
+    # NB: we don't use the chdir attribute so the test working directory is the repository root
+    content = open(os.path.join(os.getenv('TEST_TARGET').lstrip('/').split(':')[0], 'fixtures/hello.json'), 'r').read()
     data = json.loads(content)
     assert data["message"] == "Hello, world.", "Message is as expected"

--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -17,7 +17,12 @@ import os
 from pathlib import Path
 from typing import List
 
-import pytest
+try:
+    import pytest
+except ModuleNotFoundError as e:
+    print("ERROR: pytest must be included in the deps of the py_pytest_main or py_test target")
+    raise e
+
 # None means coverage wasn't enabled
 cov = None
 # For workaround of https://github.com/nedbat/coveragepy/issues/963
@@ -37,7 +42,7 @@ if "COVERAGE_MANIFEST" in os.environ:
             coveragepy_absfile_mapping = {coverage.files.abs_file(mfe): mfe for mfe in manifest_entries}
         cov.start()
     except ModuleNotFoundError as e:
-        print("WARNING: python coverage setup failed. Do you need to include the 'coverage' library as a dependency of py_pytest_main?", e)
+        print("WARNING: python coverage setup failed. Do you need to include the 'coverage' package as a dependency of py_pytest_main?", e)
         pass
 
 from pytest_shard import ShardPlugin


### PR DESCRIPTION
Comes from https://github.com/caseyduquettesc/rules_python_pytest/pull/13 It's much easier to properly gazelle-generate a BUILD file in this shape rather than the awkward way you're forced to hold our py_pytest_main.
