### PR TITLE
feat: drop rattler_installs_packages for uv crates

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,14 +1,14 @@
 {
-  "checksum": "d106312d2f6264156c52e22eaf1d544f39fa5380fa99cb923f75c2320aaafd25",
+  "checksum": "81a92b86099c7c9b831ce831b33ad24c552a0c97ef3d8dc37836db3d08529ec4",
   "crates": {
-    "addr2line 0.21.0": {
+    "addr2line 0.24.2": {
       "name": "addr2line",
-      "version": "0.21.0",
+      "version": "0.24.2",
       "package_url": "https://github.com/gimli-rs/addr2line",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/addr2line/0.21.0/download",
-          "sha256": "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+          "url": "https://static.crates.io/crates/addr2line/0.24.2/download",
+          "sha256": "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
         }
       },
       "targets": [
@@ -33,14 +33,14 @@
         "deps": {
           "common": [
             {
-              "id": "gimli 0.28.1",
+              "id": "gimli 0.31.1",
               "target": "gimli"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.21.0"
+        "version": "0.24.2"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -49,20 +49,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "adler 1.0.2": {
-      "name": "adler",
-      "version": "1.0.2",
-      "package_url": "https://github.com/jonas-schievink/adler.git",
+    "adler2 2.0.0": {
+      "name": "adler2",
+      "version": "2.0.0",
+      "package_url": "https://github.com/oyvindln/adler2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/adler/1.0.2/download",
-          "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+          "url": "https://static.crates.io/crates/adler2/2.0.0/download",
+          "sha256": "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "adler",
+            "crate_name": "adler2",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -73,13 +73,13 @@
           }
         }
       ],
-      "library_target_name": "adler",
+      "library_target_name": "adler2",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2015",
-        "version": "1.0.2"
+        "edition": "2021",
+        "version": "2.0.0"
       },
       "license": "0BSD OR MIT OR Apache-2.0",
       "license_ids": [
@@ -89,73 +89,14 @@
       ],
       "license_file": "LICENSE-0BSD"
     },
-    "aes 0.8.3": {
-      "name": "aes",
-      "version": "0.8.3",
-      "package_url": "https://github.com/RustCrypto/block-ciphers",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/aes/0.8.3/download",
-          "sha256": "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "aes",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "aes",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "cipher 0.4.4",
-              "target": "cipher"
-            }
-          ],
-          "selects": {
-            "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
-              {
-                "id": "cpufeatures 0.2.12",
-                "target": "cpufeatures"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.8.3"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "aho-corasick 1.1.2": {
+    "aho-corasick 1.1.3": {
       "name": "aho-corasick",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "package_url": "https://github.com/BurntSushi/aho-corasick",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/aho-corasick/1.1.2/download",
-          "sha256": "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+          "url": "https://static.crates.io/crates/aho-corasick/1.1.3/download",
+          "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
         }
       },
       "targets": [
@@ -179,6 +120,7 @@
         ],
         "crate_features": {
           "common": [
+            "default",
             "perf-literal",
             "std"
           ],
@@ -187,14 +129,14 @@
         "deps": {
           "common": [
             {
-              "id": "memchr 2.7.1",
+              "id": "memchr 2.7.4",
               "target": "memchr"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.2"
+        "version": "1.1.3"
       },
       "license": "Unlicense OR MIT",
       "license_ids": [
@@ -203,101 +145,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "android-tzdata 0.1.1": {
-      "name": "android-tzdata",
-      "version": "0.1.1",
-      "package_url": "https://github.com/RumovZ/android-tzdata",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/android-tzdata/0.1.1/download",
-          "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "android_tzdata",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "android_tzdata",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.1.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "android_system_properties 0.1.5": {
-      "name": "android_system_properties",
-      "version": "0.1.5",
-      "package_url": "https://github.com/nical/android_system_properties",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/android_system_properties/0.1.5/download",
-          "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "android_system_properties",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "android_system_properties",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "libc 0.2.161",
-              "target": "libc"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.5"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "anstream 0.6.11": {
+    "anstream 0.6.15": {
       "name": "anstream",
-      "version": "0.6.11",
+      "version": "0.6.15",
       "package_url": "https://github.com/rust-cli/anstyle.git",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anstream/0.6.11/download",
-          "sha256": "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+          "url": "https://static.crates.io/crates/anstream/0.6.15/download",
+          "sha256": "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
         }
       },
       "targets": [
@@ -334,45 +189,49 @@
               "target": "anstyle"
             },
             {
-              "id": "anstyle-parse 0.2.3",
+              "id": "anstyle-parse 0.2.5",
               "target": "anstyle_parse"
             },
             {
-              "id": "anstyle-query 1.0.2",
+              "id": "anstyle-query 1.1.1",
               "target": "anstyle_query"
             },
             {
-              "id": "colorchoice 1.0.0",
+              "id": "colorchoice 1.0.2",
               "target": "colorchoice"
             },
             {
-              "id": "utf8parse 0.2.1",
+              "id": "is_terminal_polyfill 1.70.1",
+              "target": "is_terminal_polyfill"
+            },
+            {
+              "id": "utf8parse 0.2.2",
               "target": "utf8parse"
             }
           ],
           "selects": {
             "aarch64-pc-windows-msvc": [
               {
-                "id": "anstyle-wincon 3.0.2",
+                "id": "anstyle-wincon 3.0.4",
                 "target": "anstyle_wincon"
               }
             ],
             "i686-pc-windows-msvc": [
               {
-                "id": "anstyle-wincon 3.0.2",
+                "id": "anstyle-wincon 3.0.4",
                 "target": "anstyle_wincon"
               }
             ],
             "x86_64-pc-windows-msvc": [
               {
-                "id": "anstyle-wincon 3.0.2",
+                "id": "anstyle-wincon 3.0.4",
                 "target": "anstyle_wincon"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.6.11"
+        "version": "0.6.15"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -427,14 +286,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "anstyle-parse 0.2.3": {
+    "anstyle-parse 0.2.5": {
       "name": "anstyle-parse",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "package_url": "https://github.com/rust-cli/anstyle.git",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anstyle-parse/0.2.3/download",
-          "sha256": "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+          "url": "https://static.crates.io/crates/anstyle-parse/0.2.5/download",
+          "sha256": "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
         }
       },
       "targets": [
@@ -466,14 +325,14 @@
         "deps": {
           "common": [
             {
-              "id": "utf8parse 0.2.1",
+              "id": "utf8parse 0.2.2",
               "target": "utf8parse"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.3"
+        "version": "0.2.5"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -482,14 +341,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "anstyle-query 1.0.2": {
+    "anstyle-query 1.1.1": {
       "name": "anstyle-query",
-      "version": "1.0.2",
+      "version": "1.1.1",
       "package_url": "https://github.com/rust-cli/anstyle",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anstyle-query/1.0.2/download",
-          "sha256": "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+          "url": "https://static.crates.io/crates/anstyle-query/1.1.1/download",
+          "sha256": "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
         }
       },
       "targets": [
@@ -523,7 +382,7 @@
           }
         },
         "edition": "2021",
-        "version": "1.0.2"
+        "version": "1.1.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -532,14 +391,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "anstyle-wincon 3.0.2": {
+    "anstyle-wincon 3.0.4": {
       "name": "anstyle-wincon",
-      "version": "3.0.2",
+      "version": "3.0.4",
       "package_url": "https://github.com/rust-cli/anstyle.git",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anstyle-wincon/3.0.2/download",
-          "sha256": "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+          "url": "https://static.crates.io/crates/anstyle-wincon/3.0.4/download",
+          "sha256": "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
         }
       },
       "targets": [
@@ -578,7 +437,7 @@
           }
         },
         "edition": "2021",
-        "version": "3.0.2"
+        "version": "3.0.4"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -587,14 +446,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "anyhow 1.0.79": {
+    "anyhow 1.0.91": {
       "name": "anyhow",
-      "version": "1.0.79",
+      "version": "1.0.91",
       "package_url": "https://github.com/dtolnay/anyhow",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anyhow/1.0.79/download",
-          "sha256": "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+          "url": "https://static.crates.io/crates/anyhow/1.0.91/download",
+          "sha256": "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
         }
       },
       "targets": [
@@ -638,14 +497,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.79",
+              "id": "anyhow 1.0.91",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.79"
+        "version": "1.0.91"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -693,134 +552,353 @@
         ],
         "crate_features": {
           "common": [
+            "bzip2",
             "deflate",
             "flate2",
-            "futures-io"
+            "futures-io",
+            "gzip",
+            "libzstd",
+            "xz",
+            "xz2",
+            "zstd",
+            "zstd-safe"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "tokio"
+            ],
+            "aarch64-apple-ios": [
+              "tokio"
+            ],
+            "aarch64-apple-ios-sim": [
+              "tokio"
+            ],
+            "aarch64-fuchsia": [
+              "tokio"
+            ],
+            "aarch64-linux-android": [
+              "tokio"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "tokio"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "tokio"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "tokio"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "tokio"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "tokio"
+            ],
+            "armv7-linux-androideabi": [
+              "tokio"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "tokio"
+            ],
+            "i686-apple-darwin": [
+              "tokio"
+            ],
+            "i686-linux-android": [
+              "tokio"
+            ],
+            "i686-pc-windows-msvc": [
+              "tokio"
+            ],
+            "i686-unknown-freebsd": [
+              "tokio"
+            ],
+            "i686-unknown-linux-gnu": [
+              "tokio"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "tokio"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "tokio"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "tokio"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "tokio"
+            ],
+            "thumbv7em-none-eabi": [
+              "tokio"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "tokio"
+            ],
+            "x86_64-apple-darwin": [
+              "tokio"
+            ],
+            "x86_64-apple-ios": [
+              "tokio"
+            ],
+            "x86_64-fuchsia": [
+              "tokio"
+            ],
+            "x86_64-linux-android": [
+              "tokio"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "tokio"
+            ],
+            "x86_64-unknown-freebsd": [
+              "tokio"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "tokio"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "tokio"
+            ],
+            "x86_64-unknown-none": [
+              "tokio"
+            ]
+          }
         },
         "deps": {
           "common": [
             {
-              "id": "flate2 1.0.28",
+              "id": "bzip2 0.4.4",
+              "target": "bzip2"
+            },
+            {
+              "id": "flate2 1.0.34",
               "target": "flate2"
             },
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.30",
+              "id": "futures-io 0.3.31",
               "target": "futures_io"
             },
             {
-              "id": "memchr 2.7.1",
+              "id": "memchr 2.7.4",
               "target": "memchr"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
+            },
+            {
+              "id": "xz2 0.1.7",
+              "target": "xz2"
+            },
+            {
+              "id": "zstd 0.13.2",
+              "target": "zstd",
+              "alias": "libzstd"
+            },
+            {
+              "id": "zstd-safe 7.2.1",
+              "target": "zstd_safe"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "aarch64-apple-ios": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "aarch64-apple-ios-sim": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "aarch64-fuchsia": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "aarch64-linux-android": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "armv7-linux-androideabi": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "i686-apple-darwin": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "i686-linux-android": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "i686-unknown-freebsd": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "riscv32imc-unknown-none-elf": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "riscv64gc-unknown-none-elf": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "thumbv7em-none-eabi": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "thumbv8m.main-none-eabi": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-apple-ios": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-fuchsia": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-linux-android": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "x86_64-unknown-none": [
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.4.17"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "async-once-cell 0.5.3": {
-      "name": "async-once-cell",
-      "version": "0.5.3",
-      "package_url": "https://github.com/danieldg/async-once-cell",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/async-once-cell/0.5.3/download",
-          "sha256": "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "async_once_cell",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "async_once_cell",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.5.3"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "async-recursion 1.1.1": {
-      "name": "async-recursion",
-      "version": "1.1.1",
-      "package_url": "https://github.com/dcchut/async-recursion",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/async-recursion/1.1.1/download",
-          "sha256": "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "async_recursion",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "async_recursion",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.89",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.82",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.1.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -865,11 +943,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
@@ -885,14 +963,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "async_http_range_reader 0.7.1": {
+    "async_http_range_reader 0.8.0": {
       "name": "async_http_range_reader",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "package_url": "https://github.com/prefix-dev/async_http_range_reader",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/async_http_range_reader/0.7.1/download",
-          "sha256": "8561e6613f8361df8bed11c0eef05b98384643bc81f6b753eec7c1d91f097509"
+          "url": "https://static.crates.io/crates/async_http_range_reader/0.8.0/download",
+          "sha256": "f1a0e0571c5d724d17fbe0b608d31a91e94938722c141877d3a2982216b084c2"
         }
       },
       "targets": [
@@ -921,11 +999,11 @@
               "target": "bisection"
             },
             {
-              "id": "futures 0.3.30",
+              "id": "futures 0.3.31",
               "target": "futures"
             },
             {
-              "id": "http-content-range 0.1.2",
+              "id": "http-content-range 0.1.4",
               "target": "http_content_range"
             },
             {
@@ -933,7 +1011,7 @@
               "target": "itertools"
             },
             {
-              "id": "memmap2 0.9.4",
+              "id": "memmap2 0.9.5",
               "target": "memmap2"
             },
             {
@@ -953,11 +1031,11 @@
               "target": "tokio"
             },
             {
-              "id": "tokio-stream 0.1.14",
+              "id": "tokio-stream 0.1.16",
               "target": "tokio_stream"
             },
             {
-              "id": "tokio-util 0.7.10",
+              "id": "tokio-util 0.7.12",
               "target": "tokio_util"
             },
             {
@@ -968,7 +1046,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.1"
+        "version": "0.8.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -976,14 +1054,16 @@
       ],
       "license_file": "LICENSE"
     },
-    "async_zip 0.0.16": {
+    "async_zip 0.0.17": {
       "name": "async_zip",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "package_url": "https://github.com/Majored/rs-async-zip",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/async_zip/0.0.16/download",
-          "sha256": "527207465fb6dcafbf661b0d4a51d0d2306c9d0c2975423079a6caa807930daf"
+        "Git": {
+          "remote": "https://github.com/charliermarsh/rs-async-zip",
+          "commitish": {
+            "Rev": "011b24604fa7bc223daaad7712c0694bac8f0a87"
+          }
         }
       },
       "targets": [
@@ -1021,7 +1101,7 @@
               "target": "async_compression"
             },
             {
-              "id": "crc32fast 1.3.2",
+              "id": "crc32fast 1.4.2",
               "target": "crc32fast"
             },
             {
@@ -1029,7 +1109,7 @@
               "target": "futures_lite"
             },
             {
-              "id": "pin-project 1.1.4",
+              "id": "pin-project 1.1.7",
               "target": "pin_project"
             },
             {
@@ -1041,14 +1121,14 @@
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.7.10",
+              "id": "tokio-util 0.7.12",
               "target": "tokio_util"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.0.16"
+        "version": "0.0.17"
       },
       "license": "MIT",
       "license_ids": [
@@ -1056,14 +1136,53 @@
       ],
       "license_file": "LICENSE"
     },
-    "autocfg 1.1.0": {
+    "atomic-waker 1.1.2": {
+      "name": "atomic-waker",
+      "version": "1.1.2",
+      "package_url": "https://github.com/smol-rs/atomic-waker",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/atomic-waker/1.1.2/download",
+          "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "atomic_waker",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "atomic_waker",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "1.1.2"
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "autocfg 1.4.0": {
       "name": "autocfg",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "package_url": "https://github.com/cuviper/autocfg",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/autocfg/1.1.0/download",
-          "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+          "url": "https://static.crates.io/crates/autocfg/1.4.0/download",
+          "sha256": "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
         }
       },
       "targets": [
@@ -1086,7 +1205,7 @@
           "**"
         ],
         "edition": "2015",
-        "version": "1.1.0"
+        "version": "1.4.0"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -1095,20 +1214,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "backtrace 0.3.69": {
-      "name": "backtrace",
-      "version": "0.3.69",
-      "package_url": "https://github.com/rust-lang/backtrace-rs",
+    "backoff 0.4.0": {
+      "name": "backoff",
+      "version": "0.4.0",
+      "package_url": "https://github.com/ihrwein/backoff",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/backtrace/0.3.69/download",
-          "sha256": "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+          "url": "https://static.crates.io/crates/backoff/0.4.0/download",
+          "sha256": "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "backtrace",
+            "crate_name": "backoff",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -1117,11 +1236,79 @@
               ]
             }
           }
+        }
+      ],
+      "library_target_name": "backoff",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "futures",
+            "futures-core",
+            "pin-project-lite",
+            "tokio",
+            "tokio_1"
+          ],
+          "selects": {}
         },
+        "deps": {
+          "common": [
+            {
+              "id": "futures-core 0.3.31",
+              "target": "futures_core"
+            },
+            {
+              "id": "getrandom 0.2.15",
+              "target": "getrandom"
+            },
+            {
+              "id": "instant 0.1.13",
+              "target": "instant"
+            },
+            {
+              "id": "pin-project-lite 0.2.15",
+              "target": "pin_project_lite"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio",
+              "alias": "tokio_1"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.4.0"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "backtrace 0.3.74": {
+      "name": "backtrace",
+      "version": "0.3.74",
+      "package_url": "https://github.com/rust-lang/backtrace-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/backtrace/0.3.74/download",
+          "sha256": "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+        }
+      },
+      "targets": [
         {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
+          "Library": {
+            "crate_name": "backtrace",
+            "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -1146,22 +1333,18 @@
         "deps": {
           "common": [
             {
-              "id": "backtrace 0.3.69",
-              "target": "build_script_build"
-            },
-            {
               "id": "cfg-if 1.0.0",
               "target": "cfg_if"
             },
             {
-              "id": "rustc-demangle 0.1.23",
+              "id": "rustc-demangle 0.1.24",
               "target": "rustc_demangle"
             }
           ],
           "selects": {
             "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
               {
-                "id": "addr2line 0.21.0",
+                "id": "addr2line 0.24.2",
                 "target": "addr2line"
               },
               {
@@ -1169,35 +1352,24 @@
                 "target": "libc"
               },
               {
-                "id": "miniz_oxide 0.7.2",
+                "id": "miniz_oxide 0.8.0",
                 "target": "miniz_oxide"
               },
               {
-                "id": "object 0.32.2",
+                "id": "object 0.36.5",
                 "target": "object"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-targets 0.52.6",
+                "target": "windows_targets"
               }
             ]
           }
         },
-        "edition": "2018",
-        "version": "0.3.69"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cc 1.0.83",
-              "target": "cc"
-            }
-          ],
-          "selects": {}
-        }
+        "edition": "2021",
+        "version": "0.3.74"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -1238,7 +1410,7 @@
         "deps": {
           "common": [
             {
-              "id": "backtrace 0.3.69",
+              "id": "backtrace 0.3.74",
               "target": "backtrace"
             }
           ],
@@ -1253,53 +1425,6 @@
         "MIT"
       ],
       "license_file": null
-    },
-    "base64 0.21.7": {
-      "name": "base64",
-      "version": "0.21.7",
-      "package_url": "https://github.com/marshallpierce/rust-base64",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/base64/0.21.7/download",
-          "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "base64",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "base64",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.21.7"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
     },
     "base64 0.22.1": {
       "name": "base64",
@@ -1342,45 +1467,6 @@
         "version": "0.22.1"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "base64ct 1.6.0": {
-      "name": "base64ct",
-      "version": "1.6.0",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/base64ct",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/base64ct/1.6.0/download",
-          "sha256": "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "base64ct",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "base64ct",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "1.6.0"
-      },
-      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -1464,14 +1550,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "bitflags 2.4.2": {
+    "bitflags 2.6.0": {
       "name": "bitflags",
-      "version": "2.4.2",
+      "version": "2.6.0",
       "package_url": "https://github.com/bitflags/bitflags",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/bitflags/2.4.2/download",
-          "sha256": "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+          "url": "https://static.crates.io/crates/bitflags/2.6.0/download",
+          "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
         }
       },
       "targets": [
@@ -1494,136 +1580,105 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "std"
+            ],
+            "aarch64-apple-ios": [
+              "std"
+            ],
+            "aarch64-apple-ios-sim": [
+              "std"
+            ],
+            "aarch64-fuchsia": [
+              "std"
+            ],
+            "aarch64-linux-android": [
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "std"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "std"
+            ],
+            "armv7-linux-androideabi": [
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "std"
+            ],
+            "i686-apple-darwin": [
+              "std"
+            ],
+            "i686-linux-android": [
+              "std"
+            ],
+            "i686-unknown-freebsd": [
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "std"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std"
+            ],
+            "thumbv7em-none-eabi": [
+              "std"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "std"
+            ],
+            "wasm32-unknown-unknown": [
+              "std"
+            ],
+            "wasm32-wasi": [
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "std"
+            ],
+            "x86_64-apple-ios": [
+              "std"
+            ],
+            "x86_64-fuchsia": [
+              "std"
+            ],
+            "x86_64-linux-android": [
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-none": [
+              "std"
+            ]
+          }
         },
         "edition": "2021",
-        "version": "2.4.2"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "bitvec 1.0.1": {
-      "name": "bitvec",
-      "version": "1.0.1",
-      "package_url": "https://github.com/bitvecto-rs/bitvec",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/bitvec/1.0.1/download",
-          "sha256": "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bitvec",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "bitvec",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "atomic",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "funty 2.0.0",
-              "target": "funty"
-            },
-            {
-              "id": "radium 0.7.0",
-              "target": "radium"
-            },
-            {
-              "id": "tap 1.0.1",
-              "target": "tap"
-            },
-            {
-              "id": "wyz 0.5.1",
-              "target": "wyz"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.0.1"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE.txt"
-    },
-    "blake2 0.10.6": {
-      "name": "blake2",
-      "version": "0.10.6",
-      "package_url": "https://github.com/RustCrypto/hashes",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/blake2/0.10.6/download",
-          "sha256": "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "blake2",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "blake2",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.10.6"
+        "version": "2.6.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -1680,14 +1735,107 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "bumpalo 3.14.0": {
+    "boxcar 0.2.6": {
+      "name": "boxcar",
+      "version": "0.2.6",
+      "package_url": "https://github.com/ibraheemdev/boxcar",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/boxcar/0.2.6/download",
+          "sha256": "fba19c552ee63cb6646b75e1166d1bdb8a6d34a6d19e319dec88c8adadff2db3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "boxcar",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "boxcar",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.2.6"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "bstr 1.10.0": {
+      "name": "bstr",
+      "version": "1.10.0",
+      "package_url": "https://github.com/BurntSushi/bstr",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/bstr/1.10.0/download",
+          "sha256": "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bstr",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "bstr",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "memchr 2.7.4",
+              "target": "memchr"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.10.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "bumpalo 3.16.0": {
       "name": "bumpalo",
-      "version": "3.14.0",
+      "version": "3.16.0",
       "package_url": "https://github.com/fitzgen/bumpalo",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/bumpalo/3.14.0/download",
-          "sha256": "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+          "url": "https://static.crates.io/crates/bumpalo/3.16.0/download",
+          "sha256": "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
         }
       },
       "targets": [
@@ -1716,7 +1864,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "3.14.0"
+        "version": "3.16.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -1724,6 +1872,132 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "bytecheck 0.8.0": {
+      "name": "bytecheck",
+      "version": "0.8.0",
+      "package_url": "https://github.com/rkyv/bytecheck",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/bytecheck/0.8.0/download",
+          "sha256": "50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bytecheck",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "bytecheck",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "simdutf8"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "ptr_meta 0.3.0",
+              "target": "ptr_meta"
+            },
+            {
+              "id": "rancor 0.1.0",
+              "target": "rancor"
+            },
+            {
+              "id": "simdutf8 0.1.5",
+              "target": "simdutf8"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "bytecheck_derive 0.8.0",
+              "target": "bytecheck_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.8.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "bytecheck_derive 0.8.0": {
+      "name": "bytecheck_derive",
+      "version": "0.8.0",
+      "package_url": "https://github.com/rkyv/bytecheck",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/bytecheck_derive/0.8.0/download",
+          "sha256": "523363cbe1df49b68215efdf500b103ac3b0fb4836aed6d15689a076eadb8fff"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "bytecheck_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "bytecheck_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.8.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "byteorder 1.5.0": {
       "name": "byteorder",
@@ -1935,11 +2209,11 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.83",
+              "id": "cc 1.1.31",
               "target": "cc"
             },
             {
-              "id": "pkg-config 0.3.29",
+              "id": "pkg-config 0.3.31",
               "target": "pkg_config"
             }
           ],
@@ -1954,20 +2228,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cacache 13.0.0": {
-      "name": "cacache",
-      "version": "13.0.0",
-      "package_url": "https://github.com/zkat/cacache-rs",
+    "cachedir 0.3.1": {
+      "name": "cachedir",
+      "version": "0.3.1",
+      "package_url": "https://github.com/jstasiak/cachedir",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cacache/13.0.0/download",
-          "sha256": "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7"
+          "url": "https://static.crates.io/crates/cachedir/0.3.1/download",
+          "sha256": "4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "cacache",
+            "crate_name": "cachedir",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -1978,177 +2252,148 @@
           }
         }
       ],
-      "library_target_name": "cacache",
+      "library_target_name": "cachedir",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "futures",
-            "libc",
-            "memmap2",
-            "mmap",
-            "tokio",
-            "tokio-runtime",
-            "tokio-stream"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "digest 0.10.7",
-              "target": "digest"
+              "id": "tempfile 3.13.0",
+              "target": "tempfile"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "cargo-util 0.2.15": {
+      "name": "cargo-util",
+      "version": "0.2.15",
+      "package_url": "https://github.com/rust-lang/cargo",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/cargo-util/0.2.15/download",
+          "sha256": "b6dd67a24439ca5260a08128b6cbf4b0f4453497a2f60508163ab9d5b534b122"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "cargo_util",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "cargo_util",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.91",
+              "target": "anyhow"
             },
             {
-              "id": "either 1.9.0",
-              "target": "either"
-            },
-            {
-              "id": "futures 0.3.30",
-              "target": "futures"
+              "id": "filetime 0.2.25",
+              "target": "filetime"
             },
             {
               "id": "hex 0.4.3",
               "target": "hex"
             },
             {
-              "id": "memmap2 0.5.10",
-              "target": "memmap2"
+              "id": "ignore 0.4.23",
+              "target": "ignore"
             },
             {
-              "id": "miette 5.10.0",
-              "target": "miette"
+              "id": "jobserver 0.1.32",
+              "target": "jobserver"
             },
             {
-              "id": "reflink-copy 0.1.14",
-              "target": "reflink_copy"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.132",
-              "target": "serde_json"
-            },
-            {
-              "id": "sha1 0.10.6",
-              "target": "sha1"
+              "id": "same-file 1.0.6",
+              "target": "same_file"
             },
             {
               "id": "sha2 0.10.8",
               "target": "sha2"
             },
             {
-              "id": "ssri 9.2.0",
-              "target": "ssri"
+              "id": "shell-escape 0.1.5",
+              "target": "shell_escape"
             },
             {
               "id": "tempfile 3.13.0",
               "target": "tempfile"
             },
             {
-              "id": "thiserror 1.0.65",
-              "target": "thiserror"
+              "id": "tracing 0.1.40",
+              "target": "tracing"
             },
             {
-              "id": "tokio 1.41.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tokio-stream 0.1.14",
-              "target": "tokio_stream"
-            },
-            {
-              "id": "walkdir 2.4.0",
+              "id": "walkdir 2.5.0",
               "target": "walkdir"
             }
           ],
           "selects": {
-            "aarch64-unknown-linux-gnu": [
+            "cfg(target_os = \"macos\")": [
+              {
+                "id": "core-foundation 0.9.4",
+                "target": "core_foundation"
+              }
+            ],
+            "cfg(unix)": [
               {
                 "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
-            "aarch64-unknown-nixos-gnu": [
+            "cfg(windows)": [
               {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ],
-            "arm-unknown-linux-gnueabi": [
+                "id": "miow 0.6.0",
+                "target": "miow"
+              },
               {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ],
-            "i686-unknown-linux-gnu": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ],
-            "powerpc-unknown-linux-gnu": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ],
-            "s390x-unknown-linux-gnu": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "serde_derive 1.0.213",
-              "target": "serde_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "13.0.0"
+        "version": "0.2.15"
       },
-      "license": "Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
-        "Apache-2.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE.md"
+      "license_file": "LICENSE-APACHE"
     },
-    "cc 1.0.83": {
+    "cc 1.1.31": {
       "name": "cc",
-      "version": "1.0.83",
+      "version": "1.1.31",
       "package_url": "https://github.com/rust-lang/cc-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cc/1.0.83/download",
-          "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+          "url": "https://static.crates.io/crates/cc/1.1.31/download",
+          "sha256": "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
         }
       },
       "targets": [
@@ -2172,7 +2417,6 @@
         ],
         "crate_features": {
           "common": [
-            "jobserver",
             "parallel"
           ],
           "selects": {}
@@ -2180,21 +2424,22 @@
         "deps": {
           "common": [
             {
-              "id": "jobserver 0.1.27",
+              "id": "jobserver 0.1.32",
               "target": "jobserver"
+            },
+            {
+              "id": "libc 0.2.161",
+              "target": "libc"
+            },
+            {
+              "id": "shlex 1.3.0",
+              "target": "shlex"
             }
           ],
-          "selects": {
-            "cfg(unix)": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.83"
+        "version": "1.1.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2242,20 +2487,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "chrono 0.4.33": {
-      "name": "chrono",
-      "version": "0.4.33",
-      "package_url": "https://github.com/chronotope/chrono",
+    "charset 0.1.5": {
+      "name": "charset",
+      "version": "0.1.5",
+      "package_url": "https://github.com/hsivonen/charset",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/chrono/0.4.33/download",
-          "sha256": "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+          "url": "https://static.crates.io/crates/charset/0.1.5/download",
+          "sha256": "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "chrono",
+            "crate_name": "charset",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -2266,7 +2511,7 @@
           }
         }
       ],
-      "library_target_name": "chrono",
+      "library_target_name": "charset",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -2274,226 +2519,20 @@
         "deps": {
           "common": [
             {
-              "id": "num-traits 0.2.17",
-              "target": "num_traits"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.33"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE.txt"
-    },
-    "ciborium 0.2.2": {
-      "name": "ciborium",
-      "version": "0.2.2",
-      "package_url": "https://github.com/enarx/ciborium",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ciborium/0.2.2/download",
-          "sha256": "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ciborium",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ciborium",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ciborium-io 0.2.2",
-              "target": "ciborium_io"
+              "id": "base64 0.22.1",
+              "target": "base64"
             },
             {
-              "id": "ciborium-ll 0.2.2",
-              "target": "ciborium_ll"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
+              "id": "encoding_rs 0.8.35",
+              "target": "encoding_rs"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.2.2"
+        "edition": "2018",
+        "version": "0.1.5"
       },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "ciborium-io 0.2.2": {
-      "name": "ciborium-io",
-      "version": "0.2.2",
-      "package_url": "https://github.com/enarx/ciborium",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ciborium-io/0.2.2/download",
-          "sha256": "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ciborium_io",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ciborium_io",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.2.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "ciborium-ll 0.2.2": {
-      "name": "ciborium-ll",
-      "version": "0.2.2",
-      "package_url": "https://github.com/enarx/ciborium",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ciborium-ll/0.2.2/download",
-          "sha256": "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ciborium_ll",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ciborium_ll",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "ciborium-io 0.2.2",
-              "target": "ciborium_io"
-            },
-            {
-              "id": "half 2.3.1",
-              "target": "half"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.2.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "cipher 0.4.4": {
-      "name": "cipher",
-      "version": "0.4.4",
-      "package_url": "https://github.com/RustCrypto/traits",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/cipher/0.4.4/download",
-          "sha256": "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "cipher",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "cipher",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "crypto-common 0.1.6",
-              "target": "crypto_common"
-            },
-            {
-              "id": "inout 0.1.3",
-              "target": "inout"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.4"
-      },
-      "license": "MIT OR Apache-2.0",
+      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -2613,7 +2652,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstream 0.6.11",
+              "id": "anstream 0.6.15",
               "target": "anstream"
             },
             {
@@ -2687,11 +2726,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
@@ -2746,14 +2785,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "colorchoice 1.0.0": {
+    "colorchoice 1.0.2": {
       "name": "colorchoice",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "package_url": "https://github.com/rust-cli/anstyle",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/colorchoice/1.0.0/download",
-          "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+          "url": "https://static.crates.io/crates/colorchoice/1.0.2/download",
+          "sha256": "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
         }
       },
       "targets": [
@@ -2776,7 +2815,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "1.0.0"
+        "version": "1.0.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2785,68 +2824,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "concurrent-queue 2.5.0": {
-      "name": "concurrent-queue",
-      "version": "2.5.0",
-      "package_url": "https://github.com/smol-rs/concurrent-queue",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/concurrent-queue/2.5.0/download",
-          "sha256": "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "concurrent_queue",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "concurrent_queue",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "crossbeam-utils 0.8.19",
-              "target": "crossbeam_utils"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.5.0"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "configparser 3.0.4": {
+    "configparser 3.1.0": {
       "name": "configparser",
-      "version": "3.0.4",
+      "version": "3.1.0",
       "package_url": "https://github.com/QEDK/configparser-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/configparser/3.0.4/download",
-          "sha256": "4ec6d3da8e550377a85339063af6e3735f4b1d9392108da4e083a1b3b9820288"
+          "url": "https://static.crates.io/crates/configparser/3.1.0/download",
+          "sha256": "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
         }
       },
       "targets": [
@@ -2869,7 +2854,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "3.0.4"
+        "version": "3.1.0"
       },
       "license": "MIT OR LGPL-3.0-or-later",
       "license_ids": [
@@ -2878,20 +2863,20 @@
       ],
       "license_file": "LICENSE-LGPL"
     },
-    "constant_time_eq 0.1.5": {
-      "name": "constant_time_eq",
-      "version": "0.1.5",
-      "package_url": "https://github.com/cesarb/constant_time_eq",
+    "core-foundation 0.9.4": {
+      "name": "core-foundation",
+      "version": "0.9.4",
+      "package_url": "https://github.com/servo/core-foundation-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/constant_time_eq/0.1.5/download",
-          "sha256": "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+          "url": "https://static.crates.io/crates/core-foundation/0.9.4/download",
+          "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "constant_time_eq",
+            "crate_name": "core_foundation",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -2902,28 +2887,50 @@
           }
         }
       ],
-      "library_target_name": "constant_time_eq",
+      "library_target_name": "core_foundation",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2015",
-        "version": "0.1.5"
+        "crate_features": {
+          "common": [
+            "default",
+            "link",
+            "mac_os_10_7_support"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "core-foundation-sys 0.8.7",
+              "target": "core_foundation_sys"
+            },
+            {
+              "id": "libc 0.2.161",
+              "target": "libc"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.9.4"
       },
-      "license": "CC0-1.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
-        "CC0-1.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE.txt"
+      "license_file": "LICENSE-APACHE"
     },
-    "core-foundation-sys 0.8.6": {
+    "core-foundation-sys 0.8.7": {
       "name": "core-foundation-sys",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "package_url": "https://github.com/servo/core-foundation-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/core-foundation-sys/0.8.6/download",
-          "sha256": "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+          "url": "https://static.crates.io/crates/core-foundation-sys/0.8.7/download",
+          "sha256": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
         }
       },
       "targets": [
@@ -2945,8 +2952,16 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "link",
+            "mac_os_10_7_support"
+          ],
+          "selects": {}
+        },
         "edition": "2018",
-        "version": "0.8.6"
+        "version": "0.8.7"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2955,14 +2970,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cpufeatures 0.2.12": {
+    "cpufeatures 0.2.14": {
       "name": "cpufeatures",
-      "version": "0.2.12",
+      "version": "0.2.14",
       "package_url": "https://github.com/RustCrypto/utils",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cpufeatures/0.2.12/download",
-          "sha256": "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+          "url": "https://static.crates.io/crates/cpufeatures/0.2.14/download",
+          "sha256": "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
         }
       },
       "targets": [
@@ -3014,7 +3029,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.2.12"
+        "version": "0.2.14"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -3023,14 +3038,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "crc32fast 1.3.2": {
+    "crc32fast 1.4.2": {
       "name": "crc32fast",
-      "version": "1.3.2",
+      "version": "1.4.2",
       "package_url": "https://github.com/srijs/rust-crc32fast",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/crc32fast/1.3.2/download",
-          "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+          "url": "https://static.crates.io/crates/crc32fast/1.4.2/download",
+          "sha256": "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
         }
       },
       "targets": [
@@ -3038,18 +3053,6 @@
           "Library": {
             "crate_name": "crc32fast",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -3076,24 +3079,12 @@
             {
               "id": "cfg-if 1.0.0",
               "target": "cfg_if"
-            },
-            {
-              "id": "crc32fast 1.3.2",
-              "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.3.2"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ]
+        "version": "1.4.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -3102,14 +3093,128 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "crossbeam-utils 0.8.19": {
-      "name": "crossbeam-utils",
-      "version": "0.8.19",
+    "crossbeam-deque 0.8.5": {
+      "name": "crossbeam-deque",
+      "version": "0.8.5",
       "package_url": "https://github.com/crossbeam-rs/crossbeam",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/crossbeam-utils/0.8.19/download",
-          "sha256": "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+          "url": "https://static.crates.io/crates/crossbeam-deque/0.8.5/download",
+          "sha256": "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crossbeam_deque",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crossbeam_deque",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "crossbeam-epoch 0.9.18",
+              "target": "crossbeam_epoch"
+            },
+            {
+              "id": "crossbeam-utils 0.8.20",
+              "target": "crossbeam_utils"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.8.5"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "crossbeam-epoch 0.9.18": {
+      "name": "crossbeam-epoch",
+      "version": "0.9.18",
+      "package_url": "https://github.com/crossbeam-rs/crossbeam",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crossbeam-epoch/0.9.18/download",
+          "sha256": "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crossbeam_epoch",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crossbeam_epoch",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "crossbeam-utils 0.8.20",
+              "target": "crossbeam_utils"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.9.18"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "crossbeam-utils 0.8.20": {
+      "name": "crossbeam-utils",
+      "version": "0.8.20",
+      "package_url": "https://github.com/crossbeam-rs/crossbeam",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crossbeam-utils/0.8.20/download",
+          "sha256": "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
         }
       },
       "targets": [
@@ -3144,45 +3249,23 @@
           "**"
         ],
         "crate_features": {
-          "common": [],
-          "selects": {
-            "arm-unknown-linux-gnueabi": [
-              "default",
-              "std"
-            ],
-            "armv7-linux-androideabi": [
-              "default",
-              "std"
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              "default",
-              "std"
-            ],
-            "powerpc-unknown-linux-gnu": [
-              "default",
-              "std"
-            ],
-            "thumbv7em-none-eabi": [
-              "default",
-              "std"
-            ],
-            "thumbv8m.main-none-eabi": [
-              "default",
-              "std"
-            ]
-          }
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "crossbeam-utils 0.8.19",
+              "id": "crossbeam-utils 0.8.20",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.19"
+        "version": "0.8.20"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -3198,73 +3281,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "crunchy 0.2.2": {
-      "name": "crunchy",
-      "version": "0.2.2",
-      "package_url": null,
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/crunchy/0.2.2/download",
-          "sha256": "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "crunchy",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "crunchy",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "crunchy 0.2.2",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.2.2"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": null
     },
     "crypto-common 0.1.6": {
       "name": "crypto-common",
@@ -3360,11 +3376,11 @@
               "target": "csv_core"
             },
             {
-              "id": "itoa 1.0.10",
+              "id": "itoa 1.0.11",
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.16",
+              "id": "ryu 1.0.18",
               "target": "ryu"
             },
             {
@@ -3422,7 +3438,7 @@
         "deps": {
           "common": [
             {
-              "id": "memchr 2.7.1",
+              "id": "memchr 2.7.4",
               "target": "memchr"
             }
           ],
@@ -3438,20 +3454,20 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "darling 0.20.5": {
-      "name": "darling",
-      "version": "0.20.5",
-      "package_url": "https://github.com/TedDriggs/darling",
+    "dashmap 6.1.0": {
+      "name": "dashmap",
+      "version": "6.1.0",
+      "package_url": "https://github.com/xacrimon/dashmap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/darling/0.20.5/download",
-          "sha256": "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+          "url": "https://static.crates.io/crates/dashmap/6.1.0/download",
+          "sha256": "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "darling",
+            "crate_name": "dashmap",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -3462,144 +3478,7 @@
           }
         }
       ],
-      "library_target_name": "darling",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "suggestions"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "darling_core 0.20.5",
-              "target": "darling_core"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "darling_macro 0.20.5",
-              "target": "darling_macro"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.20.5"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "darling_core 0.20.5": {
-      "name": "darling_core",
-      "version": "0.20.5",
-      "package_url": "https://github.com/TedDriggs/darling",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/darling_core/0.20.5/download",
-          "sha256": "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "darling_core",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "darling_core",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "strsim",
-            "suggestions"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "fnv 1.0.7",
-              "target": "fnv"
-            },
-            {
-              "id": "ident_case 1.0.1",
-              "target": "ident_case"
-            },
-            {
-              "id": "proc-macro2 1.0.89",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "strsim 0.10.0",
-              "target": "strsim"
-            },
-            {
-              "id": "syn 2.0.82",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.20.5"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "darling_macro 0.20.5": {
-      "name": "darling_macro",
-      "version": "0.20.5",
-      "package_url": "https://github.com/TedDriggs/darling",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/darling_macro/0.20.5/download",
-          "sha256": "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "darling_macro",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "darling_macro",
+      "library_target_name": "dashmap",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -3607,22 +3486,34 @@
         "deps": {
           "common": [
             {
-              "id": "darling_core 0.20.5",
-              "target": "darling_core"
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
             },
             {
-              "id": "quote 1.0.35",
-              "target": "quote"
+              "id": "crossbeam-utils 0.8.20",
+              "target": "crossbeam_utils"
             },
             {
-              "id": "syn 2.0.82",
-              "target": "syn"
+              "id": "hashbrown 0.14.5",
+              "target": "hashbrown"
+            },
+            {
+              "id": "lock_api 0.4.12",
+              "target": "lock_api"
+            },
+            {
+              "id": "once_cell 1.20.2",
+              "target": "once_cell"
+            },
+            {
+              "id": "parking_lot_core 0.9.10",
+              "target": "parking_lot_core"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.20.5"
+        "version": "6.1.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -3630,14 +3521,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "data-encoding 2.5.0": {
+    "data-encoding 2.6.0": {
       "name": "data-encoding",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "package_url": "https://github.com/ia0/data-encoding",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/data-encoding/2.5.0/download",
-          "sha256": "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+          "url": "https://static.crates.io/crates/data-encoding/2.6.0/download",
+          "sha256": "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
         }
       },
       "targets": [
@@ -3668,69 +3559,13 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.5.0"
+        "version": "2.6.0"
       },
       "license": "MIT",
       "license_ids": [
         "MIT"
       ],
       "license_file": "LICENSE"
-    },
-    "deranged 0.3.11": {
-      "name": "deranged",
-      "version": "0.3.11",
-      "package_url": "https://github.com/jhpratt/deranged",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/deranged/0.3.11/download",
-          "sha256": "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "deranged",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "deranged",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "powerfmt",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "powerfmt 0.2.0",
-              "target": "powerfmt"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.3.11"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-Apache"
     },
     "digest 0.10.7": {
       "name": "digest",
@@ -3767,9 +3602,7 @@
             "block-buffer",
             "core-api",
             "default",
-            "mac",
-            "std",
-            "subtle"
+            "std"
           ],
           "selects": {}
         },
@@ -3782,10 +3615,6 @@
             {
               "id": "crypto-common 0.1.6",
               "target": "crypto_common"
-            },
-            {
-              "id": "subtle 2.5.0",
-              "target": "subtle"
             }
           ],
           "selects": {}
@@ -3800,14 +3629,129 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "dunce 1.0.4": {
+    "directories 5.0.1": {
+      "name": "directories",
+      "version": "5.0.1",
+      "package_url": "https://github.com/soc/directories-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/directories/5.0.1/download",
+          "sha256": "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "directories",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "directories",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "dirs-sys 0.4.1",
+              "target": "dirs_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "5.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "dirs-sys 0.4.1": {
+      "name": "dirs-sys",
+      "version": "0.4.1",
+      "package_url": "https://github.com/dirs-dev/dirs-sys-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/dirs-sys/0.4.1/download",
+          "sha256": "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "dirs_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "dirs_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "option-ext 0.2.0",
+              "target": "option_ext"
+            }
+          ],
+          "selects": {
+            "cfg(target_os = \"redox\")": [
+              {
+                "id": "redox_users 0.4.6",
+                "target": "redox_users"
+              }
+            ],
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.48.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2015",
+        "version": "0.4.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "dunce 1.0.5": {
       "name": "dunce",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "package_url": "https://gitlab.com/kornelski/dunce",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/dunce/1.0.4/download",
-          "sha256": "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+          "url": "https://static.crates.io/crates/dunce/1.0.5/download",
+          "sha256": "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
         }
       },
       "targets": [
@@ -3830,7 +3774,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "1.0.4"
+        "version": "1.0.5"
       },
       "license": "CC0-1.0 OR MIT-0 OR Apache-2.0",
       "license_ids": [
@@ -3840,14 +3784,53 @@
       ],
       "license_file": "LICENSE"
     },
-    "either 1.9.0": {
-      "name": "either",
-      "version": "1.9.0",
-      "package_url": "https://github.com/bluss/either",
+    "dyn-clone 1.0.17": {
+      "name": "dyn-clone",
+      "version": "1.0.17",
+      "package_url": "https://github.com/dtolnay/dyn-clone",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/either/1.9.0/download",
-          "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+          "url": "https://static.crates.io/crates/dyn-clone/1.0.17/download",
+          "sha256": "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "dyn_clone",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "dyn_clone",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "1.0.17"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "either 1.13.0": {
+      "name": "either",
+      "version": "1.13.0",
+      "package_url": "https://github.com/rayon-rs/either",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/either/1.13.0/download",
+          "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
         }
       },
       "targets": [
@@ -3877,7 +3860,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.9.0"
+        "version": "1.13.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -3886,20 +3869,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "elsa 1.10.0": {
-      "name": "elsa",
-      "version": "1.10.0",
-      "package_url": "https://github.com/manishearth/elsa",
+    "encoding_rs 0.8.35": {
+      "name": "encoding_rs",
+      "version": "0.8.35",
+      "package_url": "https://github.com/hsivonen/encoding_rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/elsa/1.10.0/download",
-          "sha256": "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
+          "url": "https://static.crates.io/crates/encoding_rs/0.8.35/download",
+          "sha256": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "elsa",
+            "crate_name": "encoding_rs",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -3910,13 +3893,14 @@
           }
         }
       ],
-      "library_target_name": "elsa",
+      "library_target_name": "encoding_rs",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
         "crate_features": {
           "common": [
+            "alloc",
             "default"
           ],
           "selects": {}
@@ -3924,16 +3908,65 @@
         "deps": {
           "common": [
             {
-              "id": "stable_deref_trait 1.2.0",
-              "target": "stable_deref_trait"
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.10.0"
+        "version": "0.8.35"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause",
+      "license_ids": [
+        "Apache-2.0",
+        "BSD-3-Clause",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "encoding_rs_io 0.1.7": {
+      "name": "encoding_rs_io",
+      "version": "0.1.7",
+      "package_url": "https://github.com/BurntSushi/encoding_rs_io",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/encoding_rs_io/0.1.7/download",
+          "sha256": "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "encoding_rs_io",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "encoding_rs_io",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "encoding_rs 0.8.35",
+              "target": "encoding_rs"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.1.7"
+      },
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -3979,14 +4012,72 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "errno 0.3.8": {
+    "erased-serde 0.4.5": {
+      "name": "erased-serde",
+      "version": "0.4.5",
+      "package_url": "https://github.com/dtolnay/erased-serde",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/erased-serde/0.4.5/download",
+          "sha256": "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "erased_serde",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "erased_serde",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "typeid 1.0.2",
+              "target": "typeid"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.4.5"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "errno 0.3.9": {
       "name": "errno",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "package_url": "https://github.com/lambda-fairy/rust-errno",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/errno/0.3.8/download",
-          "sha256": "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+          "url": "https://static.crates.io/crates/errno/0.3.9/download",
+          "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
         }
       },
       "targets": [
@@ -4044,7 +4135,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.3.8"
+        "version": "0.3.9"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -4053,20 +4144,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "event-listener 5.3.1": {
-      "name": "event-listener",
-      "version": "5.3.1",
-      "package_url": "https://github.com/smol-rs/event-listener",
+    "etcetera 0.8.0": {
+      "name": "etcetera",
+      "version": "0.8.0",
+      "package_url": "https://github.com/lunacookies/etcetera",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/event-listener/5.3.1/download",
-          "sha256": "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+          "url": "https://static.crates.io/crates/etcetera/0.8.0/download",
+          "sha256": "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "event_listener",
+            "crate_name": "etcetera",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -4077,229 +4168,35 @@
           }
         }
       ],
-      "library_target_name": "event_listener",
+      "library_target_name": "etcetera",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "parking",
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "concurrent-queue 2.5.0",
-              "target": "concurrent_queue"
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
             },
             {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
+              "id": "home 0.5.9",
+              "target": "home"
             }
           ],
           "selects": {
-            "aarch64-apple-darwin": [
+            "cfg(windows)": [
               {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "aarch64-apple-ios": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "aarch64-apple-ios-sim": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "aarch64-fuchsia": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "aarch64-linux-android": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "aarch64-pc-windows-msvc": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "aarch64-unknown-linux-gnu": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "aarch64-unknown-nixos-gnu": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "aarch64-unknown-nto-qnx710": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "arm-unknown-linux-gnueabi": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "armv7-linux-androideabi": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "i686-apple-darwin": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "i686-linux-android": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "i686-pc-windows-msvc": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "i686-unknown-freebsd": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "i686-unknown-linux-gnu": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "powerpc-unknown-linux-gnu": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "riscv32imc-unknown-none-elf": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "riscv64gc-unknown-none-elf": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "s390x-unknown-linux-gnu": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "thumbv7em-none-eabi": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "thumbv8m.main-none-eabi": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-apple-darwin": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-apple-ios": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-fuchsia": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-linux-android": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-unknown-freebsd": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-unknown-none": [
-              {
-                "id": "parking 2.2.1",
-                "target": "parking"
+                "id": "windows-sys 0.48.0",
+                "target": "windows_sys"
               }
             ]
           }
         },
-        "edition": "2021",
-        "version": "5.3.1"
+        "edition": "2018",
+        "version": "0.8.0"
       },
-      "license": "Apache-2.0 OR MIT",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -4353,14 +4250,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "filetime 0.2.23": {
+    "filetime 0.2.25": {
       "name": "filetime",
-      "version": "0.2.23",
+      "version": "0.2.25",
       "package_url": "https://github.com/alexcrichton/filetime",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/filetime/0.2.23/download",
-          "sha256": "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+          "url": "https://static.crates.io/crates/filetime/0.2.25/download",
+          "sha256": "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
         }
       },
       "targets": [
@@ -4392,8 +4289,8 @@
           "selects": {
             "cfg(target_os = \"redox\")": [
               {
-                "id": "redox_syscall 0.4.1",
-                "target": "syscall"
+                "id": "libredox 0.1.3",
+                "target": "libredox"
               }
             ],
             "cfg(unix)": [
@@ -4404,14 +4301,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.52.0",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.23"
+        "version": "0.2.25"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -4420,53 +4317,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "fixedbitset 0.4.2": {
-      "name": "fixedbitset",
-      "version": "0.4.2",
-      "package_url": "https://github.com/petgraph/fixedbitset",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/fixedbitset/0.4.2/download",
-          "sha256": "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "fixedbitset",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "fixedbitset",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.4.2"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "flate2 1.0.28": {
+    "flate2 1.0.34": {
       "name": "flate2",
-      "version": "1.0.28",
+      "version": "1.0.34",
       "package_url": "https://github.com/rust-lang/flate2-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/flate2/1.0.28/download",
-          "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+          "url": "https://static.crates.io/crates/flate2/1.0.34/download",
+          "sha256": "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
         }
       },
       "targets": [
@@ -4500,18 +4358,18 @@
         "deps": {
           "common": [
             {
-              "id": "crc32fast 1.3.2",
+              "id": "crc32fast 1.4.2",
               "target": "crc32fast"
             },
             {
-              "id": "miniz_oxide 0.7.2",
+              "id": "miniz_oxide 0.8.0",
               "target": "miniz_oxide"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.28"
+        "version": "1.0.34"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -4663,11 +4521,21 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "tokio"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
               "id": "fs-err 2.11.0",
               "target": "build_script_build"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
             }
           ],
           "selects": {}
@@ -4685,7 +4553,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.4.0",
               "target": "autocfg"
             }
           ],
@@ -4699,20 +4567,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "fs4 0.8.4": {
-      "name": "fs4",
-      "version": "0.8.4",
-      "package_url": "https://github.com/al8n/fs4-rs",
+    "fs2 0.4.3": {
+      "name": "fs2",
+      "version": "0.4.3",
+      "package_url": "https://github.com/danburkert/fs2-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/fs4/0.8.4/download",
-          "sha256": "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+          "url": "https://static.crates.io/crates/fs2/0.4.3/download",
+          "sha256": "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "fs4",
+            "crate_name": "fs2",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -4723,129 +4591,46 @@
           }
         }
       ],
-      "library_target_name": "fs4",
+      "library_target_name": "fs2",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "sync"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [],
           "selects": {
-            "cfg(not(windows))": [
+            "cfg(unix)": [
               {
-                "id": "rustix 0.38.37",
-                "target": "rustix"
+                "id": "libc 0.2.161",
+                "target": "libc"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.52.0",
-                "target": "windows_sys"
+                "id": "winapi 0.3.9",
+                "target": "winapi"
               }
             ]
           }
         },
-        "edition": "2021",
-        "version": "0.8.4"
+        "edition": "2015",
+        "version": "0.4.3"
       },
-      "license": "MIT OR Apache-2.0",
+      "license": "MIT/Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "fs_extra 1.3.0": {
-      "name": "fs_extra",
-      "version": "1.3.0",
-      "package_url": "https://github.com/webdesus/fs_extra",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/fs_extra/1.3.0/download",
-          "sha256": "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "fs_extra",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "fs_extra",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "1.3.0"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "funty 2.0.0": {
-      "name": "funty",
-      "version": "2.0.0",
-      "package_url": "https://github.com/myrrlyn/funty",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/funty/2.0.0/download",
-          "sha256": "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "funty",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "funty",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "2.0.0"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE.txt"
-    },
-    "futures 0.3.30": {
+    "futures 0.3.31": {
       "name": "futures",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures/0.3.30/download",
-          "sha256": "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+          "url": "https://static.crates.io/crates/futures/0.3.31/download",
+          "sha256": "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
         }
       },
       "targets": [
@@ -4881,38 +4666,38 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.30",
+              "id": "futures-channel 0.3.31",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "futures-executor 0.3.30",
+              "id": "futures-executor 0.3.31",
               "target": "futures_executor"
             },
             {
-              "id": "futures-io 0.3.30",
+              "id": "futures-io 0.3.31",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.30",
+              "id": "futures-sink 0.3.31",
               "target": "futures_sink"
             },
             {
-              "id": "futures-task 0.3.30",
+              "id": "futures-task 0.3.31",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.30",
+              "id": "futures-util 0.3.31",
               "target": "futures_util"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -4921,14 +4706,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "futures-channel 0.3.30": {
+    "futures-channel 0.3.31": {
       "name": "futures-channel",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures-channel/0.3.30/download",
-          "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+          "url": "https://static.crates.io/crates/futures-channel/0.3.31/download",
+          "sha256": "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
         }
       },
       "targets": [
@@ -5059,18 +4844,18 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "futures-sink 0.3.30",
+              "id": "futures-sink 0.3.31",
               "target": "futures_sink"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5079,14 +4864,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "futures-core 0.3.30": {
+    "futures-core 0.3.31": {
       "name": "futures-core",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures-core/0.3.30/download",
-          "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+          "url": "https://static.crates.io/crates/futures-core/0.3.31/download",
+          "sha256": "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
         }
       },
       "targets": [
@@ -5117,7 +4902,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5126,14 +4911,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "futures-executor 0.3.30": {
+    "futures-executor 0.3.31": {
       "name": "futures-executor",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures-executor/0.3.30/download",
-          "sha256": "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+          "url": "https://static.crates.io/crates/futures-executor/0.3.31/download",
+          "sha256": "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
         }
       },
       "targets": [
@@ -5164,22 +4949,22 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "futures-task 0.3.30",
+              "id": "futures-task 0.3.31",
               "target": "futures_task"
             },
             {
-              "id": "futures-util 0.3.30",
+              "id": "futures-util 0.3.31",
               "target": "futures_util"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5188,14 +4973,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "futures-io 0.3.30": {
+    "futures-io 0.3.31": {
       "name": "futures-io",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures-io/0.3.30/download",
-          "sha256": "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+          "url": "https://static.crates.io/crates/futures-io/0.3.31/download",
+          "sha256": "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
         }
       },
       "targets": [
@@ -5225,7 +5010,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5280,11 +5065,11 @@
               "target": "fastrand"
             },
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.30",
+              "id": "futures-io 0.3.31",
               "target": "futures_io"
             },
             {
@@ -5292,7 +5077,7 @@
               "target": "parking"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             }
           ],
@@ -5308,14 +5093,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "futures-macro 0.3.30": {
+    "futures-macro 0.3.31": {
       "name": "futures-macro",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures-macro/0.3.30/download",
-          "sha256": "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+          "url": "https://static.crates.io/crates/futures-macro/0.3.31/download",
+          "sha256": "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
         }
       },
       "targets": [
@@ -5344,18 +5129,18 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5364,14 +5149,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "futures-sink 0.3.30": {
+    "futures-sink 0.3.31": {
       "name": "futures-sink",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures-sink/0.3.30/download",
-          "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+          "url": "https://static.crates.io/crates/futures-sink/0.3.31/download",
+          "sha256": "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
         }
       },
       "targets": [
@@ -5402,7 +5187,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5411,14 +5196,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "futures-task 0.3.30": {
+    "futures-task 0.3.31": {
       "name": "futures-task",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures-task/0.3.30/download",
-          "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+          "url": "https://static.crates.io/crates/futures-task/0.3.31/download",
+          "sha256": "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
         }
       },
       "targets": [
@@ -5448,7 +5233,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5457,14 +5242,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "futures-util 0.3.30": {
+    "futures-util 0.3.31": {
       "name": "futures-util",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/futures-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/futures-util/0.3.30/download",
-          "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+          "url": "https://static.crates.io/crates/futures-util/0.3.31/download",
+          "sha256": "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
         }
       },
       "targets": [
@@ -5514,31 +5299,31 @@
         "deps": {
           "common": [
             {
-              "id": "futures-channel 0.3.30",
+              "id": "futures-channel 0.3.31",
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.30",
+              "id": "futures-io 0.3.31",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.30",
+              "id": "futures-sink 0.3.31",
               "target": "futures_sink"
             },
             {
-              "id": "futures-task 0.3.30",
+              "id": "futures-task 0.3.31",
               "target": "futures_task"
             },
             {
-              "id": "memchr 2.7.1",
+              "id": "memchr 2.7.4",
               "target": "memchr"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             },
             {
@@ -5556,13 +5341,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "futures-macro 0.3.30",
+              "id": "futures-macro 0.3.31",
               "target": "futures_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.30"
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5614,8 +5399,7 @@
         ],
         "crate_features": {
           "common": [
-            "more_lengths",
-            "serde"
+            "more_lengths"
           ],
           "selects": {}
         },
@@ -5624,10 +5408,6 @@
             {
               "id": "generic-array 0.14.7",
               "target": "build_script_build"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
             },
             {
               "id": "typenum 1.17.0",
@@ -5649,7 +5429,7 @@
         "deps": {
           "common": [
             {
-              "id": "version_check 0.9.4",
+              "id": "version_check 0.9.5",
               "target": "version_check"
             }
           ],
@@ -5662,14 +5442,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "getrandom 0.2.12": {
+    "getrandom 0.2.15": {
       "name": "getrandom",
-      "version": "0.2.12",
+      "version": "0.2.15",
       "package_url": "https://github.com/rust-random/getrandom",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/getrandom/0.2.12/download",
-          "sha256": "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+          "url": "https://static.crates.io/crates/getrandom/0.2.15/download",
+          "sha256": "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
         }
       },
       "targets": [
@@ -5691,6 +5471,23 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "js",
+              "js-sys",
+              "wasm-bindgen"
+            ],
+            "wasm32-wasi": [
+              "js",
+              "js-sys",
+              "wasm-bindgen"
+            ]
+          }
+        },
         "deps": {
           "common": [
             {
@@ -5710,11 +5507,21 @@
                 "id": "libc 0.2.161",
                 "target": "libc"
               }
+            ],
+            "wasm32-unknown-unknown": [
+              {
+                "id": "js-sys 0.3.72",
+                "target": "js_sys"
+              },
+              {
+                "id": "wasm-bindgen 0.2.95",
+                "target": "wasm_bindgen"
+              }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.12"
+        "version": "0.2.15"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5723,14 +5530,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "gimli 0.28.1": {
+    "gimli 0.31.1": {
       "name": "gimli",
-      "version": "0.28.1",
+      "version": "0.31.1",
       "package_url": "https://github.com/gimli-rs/gimli",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/gimli/0.28.1/download",
-          "sha256": "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+          "url": "https://static.crates.io/crates/gimli/0.31.1/download",
+          "sha256": "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
         }
       },
       "targets": [
@@ -5760,7 +5567,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.28.1"
+        "version": "0.31.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5769,20 +5576,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "half 2.3.1": {
-      "name": "half",
-      "version": "2.3.1",
-      "package_url": "https://github.com/starkat99/half-rs",
+    "globset 0.4.15": {
+      "name": "globset",
+      "version": "0.4.15",
+      "package_url": "https://github.com/BurntSushi/ripgrep/tree/master/crates/globset",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/half/2.3.1/download",
-          "sha256": "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+          "url": "https://static.crates.io/crates/globset/0.4.15/download",
+          "sha256": "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "half",
+            "crate_name": "globset",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -5793,7 +5600,78 @@
           }
         }
       ],
-      "library_target_name": "half",
+      "library_target_name": "globset",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "log"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "aho-corasick 1.1.3",
+              "target": "aho_corasick"
+            },
+            {
+              "id": "bstr 1.10.0",
+              "target": "bstr"
+            },
+            {
+              "id": "log 0.4.22",
+              "target": "log"
+            },
+            {
+              "id": "regex-automata 0.4.8",
+              "target": "regex_automata"
+            },
+            {
+              "id": "regex-syntax 0.8.5",
+              "target": "regex_syntax"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.4.15"
+      },
+      "license": "Unlicense OR MIT",
+      "license_ids": [
+        "MIT",
+        "Unlicense"
+      ],
+      "license_file": "LICENSE-MIT"
+    },
+    "globwalk 0.9.1": {
+      "name": "globwalk",
+      "version": "0.9.1",
+      "package_url": "https://github.com/gilnaa/globwalk",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/globwalk/0.9.1/download",
+          "sha256": "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "globwalk",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "globwalk",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -5801,37 +5679,190 @@
         "deps": {
           "common": [
             {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
+              "id": "bitflags 2.6.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "ignore 0.4.23",
+              "target": "ignore"
+            },
+            {
+              "id": "walkdir 2.5.0",
+              "target": "walkdir"
             }
           ],
-          "selects": {
-            "cfg(target_arch = \"spirv\")": [
-              {
-                "id": "crunchy 0.2.2",
-                "target": "crunchy"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
-        "version": "2.3.1"
+        "version": "0.9.1"
       },
-      "license": "MIT OR Apache-2.0",
+      "license": "MIT",
       "license_ids": [
-        "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE"
     },
-    "hashbrown 0.12.3": {
+    "goblin 0.8.2": {
+      "name": "goblin",
+      "version": "0.8.2",
+      "package_url": "https://github.com/m4b/goblin",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/goblin/0.8.2/download",
+          "sha256": "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "goblin",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "goblin",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "elf32",
+            "elf64",
+            "endian_fd",
+            "log",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "log 0.4.22",
+              "target": "log"
+            },
+            {
+              "id": "plain 0.2.3",
+              "target": "plain"
+            },
+            {
+              "id": "scroll 0.12.0",
+              "target": "scroll"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.8.2"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "h2 0.4.6": {
+      "name": "h2",
+      "version": "0.4.6",
+      "package_url": "https://github.com/hyperium/h2",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/h2/0.4.6/download",
+          "sha256": "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "h2",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "h2",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "atomic-waker 1.1.2",
+              "target": "atomic_waker"
+            },
+            {
+              "id": "bytes 1.8.0",
+              "target": "bytes"
+            },
+            {
+              "id": "fnv 1.0.7",
+              "target": "fnv"
+            },
+            {
+              "id": "futures-core 0.3.31",
+              "target": "futures_core"
+            },
+            {
+              "id": "futures-sink 0.3.31",
+              "target": "futures_sink"
+            },
+            {
+              "id": "http 1.1.0",
+              "target": "http"
+            },
+            {
+              "id": "indexmap 2.6.0",
+              "target": "indexmap"
+            },
+            {
+              "id": "slab 0.4.9",
+              "target": "slab"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-util 0.7.12",
+              "target": "tokio_util"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.4.6"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "hashbrown 0.14.5": {
       "name": "hashbrown",
-      "version": "0.12.3",
+      "version": "0.14.5",
       "package_url": "https://github.com/rust-lang/hashbrown",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/hashbrown/0.12.3/download",
-          "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+          "url": "https://static.crates.io/crates/hashbrown/0.14.5/download",
+          "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
         }
       },
       "targets": [
@@ -5853,8 +5884,14 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "raw"
+          ],
+          "selects": {}
+        },
         "edition": "2021",
-        "version": "0.12.3"
+        "version": "0.14.5"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -6027,60 +6064,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "hmac 0.12.1": {
-      "name": "hmac",
-      "version": "0.12.1",
-      "package_url": "https://github.com/RustCrypto/MACs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/hmac/0.12.1/download",
-          "sha256": "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "hmac",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "hmac",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "reset"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.12.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "home 0.5.9": {
       "name": "home",
       "version": "0.5.9",
@@ -6232,7 +6215,7 @@
               "target": "fnv"
             },
             {
-              "id": "itoa 1.0.10",
+              "id": "itoa 1.0.11",
               "target": "itoa"
             }
           ],
@@ -6335,7 +6318,7 @@
               "target": "bytes"
             },
             {
-              "id": "futures-util 0.3.30",
+              "id": "futures-util 0.3.31",
               "target": "futures_util"
             },
             {
@@ -6347,7 +6330,7 @@
               "target": "http_body"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             }
           ],
@@ -6362,84 +6345,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "http-cache-semantics 2.1.0": {
-      "name": "http-cache-semantics",
-      "version": "2.1.0",
-      "package_url": "https://github.com/kornelski/rusty-http-cache-semantics",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/http-cache-semantics/2.1.0/download",
-          "sha256": "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "http_cache_semantics",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "http_cache_semantics",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "reqwest",
-            "serde"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "http-serde 2.1.1",
-              "target": "http_serde"
-            },
-            {
-              "id": "reqwest 0.12.8",
-              "target": "reqwest"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            },
-            {
-              "id": "time 0.3.36",
-              "target": "time"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.1.0"
-      },
-      "license": "BSD-2-Clause",
-      "license_ids": [
-        "BSD-2-Clause"
-      ],
-      "license_file": "LICENSE"
-    },
-    "http-content-range 0.1.2": {
+    "http-content-range 0.1.4": {
       "name": "http-content-range",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "package_url": "https://github.com/nyurik/http-content-range",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/http-content-range/0.1.2/download",
-          "sha256": "9f0d1a8ef218a86416107794b34cc446958d9203556c312bb41eab4c924c1d2e"
+          "url": "https://static.crates.io/crates/http-content-range/0.1.4/download",
+          "sha256": "aa7929c876417cd3ece616950474c7dff5b0150a2b53bd7e7fda55afa086c22b"
         }
       },
       "targets": [
@@ -6462,75 +6375,23 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.1.2"
+        "version": "0.1.4"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": "LICENSE-APACHE"
     },
-    "http-serde 2.1.1": {
-      "name": "http-serde",
-      "version": "2.1.1",
-      "package_url": "https://gitlab.com/kornelski/http-serde",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/http-serde/2.1.1/download",
-          "sha256": "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "http_serde",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "http_serde",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.1.1"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "httparse 1.8.0": {
+    "httparse 1.9.5": {
       "name": "httparse",
-      "version": "1.8.0",
+      "version": "1.9.5",
       "package_url": "https://github.com/seanmonstar/httparse",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/httparse/1.8.0/download",
-          "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+          "url": "https://static.crates.io/crates/httparse/1.9.5/download",
+          "sha256": "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
         }
       },
       "targets": [
@@ -6574,14 +6435,14 @@
         "deps": {
           "common": [
             {
-              "id": "httparse 1.8.0",
+              "id": "httparse 1.9.5",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.8.0"
+        "version": "1.9.5"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -6591,7 +6452,7 @@
           "**"
         ]
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -6631,7 +6492,8 @@
           "common": [
             "client",
             "default",
-            "http1"
+            "http1",
+            "http2"
           ],
           "selects": {}
         },
@@ -6642,12 +6504,16 @@
               "target": "bytes"
             },
             {
-              "id": "futures-channel 0.3.30",
+              "id": "futures-channel 0.3.31",
               "target": "futures_channel"
             },
             {
-              "id": "futures-util 0.3.30",
+              "id": "futures-util 0.3.31",
               "target": "futures_util"
+            },
+            {
+              "id": "h2 0.4.6",
+              "target": "h2"
             },
             {
               "id": "http 1.1.0",
@@ -6658,15 +6524,15 @@
               "target": "http_body"
             },
             {
-              "id": "httparse 1.8.0",
+              "id": "httparse 1.9.5",
               "target": "httparse"
             },
             {
-              "id": "itoa 1.0.10",
+              "id": "itoa 1.0.11",
               "target": "itoa"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             },
             {
@@ -6725,7 +6591,10 @@
         "crate_features": {
           "common": [
             "http1",
+            "http2",
+            "native-tokio",
             "ring",
+            "rustls-native-certs",
             "tls12",
             "webpki-roots",
             "webpki-tokio"
@@ -6735,7 +6604,7 @@
         "deps": {
           "common": [
             {
-              "id": "futures-util 0.3.30",
+              "id": "futures-util 0.3.31",
               "target": "futures_util"
             },
             {
@@ -6755,6 +6624,10 @@
               "target": "rustls"
             },
             {
+              "id": "rustls-native-certs 0.8.0",
+              "target": "rustls_native_certs"
+            },
+            {
               "id": "rustls-pki-types 1.10.0",
               "target": "rustls_pki_types",
               "alias": "pki_types"
@@ -6768,7 +6641,7 @@
               "target": "tokio_rustls"
             },
             {
-              "id": "tower-service 0.3.2",
+              "id": "tower-service 0.3.3",
               "target": "tower_service"
             },
             {
@@ -6824,6 +6697,7 @@
             "client-legacy",
             "default",
             "http1",
+            "http2",
             "tokio"
           ],
           "selects": {}
@@ -6835,11 +6709,11 @@
               "target": "bytes"
             },
             {
-              "id": "futures-channel 0.3.30",
+              "id": "futures-channel 0.3.31",
               "target": "futures_channel"
             },
             {
-              "id": "futures-util 0.3.30",
+              "id": "futures-util 0.3.31",
               "target": "futures_util"
             },
             {
@@ -6855,11 +6729,11 @@
               "target": "hyper"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             },
             {
-              "id": "socket2 0.5.5",
+              "id": "socket2 0.5.7",
               "target": "socket2"
             },
             {
@@ -6867,7 +6741,7 @@
               "target": "tokio"
             },
             {
-              "id": "tower-service 0.3.2",
+              "id": "tower-service 0.3.3",
               "target": "tower_service"
             },
             {
@@ -6882,200 +6756,6 @@
       },
       "license": "MIT",
       "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "iana-time-zone 0.1.60": {
-      "name": "iana-time-zone",
-      "version": "0.1.60",
-      "package_url": "https://github.com/strawlab/iana-time-zone",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/iana-time-zone/0.1.60/download",
-          "sha256": "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "iana_time_zone",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "iana_time_zone",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
-              {
-                "id": "core-foundation-sys 0.8.6",
-                "target": "core_foundation_sys"
-              }
-            ],
-            "cfg(target_arch = \"wasm32\")": [
-              {
-                "id": "js-sys 0.3.68",
-                "target": "js_sys"
-              },
-              {
-                "id": "wasm-bindgen 0.2.91",
-                "target": "wasm_bindgen"
-              }
-            ],
-            "cfg(target_os = \"android\")": [
-              {
-                "id": "android_system_properties 0.1.5",
-                "target": "android_system_properties"
-              }
-            ],
-            "cfg(target_os = \"haiku\")": [
-              {
-                "id": "iana-time-zone-haiku 0.1.2",
-                "target": "iana_time_zone_haiku"
-              }
-            ],
-            "cfg(target_os = \"windows\")": [
-              {
-                "id": "windows-core 0.52.0",
-                "target": "windows_core"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.1.60"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "iana-time-zone-haiku 0.1.2": {
-      "name": "iana-time-zone-haiku",
-      "version": "0.1.2",
-      "package_url": "https://github.com/strawlab/iana-time-zone",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download",
-          "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "iana_time_zone_haiku",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "iana_time_zone_haiku",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "iana-time-zone-haiku 0.1.2",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.2"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cc 1.0.83",
-              "target": "cc"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "ident_case 1.0.1": {
-      "name": "ident_case",
-      "version": "1.0.1",
-      "package_url": "https://github.com/TedDriggs/ident_case",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ident_case/1.0.1/download",
-          "sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ident_case",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ident_case",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "1.0.1"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE"
@@ -7120,11 +6800,11 @@
         "deps": {
           "common": [
             {
-              "id": "unicode-bidi 0.3.15",
+              "id": "unicode-bidi 0.3.17",
               "target": "unicode_bidi"
             },
             {
-              "id": "unicode-normalization 0.1.22",
+              "id": "unicode-normalization 0.1.24",
               "target": "unicode_normalization"
             }
           ],
@@ -7140,20 +6820,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "include_dir 0.7.3": {
-      "name": "include_dir",
-      "version": "0.7.3",
-      "package_url": "https://github.com/Michael-F-Bryan/include_dir",
+    "ignore 0.4.23": {
+      "name": "ignore",
+      "version": "0.4.23",
+      "package_url": "https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/include_dir/0.7.3/download",
-          "sha256": "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+          "url": "https://static.crates.io/crates/ignore/0.4.23/download",
+          "sha256": "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "include_dir",
+            "crate_name": "ignore",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -7164,60 +6844,7 @@
           }
         }
       ],
-      "library_target_name": "include_dir",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "include_dir_macros 0.7.3",
-              "target": "include_dir_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.7.3"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "include_dir_macros 0.7.3": {
-      "name": "include_dir_macros",
-      "version": "0.7.3",
-      "package_url": "https://github.com/Michael-F-Bryan/include_dir",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/include_dir_macros/0.7.3/download",
-          "sha256": "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "include_dir_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "include_dir_macros",
+      "library_target_name": "ignore",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -7225,105 +6852,52 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.89",
-              "target": "proc_macro2"
+              "id": "crossbeam-deque 0.8.5",
+              "target": "crossbeam_deque"
             },
             {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.3"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "indexmap 1.9.3": {
-      "name": "indexmap",
-      "version": "1.9.3",
-      "package_url": "https://github.com/bluss/indexmap",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/indexmap/1.9.3/download",
-          "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "indexmap",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "indexmap",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "hashbrown 0.12.3",
-              "target": "hashbrown"
+              "id": "globset 0.4.15",
+              "target": "globset"
             },
             {
-              "id": "indexmap 1.9.3",
-              "target": "build_script_build"
+              "id": "log 0.4.22",
+              "target": "log"
+            },
+            {
+              "id": "memchr 2.7.4",
+              "target": "memchr"
+            },
+            {
+              "id": "regex-automata 0.4.8",
+              "target": "regex_automata"
+            },
+            {
+              "id": "same-file 1.0.6",
+              "target": "same_file"
+            },
+            {
+              "id": "walkdir 2.5.0",
+              "target": "walkdir"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "winapi-util 0.1.9",
+                "target": "winapi_util"
+              }
+            ]
+          }
         },
         "edition": "2021",
-        "version": "1.9.3"
+        "version": "0.4.23"
       },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "autocfg 1.1.0",
-              "target": "autocfg"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "Apache-2.0 OR MIT",
+      "license": "Unlicense OR MIT",
       "license_ids": [
-        "Apache-2.0",
-        "MIT"
+        "MIT",
+        "Unlicense"
       ],
-      "license_file": "LICENSE-APACHE"
+      "license_file": "LICENSE-MIT"
     },
     "indexmap 2.6.0": {
       "name": "indexmap",
@@ -7389,20 +6963,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "inout 0.1.3": {
-      "name": "inout",
-      "version": "0.1.3",
-      "package_url": "https://github.com/RustCrypto/utils",
+    "instant 0.1.13": {
+      "name": "instant",
+      "version": "0.1.13",
+      "package_url": "https://github.com/sebcrozet/instant",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/inout/0.1.3/download",
-          "sha256": "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+          "url": "https://static.crates.io/crates/instant/0.1.13/download",
+          "sha256": "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "inout",
+            "crate_name": "instant",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -7413,38 +6987,70 @@
           }
         }
       ],
-      "library_target_name": "inout",
+      "library_target_name": "instant",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "js-sys",
+              "wasm-bindgen",
+              "wasm-bindgen_rs",
+              "web-sys"
+            ],
+            "wasm32-wasi": [
+              "js-sys",
+              "wasm-bindgen",
+              "wasm-bindgen_rs",
+              "web-sys"
+            ]
+          }
+        },
         "deps": {
           "common": [
             {
-              "id": "generic-array 0.14.7",
-              "target": "generic_array"
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
             }
           ],
-          "selects": {}
+          "selects": {
+            "wasm32-unknown-unknown": [
+              {
+                "id": "js-sys 0.3.72",
+                "target": "js_sys"
+              },
+              {
+                "id": "wasm-bindgen 0.2.95",
+                "target": "wasm_bindgen",
+                "alias": "wasm_bindgen_rs"
+              },
+              {
+                "id": "web-sys 0.3.72",
+                "target": "web_sys"
+              }
+            ]
+          }
         },
-        "edition": "2021",
-        "version": "0.1.3"
+        "edition": "2018",
+        "version": "0.1.13"
       },
-      "license": "MIT OR Apache-2.0",
+      "license": "BSD-3-Clause",
       "license_ids": [
-        "Apache-2.0",
-        "MIT"
+        "BSD-3-Clause"
       ],
-      "license_file": "LICENSE-APACHE"
+      "license_file": "LICENSE"
     },
-    "ipnet 2.9.0": {
+    "ipnet 2.10.1": {
       "name": "ipnet",
-      "version": "2.9.0",
+      "version": "2.10.1",
       "package_url": "https://github.com/krisprice/ipnet",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ipnet/2.9.0/download",
-          "sha256": "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+          "url": "https://static.crates.io/crates/ipnet/2.10.1/download",
+          "sha256": "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
         }
       },
       "targets": [
@@ -7474,7 +7080,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.9.0"
+        "version": "2.10.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -7521,6 +7127,51 @@
       ],
       "license_file": "LICENSE"
     },
+    "is_terminal_polyfill 1.70.1": {
+      "name": "is_terminal_polyfill",
+      "version": "1.70.1",
+      "package_url": "https://github.com/polyfill-rs/is_terminal_polyfill",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/is_terminal_polyfill/1.70.1/download",
+          "sha256": "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "is_terminal_polyfill",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "is_terminal_polyfill",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.70.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "itertools 0.12.1": {
       "name": "itertools",
       "version": "0.12.1",
@@ -7561,7 +7212,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.9.0",
+              "id": "either 1.13.0",
               "target": "either"
             }
           ],
@@ -7617,7 +7268,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.9.0",
+              "id": "either 1.13.0",
               "target": "either"
             }
           ],
@@ -7633,14 +7284,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "itoa 1.0.10": {
+    "itoa 1.0.11": {
       "name": "itoa",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "package_url": "https://github.com/dtolnay/itoa",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/itoa/1.0.10/download",
-          "sha256": "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+          "url": "https://static.crates.io/crates/itoa/1.0.11/download",
+          "sha256": "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
         }
       },
       "targets": [
@@ -7663,7 +7314,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.10"
+        "version": "1.0.11"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -7672,14 +7323,204 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "jobserver 0.1.27": {
-      "name": "jobserver",
-      "version": "0.1.27",
-      "package_url": "https://github.com/alexcrichton/jobserver-rs",
+    "jiff 0.1.13": {
+      "name": "jiff",
+      "version": "0.1.13",
+      "package_url": "https://github.com/BurntSushi/jiff",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/jobserver/0.1.27/download",
-          "sha256": "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+          "url": "https://static.crates.io/crates/jiff/0.1.13/download",
+          "sha256": "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "jiff",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "jiff",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "serde",
+            "std",
+            "tz-system",
+            "tzdb-bundle-platform",
+            "tzdb-zoneinfo"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            }
+          ],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "jiff-tzdb-platform 0.1.1",
+                "target": "jiff_tzdb_platform"
+              },
+              {
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "jiff-tzdb-platform 0.1.1",
+                "target": "jiff_tzdb_platform"
+              },
+              {
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
+              }
+            ],
+            "wasm32-unknown-unknown": [
+              {
+                "id": "jiff-tzdb-platform 0.1.1",
+                "target": "jiff_tzdb_platform"
+              }
+            ],
+            "wasm32-wasi": [
+              {
+                "id": "jiff-tzdb-platform 0.1.1",
+                "target": "jiff_tzdb_platform"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "jiff-tzdb-platform 0.1.1",
+                "target": "jiff_tzdb_platform"
+              },
+              {
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.1.13"
+      },
+      "license": "Unlicense OR MIT",
+      "license_ids": [
+        "MIT",
+        "Unlicense"
+      ],
+      "license_file": "LICENSE-MIT"
+    },
+    "jiff-tzdb 0.1.1": {
+      "name": "jiff-tzdb",
+      "version": "0.1.1",
+      "package_url": "https://github.com/BurntSushi/jiff",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/jiff-tzdb/0.1.1/download",
+          "sha256": "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "jiff_tzdb",
+            "crate_root": "lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "jiff_tzdb",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.1.1"
+      },
+      "license": "Unlicense OR MIT",
+      "license_ids": [
+        "MIT",
+        "Unlicense"
+      ],
+      "license_file": "LICENSE-MIT"
+    },
+    "jiff-tzdb-platform 0.1.1": {
+      "name": "jiff-tzdb-platform",
+      "version": "0.1.1",
+      "package_url": "https://github.com/BurntSushi/jiff",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/jiff-tzdb-platform/0.1.1/download",
+          "sha256": "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "jiff_tzdb_platform",
+            "crate_root": "lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "jiff_tzdb_platform",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "jiff-tzdb 0.1.1",
+              "target": "jiff_tzdb"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.1"
+      },
+      "license": "Unlicense OR MIT",
+      "license_ids": [
+        "MIT",
+        "Unlicense"
+      ],
+      "license_file": "LICENSE-MIT"
+    },
+    "jobserver 0.1.32": {
+      "name": "jobserver",
+      "version": "0.1.32",
+      "package_url": "https://github.com/rust-lang/jobserver-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/jobserver/0.1.32/download",
+          "sha256": "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
         }
       },
       "targets": [
@@ -7712,24 +7553,24 @@
             ]
           }
         },
-        "edition": "2018",
-        "version": "0.1.27"
+        "edition": "2021",
+        "version": "0.1.32"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "js-sys 0.3.68": {
+    "js-sys 0.3.72": {
       "name": "js-sys",
-      "version": "0.3.68",
+      "version": "0.3.72",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/js-sys/0.3.68/download",
-          "sha256": "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+          "url": "https://static.crates.io/crates/js-sys/0.3.72/download",
+          "sha256": "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
         }
       },
       "targets": [
@@ -7754,16 +7595,304 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen 0.2.91",
+              "id": "wasm-bindgen 0.2.95",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.3.68"
+        "edition": "2021",
+        "version": "0.3.72"
       },
       "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "junction 1.2.0": {
+      "name": "junction",
+      "version": "1.2.0",
+      "package_url": "https://github.com/tesuji/junction",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/junction/1.2.0/download",
+          "sha256": "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "junction",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "junction",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "unstable_admin"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "scopeguard 1.2.0",
+                "target": "scopeguard"
+              },
+              {
+                "id": "windows-sys 0.52.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "1.2.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "krata-tokio-tar 0.4.2": {
+      "name": "krata-tokio-tar",
+      "version": "0.4.2",
+      "package_url": "https://github.com/edera-dev/tokio-tar",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/krata-tokio-tar/0.4.2/download",
+          "sha256": "e8bd5fee9b96acb5fc36b401896d601e6fdcce52b0e651ce24a3b21fb524e79f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tokio_tar",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tokio_tar",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "xattr"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "filetime 0.2.25",
+              "target": "filetime"
+            },
+            {
+              "id": "futures-core 0.3.31",
+              "target": "futures_core"
+            },
+            {
+              "id": "portable-atomic 1.9.0",
+              "target": "portable_atomic"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-stream 0.1.16",
+              "target": "tokio_stream"
+            }
+          ],
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "aarch64-apple-ios": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "aarch64-apple-ios-sim": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "aarch64-fuchsia": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "aarch64-linux-android": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "armv7-linux-androideabi": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "cfg(target_os = \"redox\")": [
+              {
+                "id": "redox_syscall 0.3.5",
+                "target": "syscall"
+              }
+            ],
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "i686-apple-darwin": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "i686-linux-android": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "i686-unknown-freebsd": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "x86_64-apple-ios": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "x86_64-fuchsia": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "x86_64-linux-android": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "xattr 1.3.1",
+                "target": "xattr"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.4.2"
+      },
+      "license": "MIT/Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -7918,6 +8047,61 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "libredox 0.1.3": {
+      "name": "libredox",
+      "version": "0.1.3",
+      "package_url": "https://gitlab.redox-os.org/redox-os/libredox.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/libredox/0.1.3/download",
+          "sha256": "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "libredox",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "libredox",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.6.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "libc 0.2.161",
+              "target": "libc"
+            },
+            {
+              "id": "redox_syscall 0.5.7",
+              "target": "syscall"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.3"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "linux-raw-sys 0.4.14": {
       "name": "linux-raw-sys",
       "version": "0.4.14",
@@ -8007,14 +8191,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "lock_api 0.4.11": {
+    "lock_api 0.4.12": {
       "name": "lock_api",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "package_url": "https://github.com/Amanieu/parking_lot",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/lock_api/0.4.11/download",
-          "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+          "url": "https://static.crates.io/crates/lock_api/0.4.12/download",
+          "sha256": "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
         }
       },
       "targets": [
@@ -8058,7 +8242,7 @@
         "deps": {
           "common": [
             {
-              "id": "lock_api 0.4.11",
+              "id": "lock_api 0.4.12",
               "target": "build_script_build"
             },
             {
@@ -8068,8 +8252,8 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.4.11"
+        "edition": "2021",
+        "version": "0.4.12"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -8081,7 +8265,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.4.0",
               "target": "autocfg"
             }
           ],
@@ -8095,14 +8279,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "log 0.4.20": {
+    "log 0.4.22": {
       "name": "log",
-      "version": "0.4.20",
+      "version": "0.4.22",
       "package_url": "https://github.com/rust-lang/log",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/log/0.4.20/download",
-          "sha256": "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+          "url": "https://static.crates.io/crates/log/0.4.22/download",
+          "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
         }
       },
       "targets": [
@@ -8124,8 +8308,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2015",
-        "version": "0.4.20"
+        "edition": "2021",
+        "version": "0.4.22"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -8133,6 +8317,147 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "lzma-sys 0.1.20": {
+      "name": "lzma-sys",
+      "version": "0.1.20",
+      "package_url": "https://github.com/alexcrichton/xz2-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/lzma-sys/0.1.20/download",
+          "sha256": "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "lzma_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "lzma_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "libc 0.2.161",
+              "target": "libc"
+            },
+            {
+              "id": "lzma-sys 0.1.20",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.20"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.1.31",
+              "target": "cc"
+            },
+            {
+              "id": "pkg-config 0.3.31",
+              "target": "pkg_config"
+            }
+          ],
+          "selects": {}
+        },
+        "links": "lzma"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "mailparse 0.15.0": {
+      "name": "mailparse",
+      "version": "0.15.0",
+      "package_url": "https://github.com/staktrace/mailparse",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/mailparse/0.15.0/download",
+          "sha256": "3da03d5980411a724e8aaf7b61a7b5e386ec55a7fb49ee3d0ff79efc7e5e7c7e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "mailparse",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "mailparse",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "charset 0.1.5",
+              "target": "charset"
+            },
+            {
+              "id": "data-encoding 2.6.0",
+              "target": "data_encoding"
+            },
+            {
+              "id": "quoted_printable 0.5.1",
+              "target": "quoted_printable"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.15.0"
+      },
+      "license": "0BSD",
+      "license_ids": [
+        "0BSD"
+      ],
+      "license_file": "LICENSE"
     },
     "md-5 0.10.6": {
       "name": "md-5",
@@ -8193,14 +8518,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "memchr 2.7.1": {
+    "memchr 2.7.4": {
       "name": "memchr",
-      "version": "2.7.1",
+      "version": "2.7.4",
       "package_url": "https://github.com/BurntSushi/memchr",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/memchr/2.7.1/download",
-          "sha256": "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+          "url": "https://static.crates.io/crates/memchr/2.7.4/download",
+          "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
         }
       },
       "targets": [
@@ -8231,7 +8556,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.7.1"
+        "version": "2.7.4"
       },
       "license": "Unlicense OR MIT",
       "license_ids": [
@@ -8240,14 +8565,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "memmap2 0.5.10": {
+    "memmap2 0.9.5": {
       "name": "memmap2",
-      "version": "0.5.10",
+      "version": "0.9.5",
       "package_url": "https://github.com/RazrFalcon/memmap2-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/memmap2/0.5.10/download",
-          "sha256": "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+          "url": "https://static.crates.io/crates/memmap2/0.9.5/download",
+          "sha256": "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
         }
       },
       "targets": [
@@ -8281,7 +8606,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.5.10"
+        "version": "0.9.5"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -8289,126 +8614,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "memmap2 0.9.4": {
-      "name": "memmap2",
-      "version": "0.9.4",
-      "package_url": "https://github.com/RazrFalcon/memmap2-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/memmap2/0.9.4/download",
-          "sha256": "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "memmap2",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "memmap2",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(unix)": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.9.4"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "miette 5.10.0": {
-      "name": "miette",
-      "version": "5.10.0",
-      "package_url": "https://github.com/zkat/miette",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/miette/5.10.0/download",
-          "sha256": "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "miette",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "miette",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "once_cell 1.19.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "thiserror 1.0.65",
-              "target": "thiserror"
-            },
-            {
-              "id": "unicode-width 0.1.11",
-              "target": "unicode_width"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "miette-derive 5.10.0",
-              "target": "miette_derive"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "5.10.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
     },
     "miette 7.2.0": {
       "name": "miette",
@@ -8461,7 +8666,7 @@
         "deps": {
           "common": [
             {
-              "id": "backtrace 0.3.69",
+              "id": "backtrace 0.3.74",
               "target": "backtrace"
             },
             {
@@ -8473,11 +8678,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "owo-colors 4.0.0",
+              "id": "owo-colors 4.1.0",
               "target": "owo_colors"
             },
             {
-              "id": "supports-color 3.0.0",
+              "id": "supports-color 3.0.1",
               "target": "supports_color"
             },
             {
@@ -8501,7 +8706,7 @@
               "target": "thiserror"
             },
             {
-              "id": "unicode-width 0.1.11",
+              "id": "unicode-width 0.1.14",
               "target": "unicode_width"
             }
           ],
@@ -8518,61 +8723,6 @@
           "selects": {}
         },
         "version": "7.2.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "miette-derive 5.10.0": {
-      "name": "miette-derive",
-      "version": "5.10.0",
-      "package_url": "https://github.com/zkat/miette",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/miette-derive/5.10.0/download",
-          "sha256": "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "miette_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "miette_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.89",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.82",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "5.10.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -8616,11 +8766,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
@@ -8674,14 +8824,98 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "miniz_oxide 0.7.2": {
+    "mime_guess 2.0.5": {
+      "name": "mime_guess",
+      "version": "2.0.5",
+      "package_url": "https://github.com/abonander/mime_guess",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/mime_guess/2.0.5/download",
+          "sha256": "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "mime_guess",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "mime_guess",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "mime 0.3.17",
+              "target": "mime"
+            },
+            {
+              "id": "mime_guess 2.0.5",
+              "target": "build_script_build"
+            },
+            {
+              "id": "unicase 2.8.0",
+              "target": "unicase"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "2.0.5"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "unicase 2.8.0",
+              "target": "unicase"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "miniz_oxide 0.8.0": {
       "name": "miniz_oxide",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "package_url": "https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/miniz_oxide/0.7.2/download",
-          "sha256": "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+          "url": "https://static.crates.io/crates/miniz_oxide/0.8.0/download",
+          "sha256": "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
         }
       },
       "targets": [
@@ -8712,14 +8946,14 @@
         "deps": {
           "common": [
             {
-              "id": "adler 1.0.2",
-              "target": "adler"
+              "id": "adler2 2.0.0",
+              "target": "adler2"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.7.2"
+        "edition": "2021",
+        "version": "0.8.0"
       },
       "license": "MIT OR Zlib OR Apache-2.0",
       "license_ids": [
@@ -8809,20 +9043,20 @@
       ],
       "license_file": "LICENSE"
     },
-    "num-conv 0.1.0": {
-      "name": "num-conv",
-      "version": "0.1.0",
-      "package_url": "https://github.com/jhpratt/num-conv",
+    "miow 0.6.0": {
+      "name": "miow",
+      "version": "0.6.0",
+      "package_url": "https://github.com/yoshuawuyts/miow",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/num-conv/0.1.0/download",
-          "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+          "url": "https://static.crates.io/crates/miow/0.6.0/download",
+          "sha256": "359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "num_conv",
+            "crate_name": "miow",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -8833,29 +9067,187 @@
           }
         }
       ],
-      "library_target_name": "num_conv",
+      "library_target_name": "miow",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2021",
-        "version": "0.1.0"
+        "deps": {
+          "common": [
+            {
+              "id": "windows-sys 0.48.0",
+              "target": "windows_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.6.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
-      "license_file": "LICENSE-Apache"
+      "license_file": "LICENSE-APACHE"
     },
-    "num-traits 0.2.17": {
+    "munge 0.4.1": {
+      "name": "munge",
+      "version": "0.4.1",
+      "package_url": "https://github.com/djkoloski/munge",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/munge/0.4.1/download",
+          "sha256": "64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "munge",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "munge",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "munge_macro 0.4.1",
+              "target": "munge_macro"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.4.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "munge_macro 0.4.1": {
+      "name": "munge_macro",
+      "version": "0.4.1",
+      "package_url": "https://github.com/djkoloski/munge",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/munge_macro/0.4.1/download",
+          "sha256": "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "munge_macro",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "munge_macro",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.4.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "nanoid 0.4.0": {
+      "name": "nanoid",
+      "version": "0.4.0",
+      "package_url": "https://github.com/nikolay-govorov/nanoid.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/nanoid/0.4.0/download",
+          "sha256": "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "nanoid",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "nanoid",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.4.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "num-traits 0.2.19": {
       "name": "num-traits",
-      "version": "0.2.17",
+      "version": "0.2.19",
       "package_url": "https://github.com/rust-num/num-traits",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/num-traits/0.2.17/download",
-          "sha256": "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+          "url": "https://static.crates.io/crates/num-traits/0.2.19/download",
+          "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
         }
       },
       "targets": [
@@ -8889,17 +9281,23 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "num-traits 0.2.17",
+              "id": "num-traits 0.2.19",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.2.17"
+        "edition": "2021",
+        "version": "0.2.19"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -8911,7 +9309,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.4.0",
               "target": "autocfg"
             }
           ],
@@ -8925,14 +9323,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "object 0.32.2": {
+    "object 0.36.5": {
       "name": "object",
-      "version": "0.32.2",
+      "version": "0.36.5",
       "package_url": "https://github.com/gimli-rs/object",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/object/0.32.2/download",
-          "sha256": "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+          "url": "https://static.crates.io/crates/object/0.36.5/download",
+          "sha256": "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
         }
       },
       "targets": [
@@ -8962,21 +9360,22 @@
             "macho",
             "pe",
             "read_core",
-            "unaligned"
+            "unaligned",
+            "xcoff"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "memchr 2.7.1",
+              "id": "memchr 2.7.4",
               "target": "memchr"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.32.2"
+        "version": "0.36.5"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -8985,14 +9384,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "once_cell 1.19.0": {
+    "once_cell 1.20.2": {
       "name": "once_cell",
-      "version": "1.19.0",
+      "version": "1.20.2",
       "package_url": "https://github.com/matklad/once_cell",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/once_cell/1.19.0/download",
-          "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+          "url": "https://static.crates.io/crates/once_cell/1.20.2/download",
+          "sha256": "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
         }
       },
       "targets": [
@@ -9024,7 +9423,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.19.0"
+        "version": "1.20.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -9033,14 +9432,91 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "owo-colors 4.0.0": {
+    "openssl-probe 0.1.5": {
+      "name": "openssl-probe",
+      "version": "0.1.5",
+      "package_url": "https://github.com/alexcrichton/openssl-probe",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/openssl-probe/0.1.5/download",
+          "sha256": "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "openssl_probe",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "openssl_probe",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.1.5"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "option-ext 0.2.0": {
+      "name": "option-ext",
+      "version": "0.2.0",
+      "package_url": "https://github.com/soc/option-ext.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/option-ext/0.2.0/download",
+          "sha256": "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "option_ext",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "option_ext",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.2.0"
+      },
+      "license": "MPL-2.0",
+      "license_ids": [
+        "MPL-2.0"
+      ],
+      "license_file": "LICENSE.txt"
+    },
+    "owo-colors 4.1.0": {
       "name": "owo-colors",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "package_url": "https://github.com/jam1garner/owo-colors",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/owo-colors/4.0.0/download",
-          "sha256": "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
+          "url": "https://static.crates.io/crates/owo-colors/4.1.0/download",
+          "sha256": "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
         }
       },
       "targets": [
@@ -9055,6 +9531,18 @@
               ]
             }
           }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
         }
       ],
       "library_target_name": "owo_colors",
@@ -9062,8 +9550,25 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2018",
-        "version": "4.0.0"
+        "deps": {
+          "common": [
+            {
+              "id": "owo-colors 4.1.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "4.1.0"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
       },
       "license": "MIT",
       "license_ids": [
@@ -9110,14 +9615,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "parking_lot 0.12.1": {
+    "parking_lot 0.11.2": {
       "name": "parking_lot",
-      "version": "0.12.1",
+      "version": "0.11.2",
       "package_url": "https://github.com/Amanieu/parking_lot",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/parking_lot/0.12.1/download",
-          "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+          "url": "https://static.crates.io/crates/parking_lot/0.11.2/download",
+          "sha256": "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
         }
       },
       "targets": [
@@ -9141,41 +9646,46 @@
         ],
         "crate_features": {
           "common": [
-            "default"
+            "default",
+            "wasm-bindgen"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "lock_api 0.4.11",
+              "id": "instant 0.1.13",
+              "target": "instant"
+            },
+            {
+              "id": "lock_api 0.4.12",
               "target": "lock_api"
             },
             {
-              "id": "parking_lot_core 0.9.9",
+              "id": "parking_lot_core 0.8.6",
               "target": "parking_lot_core"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.12.1"
+        "version": "0.11.2"
       },
-      "license": "MIT OR Apache-2.0",
+      "license": "Apache-2.0/MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "parking_lot_core 0.9.9": {
+    "parking_lot_core 0.8.6": {
       "name": "parking_lot_core",
-      "version": "0.9.9",
+      "version": "0.8.6",
       "package_url": "https://github.com/Amanieu/parking_lot",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/parking_lot_core/0.9.9/download",
-          "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+          "url": "https://static.crates.io/crates/parking_lot_core/0.8.6/download",
+          "sha256": "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
         }
       },
       "targets": [
@@ -9216,7 +9726,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "parking_lot_core 0.9.9",
+              "id": "instant 0.1.13",
+              "target": "instant"
+            },
+            {
+              "id": "parking_lot_core 0.8.6",
               "target": "build_script_build"
             },
             {
@@ -9227,7 +9741,7 @@
           "selects": {
             "cfg(target_os = \"redox\")": [
               {
-                "id": "redox_syscall 0.4.1",
+                "id": "redox_syscall 0.2.16",
                 "target": "syscall"
               }
             ],
@@ -9239,14 +9753,109 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-targets 0.48.5",
-                "target": "windows_targets"
+                "id": "winapi 0.3.9",
+                "target": "winapi"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.9.9"
+        "version": "0.8.6"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "Apache-2.0/MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "parking_lot_core 0.9.10": {
+      "name": "parking_lot_core",
+      "version": "0.9.10",
+      "package_url": "https://github.com/Amanieu/parking_lot",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/parking_lot_core/0.9.10/download",
+          "sha256": "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "parking_lot_core",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "parking_lot_core",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "parking_lot_core 0.9.10",
+              "target": "build_script_build"
+            },
+            {
+              "id": "smallvec 1.13.2",
+              "target": "smallvec"
+            }
+          ],
+          "selects": {
+            "cfg(target_os = \"redox\")": [
+              {
+                "id": "redox_syscall 0.5.7",
+                "target": "syscall"
+              }
+            ],
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-targets 0.52.6",
+                "target": "windows_targets"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.9.10"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -9263,20 +9872,88 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "password-hash 0.4.2": {
-      "name": "password-hash",
-      "version": "0.4.2",
-      "package_url": "https://github.com/RustCrypto/traits/tree/master/password-hash",
+    "paste 1.0.15": {
+      "name": "paste",
+      "version": "1.0.15",
+      "package_url": "https://github.com/dtolnay/paste",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/password-hash/0.4.2/download",
-          "sha256": "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+          "url": "https://static.crates.io/crates/paste/1.0.15/download",
+          "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "paste",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "paste",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "paste 1.0.15",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.15"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "path-slash 0.2.1": {
+      "name": "path-slash",
+      "version": "0.2.1",
+      "package_url": "https://github.com/rhysd/path-slash",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/path-slash/0.2.1/download",
+          "sha256": "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "password_hash",
+            "crate_name": "path_slash",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -9287,52 +9964,28 @@
           }
         }
       ],
-      "library_target_name": "password_hash",
+      "library_target_name": "path_slash",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "rand_core"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "base64ct 1.6.0",
-              "target": "base64ct"
-            },
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            },
-            {
-              "id": "subtle 2.5.0",
-              "target": "subtle"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.2"
+        "edition": "2018",
+        "version": "0.2.1"
       },
-      "license": "MIT OR Apache-2.0",
+      "license": "MIT",
       "license_ids": [
-        "Apache-2.0",
         "MIT"
       ],
-      "license_file": "LICENSE-APACHE"
+      "license_file": "LICENSE.txt"
     },
-    "pathdiff 0.2.1": {
+    "pathdiff 0.2.2": {
       "name": "pathdiff",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "package_url": "https://github.com/Manishearth/pathdiff",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pathdiff/0.2.1/download",
-          "sha256": "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+          "url": "https://static.crates.io/crates/pathdiff/0.2.2/download",
+          "sha256": "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
         }
       },
       "targets": [
@@ -9355,7 +10008,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.2.1"
+        "version": "0.2.2"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -9363,387 +10016,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "pbkdf2 0.11.0": {
-      "name": "pbkdf2",
-      "version": "0.11.0",
-      "package_url": "https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pbkdf2/0.11.0/download",
-          "sha256": "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pbkdf2",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "pbkdf2",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "hmac",
-            "password-hash",
-            "sha2",
-            "simple"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "hmac 0.12.1",
-              "target": "hmac"
-            },
-            {
-              "id": "password-hash 0.4.2",
-              "target": "password_hash"
-            },
-            {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.11.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "peg 0.8.2": {
-      "name": "peg",
-      "version": "0.8.2",
-      "package_url": "https://github.com/kevinmehall/rust-peg",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/peg/0.8.2/download",
-          "sha256": "400bcab7d219c38abf8bd7cc2054eb9bbbd4312d66f6a5557d572a203f646f61"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "peg",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "peg",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "peg-runtime 0.8.2",
-              "target": "peg_runtime"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "peg-macros 0.8.2",
-              "target": "peg_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.8.2"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "peg-macros 0.8.2": {
-      "name": "peg-macros",
-      "version": "0.8.2",
-      "package_url": "https://github.com/kevinmehall/rust-peg",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/peg-macros/0.8.2/download",
-          "sha256": "46e61cce859b76d19090f62da50a9fe92bab7c2a5f09e183763559a2ac392c90"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "peg_macros",
-            "crate_root": "lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "peg_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "peg-runtime 0.8.2",
-              "target": "peg_runtime"
-            },
-            {
-              "id": "proc-macro2 1.0.89",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.2"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "peg-runtime 0.8.2": {
-      "name": "peg-runtime",
-      "version": "0.8.2",
-      "package_url": "https://github.com/kevinmehall/rust-peg",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/peg-runtime/0.8.2/download",
-          "sha256": "36bae92c60fa2398ce4678b98b2c4b5a7c61099961ca1fa305aec04a9ad28922"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "peg_runtime",
-            "crate_root": "lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "peg_runtime",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.2"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "pep440_rs 0.4.0": {
-      "name": "pep440_rs",
-      "version": "0.4.0",
-      "package_url": "https://github.com/konstin/pep440-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pep440_rs/0.4.0/download",
-          "sha256": "e0c29f9c43de378b4e4e0cd7dbcce0e5cfb80443de8c05620368b2948bc936a1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pep440_rs",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "pep440_rs",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "serde"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "once_cell 1.19.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "regex 1.11.0",
-              "target": "regex"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            },
-            {
-              "id": "unicode-width 0.1.11",
-              "target": "unicode_width"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.0"
-      },
-      "license": "Apache-2.0 OR BSD-2-Clause",
-      "license_ids": [
-        "Apache-2.0",
-        "BSD-2-Clause"
-      ],
-      "license_file": "License-Apache"
-    },
-    "pep508_rs 0.3.0": {
-      "name": "pep508_rs",
-      "version": "0.3.0",
-      "package_url": "https://github.com/konstin/pep508_rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pep508_rs/0.3.0/download",
-          "sha256": "910c513bea0f4f833122321c0f20e8c704e01de98692f6989c2ec21f43d88b1e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pep508_rs",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "pep508_rs",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "serde"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "once_cell 1.19.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "pep440_rs 0.4.0",
-              "target": "pep440_rs"
-            },
-            {
-              "id": "regex 1.11.0",
-              "target": "regex"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            },
-            {
-              "id": "thiserror 1.0.65",
-              "target": "thiserror"
-            },
-            {
-              "id": "tracing 0.1.40",
-              "target": "tracing"
-            },
-            {
-              "id": "unicode-width 0.1.11",
-              "target": "unicode_width"
-            },
-            {
-              "id": "url 2.5.0",
-              "target": "url"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.3.0"
-      },
-      "license": "Apache-2.0 OR BSD-2-Clause",
-      "license_ids": [
-        "Apache-2.0",
-        "BSD-2-Clause"
-      ],
-      "license_file": "License-Apache"
     },
     "percent-encoding 2.3.1": {
       "name": "percent-encoding",
@@ -9792,75 +10064,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "petgraph 0.6.5": {
-      "name": "petgraph",
-      "version": "0.6.5",
-      "package_url": "https://github.com/petgraph/petgraph",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/petgraph/0.6.5/download",
-          "sha256": "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "petgraph",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "petgraph",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "graphmap",
-            "matrix_graph",
-            "stable_graph"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "fixedbitset 0.4.2",
-              "target": "fixedbitset"
-            },
-            {
-              "id": "indexmap 2.6.0",
-              "target": "indexmap"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.6.5"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "pin-project 1.1.4": {
+    "pin-project 1.1.7": {
       "name": "pin-project",
-      "version": "1.1.4",
+      "version": "1.1.7",
       "package_url": "https://github.com/taiki-e/pin-project",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pin-project/1.1.4/download",
-          "sha256": "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+          "url": "https://static.crates.io/crates/pin-project/1.1.7/download",
+          "sha256": "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
         }
       },
       "targets": [
@@ -9886,13 +10097,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pin-project-internal 1.1.4",
+              "id": "pin-project-internal 1.1.7",
               "target": "pin_project_internal"
             }
           ],
           "selects": {}
         },
-        "version": "1.1.4"
+        "version": "1.1.7"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -9901,14 +10112,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pin-project-internal 1.1.4": {
+    "pin-project-internal 1.1.7": {
       "name": "pin-project-internal",
-      "version": "1.1.4",
+      "version": "1.1.7",
       "package_url": "https://github.com/taiki-e/pin-project",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pin-project-internal/1.1.4/download",
-          "sha256": "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+          "url": "https://static.crates.io/crates/pin-project-internal/1.1.7/download",
+          "sha256": "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
         }
       },
       "targets": [
@@ -9937,18 +10148,18 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.4"
+        "version": "1.1.7"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -9957,14 +10168,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pin-project-lite 0.2.14": {
+    "pin-project-lite 0.2.15": {
       "name": "pin-project-lite",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "package_url": "https://github.com/taiki-e/pin-project-lite",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pin-project-lite/0.2.14/download",
-          "sha256": "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+          "url": "https://static.crates.io/crates/pin-project-lite/0.2.15/download",
+          "sha256": "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
         }
       },
       "targets": [
@@ -9987,7 +10198,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.2.14"
+        "version": "0.2.15"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -10035,14 +10246,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pkg-config 0.3.29": {
+    "pkg-config 0.3.31": {
       "name": "pkg-config",
-      "version": "0.3.29",
+      "version": "0.3.31",
       "package_url": "https://github.com/rust-lang/pkg-config-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pkg-config/0.3.29/download",
-          "sha256": "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+          "url": "https://static.crates.io/crates/pkg-config/0.3.31/download",
+          "sha256": "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
         }
       },
       "targets": [
@@ -10064,8 +10275,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2015",
-        "version": "0.3.29"
+        "edition": "2018",
+        "version": "0.3.31"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -10074,20 +10285,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "powerfmt 0.2.0": {
-      "name": "powerfmt",
-      "version": "0.2.0",
-      "package_url": "https://github.com/jhpratt/powerfmt",
+    "plain 0.2.3": {
+      "name": "plain",
+      "version": "0.2.3",
+      "package_url": "https://github.com/randomites/plain",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/powerfmt/0.2.0/download",
-          "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+          "url": "https://static.crates.io/crates/plain/0.2.3/download",
+          "sha256": "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "powerfmt",
+            "crate_name": "plain",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -10098,20 +10309,150 @@
           }
         }
       ],
-      "library_target_name": "powerfmt",
+      "library_target_name": "plain",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "edition": "2021",
-        "version": "0.2.0"
+        "edition": "2015",
+        "version": "0.2.3"
       },
-      "license": "MIT OR Apache-2.0",
+      "license": "MIT/Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
-      "license_file": "LICENSE-Apache"
+      "license_file": "LICENSE-APACHE"
+    },
+    "platform-info 2.0.4": {
+      "name": "platform-info",
+      "version": "2.0.4",
+      "package_url": "https://github.com/uutils/platform-info",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/platform-info/2.0.4/download",
+          "sha256": "91077ffd05d058d70d79eefcd7d7f6aac34980860a7519960f7913b6563a8c3a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "platform_info",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "platform_info",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(not(target_os = \"windows\"))": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "winapi 0.3.9",
+                "target": "winapi"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "2.0.4"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "portable-atomic 1.9.0": {
+      "name": "portable-atomic",
+      "version": "1.9.0",
+      "package_url": "https://github.com/taiki-e/portable-atomic",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/portable-atomic/1.9.0/download",
+          "sha256": "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "portable_atomic",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "portable_atomic",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "fallback"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "portable-atomic 1.9.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.9.0"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "ppv-lite86 0.2.20": {
       "name": "ppv-lite86",
@@ -10142,6 +10483,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "simd",
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -10160,6 +10508,65 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "priority-queue 2.1.1": {
+      "name": "priority-queue",
+      "version": "2.1.1",
+      "package_url": "https://github.com/garro95/priority-queue",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/priority-queue/2.1.1/download",
+          "sha256": "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "priority_queue",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "priority_queue",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "equivalent 1.0.1",
+              "target": "equivalent"
+            },
+            {
+              "id": "indexmap 2.6.0",
+              "target": "indexmap"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.1.1"
+      },
+      "license": "LGPL-3.0-or-later OR MPL-2.0",
+      "license_ids": [
+        "LGPL-3.0",
+        "MPL-2.0"
+      ],
+      "license_file": null
     },
     "proc-macro2 1.0.89": {
       "name": "proc-macro2",
@@ -10216,7 +10623,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.12",
+              "id": "unicode-ident 1.0.13",
               "target": "unicode_ident"
             }
           ],
@@ -10239,6 +10646,181 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "ptr_meta 0.3.0": {
+      "name": "ptr_meta",
+      "version": "0.3.0",
+      "package_url": "https://github.com/rkyv/ptr_meta",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ptr_meta/0.3.0/download",
+          "sha256": "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ptr_meta",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ptr_meta",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "derive",
+            "ptr_meta_derive",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "ptr_meta_derive 0.3.0",
+              "target": "ptr_meta_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.3.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "ptr_meta_derive 0.3.0": {
+      "name": "ptr_meta_derive",
+      "version": "0.3.0",
+      "package_url": "https://github.com/rkyv/ptr_meta",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ptr_meta_derive/0.3.0/download",
+          "sha256": "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "ptr_meta_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ptr_meta_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.3.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "pubgrub 0.2.1": {
+      "name": "pubgrub",
+      "version": "0.2.1",
+      "package_url": "https://github.com/pubgrub-rs/pubgrub",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/pubgrub",
+          "commitish": {
+            "Rev": "388685a8711092971930986644cfed152d1a1f6c"
+          }
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "pubgrub",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "pubgrub",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "indexmap 2.6.0",
+              "target": "indexmap"
+            },
+            {
+              "id": "log 0.4.22",
+              "target": "log"
+            },
+            {
+              "id": "priority-queue 2.1.1",
+              "target": "priority_queue"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.1"
+      },
+      "license": "MPL-2.0",
+      "license_ids": [
+        "MPL-2.0"
+      ],
+      "license_file": "LICENSE"
     },
     "py 0.1.0": {
       "name": "py",
@@ -10267,12 +10849,48 @@
         "deps": {
           "common": [
             {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
+            },
+            {
               "id": "miette 7.2.0",
               "target": "miette"
             },
             {
-              "id": "rattler_installs_packages 0.9.0",
-              "target": "rattler_installs_packages"
+              "id": "tempfile 3.13.0",
+              "target": "tempfile"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "uv-cache 0.0.1",
+              "target": "uv_cache"
+            },
+            {
+              "id": "uv-distribution-filename 0.0.1",
+              "target": "uv_distribution_filename"
+            },
+            {
+              "id": "uv-extract 0.0.1",
+              "target": "uv_extract"
+            },
+            {
+              "id": "uv-install-wheel 0.0.1",
+              "target": "uv_install_wheel"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "uv-python 0.0.1",
+              "target": "uv_python"
+            },
+            {
+              "id": "uv-virtualenv 0.0.4",
+              "target": "uv_virtualenv"
             }
           ],
           "selects": {}
@@ -10283,69 +10901,6 @@
       "license": "Apache 2",
       "license_ids": [],
       "license_file": null
-    },
-    "pyproject-toml 0.9.0": {
-      "name": "pyproject-toml",
-      "version": "0.9.0",
-      "package_url": "https://github.com/PyO3/pyproject-toml-rs.git",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pyproject-toml/0.9.0/download",
-          "sha256": "95c3dd745f99aa3c554b7bb00859f7d18c2f1d6afd749ccc86d60b61e702abd9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pyproject_toml",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "pyproject_toml",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "indexmap 2.6.0",
-              "target": "indexmap"
-            },
-            {
-              "id": "pep440_rs 0.4.0",
-              "target": "pep440_rs"
-            },
-            {
-              "id": "pep508_rs 0.3.0",
-              "target": "pep508_rs"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            },
-            {
-              "id": "toml 0.8.10",
-              "target": "toml"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.9.0"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
     },
     "quinn 0.11.5": {
       "name": "quinn",
@@ -10383,7 +10938,7 @@
               "target": "bytes"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             },
             {
@@ -10401,7 +10956,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "socket2 0.5.5",
+              "id": "socket2 0.5.7",
               "target": "socket2"
             },
             {
@@ -10481,7 +11036,7 @@
               "target": "thiserror"
             },
             {
-              "id": "tinyvec 1.6.0",
+              "id": "tinyvec 1.8.0",
               "target": "tinyvec"
             },
             {
@@ -10537,14 +11092,14 @@
               "target": "libc"
             },
             {
-              "id": "socket2 0.5.5",
+              "id": "socket2 0.5.7",
               "target": "socket2"
             }
           ],
           "selects": {
             "cfg(windows)": [
               {
-                "id": "once_cell 1.19.0",
+                "id": "once_cell 1.20.2",
                 "target": "once_cell"
               },
               {
@@ -10564,14 +11119,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "quote 1.0.35": {
+    "quote 1.0.37": {
       "name": "quote",
-      "version": "1.0.35",
+      "version": "1.0.37",
       "package_url": "https://github.com/dtolnay/quote",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/quote/1.0.35/download",
-          "sha256": "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+          "url": "https://static.crates.io/crates/quote/1.0.37/download",
+          "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
         }
       },
       "targets": [
@@ -10610,7 +11165,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.35"
+        "version": "1.0.37"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -10619,20 +11174,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "radium 0.7.0": {
-      "name": "radium",
-      "version": "0.7.0",
-      "package_url": "https://github.com/bitvecto-rs/radium",
+    "quoted_printable 0.5.1": {
+      "name": "quoted_printable",
+      "version": "0.5.1",
+      "package_url": "https://github.com/staktrace/quoted-printable",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/radium/0.7.0/download",
-          "sha256": "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+          "url": "https://static.crates.io/crates/quoted_printable/0.5.1/download",
+          "sha256": "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "radium",
+            "crate_name": "quoted_printable",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -10641,11 +11196,44 @@
               ]
             }
           }
+        }
+      ],
+      "library_target_name": "quoted_printable",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
         },
+        "edition": "2018",
+        "version": "0.5.1"
+      },
+      "license": "0BSD",
+      "license_ids": [
+        "0BSD"
+      ],
+      "license_file": "LICENSE"
+    },
+    "rancor 0.1.0": {
+      "name": "rancor",
+      "version": "0.1.0",
+      "package_url": "https://github.com/rkyv/rancor",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rancor/0.1.0/download",
+          "sha256": "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+        }
+      },
+      "targets": [
         {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
+          "Library": {
+            "crate_name": "rancor",
+            "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -10655,36 +11243,34 @@
           }
         }
       ],
-      "library_target_name": "radium",
+      "library_target_name": "rancor",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "alloc"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "radium 0.7.0",
-              "target": "build_script_build"
+              "id": "ptr_meta 0.3.0",
+              "target": "ptr_meta"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.7.0"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ]
+        "edition": "2021",
+        "version": "0.1.0"
       },
       "license": "MIT",
       "license_ids": [
         "MIT"
       ],
-      "license_file": "LICENSE.txt"
+      "license_file": "LICENSE"
     },
     "rand 0.8.5": {
       "name": "rand",
@@ -10715,14 +11301,176 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "getrandom",
+            "libc",
+            "rand_chacha",
+            "small_rng",
+            "std",
+            "std_rng"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
+            {
+              "id": "rand_chacha 0.3.1",
+              "target": "rand_chacha"
+            },
             {
               "id": "rand_core 0.6.4",
               "target": "rand_core"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "aarch64-apple-ios": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "aarch64-apple-ios-sim": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "aarch64-fuchsia": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "aarch64-linux-android": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "armv7-linux-androideabi": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "i686-apple-darwin": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "i686-linux-android": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "i686-unknown-freebsd": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "x86_64-apple-ios": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "x86_64-fuchsia": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "x86_64-linux-android": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "libc 0.2.161",
+                "target": "libc"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.8.5"
@@ -10763,6 +11511,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -10815,6 +11569,23 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "getrandom",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "getrandom 0.2.15",
+              "target": "getrandom"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
         "version": "0.6.4"
       },
@@ -10825,20 +11596,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rattler_digest 0.19.5": {
-      "name": "rattler_digest",
-      "version": "0.19.5",
-      "package_url": "https://github.com/mamba-org/rattler",
+    "rayon 1.10.0": {
+      "name": "rayon",
+      "version": "1.10.0",
+      "package_url": "https://github.com/rayon-rs/rayon",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rattler_digest/0.19.5/download",
-          "sha256": "eeb0228f734983274fb6938844123e88aa55158d53ead37e8ae3deb641fe05aa"
+          "url": "https://static.crates.io/crates/rayon/1.10.0/download",
+          "sha256": "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "rattler_digest",
+            "crate_name": "rayon",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -10849,82 +11620,61 @@
           }
         }
       ],
-      "library_target_name": "rattler_digest",
+      "library_target_name": "rayon",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "generic-array",
-            "serde"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "blake2 0.10.6",
-              "target": "blake2"
+              "id": "either 1.13.0",
+              "target": "either"
             },
             {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "generic-array 0.14.7",
-              "target": "generic_array"
-            },
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "md-5 0.10.6",
-              "target": "md5"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            },
-            {
-              "id": "serde_with 3.11.0",
-              "target": "serde_with"
-            },
-            {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
+              "id": "rayon-core 1.12.1",
+              "target": "rayon_core"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.19.5"
+        "version": "1.10.0"
       },
-      "license": "BSD-3-Clause",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
-        "BSD-3-Clause"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": null
+      "license_file": "LICENSE-APACHE"
     },
-    "rattler_installs_packages 0.9.0": {
-      "name": "rattler_installs_packages",
-      "version": "0.9.0",
-      "package_url": "https://github.com/prefix-dev/rip",
+    "rayon-core 1.12.1": {
+      "name": "rayon-core",
+      "version": "1.12.1",
+      "package_url": "https://github.com/rayon-rs/rayon",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/prefix-dev/rip",
-          "commitish": {
-            "Rev": "1b4d909496f68c292800ebbd3667c8682b01d218"
-          },
-          "strip_prefix": "crates/rattler_installs_packages"
+        "Http": {
+          "url": "https://static.crates.io/crates/rayon-core/1.12.1/download",
+          "sha256": "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "rattler_installs_packages",
+            "crate_name": "rayon_core",
             "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -10934,256 +11684,55 @@
           }
         }
       ],
-      "library_target_name": "rattler_installs_packages",
+      "library_target_name": "rayon_core",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "rustls-tls"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "async-once-cell 0.5.3",
-              "target": "async_once_cell"
+              "id": "crossbeam-deque 0.8.5",
+              "target": "crossbeam_deque"
             },
             {
-              "id": "async_http_range_reader 0.7.1",
-              "target": "async_http_range_reader"
+              "id": "crossbeam-utils 0.8.20",
+              "target": "crossbeam_utils"
             },
             {
-              "id": "async_zip 0.0.16",
-              "target": "async_zip"
-            },
-            {
-              "id": "bytes 1.8.0",
-              "target": "bytes"
-            },
-            {
-              "id": "cacache 13.0.0",
-              "target": "cacache"
-            },
-            {
-              "id": "ciborium 0.2.2",
-              "target": "ciborium"
-            },
-            {
-              "id": "configparser 3.0.4",
-              "target": "configparser"
-            },
-            {
-              "id": "csv 1.3.0",
-              "target": "csv"
-            },
-            {
-              "id": "data-encoding 2.5.0",
-              "target": "data_encoding"
-            },
-            {
-              "id": "dunce 1.0.4",
-              "target": "dunce"
-            },
-            {
-              "id": "elsa 1.10.0",
-              "target": "elsa"
-            },
-            {
-              "id": "flate2 1.0.28",
-              "target": "flate2"
-            },
-            {
-              "id": "fs-err 2.11.0",
-              "target": "fs_err"
-            },
-            {
-              "id": "fs4 0.8.4",
-              "target": "fs4"
-            },
-            {
-              "id": "fs_extra 1.3.0",
-              "target": "fs_extra"
-            },
-            {
-              "id": "futures 0.3.30",
-              "target": "futures"
-            },
-            {
-              "id": "html-escape 0.2.13",
-              "target": "html_escape"
-            },
-            {
-              "id": "http 1.1.0",
-              "target": "http"
-            },
-            {
-              "id": "http-cache-semantics 2.1.0",
-              "target": "http_cache_semantics"
-            },
-            {
-              "id": "include_dir 0.7.3",
-              "target": "include_dir"
-            },
-            {
-              "id": "indexmap 2.6.0",
-              "target": "indexmap"
-            },
-            {
-              "id": "itertools 0.12.1",
-              "target": "itertools"
-            },
-            {
-              "id": "miette 7.2.0",
-              "target": "miette"
-            },
-            {
-              "id": "mime 0.3.17",
-              "target": "mime"
-            },
-            {
-              "id": "once_cell 1.19.0",
-              "target": "once_cell"
-            },
-            {
-              "id": "parking_lot 0.12.1",
-              "target": "parking_lot"
-            },
-            {
-              "id": "pathdiff 0.2.1",
-              "target": "pathdiff"
-            },
-            {
-              "id": "peg 0.8.2",
-              "target": "peg"
-            },
-            {
-              "id": "pep440_rs 0.4.0",
-              "target": "pep440_rs"
-            },
-            {
-              "id": "pep508_rs 0.3.0",
-              "target": "pep508_rs"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "pyproject-toml 0.9.0",
-              "target": "pyproject_toml"
-            },
-            {
-              "id": "rattler_digest 0.19.5",
-              "target": "rattler_digest"
-            },
-            {
-              "id": "regex 1.11.0",
-              "target": "regex"
-            },
-            {
-              "id": "reqwest 0.12.8",
-              "target": "reqwest"
-            },
-            {
-              "id": "reqwest-middleware 0.3.3",
-              "target": "reqwest_middleware"
-            },
-            {
-              "id": "resolvo 0.4.1",
-              "target": "resolvo"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.132",
-              "target": "serde_json"
-            },
-            {
-              "id": "serde_with 3.11.0",
-              "target": "serde_with"
-            },
-            {
-              "id": "smallvec 1.13.2",
-              "target": "smallvec"
-            },
-            {
-              "id": "tar 0.4.40",
-              "target": "tar"
-            },
-            {
-              "id": "tempfile 3.13.0",
-              "target": "tempfile"
-            },
-            {
-              "id": "thiserror 1.0.65",
-              "target": "thiserror"
-            },
-            {
-              "id": "tl 0.7.8",
-              "target": "tl"
-            },
-            {
-              "id": "tokio 1.41.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tokio-util 0.7.10",
-              "target": "tokio_util"
-            },
-            {
-              "id": "tracing 0.1.40",
-              "target": "tracing"
-            },
-            {
-              "id": "url 2.5.0",
-              "target": "url"
-            },
-            {
-              "id": "which 6.0.3",
-              "target": "which"
-            },
-            {
-              "id": "zip 0.6.6",
-              "target": "zip"
+              "id": "rayon-core 1.12.1",
+              "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "async-recursion 1.1.1",
-              "target": "async_recursion"
-            },
-            {
-              "id": "async-trait 0.1.83",
-              "target": "async_trait"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.9.0"
+        "version": "1.12.1"
       },
-      "license": "BSD-3-Clause",
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "links": "rayon-core"
+      },
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
-        "BSD-3-Clause"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": null
+      "license_file": "LICENSE-APACHE"
     },
-    "redox_syscall 0.4.1": {
+    "redox_syscall 0.2.16": {
       "name": "redox_syscall",
-      "version": "0.4.1",
+      "version": "0.2.16",
       "package_url": "https://gitlab.redox-os.org/redox-os/syscall",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/redox_syscall/0.4.1/download",
-          "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+          "url": "https://static.crates.io/crates/redox_syscall/0.2.16/download",
+          "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
         }
       },
       "targets": [
@@ -11215,7 +11764,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.1"
+        "version": "0.2.16"
       },
       "license": "MIT",
       "license_ids": [
@@ -11223,14 +11772,163 @@
       ],
       "license_file": "LICENSE"
     },
-    "reflink-copy 0.1.14": {
+    "redox_syscall 0.3.5": {
+      "name": "redox_syscall",
+      "version": "0.3.5",
+      "package_url": "https://gitlab.redox-os.org/redox-os/syscall",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/redox_syscall/0.3.5/download",
+          "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "syscall",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "syscall",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.5"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "redox_syscall 0.5.7": {
+      "name": "redox_syscall",
+      "version": "0.5.7",
+      "package_url": "https://gitlab.redox-os.org/redox-os/syscall",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/redox_syscall/0.5.7/download",
+          "sha256": "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "syscall",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "syscall",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.6.0",
+              "target": "bitflags"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.7"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "redox_users 0.4.6": {
+      "name": "redox_users",
+      "version": "0.4.6",
+      "package_url": "https://gitlab.redox-os.org/redox-os/users",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/redox_users/0.4.6/download",
+          "sha256": "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "redox_users",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "redox_users",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "getrandom 0.2.15",
+              "target": "getrandom"
+            },
+            {
+              "id": "libredox 0.1.3",
+              "target": "libredox"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.4.6"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "reflink-copy 0.1.19": {
       "name": "reflink-copy",
-      "version": "0.1.14",
+      "version": "0.1.19",
       "package_url": "https://github.com/cargo-bins/reflink-copy",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/reflink-copy/0.1.14/download",
-          "sha256": "767be24c0da52e7448d495b8d162506a9aa125426651d547d545d6c2b4b65b62"
+          "url": "https://static.crates.io/crates/reflink-copy/0.1.19/download",
+          "sha256": "dc31414597d1cd7fdd2422798b7652a6329dda0fe0219e6335a13d5bcaa9aeb6"
         }
       },
       "targets": [
@@ -11268,14 +11966,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows 0.52.0",
+                "id": "windows 0.58.0",
                 "target": "windows"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.1.14"
+        "version": "0.1.19"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -11284,14 +11982,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "regex 1.11.0": {
+    "regex 1.11.1": {
       "name": "regex",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "package_url": "https://github.com/rust-lang/regex",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex/1.11.0/download",
-          "sha256": "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+          "url": "https://static.crates.io/crates/regex/1.11.1/download",
+          "sha256": "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
         }
       },
       "targets": [
@@ -11338,11 +12036,11 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 1.1.2",
+              "id": "aho-corasick 1.1.3",
               "target": "aho_corasick"
             },
             {
-              "id": "memchr 2.7.1",
+              "id": "memchr 2.7.4",
               "target": "memchr"
             },
             {
@@ -11357,7 +12055,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.11.0"
+        "version": "1.11.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11401,9 +12099,11 @@
             "dfa-onepass",
             "hybrid",
             "meta",
+            "nfa",
             "nfa-backtrack",
             "nfa-pikevm",
             "nfa-thompson",
+            "perf",
             "perf-inline",
             "perf-literal",
             "perf-literal-multisubstring",
@@ -11425,11 +12125,11 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 1.1.2",
+              "id": "aho-corasick 1.1.3",
               "target": "aho_corasick"
             },
             {
-              "id": "memchr 2.7.1",
+              "id": "memchr 2.7.4",
               "target": "memchr"
             },
             {
@@ -11503,6 +12203,59 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "rend 0.5.2": {
+      "name": "rend",
+      "version": "0.5.2",
+      "package_url": "https://github.com/djkoloski/rend",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rend/0.5.2/download",
+          "sha256": "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rend",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rend",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "bytecheck"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bytecheck 0.8.0",
+              "target": "bytecheck"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.2"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "reqwest 0.12.8": {
       "name": "reqwest",
       "version": "0.12.8",
@@ -11537,9 +12290,16 @@
             "__rustls",
             "__rustls-ring",
             "__tls",
+            "blocking",
+            "gzip",
+            "h2",
+            "http2",
             "json",
+            "multipart",
             "rustls-tls",
+            "rustls-tls-native-roots",
             "rustls-tls-webpki-roots",
+            "socks",
             "stream"
           ],
           "selects": {}
@@ -11555,16 +12315,20 @@
               "target": "bytes"
             },
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "futures-util 0.3.30",
+              "id": "futures-util 0.3.31",
               "target": "futures_util"
             },
             {
               "id": "http 1.1.0",
               "target": "http"
+            },
+            {
+              "id": "mime_guess 2.0.5",
+              "target": "mime_guess"
             },
             {
               "id": "serde 1.0.213",
@@ -11583,16 +12347,28 @@
               "target": "sync_wrapper"
             },
             {
-              "id": "tower-service 0.3.2",
+              "id": "tower-service 0.3.3",
               "target": "tower_service"
             },
             {
-              "id": "url 2.5.0",
+              "id": "url 2.5.2",
               "target": "url"
             }
           ],
           "selects": {
             "aarch64-apple-darwin": [
+              {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
               {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
@@ -11600,6 +12376,10 @@
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11614,7 +12394,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11624,12 +12408,28 @@
             ],
             "aarch64-apple-ios": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11644,7 +12444,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11654,12 +12458,28 @@
             ],
             "aarch64-apple-ios-sim": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11674,7 +12494,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11684,12 +12508,28 @@
             ],
             "aarch64-fuchsia": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11704,7 +12544,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11714,12 +12558,28 @@
             ],
             "aarch64-linux-android": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11734,7 +12594,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11744,12 +12608,28 @@
             ],
             "aarch64-pc-windows-msvc": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11764,7 +12644,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11774,12 +12658,28 @@
             ],
             "aarch64-unknown-linux-gnu": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11794,7 +12694,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11804,12 +12708,28 @@
             ],
             "aarch64-unknown-nixos-gnu": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11824,7 +12744,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11834,12 +12758,28 @@
             ],
             "aarch64-unknown-nto-qnx710": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11854,7 +12794,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11864,12 +12808,28 @@
             ],
             "arm-unknown-linux-gnueabi": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11884,7 +12844,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11894,12 +12858,28 @@
             ],
             "armv7-linux-androideabi": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11914,7 +12894,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11924,12 +12908,28 @@
             ],
             "armv7-unknown-linux-gnueabi": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -11944,7 +12944,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -11970,11 +12974,11 @@
                 "target": "hyper_util"
               },
               {
-                "id": "ipnet 2.9.0",
+                "id": "ipnet 2.10.1",
                 "target": "ipnet"
               },
               {
-                "id": "log 0.4.20",
+                "id": "log 0.4.22",
                 "target": "log"
               },
               {
@@ -11982,7 +12986,7 @@
                 "target": "mime"
               },
               {
-                "id": "once_cell 1.19.0",
+                "id": "once_cell 1.20.2",
                 "target": "once_cell"
               },
               {
@@ -11990,7 +12994,7 @@
                 "target": "percent_encoding"
               },
               {
-                "id": "pin-project-lite 0.2.14",
+                "id": "pin-project-lite 0.2.15",
                 "target": "pin_project_lite"
               },
               {
@@ -12000,19 +13004,19 @@
             ],
             "cfg(target_arch = \"wasm32\")": [
               {
-                "id": "js-sys 0.3.68",
+                "id": "js-sys 0.3.72",
                 "target": "js_sys"
               },
               {
-                "id": "wasm-bindgen 0.2.91",
+                "id": "wasm-bindgen 0.2.95",
                 "target": "wasm_bindgen"
               },
               {
-                "id": "wasm-bindgen-futures 0.4.41",
+                "id": "wasm-bindgen-futures 0.4.45",
                 "target": "wasm_bindgen_futures"
               },
               {
-                "id": "web-sys 0.3.68",
+                "id": "web-sys 0.3.72",
                 "target": "web_sys"
               }
             ],
@@ -12024,12 +13028,28 @@
             ],
             "i686-apple-darwin": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12044,7 +13064,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12054,12 +13078,28 @@
             ],
             "i686-linux-android": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12074,7 +13114,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12084,12 +13128,28 @@
             ],
             "i686-pc-windows-msvc": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12104,7 +13164,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12114,12 +13178,28 @@
             ],
             "i686-unknown-freebsd": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12134,7 +13214,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12144,12 +13228,28 @@
             ],
             "i686-unknown-linux-gnu": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12164,7 +13264,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12174,12 +13278,28 @@
             ],
             "powerpc-unknown-linux-gnu": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12194,7 +13314,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12204,12 +13328,28 @@
             ],
             "riscv32imc-unknown-none-elf": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12224,7 +13364,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12234,12 +13378,28 @@
             ],
             "riscv64gc-unknown-none-elf": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12254,7 +13414,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12264,12 +13428,28 @@
             ],
             "s390x-unknown-linux-gnu": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12284,7 +13464,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12294,12 +13478,28 @@
             ],
             "thumbv7em-none-eabi": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12314,7 +13514,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12324,12 +13528,28 @@
             ],
             "thumbv8m.main-none-eabi": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12344,7 +13564,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12354,17 +13578,29 @@
             ],
             "wasm32-unknown-unknown": [
               {
-                "id": "wasm-streams 0.4.0",
+                "id": "wasm-streams 0.4.1",
                 "target": "wasm_streams"
               }
             ],
             "wasm32-wasi": [
               {
-                "id": "wasm-streams 0.4.0",
+                "id": "wasm-streams 0.4.1",
                 "target": "wasm_streams"
               }
             ],
             "x86_64-apple-darwin": [
+              {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
               {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
@@ -12372,6 +13608,10 @@
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12386,7 +13626,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12396,12 +13640,28 @@
             ],
             "x86_64-apple-ios": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12416,7 +13676,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12426,12 +13690,28 @@
             ],
             "x86_64-fuchsia": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12446,7 +13726,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12456,12 +13740,28 @@
             ],
             "x86_64-linux-android": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12476,7 +13776,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12486,12 +13790,28 @@
             ],
             "x86_64-pc-windows-msvc": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12506,7 +13826,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12516,12 +13840,28 @@
             ],
             "x86_64-unknown-freebsd": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12536,7 +13876,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12546,12 +13890,28 @@
             ],
             "x86_64-unknown-linux-gnu": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12566,7 +13926,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12576,12 +13940,28 @@
             ],
             "x86_64-unknown-nixos-gnu": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12596,7 +13976,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12606,12 +13990,28 @@
             ],
             "x86_64-unknown-none": [
               {
+                "id": "async-compression 0.4.17",
+                "target": "async_compression"
+              },
+              {
+                "id": "futures-channel 0.3.31",
+                "target": "futures_channel"
+              },
+              {
+                "id": "h2 0.4.6",
+                "target": "h2"
+              },
+              {
                 "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
                 "id": "rustls 0.23.15",
                 "target": "rustls"
+              },
+              {
+                "id": "rustls-native-certs 0.8.0",
+                "target": "rustls_native_certs"
               },
               {
                 "id": "rustls-pemfile 2.2.0",
@@ -12626,7 +14026,11 @@
                 "target": "tokio_rustls"
               },
               {
-                "id": "tokio-util 0.7.10",
+                "id": "tokio-socks 0.5.2",
+                "target": "tokio_socks"
+              },
+              {
+                "id": "tokio-util 0.7.12",
                 "target": "tokio_util"
               },
               {
@@ -12651,9 +14055,12 @@
       "version": "0.3.3",
       "package_url": "https://github.com/TrueLayer/reqwest-middleware",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/reqwest-middleware/0.3.3/download",
-          "sha256": "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+        "Git": {
+          "remote": "https://github.com/astral-sh/reqwest-middleware",
+          "commitish": {
+            "Rev": "5e3eaf254b5bd481c75d2710eed055f95b756913"
+          },
+          "strip_prefix": "reqwest-middleware"
         }
       },
       "targets": [
@@ -12675,10 +14082,16 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "multipart"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.79",
+              "id": "anyhow 1.0.91",
               "target": "anyhow"
             },
             {
@@ -12698,7 +14111,7 @@
               "target": "thiserror"
             },
             {
-              "id": "tower-service 0.3.2",
+              "id": "tower-service 0.3.3",
               "target": "tower_service"
             }
           ],
@@ -12723,20 +14136,23 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "resolvo 0.4.1": {
-      "name": "resolvo",
-      "version": "0.4.1",
-      "package_url": "https://github.com/mamba-org/resolvo",
+    "reqwest-retry 0.7.1": {
+      "name": "reqwest-retry",
+      "version": "0.7.1",
+      "package_url": "https://github.com/TrueLayer/reqwest-middleware",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/resolvo/0.4.1/download",
-          "sha256": "d299d168910c5d71f3c0f5441abe38ca4a6ae21f70fae909bfc6bead28f6620f"
+        "Git": {
+          "remote": "https://github.com/astral-sh/reqwest-middleware",
+          "commitish": {
+            "Rev": "5e3eaf254b5bd481c75d2710eed055f95b756913"
+          },
+          "strip_prefix": "reqwest-retry"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "resolvo",
+            "crate_name": "reqwest_retry",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -12747,71 +14163,148 @@
           }
         }
       ],
-      "library_target_name": "resolvo",
+      "library_target_name": "reqwest_retry",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "tokio"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "bitvec 1.0.1",
-              "target": "bitvec"
+              "id": "anyhow 1.0.91",
+              "target": "anyhow"
             },
             {
-              "id": "elsa 1.10.0",
-              "target": "elsa"
-            },
-            {
-              "id": "event-listener 5.3.1",
-              "target": "event_listener"
-            },
-            {
-              "id": "futures 0.3.30",
+              "id": "futures 0.3.31",
               "target": "futures"
             },
             {
-              "id": "itertools 0.13.0",
-              "target": "itertools"
+              "id": "http 1.1.0",
+              "target": "http"
             },
             {
-              "id": "petgraph 0.6.5",
-              "target": "petgraph"
+              "id": "reqwest 0.12.8",
+              "target": "reqwest"
             },
             {
-              "id": "tokio 1.41.0",
-              "target": "tokio"
+              "id": "reqwest-middleware 0.3.3",
+              "target": "reqwest_middleware"
+            },
+            {
+              "id": "retry-policies 0.4.0",
+              "target": "retry_policies"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
             },
             {
               "id": "tracing 0.1.40",
               "target": "tracing"
             }
           ],
+          "selects": {
+            "cfg(not(target_arch = \"wasm32\"))": [
+              {
+                "id": "hyper 1.5.0",
+                "target": "hyper"
+              },
+              {
+                "id": "tokio 1.41.0",
+                "target": "tokio"
+              }
+            ],
+            "cfg(target_arch = \"wasm32\")": [
+              {
+                "id": "getrandom 0.2.15",
+                "target": "getrandom"
+              },
+              {
+                "id": "parking_lot 0.11.2",
+                "target": "parking_lot"
+              },
+              {
+                "id": "wasm-timer 0.2.5",
+                "target": "wasm_timer"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.83",
+              "target": "async_trait"
+            }
+          ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.4.1"
+        "version": "0.7.1"
       },
-      "license": "BSD-3-Clause",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
-        "BSD-3-Clause"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": "LICENSE-APACHE"
     },
-    "ring 0.17.7": {
+    "retry-policies 0.4.0": {
+      "name": "retry-policies",
+      "version": "0.4.0",
+      "package_url": "https://github.com/TrueLayer/retry-policies",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/retry-policies/0.4.0/download",
+          "sha256": "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "retry_policies",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "retry_policies",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.4.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "ring 0.17.8": {
       "name": "ring",
-      "version": "0.17.7",
+      "version": "0.17.8",
       "package_url": "https://github.com/briansmith/ring",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ring/0.17.7/download",
-          "sha256": "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+          "url": "https://static.crates.io/crates/ring/0.17.8/download",
+          "sha256": "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
         }
       },
       "targets": [
@@ -12856,11 +14349,15 @@
         "deps": {
           "common": [
             {
-              "id": "getrandom 0.2.12",
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "getrandom 0.2.15",
               "target": "getrandom"
             },
             {
-              "id": "ring 0.17.7",
+              "id": "ring 0.17.8",
               "target": "build_script_build"
             },
             {
@@ -12877,7 +14374,7 @@
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"windows\"))": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ],
@@ -12890,7 +14387,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.17.7"
+        "version": "0.17.8"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -12902,26 +14399,343 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.83",
+              "id": "cc 1.1.31",
               "target": "cc"
             }
           ],
           "selects": {}
         },
-        "links": "ring_core_0_17_7"
+        "links": "ring_core_0_17_8"
       },
       "license": null,
       "license_ids": [],
       "license_file": "LICENSE"
     },
-    "rustc-demangle 0.1.23": {
-      "name": "rustc-demangle",
-      "version": "0.1.23",
-      "package_url": "https://github.com/alexcrichton/rustc-demangle",
+    "rkyv 0.8.8": {
+      "name": "rkyv",
+      "version": "0.8.8",
+      "package_url": "https://github.com/rkyv/rkyv",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustc-demangle/0.1.23/download",
-          "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+          "url": "https://static.crates.io/crates/rkyv/0.8.8/download",
+          "sha256": "395027076c569819ea6035ee62e664f5e03d74e281744f55261dd1afd939212b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rkyv",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rkyv",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "bytecheck",
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bytecheck 0.8.0",
+              "target": "bytecheck"
+            },
+            {
+              "id": "hashbrown 0.14.5",
+              "target": "hashbrown"
+            },
+            {
+              "id": "munge 0.4.1",
+              "target": "munge"
+            },
+            {
+              "id": "ptr_meta 0.3.0",
+              "target": "ptr_meta"
+            },
+            {
+              "id": "rancor 0.1.0",
+              "target": "rancor"
+            },
+            {
+              "id": "rend 0.5.2",
+              "target": "rend"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "rkyv_derive 0.8.8",
+              "target": "rkyv_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.8.8"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "rkyv_derive 0.8.8": {
+      "name": "rkyv_derive",
+      "version": "0.8.8",
+      "package_url": "https://github.com/rkyv/rkyv",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rkyv_derive/0.8.8/download",
+          "sha256": "09cb82b74b4810f07e460852c32f522e979787691b0b7b7439fe473e49d49b2f"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "rkyv_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rkyv_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "bytecheck"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.8.8"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "rmp 0.8.14": {
+      "name": "rmp",
+      "version": "0.8.14",
+      "package_url": "https://github.com/3Hren/msgpack-rust",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rmp/0.8.14/download",
+          "sha256": "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rmp",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rmp",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "byteorder 1.5.0",
+              "target": "byteorder"
+            },
+            {
+              "id": "num-traits 0.2.19",
+              "target": "num_traits"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "paste 1.0.15",
+              "target": "paste"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.8.14"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "rmp-serde 1.3.0": {
+      "name": "rmp-serde",
+      "version": "1.3.0",
+      "package_url": "https://github.com/3Hren/msgpack-rust",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rmp-serde/1.3.0/download",
+          "sha256": "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rmp_serde",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rmp_serde",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "byteorder 1.5.0",
+              "target": "byteorder"
+            },
+            {
+              "id": "rmp 0.8.14",
+              "target": "rmp"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.3.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "rust-netrc 0.1.1": {
+      "name": "rust-netrc",
+      "version": "0.1.1",
+      "package_url": "https://github.com/gribouille/netrc",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/gribouille/netrc",
+          "commitish": {
+            "Rev": "544f3890b621f0dc30fcefb4f804269c160ce2e9"
+          }
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "netrc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "netrc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "rustc-demangle 0.1.24": {
+      "name": "rustc-demangle",
+      "version": "0.1.24",
+      "package_url": "https://github.com/rust-lang/rustc-demangle",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rustc-demangle/0.1.24/download",
+          "sha256": "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
         }
       },
       "targets": [
@@ -12944,7 +14758,7 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.1.23"
+        "version": "0.1.24"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -12982,6 +14796,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
         "edition": "2021",
         "version": "2.0.0"
       },
@@ -13037,18 +14858,93 @@
           "common": [
             "alloc",
             "default",
-            "fs",
             "libc-extra-traits",
             "std",
             "termios",
             "use-libc-auxv"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "fs"
+            ],
+            "aarch64-apple-ios": [
+              "fs"
+            ],
+            "aarch64-apple-ios-sim": [
+              "fs"
+            ],
+            "aarch64-fuchsia": [
+              "fs"
+            ],
+            "aarch64-linux-android": [
+              "fs"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "fs"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "fs"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "fs"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "fs"
+            ],
+            "armv7-linux-androideabi": [
+              "fs"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "fs"
+            ],
+            "i686-apple-darwin": [
+              "fs"
+            ],
+            "i686-linux-android": [
+              "fs"
+            ],
+            "i686-unknown-freebsd": [
+              "fs"
+            ],
+            "i686-unknown-linux-gnu": [
+              "fs"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "fs"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "fs"
+            ],
+            "wasm32-wasi": [
+              "fs"
+            ],
+            "x86_64-apple-darwin": [
+              "fs"
+            ],
+            "x86_64-apple-ios": [
+              "fs"
+            ],
+            "x86_64-fuchsia": [
+              "fs"
+            ],
+            "x86_64-linux-android": [
+              "fs"
+            ],
+            "x86_64-unknown-freebsd": [
+              "fs"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "fs"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "fs"
+            ]
+          }
         },
         "deps": {
           "common": [
             {
-              "id": "bitflags 2.4.2",
+              "id": "bitflags 2.6.0",
               "target": "bitflags"
             },
             {
@@ -13059,7 +14955,7 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13070,7 +14966,7 @@
             ],
             "aarch64-apple-ios": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13081,7 +14977,7 @@
             ],
             "aarch64-apple-ios-sim": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13092,7 +14988,7 @@
             ],
             "aarch64-fuchsia": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13103,7 +14999,7 @@
             ],
             "aarch64-linux-android": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13114,7 +15010,7 @@
             ],
             "aarch64-unknown-nto-qnx710": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13125,7 +15021,7 @@
             ],
             "armv7-linux-androideabi": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13148,7 +15044,7 @@
             ],
             "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13159,7 +15055,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13170,7 +15066,7 @@
             ],
             "i686-apple-darwin": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13181,7 +15077,7 @@
             ],
             "i686-linux-android": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13192,7 +15088,7 @@
             ],
             "i686-unknown-freebsd": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13203,7 +15099,7 @@
             ],
             "powerpc-unknown-linux-gnu": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13214,7 +15110,7 @@
             ],
             "riscv32imc-unknown-none-elf": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13225,7 +15121,7 @@
             ],
             "riscv64gc-unknown-none-elf": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13236,7 +15132,7 @@
             ],
             "s390x-unknown-linux-gnu": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13247,7 +15143,7 @@
             ],
             "thumbv7em-none-eabi": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13258,7 +15154,7 @@
             ],
             "thumbv8m.main-none-eabi": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13269,7 +15165,7 @@
             ],
             "wasm32-unknown-unknown": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13280,7 +15176,7 @@
             ],
             "wasm32-wasi": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13291,7 +15187,7 @@
             ],
             "x86_64-apple-darwin": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13302,7 +15198,7 @@
             ],
             "x86_64-apple-ios": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13313,7 +15209,7 @@
             ],
             "x86_64-fuchsia": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13324,7 +15220,7 @@
             ],
             "x86_64-linux-android": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13335,7 +15231,7 @@
             ],
             "x86_64-unknown-freebsd": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13346,7 +15242,7 @@
             ],
             "x86_64-unknown-none": [
               {
-                "id": "errno 0.3.8",
+                "id": "errno 0.3.9",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -13427,11 +15323,11 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.19.0",
+              "id": "once_cell 1.20.2",
               "target": "once_cell"
             },
             {
-              "id": "ring 0.17.7",
+              "id": "ring 0.17.8",
               "target": "ring"
             },
             {
@@ -13448,7 +15344,7 @@
               "target": "webpki"
             },
             {
-              "id": "subtle 2.5.0",
+              "id": "subtle 2.6.1",
               "target": "subtle"
             },
             {
@@ -13471,7 +15367,7 @@
         "link_deps": {
           "common": [
             {
-              "id": "ring 0.17.7",
+              "id": "ring 0.17.8",
               "target": "ring"
             }
           ],
@@ -13485,6 +15381,79 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "rustls-native-certs 0.8.0": {
+      "name": "rustls-native-certs",
+      "version": "0.8.0",
+      "package_url": "https://github.com/rustls/rustls-native-certs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rustls-native-certs/0.8.0/download",
+          "sha256": "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustls_native_certs",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustls_native_certs",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rustls-pemfile 2.2.0",
+              "target": "rustls_pemfile"
+            },
+            {
+              "id": "rustls-pki-types 1.10.0",
+              "target": "rustls_pki_types",
+              "alias": "pki_types"
+            }
+          ],
+          "selects": {
+            "cfg(all(unix, not(target_os = \"macos\")))": [
+              {
+                "id": "openssl-probe 0.1.5",
+                "target": "openssl_probe"
+              }
+            ],
+            "cfg(target_os = \"macos\")": [
+              {
+                "id": "security-framework 2.11.1",
+                "target": "security_framework"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "schannel 0.1.26",
+                "target": "schannel"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.8.0"
+      },
+      "license": "Apache-2.0 OR ISC OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "ISC",
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "rustls-pemfile 2.2.0": {
       "name": "rustls-pemfile",
@@ -13630,7 +15599,7 @@
         "deps": {
           "common": [
             {
-              "id": "ring 0.17.7",
+              "id": "ring 0.17.8",
               "target": "ring"
             },
             {
@@ -13654,14 +15623,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ryu 1.0.16": {
+    "ryu 1.0.18": {
       "name": "ryu",
-      "version": "1.0.16",
+      "version": "1.0.18",
       "package_url": "https://github.com/dtolnay/ryu",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ryu/1.0.16/download",
-          "sha256": "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+          "url": "https://static.crates.io/crates/ryu/1.0.18/download",
+          "sha256": "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
         }
       },
       "targets": [
@@ -13684,7 +15653,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.16"
+        "version": "1.0.18"
       },
       "license": "Apache-2.0 OR BSL-1.0",
       "license_ids": [
@@ -13727,7 +15696,7 @@
           "selects": {
             "cfg(windows)": [
               {
-                "id": "winapi-util 0.1.6",
+                "id": "winapi-util 0.1.9",
                 "target": "winapi_util"
               }
             ]
@@ -13742,6 +15711,213 @@
         "Unlicense"
       ],
       "license_file": "LICENSE-MIT"
+    },
+    "schannel 0.1.26": {
+      "name": "schannel",
+      "version": "0.1.26",
+      "package_url": "https://github.com/steffengy/schannel-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/schannel/0.1.26/download",
+          "sha256": "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "schannel",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "schannel",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows-sys 0.59.0",
+              "target": "windows_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.26"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.md"
+    },
+    "schemars 0.8.21": {
+      "name": "schemars",
+      "version": "0.8.21",
+      "package_url": "https://github.com/GREsau/schemars",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/schemars/0.8.21/download",
+          "sha256": "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "schemars",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "schemars",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "derive",
+            "schemars_derive",
+            "url"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "dyn-clone 1.0.17",
+              "target": "dyn_clone"
+            },
+            {
+              "id": "schemars 0.8.21",
+              "target": "build_script_build"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.132",
+              "target": "serde_json"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "schemars_derive 0.8.21",
+              "target": "schemars_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.8.21"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "schemars_derive 0.8.21": {
+      "name": "schemars_derive",
+      "version": "0.8.21",
+      "package_url": "https://github.com/GREsau/schemars",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/schemars_derive/0.8.21/download",
+          "sha256": "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "schemars_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "schemars_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "serde_derive_internals 0.29.1",
+              "target": "serde_derive_internals"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.8.21"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "scopeguard 1.2.0": {
       "name": "scopeguard",
@@ -13774,6 +15950,294 @@
         ],
         "edition": "2015",
         "version": "1.2.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "scroll 0.12.0": {
+      "name": "scroll",
+      "version": "0.12.0",
+      "package_url": "https://github.com/m4b/scroll",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/scroll/0.12.0/download",
+          "sha256": "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "scroll",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "scroll",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "derive",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "scroll_derive 0.12.0",
+              "target": "scroll_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.12.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "scroll_derive 0.12.0": {
+      "name": "scroll_derive",
+      "version": "0.12.0",
+      "package_url": "https://github.com/m4b/scroll",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/scroll_derive/0.12.0/download",
+          "sha256": "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "scroll_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "scroll_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.12.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "seahash 4.1.0": {
+      "name": "seahash",
+      "version": "4.1.0",
+      "package_url": "https://gitlab.redox-os.org/redox-os/seahash",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/seahash/4.1.0/download",
+          "sha256": "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "seahash",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "seahash",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "4.1.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "security-framework 2.11.1": {
+      "name": "security-framework",
+      "version": "2.11.1",
+      "package_url": "https://github.com/kornelski/rust-security-framework",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/security-framework/2.11.1/download",
+          "sha256": "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "security_framework",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "security_framework",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "OSX_10_10",
+            "OSX_10_11",
+            "OSX_10_12",
+            "OSX_10_9",
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.6.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "core-foundation 0.9.4",
+              "target": "core_foundation"
+            },
+            {
+              "id": "core-foundation-sys 0.8.7",
+              "target": "core_foundation_sys"
+            },
+            {
+              "id": "libc 0.2.161",
+              "target": "libc"
+            },
+            {
+              "id": "security-framework-sys 2.12.0",
+              "target": "security_framework_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.11.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "security-framework-sys 2.12.0": {
+      "name": "security-framework-sys",
+      "version": "2.12.0",
+      "package_url": "https://github.com/kornelski/rust-security-framework",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/security-framework-sys/2.12.0/download",
+          "sha256": "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "security_framework_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "security_framework_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "OSX_10_10",
+            "OSX_10_11",
+            "OSX_10_12",
+            "OSX_10_9"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "core-foundation-sys 0.8.7",
+              "target": "core_foundation_sys"
+            },
+            {
+              "id": "libc 0.2.161",
+              "target": "libc"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.12.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13828,6 +16292,7 @@
             "alloc",
             "default",
             "derive",
+            "rc",
             "serde_derive",
             "std"
           ],
@@ -13861,6 +16326,62 @@
         "data_glob": [
           "**"
         ]
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "serde-untagged 0.1.6": {
+      "name": "serde-untagged",
+      "version": "0.1.6",
+      "package_url": "https://github.com/dtolnay/serde-untagged",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/serde-untagged/0.1.6/download",
+          "sha256": "2676ba99bd82f75cae5cbd2c8eda6fa0b8760f18978ea840e980dd5567b5c5b6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "serde_untagged",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "serde_untagged",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "erased-serde 0.4.5",
+              "target": "erased_serde"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "typeid 1.0.2",
+              "target": "typeid"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.6"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13911,11 +16432,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
@@ -13923,6 +16444,62 @@
         },
         "edition": "2015",
         "version": "1.0.213"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "serde_derive_internals 0.29.1": {
+      "name": "serde_derive_internals",
+      "version": "0.29.1",
+      "package_url": "https://github.com/serde-rs/serde",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/serde_derive_internals/0.29.1/download",
+          "sha256": "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "serde_derive_internals",
+            "crate_root": "lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "serde_derive_internals",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.29.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13982,15 +16559,15 @@
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.10",
+              "id": "itoa 1.0.11",
               "target": "itoa"
             },
             {
-              "id": "memchr 2.7.1",
+              "id": "memchr 2.7.4",
               "target": "memchr"
             },
             {
-              "id": "ryu 1.0.16",
+              "id": "ryu 1.0.18",
               "target": "ryu"
             },
             {
@@ -14022,14 +16599,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_spanned 0.6.5": {
+    "serde_spanned 0.6.8": {
       "name": "serde_spanned",
-      "version": "0.6.5",
+      "version": "0.6.8",
       "package_url": "https://github.com/toml-rs/toml",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_spanned/0.6.5/download",
-          "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+          "url": "https://static.crates.io/crates/serde_spanned/0.6.8/download",
+          "sha256": "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
         }
       },
       "targets": [
@@ -14067,7 +16644,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.5"
+        "version": "0.6.8"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -14112,11 +16689,11 @@
               "target": "form_urlencoded"
             },
             {
-              "id": "itoa 1.0.10",
+              "id": "itoa 1.0.11",
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.16",
+              "id": "ryu 1.0.18",
               "target": "ryu"
             },
             {
@@ -14130,268 +16707,6 @@
         "version": "0.7.1"
       },
       "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "serde_with 3.11.0": {
-      "name": "serde_with",
-      "version": "3.11.0",
-      "package_url": "https://github.com/jonasbb/serde_with/",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_with/3.11.0/download",
-          "sha256": "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "serde_with",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "serde_with",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "macros",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "serde_derive 1.0.213",
-              "target": "serde_derive"
-            },
-            {
-              "id": "serde_with_macros 3.11.0",
-              "target": "serde_with_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "3.11.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "serde_with_macros 3.11.0": {
-      "name": "serde_with_macros",
-      "version": "3.11.0",
-      "package_url": "https://github.com/jonasbb/serde_with/",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_with_macros/3.11.0/download",
-          "sha256": "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "serde_with_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "serde_with_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "darling 0.20.5",
-              "target": "darling"
-            },
-            {
-              "id": "proc-macro2 1.0.89",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.35",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.82",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "3.11.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "sha-1 0.10.1": {
-      "name": "sha-1",
-      "version": "0.10.1",
-      "package_url": "https://github.com/RustCrypto/hashes",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/sha-1/0.10.1/download",
-          "sha256": "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "sha1",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "sha1",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            }
-          ],
-          "selects": {
-            "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
-              {
-                "id": "cpufeatures 0.2.12",
-                "target": "cpufeatures"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.10.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "sha1 0.10.6": {
-      "name": "sha1",
-      "version": "0.10.6",
-      "package_url": "https://github.com/RustCrypto/hashes",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/sha1/0.10.6/download",
-          "sha256": "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "sha1",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "sha1",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            }
-          ],
-          "selects": {
-            "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
-              {
-                "id": "cpufeatures 0.2.12",
-                "target": "cpufeatures"
-              }
-            ]
-          }
-        },
-        "edition": "2018",
-        "version": "0.10.6"
-      },
-      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -14448,7 +16763,7 @@
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
               {
-                "id": "cpufeatures 0.2.12",
+                "id": "cpufeatures 0.2.14",
                 "target": "cpufeatures"
               }
             ]
@@ -14464,14 +16779,99 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "signal-hook-registry 1.4.1": {
+    "shell-escape 0.1.5": {
+      "name": "shell-escape",
+      "version": "0.1.5",
+      "package_url": "https://github.com/sfackler/shell-escape",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/shell-escape/0.1.5/download",
+          "sha256": "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "shell_escape",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "shell_escape",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.1.5"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "shlex 1.3.0": {
+      "name": "shlex",
+      "version": "1.3.0",
+      "package_url": "https://github.com/comex/rust-shlex",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/shlex/1.3.0/download",
+          "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "shlex",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "shlex",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "1.3.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "signal-hook-registry 1.4.2": {
       "name": "signal-hook-registry",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "package_url": "https://github.com/vorner/signal-hook",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/signal-hook-registry/1.4.1/download",
-          "sha256": "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+          "url": "https://static.crates.io/crates/signal-hook-registry/1.4.2/download",
+          "sha256": "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
         }
       },
       "targets": [
@@ -14503,7 +16903,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.4.1"
+        "version": "1.4.2"
       },
       "license": "Apache-2.0/MIT",
       "license_ids": [
@@ -14511,6 +16911,45 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "simdutf8 0.1.5": {
+      "name": "simdutf8",
+      "version": "0.1.5",
+      "package_url": "https://github.com/rusticstuff/simdutf8",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/simdutf8/0.1.5/download",
+          "sha256": "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "simdutf8",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "simdutf8",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.1.5"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-Apache"
     },
     "slab 0.4.9": {
       "name": "slab",
@@ -14582,7 +17021,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.4.0",
               "target": "autocfg"
             }
           ],
@@ -14625,11 +17064,137 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "const_generics",
-            "const_new"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "const_generics",
+              "const_new"
+            ],
+            "aarch64-apple-ios": [
+              "const_generics",
+              "const_new"
+            ],
+            "aarch64-apple-ios-sim": [
+              "const_generics",
+              "const_new"
+            ],
+            "aarch64-fuchsia": [
+              "const_generics",
+              "const_new"
+            ],
+            "aarch64-linux-android": [
+              "const_generics",
+              "const_new"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "const_generics",
+              "const_new"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "const_generics",
+              "const_new"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "const_generics",
+              "const_new"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "const_generics",
+              "const_new"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "const_generics",
+              "const_new"
+            ],
+            "armv7-linux-androideabi": [
+              "const_generics",
+              "const_new"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "const_generics",
+              "const_new"
+            ],
+            "i686-apple-darwin": [
+              "const_generics",
+              "const_new"
+            ],
+            "i686-linux-android": [
+              "const_generics",
+              "const_new"
+            ],
+            "i686-pc-windows-msvc": [
+              "const_generics",
+              "const_new"
+            ],
+            "i686-unknown-freebsd": [
+              "const_generics",
+              "const_new"
+            ],
+            "i686-unknown-linux-gnu": [
+              "const_generics",
+              "const_new"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "const_generics",
+              "const_new"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "const_generics",
+              "const_new"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "const_generics",
+              "const_new"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "const_generics",
+              "const_new"
+            ],
+            "thumbv7em-none-eabi": [
+              "const_generics",
+              "const_new"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-apple-darwin": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-apple-ios": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-fuchsia": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-linux-android": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-unknown-freebsd": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "const_generics",
+              "const_new"
+            ],
+            "x86_64-unknown-none": [
+              "const_generics",
+              "const_new"
+            ]
+          }
         },
         "edition": "2018",
         "version": "1.13.2"
@@ -14679,14 +17244,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "socket2 0.5.5": {
+    "socket2 0.5.7": {
       "name": "socket2",
-      "version": "0.5.5",
+      "version": "0.5.7",
       "package_url": "https://github.com/rust-lang/socket2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/socket2/0.5.5/download",
-          "sha256": "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+          "url": "https://static.crates.io/crates/socket2/0.5.7/download",
+          "sha256": "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
         }
       },
       "targets": [
@@ -14725,14 +17290,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.5.5"
+        "version": "0.5.7"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -14785,177 +17350,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "ssri 9.2.0": {
-      "name": "ssri",
-      "version": "9.2.0",
-      "package_url": "https://github.com/zkat/ssri-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ssri/9.2.0/download",
-          "sha256": "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ssri",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ssri",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "serde"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "base64 0.21.7",
-              "target": "base64"
-            },
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "miette 5.10.0",
-              "target": "miette"
-            },
-            {
-              "id": "serde 1.0.213",
-              "target": "serde"
-            },
-            {
-              "id": "sha-1 0.10.1",
-              "target": "sha1"
-            },
-            {
-              "id": "sha2 0.10.8",
-              "target": "sha2"
-            },
-            {
-              "id": "thiserror 1.0.65",
-              "target": "thiserror"
-            },
-            {
-              "id": "xxhash-rust 0.8.8",
-              "target": "xxhash_rust"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "9.2.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE.md"
-    },
-    "stable_deref_trait 1.2.0": {
-      "name": "stable_deref_trait",
-      "version": "1.2.0",
-      "package_url": "https://github.com/storyyeller/stable_deref_trait",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/stable_deref_trait/1.2.0/download",
-          "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "stable_deref_trait",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "stable_deref_trait",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "1.2.0"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "strsim 0.10.0": {
-      "name": "strsim",
-      "version": "0.10.0",
-      "package_url": "https://github.com/dguo/strsim-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/strsim/0.10.0/download",
-          "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "strsim",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "strsim",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.10.0"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
     "strsim 0.11.1": {
       "name": "strsim",
       "version": "0.11.1",
@@ -14994,14 +17388,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "subtle 2.5.0": {
+    "subtle 2.6.1": {
       "name": "subtle",
-      "version": "2.5.0",
+      "version": "2.6.1",
       "package_url": "https://github.com/dalek-cryptography/subtle",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/subtle/2.5.0/download",
-          "sha256": "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+          "url": "https://static.crates.io/crates/subtle/2.6.1/download",
+          "sha256": "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
         }
       },
       "targets": [
@@ -15024,7 +17418,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "2.5.0"
+        "version": "2.6.1"
       },
       "license": "BSD-3-Clause",
       "license_ids": [
@@ -15032,14 +17426,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "supports-color 3.0.0": {
+    "supports-color 3.0.1": {
       "name": "supports-color",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "package_url": "https://github.com/zkat/supports-color",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/supports-color/3.0.0/download",
-          "sha256": "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
+          "url": "https://static.crates.io/crates/supports-color/3.0.1/download",
+          "sha256": "8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77"
         }
       },
       "targets": [
@@ -15071,7 +17465,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "3.0.0"
+        "version": "3.0.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -15155,14 +17549,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "syn 2.0.82": {
+    "syn 2.0.85": {
       "name": "syn",
-      "version": "2.0.82",
+      "version": "2.0.85",
       "package_url": "https://github.com/dtolnay/syn",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/syn/2.0.82/download",
-          "sha256": "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+          "url": "https://static.crates.io/crates/syn/2.0.85/download",
+          "sha256": "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
         }
       },
       "targets": [
@@ -15206,18 +17600,18 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "unicode-ident 1.0.12",
+              "id": "unicode-ident 1.0.13",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.82"
+        "version": "2.0.85"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -15265,7 +17659,7 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             }
           ],
@@ -15280,21 +17674,33 @@
       ],
       "license_file": "LICENSE"
     },
-    "tap 1.0.1": {
-      "name": "tap",
-      "version": "1.0.1",
-      "package_url": "https://github.com/myrrlyn/tap",
+    "sys-info 0.9.1": {
+      "name": "sys-info",
+      "version": "0.9.1",
+      "package_url": "https://github.com/FillZpp/sys-info-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tap/1.0.1/download",
-          "sha256": "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+          "url": "https://static.crates.io/crates/sys-info/0.9.1/download",
+          "sha256": "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "tap",
-            "crate_root": "src/lib.rs",
+            "crate_name": "sys_info",
+            "crate_root": "lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -15304,35 +17710,78 @@
           }
         }
       ],
-      "library_target_name": "tap",
+      "library_target_name": "sys_info",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
+        "deps": {
+          "common": [
+            {
+              "id": "libc 0.2.161",
+              "target": "libc"
+            },
+            {
+              "id": "sys-info 0.9.1",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2015",
-        "version": "1.0.1"
+        "version": "0.9.1"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.1.31",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        },
+        "links": "info"
       },
       "license": "MIT",
       "license_ids": [
         "MIT"
       ],
-      "license_file": "LICENSE.txt"
+      "license_file": "LICENSE"
     },
-    "tar 0.4.40": {
-      "name": "tar",
-      "version": "0.4.40",
-      "package_url": "https://github.com/alexcrichton/tar-rs",
+    "target-lexicon 0.12.16": {
+      "name": "target-lexicon",
+      "version": "0.12.16",
+      "package_url": "https://github.com/bytecodealliance/target-lexicon",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tar/0.4.40/download",
-          "sha256": "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+          "url": "https://static.crates.io/crates/target-lexicon/0.12.16/download",
+          "sha256": "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "tar",
+            "crate_name": "target_lexicon",
             "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -15342,187 +17791,42 @@
           }
         }
       ],
-      "library_target_name": "tar",
+      "library_target_name": "target_lexicon",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
         "crate_features": {
           "common": [
-            "default",
-            "xattr"
+            "default"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "filetime 0.2.23",
-              "target": "filetime"
+              "id": "target-lexicon 0.12.16",
+              "target": "build_script_build"
             }
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "aarch64-apple-ios": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "aarch64-apple-ios-sim": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "aarch64-fuchsia": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "aarch64-linux-android": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "aarch64-unknown-linux-gnu": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "aarch64-unknown-nixos-gnu": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "aarch64-unknown-nto-qnx710": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "arm-unknown-linux-gnueabi": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "armv7-linux-androideabi": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "cfg(unix)": [
-              {
-                "id": "libc 0.2.161",
-                "target": "libc"
-              }
-            ],
-            "i686-apple-darwin": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "i686-linux-android": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "i686-unknown-freebsd": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "i686-unknown-linux-gnu": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "powerpc-unknown-linux-gnu": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "s390x-unknown-linux-gnu": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "x86_64-apple-darwin": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "x86_64-apple-ios": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "x86_64-fuchsia": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "x86_64-linux-android": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "x86_64-unknown-freebsd": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              {
-                "id": "xattr 1.3.1",
-                "target": "xattr"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.40"
+        "version": "0.12.16"
       },
-      "license": "MIT/Apache-2.0",
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
-        "Apache-2.0",
-        "MIT"
+        "Apache-2.0"
       ],
-      "license_file": "LICENSE-APACHE"
+      "license_file": "LICENSE"
     },
     "tempfile 3.13.0": {
       "name": "tempfile",
@@ -15564,7 +17868,7 @@
               "target": "fastrand"
             },
             {
-              "id": "once_cell 1.19.0",
+              "id": "once_cell 1.20.2",
               "target": "once_cell"
             }
           ],
@@ -15698,7 +18002,7 @@
               "target": "unicode_linebreak"
             },
             {
-              "id": "unicode-width 0.1.11",
+              "id": "unicode-width 0.1.14",
               "target": "unicode_width"
             }
           ],
@@ -15826,11 +18130,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
@@ -15846,179 +18150,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "time 0.3.36": {
-      "name": "time",
-      "version": "0.3.36",
-      "package_url": "https://github.com/time-rs/time",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/time/0.3.36/download",
-          "sha256": "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "time",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "time",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "formatting",
-            "parsing",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "deranged 0.3.11",
-              "target": "deranged"
-            },
-            {
-              "id": "itoa 1.0.10",
-              "target": "itoa"
-            },
-            {
-              "id": "num-conv 0.1.0",
-              "target": "num_conv"
-            },
-            {
-              "id": "powerfmt 0.2.0",
-              "target": "powerfmt"
-            },
-            {
-              "id": "time-core 0.1.2",
-              "target": "time_core"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.3.36"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-Apache"
-    },
-    "time-core 0.1.2": {
-      "name": "time-core",
-      "version": "0.1.2",
-      "package_url": "https://github.com/time-rs/time",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/time-core/0.1.2/download",
-          "sha256": "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "time_core",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "time_core",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "0.1.2"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-Apache"
-    },
-    "time-macros 0.2.18": {
-      "name": "time-macros",
-      "version": "0.2.18",
-      "package_url": "https://github.com/time-rs/time",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/time-macros/0.2.18/download",
-          "sha256": "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "time_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "time_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "num-conv 0.1.0",
-              "target": "num_conv"
-            },
-            {
-              "id": "time-core 0.1.2",
-              "target": "time_core"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.2.18"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-Apache"
-    },
-    "tinyvec 1.6.0": {
+    "tinyvec 1.8.0": {
       "name": "tinyvec",
-      "version": "1.6.0",
+      "version": "1.8.0",
       "package_url": "https://github.com/Lokathor/tinyvec",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tinyvec/1.6.0/download",
-          "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+          "url": "https://static.crates.io/crates/tinyvec/1.8.0/download",
+          "sha256": "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
         }
       },
       "targets": [
@@ -16058,7 +18197,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.6.0"
+        "version": "1.8.0"
       },
       "license": "Zlib OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -16113,9 +18252,11 @@
       "version": "0.7.8",
       "package_url": "https://github.com/y21/tl",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/tl/0.7.8/download",
-          "sha256": "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
+        "Git": {
+          "remote": "https://github.com/charliermarsh/tl.git",
+          "commitish": {
+            "Rev": "6e25b2ee2513d75385101a8ff9f591ef51f314ec"
+          }
         }
       },
       "targets": [
@@ -16186,7 +18327,7 @@
             "mio",
             "process",
             "rt",
-            "rt-multi-thread",
+            "signal",
             "signal-hook-registry",
             "sync",
             "time",
@@ -16337,7 +18478,7 @@
               "target": "mio"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             }
           ],
@@ -16348,11 +18489,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16362,11 +18503,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16376,11 +18517,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16390,11 +18531,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16404,17 +18545,17 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "aarch64-pc-windows-msvc": [
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               },
               {
@@ -16428,11 +18569,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16442,11 +18583,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16456,11 +18597,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16470,11 +18611,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16484,11 +18625,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16498,17 +18639,17 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "cfg(tokio_taskdump)": [
               {
-                "id": "backtrace 0.3.69",
+                "id": "backtrace 0.3.74",
                 "target": "backtrace"
               }
             ],
@@ -16518,11 +18659,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16532,17 +18673,17 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "i686-pc-windows-msvc": [
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               },
               {
@@ -16556,11 +18697,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16570,11 +18711,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16584,23 +18725,23 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "riscv32imc-unknown-none-elf": [
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "riscv64gc-unknown-none-elf": [
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16610,23 +18751,23 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "thumbv7em-none-eabi": [
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "thumbv8m.main-none-eabi": [
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16636,11 +18777,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16650,11 +18791,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16664,11 +18805,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16678,17 +18819,17 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "x86_64-pc-windows-msvc": [
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               },
               {
@@ -16702,11 +18843,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16716,11 +18857,11 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
@@ -16730,17 +18871,17 @@
                 "target": "libc"
               },
               {
-                "id": "signal-hook-registry 1.4.1",
+                "id": "signal-hook-registry 1.4.2",
                 "target": "signal_hook_registry"
               },
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ],
             "x86_64-unknown-none": [
               {
-                "id": "socket2 0.5.5",
+                "id": "socket2 0.5.7",
                 "target": "socket2"
               }
             ]
@@ -16800,11 +18941,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
@@ -16883,14 +19024,80 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "tokio-stream 0.1.14": {
+    "tokio-socks 0.5.2": {
+      "name": "tokio-socks",
+      "version": "0.5.2",
+      "package_url": "https://github.com/sticnarf/tokio-socks",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tokio-socks/0.5.2/download",
+          "sha256": "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tokio_socks",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tokio_socks",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "tokio"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "either 1.13.0",
+              "target": "either"
+            },
+            {
+              "id": "futures-util 0.3.31",
+              "target": "futures_util"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.5.2"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "tokio-stream 0.1.16": {
       "name": "tokio-stream",
-      "version": "0.1.14",
+      "version": "0.1.16",
       "package_url": "https://github.com/tokio-rs/tokio",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tokio-stream/0.1.14/download",
-          "sha256": "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+          "url": "https://static.crates.io/crates/tokio-stream/0.1.16/download",
+          "sha256": "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
         }
       },
       "targets": [
@@ -16915,7 +19122,6 @@
         "crate_features": {
           "common": [
             "default",
-            "io-util",
             "sync",
             "time",
             "tokio-util"
@@ -16925,11 +19131,11 @@
         "deps": {
           "common": [
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             },
             {
@@ -16937,14 +19143,14 @@
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.7.10",
+              "id": "tokio-util 0.7.12",
               "target": "tokio_util"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.14"
+        "version": "0.1.16"
       },
       "license": "MIT",
       "license_ids": [
@@ -16952,14 +19158,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "tokio-util 0.7.10": {
+    "tokio-util 0.7.12": {
       "name": "tokio-util",
-      "version": "0.7.10",
+      "version": "0.7.12",
       "package_url": "https://github.com/tokio-rs/tokio",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tokio-util/0.7.10/download",
-          "sha256": "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+          "url": "https://static.crates.io/crates/tokio-util/0.7.12/download",
+          "sha256": "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
         }
       },
       "targets": [
@@ -16990,163 +19196,131 @@
           "selects": {
             "aarch64-apple-darwin": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "aarch64-apple-ios": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "aarch64-apple-ios-sim": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "aarch64-fuchsia": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "aarch64-linux-android": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "aarch64-pc-windows-msvc": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "aarch64-unknown-linux-gnu": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "aarch64-unknown-nixos-gnu": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "aarch64-unknown-nto-qnx710": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "arm-unknown-linux-gnueabi": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "armv7-linux-androideabi": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "armv7-unknown-linux-gnueabi": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "i686-apple-darwin": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "i686-linux-android": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "i686-pc-windows-msvc": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "i686-unknown-freebsd": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "i686-unknown-linux-gnu": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "powerpc-unknown-linux-gnu": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "riscv32imc-unknown-none-elf": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "riscv64gc-unknown-none-elf": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "s390x-unknown-linux-gnu": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "thumbv7em-none-eabi": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "thumbv8m.main-none-eabi": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-apple-darwin": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-apple-ios": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-fuchsia": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-linux-android": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-pc-windows-msvc": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-unknown-freebsd": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-unknown-linux-gnu": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-unknown-nixos-gnu": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ],
             "x86_64-unknown-none": [
               "codec",
-              "io",
-              "tracing"
+              "io"
             ]
           }
         },
@@ -17157,19 +19331,19 @@
               "target": "bytes"
             },
             {
-              "id": "futures-core 0.3.30",
+              "id": "futures-core 0.3.31",
               "target": "futures_core"
             },
             {
-              "id": "futures-io 0.3.30",
+              "id": "futures-io 0.3.31",
               "target": "futures_io"
             },
             {
-              "id": "futures-sink 0.3.30",
+              "id": "futures-sink 0.3.31",
               "target": "futures_sink"
             },
             {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             },
             {
@@ -17177,203 +19351,10 @@
               "target": "tokio"
             }
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "aarch64-apple-ios": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "aarch64-apple-ios-sim": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "aarch64-fuchsia": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "aarch64-linux-android": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "aarch64-pc-windows-msvc": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "aarch64-unknown-linux-gnu": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "aarch64-unknown-nixos-gnu": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "aarch64-unknown-nto-qnx710": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "arm-unknown-linux-gnueabi": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "armv7-linux-androideabi": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "armv7-unknown-linux-gnueabi": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "i686-apple-darwin": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "i686-linux-android": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "i686-pc-windows-msvc": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "i686-unknown-freebsd": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "i686-unknown-linux-gnu": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "powerpc-unknown-linux-gnu": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "riscv32imc-unknown-none-elf": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "riscv64gc-unknown-none-elf": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "s390x-unknown-linux-gnu": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "thumbv7em-none-eabi": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "thumbv8m.main-none-eabi": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-apple-darwin": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-apple-ios": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-fuchsia": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-linux-android": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-unknown-freebsd": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ],
-            "x86_64-unknown-none": [
-              {
-                "id": "tracing 0.1.40",
-                "target": "tracing"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.10"
+        "version": "0.7.12"
       },
       "license": "MIT",
       "license_ids": [
@@ -17381,14 +19362,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "toml 0.8.10": {
+    "toml 0.8.19": {
       "name": "toml",
-      "version": "0.8.10",
+      "version": "0.8.19",
       "package_url": "https://github.com/toml-rs/toml",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/toml/0.8.10/download",
-          "sha256": "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+          "url": "https://static.crates.io/crates/toml/0.8.19/download",
+          "sha256": "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
         }
       },
       "targets": [
@@ -17412,6 +19393,8 @@
         ],
         "crate_features": {
           "common": [
+            "default",
+            "display",
             "parse"
           ],
           "selects": {}
@@ -17423,22 +19406,22 @@
               "target": "serde"
             },
             {
-              "id": "serde_spanned 0.6.5",
+              "id": "serde_spanned 0.6.8",
               "target": "serde_spanned"
             },
             {
-              "id": "toml_datetime 0.6.5",
+              "id": "toml_datetime 0.6.8",
               "target": "toml_datetime"
             },
             {
-              "id": "toml_edit 0.22.4",
+              "id": "toml_edit 0.22.22",
               "target": "toml_edit"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.10"
+        "version": "0.8.19"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17447,14 +19430,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "toml_datetime 0.6.5": {
+    "toml_datetime 0.6.8": {
       "name": "toml_datetime",
-      "version": "0.6.5",
+      "version": "0.6.8",
       "package_url": "https://github.com/toml-rs/toml",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/toml_datetime/0.6.5/download",
-          "sha256": "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+          "url": "https://static.crates.io/crates/toml_datetime/0.6.8/download",
+          "sha256": "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
         }
       },
       "targets": [
@@ -17492,7 +19475,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.5"
+        "version": "0.6.8"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17501,14 +19484,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "toml_edit 0.22.4": {
+    "toml_edit 0.22.22": {
       "name": "toml_edit",
-      "version": "0.22.4",
+      "version": "0.22.22",
       "package_url": "https://github.com/toml-rs/toml",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/toml_edit/0.22.4/download",
-          "sha256": "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+          "url": "https://static.crates.io/crates/toml_edit/0.22.22/download",
+          "sha256": "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
         }
       },
       "targets": [
@@ -17532,6 +19515,8 @@
         ],
         "crate_features": {
           "common": [
+            "default",
+            "display",
             "parse",
             "serde"
           ],
@@ -17548,22 +19533,22 @@
               "target": "serde"
             },
             {
-              "id": "serde_spanned 0.6.5",
+              "id": "serde_spanned 0.6.8",
               "target": "serde_spanned"
             },
             {
-              "id": "toml_datetime 0.6.5",
+              "id": "toml_datetime 0.6.8",
               "target": "toml_datetime"
             },
             {
-              "id": "winnow 0.5.39",
+              "id": "winnow 0.6.20",
               "target": "winnow"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.22.4"
+        "version": "0.22.22"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17572,14 +19557,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "tower-service 0.3.2": {
+    "tower-service 0.3.3": {
       "name": "tower-service",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "package_url": "https://github.com/tower-rs/tower",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tower-service/0.3.2/download",
-          "sha256": "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+          "url": "https://static.crates.io/crates/tower-service/0.3.3/download",
+          "sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
         }
       },
       "targets": [
@@ -17602,7 +19587,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.3.2"
+        "version": "0.3.3"
       },
       "license": "MIT",
       "license_ids": [
@@ -17643,7 +19628,6 @@
           "common": [
             "attributes",
             "default",
-            "log",
             "std",
             "tracing-attributes"
           ],
@@ -17652,11 +19636,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.20",
-              "target": "log"
-            },
-            {
-              "id": "pin-project-lite 0.2.14",
+              "id": "pin-project-lite 0.2.15",
               "target": "pin_project_lite"
             },
             {
@@ -17720,11 +19700,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
@@ -17778,7 +19758,7 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.19.0",
+              "id": "once_cell 1.20.2",
               "target": "once_cell"
             }
           ],
@@ -17830,6 +19810,74 @@
         "MIT"
       ],
       "license_file": "LICENSE"
+    },
+    "typeid 1.0.2": {
+      "name": "typeid",
+      "version": "1.0.2",
+      "package_url": "https://github.com/dtolnay/typeid",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/typeid/1.0.2/download",
+          "sha256": "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "typeid",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "typeid",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "typeid 1.0.2",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.2"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "typenum 1.17.0": {
       "name": "typenum",
@@ -17899,14 +19947,53 @@
       ],
       "license_file": "LICENSE"
     },
-    "unicode-bidi 0.3.15": {
+    "unicase 2.8.0": {
+      "name": "unicase",
+      "version": "2.8.0",
+      "package_url": "https://github.com/seanmonstar/unicase",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/unicase/2.8.0/download",
+          "sha256": "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "unicase",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "unicase",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "2.8.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "unicode-bidi 0.3.17": {
       "name": "unicode-bidi",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "package_url": "https://github.com/servo/unicode-bidi",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/unicode-bidi/0.3.15/download",
-          "sha256": "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+          "url": "https://static.crates.io/crates/unicode-bidi/0.3.17/download",
+          "sha256": "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
         }
       },
       "targets": [
@@ -17936,7 +20023,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.15"
+        "version": "0.3.17"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17945,14 +20032,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "unicode-ident 1.0.12": {
+    "unicode-ident 1.0.13": {
       "name": "unicode-ident",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "package_url": "https://github.com/dtolnay/unicode-ident",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/unicode-ident/1.0.12/download",
-          "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+          "url": "https://static.crates.io/crates/unicode-ident/1.0.13/download",
+          "sha256": "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
         }
       },
       "targets": [
@@ -17975,7 +20062,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.12"
+        "version": "1.0.13"
       },
       "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
       "license_ids": [
@@ -18023,14 +20110,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "unicode-normalization 0.1.22": {
+    "unicode-normalization 0.1.24": {
       "name": "unicode-normalization",
-      "version": "0.1.22",
+      "version": "0.1.24",
       "package_url": "https://github.com/unicode-rs/unicode-normalization",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/unicode-normalization/0.1.22/download",
-          "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+          "url": "https://static.crates.io/crates/unicode-normalization/0.1.24/download",
+          "sha256": "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
         }
       },
       "targets": [
@@ -18061,14 +20148,14 @@
         "deps": {
           "common": [
             {
-              "id": "tinyvec 1.6.0",
+              "id": "tinyvec 1.8.0",
               "target": "tinyvec"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.22"
+        "version": "0.1.24"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -18077,14 +20164,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "unicode-width 0.1.11": {
+    "unicode-width 0.1.14": {
       "name": "unicode-width",
-      "version": "0.1.11",
+      "version": "0.1.14",
       "package_url": "https://github.com/unicode-rs/unicode-width",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/unicode-width/0.1.11/download",
-          "sha256": "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+          "url": "https://static.crates.io/crates/unicode-width/0.1.14/download",
+          "sha256": "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
         }
       },
       "targets": [
@@ -18108,14 +20195,15 @@
         ],
         "crate_features": {
           "common": [
+            "cjk",
             "default"
           ],
           "selects": {}
         },
-        "edition": "2015",
-        "version": "0.1.11"
+        "edition": "2021",
+        "version": "0.1.14"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -18152,6 +20240,45 @@
       "license": "Apache 2",
       "license_ids": [],
       "license_file": null
+    },
+    "unscanny 0.1.0": {
+      "name": "unscanny",
+      "version": "0.1.0",
+      "package_url": "https://github.com/typst/unscanny",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/unscanny/0.1.0/download",
+          "sha256": "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "unscanny",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "unscanny",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "untrusted 0.9.0": {
       "name": "untrusted",
@@ -18191,14 +20318,14 @@
       ],
       "license_file": "LICENSE.txt"
     },
-    "url 2.5.0": {
+    "url 2.5.2": {
       "name": "url",
-      "version": "2.5.0",
+      "version": "2.5.2",
       "package_url": "https://github.com/servo/rust-url",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/url/2.5.0/download",
-          "sha256": "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+          "url": "https://static.crates.io/crates/url/2.5.2/download",
+          "sha256": "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
         }
       },
       "targets": [
@@ -18249,7 +20376,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.5.0"
+        "version": "2.5.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -18257,6 +20384,44 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "urlencoding 2.1.3": {
+      "name": "urlencoding",
+      "version": "2.1.3",
+      "package_url": "https://github.com/kornelski/rust_urlencoding",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/urlencoding/2.1.3/download",
+          "sha256": "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "urlencoding",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "urlencoding",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "2.1.3"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "utf8-width 0.1.7": {
       "name": "utf8-width",
@@ -18296,14 +20461,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "utf8parse 0.2.1": {
+    "utf8parse 0.2.2": {
       "name": "utf8parse",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "package_url": "https://github.com/alacritty/vte",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/utf8parse/0.2.1/download",
-          "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+          "url": "https://static.crates.io/crates/utf8parse/0.2.2/download",
+          "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
         }
       },
       "targets": [
@@ -18332,7 +20497,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.1"
+        "version": "0.2.2"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -18340,6 +20505,2600 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "uuid 1.11.0": {
+      "name": "uuid",
+      "version": "1.11.0",
+      "package_url": "https://github.com/uuid-rs/uuid",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/uuid/1.11.0/download",
+          "sha256": "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uuid",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uuid",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "1.11.0"
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "uv-auth 0.0.1": {
+      "name": "uv-auth",
+      "version": "0.0.1",
+      "package_url": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-auth"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_auth",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_auth",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.91",
+              "target": "anyhow"
+            },
+            {
+              "id": "base64 0.22.1",
+              "target": "base64"
+            },
+            {
+              "id": "futures 0.3.31",
+              "target": "futures"
+            },
+            {
+              "id": "http 1.1.0",
+              "target": "http"
+            },
+            {
+              "id": "reqwest 0.12.8",
+              "target": "reqwest"
+            },
+            {
+              "id": "reqwest-middleware 0.3.3",
+              "target": "reqwest_middleware"
+            },
+            {
+              "id": "rust-netrc 0.1.1",
+              "target": "netrc"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "urlencoding 2.1.3",
+              "target": "urlencoding"
+            },
+            {
+              "id": "uv-once-map 0.0.1",
+              "target": "uv_once_map"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.83",
+              "target": "async_trait"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.0.1"
+      },
+      "license": null,
+      "license_ids": [],
+      "license_file": null
+    },
+    "uv-cache 0.0.1": {
+      "name": "uv-cache",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-cache"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_cache",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_cache",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "directories 5.0.1",
+              "target": "directories"
+            },
+            {
+              "id": "etcetera 0.8.0",
+              "target": "etcetera"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "nanoid 0.4.0",
+              "target": "nanoid"
+            },
+            {
+              "id": "rmp-serde 1.3.0",
+              "target": "rmp_serde"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "tempfile 3.13.0",
+              "target": "tempfile"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "uv-cache-info 0.0.1",
+              "target": "uv_cache_info"
+            },
+            {
+              "id": "uv-cache-key 0.0.1",
+              "target": "uv_cache_key"
+            },
+            {
+              "id": "uv-distribution-types 0.0.1",
+              "target": "uv_distribution_types"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "uv-static 0.0.1",
+              "target": "uv_static"
+            },
+            {
+              "id": "walkdir 2.5.0",
+              "target": "walkdir"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-cache-info 0.0.1": {
+      "name": "uv-cache-info",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-cache-info"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_cache_info",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_cache_info",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "globwalk 0.9.1",
+              "target": "globwalk"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "toml 0.8.19",
+              "target": "toml"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-cache-key 0.0.1": {
+      "name": "uv-cache-key",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-cache-key"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_cache_key",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_cache_key",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "hex 0.4.3",
+              "target": "hex"
+            },
+            {
+              "id": "seahash 4.1.0",
+              "target": "seahash"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-client 0.0.1": {
+      "name": "uv-client",
+      "version": "0.0.1",
+      "package_url": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-client"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_client",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_client",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.91",
+              "target": "anyhow"
+            },
+            {
+              "id": "async_http_range_reader 0.8.0",
+              "target": "async_http_range_reader"
+            },
+            {
+              "id": "async_zip 0.0.17",
+              "target": "async_zip"
+            },
+            {
+              "id": "bytecheck 0.8.0",
+              "target": "bytecheck"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "futures 0.3.31",
+              "target": "futures"
+            },
+            {
+              "id": "html-escape 0.2.13",
+              "target": "html_escape"
+            },
+            {
+              "id": "http 1.1.0",
+              "target": "http"
+            },
+            {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
+            },
+            {
+              "id": "jiff 0.1.13",
+              "target": "jiff"
+            },
+            {
+              "id": "reqwest 0.12.8",
+              "target": "reqwest"
+            },
+            {
+              "id": "reqwest-middleware 0.3.3",
+              "target": "reqwest_middleware"
+            },
+            {
+              "id": "reqwest-retry 0.7.1",
+              "target": "reqwest_retry"
+            },
+            {
+              "id": "rkyv 0.8.8",
+              "target": "rkyv"
+            },
+            {
+              "id": "rmp-serde 1.3.0",
+              "target": "rmp_serde"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.132",
+              "target": "serde_json"
+            },
+            {
+              "id": "sys-info 0.9.1",
+              "target": "sys_info"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tl 0.7.8",
+              "target": "tl"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-util 0.7.12",
+              "target": "tokio_util"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "urlencoding 2.1.3",
+              "target": "urlencoding"
+            },
+            {
+              "id": "uv-auth 0.0.1",
+              "target": "uv_auth"
+            },
+            {
+              "id": "uv-cache 0.0.1",
+              "target": "uv_cache"
+            },
+            {
+              "id": "uv-cache-key 0.0.1",
+              "target": "uv_cache_key"
+            },
+            {
+              "id": "uv-configuration 0.0.1",
+              "target": "uv_configuration"
+            },
+            {
+              "id": "uv-distribution-filename 0.0.1",
+              "target": "uv_distribution_filename"
+            },
+            {
+              "id": "uv-distribution-types 0.0.1",
+              "target": "uv_distribution_types"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-metadata 0.1.0",
+              "target": "uv_metadata"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pep440 0.7.0",
+              "target": "uv_pep440"
+            },
+            {
+              "id": "uv-pep508 0.6.0",
+              "target": "uv_pep508"
+            },
+            {
+              "id": "uv-platform-tags 0.0.1",
+              "target": "uv_platform_tags"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "uv-static 0.0.1",
+              "target": "uv_static"
+            },
+            {
+              "id": "uv-version 0.4.21",
+              "target": "uv_version"
+            },
+            {
+              "id": "uv-warnings 0.0.1",
+              "target": "uv_warnings"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "async-trait 0.1.83",
+              "target": "async_trait"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.0.1"
+      },
+      "license": null,
+      "license_ids": [],
+      "license_file": null
+    },
+    "uv-configuration 0.0.1": {
+      "name": "uv-configuration",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-configuration"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_configuration",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_configuration",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "either 1.13.0",
+              "target": "either"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "serde-untagged 0.1.6",
+              "target": "serde_untagged"
+            },
+            {
+              "id": "serde_json 1.0.132",
+              "target": "serde_json"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "uv-auth 0.0.1",
+              "target": "uv_auth"
+            },
+            {
+              "id": "uv-cache 0.0.1",
+              "target": "uv_cache"
+            },
+            {
+              "id": "uv-cache-info 0.0.1",
+              "target": "uv_cache_info"
+            },
+            {
+              "id": "uv-cache-key 0.0.1",
+              "target": "uv_cache_key"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pep508 0.6.0",
+              "target": "uv_pep508"
+            },
+            {
+              "id": "uv-platform-tags 0.0.1",
+              "target": "uv_platform_tags"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "uv-static 0.0.1",
+              "target": "uv_static"
+            },
+            {
+              "id": "which 6.0.3",
+              "target": "which"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-distribution-filename 0.0.1": {
+      "name": "uv-distribution-filename",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-distribution-filename"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_distribution_filename",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_distribution_filename",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rkyv 0.8.8",
+              "target": "rkyv"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pep440 0.7.0",
+              "target": "uv_pep440"
+            },
+            {
+              "id": "uv-platform-tags 0.0.1",
+              "target": "uv_platform_tags"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-distribution-types 0.0.1": {
+      "name": "uv-distribution-types",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-distribution-types"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_distribution_types",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_distribution_types",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.91",
+              "target": "anyhow"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
+            },
+            {
+              "id": "jiff 0.1.13",
+              "target": "jiff"
+            },
+            {
+              "id": "rkyv 0.8.8",
+              "target": "rkyv"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.132",
+              "target": "serde_json"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "urlencoding 2.1.3",
+              "target": "urlencoding"
+            },
+            {
+              "id": "uv-cache-info 0.0.1",
+              "target": "uv_cache_info"
+            },
+            {
+              "id": "uv-cache-key 0.0.1",
+              "target": "uv_cache_key"
+            },
+            {
+              "id": "uv-distribution-filename 0.0.1",
+              "target": "uv_distribution_filename"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-git 0.0.1",
+              "target": "uv_git"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pep440 0.7.0",
+              "target": "uv_pep440"
+            },
+            {
+              "id": "uv-pep508 0.6.0",
+              "target": "uv_pep508"
+            },
+            {
+              "id": "uv-platform-tags 0.0.1",
+              "target": "uv_platform_tags"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-extract 0.0.1": {
+      "name": "uv-extract",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-extract"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_extract",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_extract",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "async-compression 0.4.17",
+              "target": "async_compression"
+            },
+            {
+              "id": "async_zip 0.0.17",
+              "target": "async_zip"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "futures 0.3.31",
+              "target": "futures"
+            },
+            {
+              "id": "krata-tokio-tar 0.4.2",
+              "target": "tokio_tar"
+            },
+            {
+              "id": "md-5 0.10.6",
+              "target": "md5"
+            },
+            {
+              "id": "rayon 1.10.0",
+              "target": "rayon"
+            },
+            {
+              "id": "reqwest 0.12.8",
+              "target": "reqwest"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "sha2 0.10.8",
+              "target": "sha2"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-util 0.7.12",
+              "target": "tokio_util"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "uv-distribution-filename 0.0.1",
+              "target": "uv_distribution_filename"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "xz2 0.1.7",
+              "target": "xz2"
+            },
+            {
+              "id": "zip 0.6.6",
+              "target": "zip"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-fs 0.0.1": {
+      "name": "uv-fs",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-fs"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_fs",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_fs",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "serde",
+            "tokio"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "backoff 0.4.0",
+              "target": "backoff"
+            },
+            {
+              "id": "cachedir 0.3.1",
+              "target": "cachedir"
+            },
+            {
+              "id": "dunce 1.0.5",
+              "target": "dunce"
+            },
+            {
+              "id": "either 1.13.0",
+              "target": "either"
+            },
+            {
+              "id": "encoding_rs_io 0.1.7",
+              "target": "encoding_rs_io"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "fs2 0.4.3",
+              "target": "fs2"
+            },
+            {
+              "id": "path-slash 0.2.1",
+              "target": "path_slash"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "tempfile 3.13.0",
+              "target": "tempfile"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "urlencoding 2.1.3",
+              "target": "urlencoding"
+            }
+          ],
+          "selects": {
+            "cfg(any(unix, target_os = \"wasi\", target_os = \"redox\"))": [
+              {
+                "id": "rustix 0.38.37",
+                "target": "rustix"
+              }
+            ],
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "winsafe 0.0.22",
+                "target": "winsafe"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "junction 1.2.0",
+                "target": "junction"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-git 0.0.1": {
+      "name": "uv-git",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-git"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_git",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_git",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.91",
+              "target": "anyhow"
+            },
+            {
+              "id": "cargo-util 0.2.15",
+              "target": "cargo_util"
+            },
+            {
+              "id": "dashmap 6.1.0",
+              "target": "dashmap"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "reqwest 0.12.8",
+              "target": "reqwest"
+            },
+            {
+              "id": "reqwest-middleware 0.3.3",
+              "target": "reqwest_middleware"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "uv-auth 0.0.1",
+              "target": "uv_auth"
+            },
+            {
+              "id": "uv-cache-key 0.0.1",
+              "target": "uv_cache_key"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-static 0.0.1",
+              "target": "uv_static"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-install-wheel 0.0.1": {
+      "name": "uv-install-wheel",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-install-wheel"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_install_wheel",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_install_wheel",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "configparser 3.1.0",
+              "target": "configparser"
+            },
+            {
+              "id": "csv 1.3.0",
+              "target": "csv"
+            },
+            {
+              "id": "data-encoding 2.6.0",
+              "target": "data_encoding"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "mailparse 0.15.0",
+              "target": "mailparse"
+            },
+            {
+              "id": "pathdiff 0.2.2",
+              "target": "pathdiff"
+            },
+            {
+              "id": "platform-info 2.0.4",
+              "target": "platform_info"
+            },
+            {
+              "id": "reflink-copy 0.1.19",
+              "target": "reflink_copy"
+            },
+            {
+              "id": "regex 1.11.1",
+              "target": "regex"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.132",
+              "target": "serde_json"
+            },
+            {
+              "id": "sha2 0.10.8",
+              "target": "sha2"
+            },
+            {
+              "id": "tempfile 3.13.0",
+              "target": "tempfile"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "uv-cache-info 0.0.1",
+              "target": "uv_cache_info"
+            },
+            {
+              "id": "uv-distribution-filename 0.0.1",
+              "target": "uv_distribution_filename"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pep440 0.7.0",
+              "target": "uv_pep440"
+            },
+            {
+              "id": "uv-platform-tags 0.0.1",
+              "target": "uv_platform_tags"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "uv-warnings 0.0.1",
+              "target": "uv_warnings"
+            },
+            {
+              "id": "walkdir 2.5.0",
+              "target": "walkdir"
+            },
+            {
+              "id": "zip 0.6.6",
+              "target": "zip"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-metadata 0.1.0": {
+      "name": "uv-metadata",
+      "version": "0.1.0",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-metadata"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_metadata",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_metadata",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "async_zip 0.0.17",
+              "target": "async_zip"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "futures 0.3.31",
+              "target": "futures"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-util 0.7.12",
+              "target": "tokio_util"
+            },
+            {
+              "id": "uv-distribution-filename 0.0.1",
+              "target": "uv_distribution_filename"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "zip 0.6.6",
+              "target": "zip"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-normalize 0.0.1": {
+      "name": "uv-normalize",
+      "version": "0.0.1",
+      "package_url": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-normalize"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_normalize",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_normalize",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rkyv 0.8.8",
+              "target": "rkyv"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": null,
+      "license_ids": [],
+      "license_file": null
+    },
+    "uv-once-map 0.0.1": {
+      "name": "uv-once-map",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-once-map"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_once_map",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_once_map",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "dashmap 6.1.0",
+              "target": "dashmap"
+            },
+            {
+              "id": "futures 0.3.31",
+              "target": "futures"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-pep440 0.7.0": {
+      "name": "uv-pep440",
+      "version": "0.7.0",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-pep440"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_pep440",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_pep440",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "tracing"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "rkyv 0.8.8",
+              "target": "rkyv"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "unicode-width 0.1.14",
+              "target": "unicode_width"
+            },
+            {
+              "id": "unscanny 0.1.0",
+              "target": "unscanny"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.7.0"
+      },
+      "license": "Apache-2.0 OR BSD-2-Clause",
+      "license_ids": [
+        "Apache-2.0",
+        "BSD-2-Clause"
+      ],
+      "license_file": "License-Apache"
+    },
+    "uv-pep508 0.6.0": {
+      "name": "uv-pep508",
+      "version": "0.6.0",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-pep508"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_pep508",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_pep508",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "non-pep508-extensions",
+            "schemars",
+            "serde"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "boxcar 0.2.6",
+              "target": "boxcar"
+            },
+            {
+              "id": "indexmap 2.6.0",
+              "target": "indexmap"
+            },
+            {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
+            },
+            {
+              "id": "pubgrub 0.2.1",
+              "target": "pubgrub"
+            },
+            {
+              "id": "regex 1.11.1",
+              "target": "regex"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "schemars 0.8.21",
+              "target": "schemars"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "smallvec 1.13.2",
+              "target": "smallvec"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "unicode-width 0.1.14",
+              "target": "unicode_width"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pep440 0.7.0",
+              "target": "uv_pep440"
+            },
+            {
+              "id": "uv-pubgrub 0.0.1",
+              "target": "uv_pubgrub"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.6.0"
+      },
+      "license": "Apache-2.0 OR BSD-2-Clause",
+      "license_ids": [
+        "Apache-2.0",
+        "BSD-2-Clause"
+      ],
+      "license_file": "License-Apache"
+    },
+    "uv-platform-tags 0.0.1": {
+      "name": "uv-platform-tags",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-platform-tags"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_platform_tags",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_platform_tags",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-pubgrub 0.0.1": {
+      "name": "uv-pubgrub",
+      "version": "0.0.1",
+      "package_url": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-pubgrub"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_pubgrub",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_pubgrub",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
+            },
+            {
+              "id": "pubgrub 0.2.1",
+              "target": "pubgrub"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "uv-pep440 0.7.0",
+              "target": "uv_pep440"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": null,
+      "license_ids": [],
+      "license_file": null
+    },
+    "uv-pypi-types 0.0.1": {
+      "name": "uv-pypi-types",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-pypi-types"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_pypi_types",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_pypi_types",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "indexmap 2.6.0",
+              "target": "indexmap"
+            },
+            {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
+            },
+            {
+              "id": "jiff 0.1.13",
+              "target": "jiff"
+            },
+            {
+              "id": "mailparse 0.15.0",
+              "target": "mailparse"
+            },
+            {
+              "id": "regex 1.11.1",
+              "target": "regex"
+            },
+            {
+              "id": "rkyv 0.8.8",
+              "target": "rkyv"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "serde-untagged 0.1.6",
+              "target": "serde_untagged"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "toml 0.8.19",
+              "target": "toml"
+            },
+            {
+              "id": "toml_edit 0.22.22",
+              "target": "toml_edit"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "uv-distribution-filename 0.0.1",
+              "target": "uv_distribution_filename"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-git 0.0.1",
+              "target": "uv_git"
+            },
+            {
+              "id": "uv-normalize 0.0.1",
+              "target": "uv_normalize"
+            },
+            {
+              "id": "uv-pep440 0.7.0",
+              "target": "uv_pep440"
+            },
+            {
+              "id": "uv-pep508 0.6.0",
+              "target": "uv_pep508"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-python 0.0.1": {
+      "name": "uv-python",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-python"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_python",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_python",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.91",
+              "target": "anyhow"
+            },
+            {
+              "id": "configparser 3.1.0",
+              "target": "configparser"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "futures 0.3.31",
+              "target": "futures"
+            },
+            {
+              "id": "goblin 0.8.2",
+              "target": "goblin"
+            },
+            {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
+            },
+            {
+              "id": "owo-colors 4.1.0",
+              "target": "owo_colors"
+            },
+            {
+              "id": "regex 1.11.1",
+              "target": "regex"
+            },
+            {
+              "id": "reqwest 0.12.8",
+              "target": "reqwest"
+            },
+            {
+              "id": "reqwest-middleware 0.3.3",
+              "target": "reqwest_middleware"
+            },
+            {
+              "id": "rmp-serde 1.3.0",
+              "target": "rmp_serde"
+            },
+            {
+              "id": "same-file 1.0.6",
+              "target": "same_file"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.132",
+              "target": "serde_json"
+            },
+            {
+              "id": "target-lexicon 0.12.16",
+              "target": "target_lexicon"
+            },
+            {
+              "id": "tempfile 3.13.0",
+              "target": "tempfile"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-util 0.7.12",
+              "target": "tokio_util"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "url 2.5.2",
+              "target": "url"
+            },
+            {
+              "id": "uv-cache 0.0.1",
+              "target": "uv_cache"
+            },
+            {
+              "id": "uv-cache-info 0.0.1",
+              "target": "uv_cache_info"
+            },
+            {
+              "id": "uv-cache-key 0.0.1",
+              "target": "uv_cache_key"
+            },
+            {
+              "id": "uv-client 0.0.1",
+              "target": "uv_client"
+            },
+            {
+              "id": "uv-distribution-filename 0.0.1",
+              "target": "uv_distribution_filename"
+            },
+            {
+              "id": "uv-extract 0.0.1",
+              "target": "uv_extract"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-install-wheel 0.0.1",
+              "target": "uv_install_wheel"
+            },
+            {
+              "id": "uv-pep440 0.7.0",
+              "target": "uv_pep440"
+            },
+            {
+              "id": "uv-pep508 0.6.0",
+              "target": "uv_pep508"
+            },
+            {
+              "id": "uv-platform-tags 0.0.1",
+              "target": "uv_platform_tags"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "uv-state 0.0.1",
+              "target": "uv_state"
+            },
+            {
+              "id": "uv-static 0.0.1",
+              "target": "uv_static"
+            },
+            {
+              "id": "uv-warnings 0.0.1",
+              "target": "uv_warnings"
+            },
+            {
+              "id": "which 6.0.3",
+              "target": "which"
+            }
+          ],
+          "selects": {
+            "cfg(target_os = \"windows\")": [
+              {
+                "id": "windows-registry 0.2.0",
+                "target": "windows_registry"
+              },
+              {
+                "id": "windows-result 0.2.0",
+                "target": "windows_result"
+              },
+              {
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-state 0.0.1": {
+      "name": "uv-state",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-state"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_state",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_state",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "directories 5.0.1",
+              "target": "directories"
+            },
+            {
+              "id": "etcetera 0.8.0",
+              "target": "etcetera"
+            },
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "tempfile 3.13.0",
+              "target": "tempfile"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-static 0.0.1": {
+      "name": "uv-static",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-static"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_static",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_static",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-version 0.4.21": {
+      "name": "uv-version",
+      "version": "0.4.21",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-version"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_version",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_version",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.4.21"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-virtualenv 0.0.4": {
+      "name": "uv-virtualenv",
+      "version": "0.0.4",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-virtualenv"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_virtualenv",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_virtualenv",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "fs-err 2.11.0",
+              "target": "fs_err"
+            },
+            {
+              "id": "itertools 0.13.0",
+              "target": "itertools"
+            },
+            {
+              "id": "pathdiff 0.2.2",
+              "target": "pathdiff"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            },
+            {
+              "id": "uv-fs 0.0.1",
+              "target": "uv_fs"
+            },
+            {
+              "id": "uv-platform-tags 0.0.1",
+              "target": "uv_platform_tags"
+            },
+            {
+              "id": "uv-pypi-types 0.0.1",
+              "target": "uv_pypi_types"
+            },
+            {
+              "id": "uv-python 0.0.1",
+              "target": "uv_python"
+            },
+            {
+              "id": "uv-version 0.4.21",
+              "target": "uv_version"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.4"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "uv-warnings 0.0.1": {
+      "name": "uv-warnings",
+      "version": "0.0.1",
+      "package_url": "https://github.com/astral-sh/uv",
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/astral-sh/uv",
+          "commitish": {
+            "Rev": "855c1917e1e0e2b48c38de71bebc845af016afae"
+          },
+          "strip_prefix": "crates/uv-warnings"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "uv_warnings",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "uv_warnings",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anstream 0.6.15",
+              "target": "anstream"
+            },
+            {
+              "id": "owo-colors 4.1.0",
+              "target": "owo_colors"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
     },
     "venv_bin 0.1.0": {
       "name": "venv_bin",
@@ -18372,14 +23131,14 @@
       "license_ids": [],
       "license_file": null
     },
-    "version_check 0.9.4": {
+    "version_check 0.9.5": {
       "name": "version_check",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "package_url": "https://github.com/SergioBenitez/version_check",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/version_check/0.9.4/download",
-          "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+          "url": "https://static.crates.io/crates/version_check/0.9.5/download",
+          "sha256": "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
         }
       },
       "targets": [
@@ -18402,7 +23161,7 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.9.4"
+        "version": "0.9.5"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -18411,14 +23170,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "walkdir 2.4.0": {
+    "walkdir 2.5.0": {
       "name": "walkdir",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "package_url": "https://github.com/BurntSushi/walkdir",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/walkdir/2.4.0/download",
-          "sha256": "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+          "url": "https://static.crates.io/crates/walkdir/2.5.0/download",
+          "sha256": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
         }
       },
       "targets": [
@@ -18450,14 +23209,14 @@
           "selects": {
             "cfg(windows)": [
               {
-                "id": "winapi-util 0.1.6",
+                "id": "winapi-util 0.1.9",
                 "target": "winapi_util"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "2.4.0"
+        "version": "2.5.0"
       },
       "license": "Unlicense/MIT",
       "license_ids": [
@@ -18559,14 +23318,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen 0.2.91": {
+    "wasm-bindgen 0.2.95": {
       "name": "wasm-bindgen",
-      "version": "0.2.91",
+      "version": "0.2.95",
       "package_url": "https://github.com/rustwasm/wasm-bindgen",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen/0.2.91/download",
-          "sha256": "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+          "url": "https://static.crates.io/crates/wasm-bindgen/0.2.95/download",
+          "sha256": "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
         }
       },
       "targets": [
@@ -18615,23 +23374,27 @@
               "target": "cfg_if"
             },
             {
-              "id": "wasm-bindgen 0.2.91",
+              "id": "once_cell 1.20.2",
+              "target": "once_cell"
+            },
+            {
+              "id": "wasm-bindgen 0.2.95",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
+        "edition": "2021",
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasm-bindgen-macro 0.2.91",
+              "id": "wasm-bindgen-macro 0.2.95",
               "target": "wasm_bindgen_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.2.91"
+        "version": "0.2.95"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -18648,14 +23411,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-backend 0.2.91": {
+    "wasm-bindgen-backend 0.2.95": {
       "name": "wasm-bindgen-backend",
-      "version": "0.2.91",
+      "version": "0.2.95",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-backend/0.2.91/download",
-          "sha256": "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+          "url": "https://static.crates.io/crates/wasm-bindgen-backend/0.2.95/download",
+          "sha256": "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
         }
       },
       "targets": [
@@ -18686,15 +23449,15 @@
         "deps": {
           "common": [
             {
-              "id": "bumpalo 3.14.0",
+              "id": "bumpalo 3.16.0",
               "target": "bumpalo"
             },
             {
-              "id": "log 0.4.20",
+              "id": "log 0.4.22",
               "target": "log"
             },
             {
-              "id": "once_cell 1.19.0",
+              "id": "once_cell 1.20.2",
               "target": "once_cell"
             },
             {
@@ -18702,22 +23465,22 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.91",
+              "id": "wasm-bindgen-shared 0.2.95",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.2.91"
+        "edition": "2021",
+        "version": "0.2.95"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -18726,14 +23489,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-futures 0.4.41": {
+    "wasm-bindgen-futures 0.4.45": {
       "name": "wasm-bindgen-futures",
-      "version": "0.4.41",
+      "version": "0.4.45",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-futures/0.4.41/download",
-          "sha256": "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+          "url": "https://static.crates.io/crates/wasm-bindgen-futures/0.4.45/download",
+          "sha256": "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
         }
       },
       "targets": [
@@ -18762,25 +23525,25 @@
               "target": "cfg_if"
             },
             {
-              "id": "js-sys 0.3.68",
+              "id": "js-sys 0.3.72",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.91",
+              "id": "wasm-bindgen 0.2.95",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {
             "cfg(target_feature = \"atomics\")": [
               {
-                "id": "web-sys 0.3.68",
+                "id": "web-sys 0.3.72",
                 "target": "web_sys"
               }
             ]
           }
         },
-        "edition": "2018",
-        "version": "0.4.41"
+        "edition": "2021",
+        "version": "0.4.45"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -18789,14 +23552,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-macro 0.2.91": {
+    "wasm-bindgen-macro 0.2.95": {
       "name": "wasm-bindgen-macro",
-      "version": "0.2.91",
+      "version": "0.2.95",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-macro/0.2.91/download",
-          "sha256": "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+          "url": "https://static.crates.io/crates/wasm-bindgen-macro/0.2.95/download",
+          "sha256": "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
         }
       },
       "targets": [
@@ -18827,18 +23590,18 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "wasm-bindgen-macro-support 0.2.91",
+              "id": "wasm-bindgen-macro-support 0.2.95",
               "target": "wasm_bindgen_macro_support"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.2.91"
+        "edition": "2021",
+        "version": "0.2.95"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -18847,14 +23610,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-macro-support 0.2.91": {
+    "wasm-bindgen-macro-support 0.2.95": {
       "name": "wasm-bindgen-macro-support",
-      "version": "0.2.91",
+      "version": "0.2.95",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.91/download",
-          "sha256": "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+          "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.95/download",
+          "sha256": "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
         }
       },
       "targets": [
@@ -18889,26 +23652,26 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-backend 0.2.91",
+              "id": "wasm-bindgen-backend 0.2.95",
               "target": "wasm_bindgen_backend"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.91",
+              "id": "wasm-bindgen-shared 0.2.95",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.2.91"
+        "edition": "2021",
+        "version": "0.2.95"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -18917,14 +23680,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-shared 0.2.91": {
+    "wasm-bindgen-shared 0.2.95": {
       "name": "wasm-bindgen-shared",
-      "version": "0.2.91",
+      "version": "0.2.95",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-shared/0.2.91/download",
-          "sha256": "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+          "url": "https://static.crates.io/crates/wasm-bindgen-shared/0.2.95/download",
+          "sha256": "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
         }
       },
       "targets": [
@@ -18961,14 +23724,14 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen-shared 0.2.91",
+              "id": "wasm-bindgen-shared 0.2.95",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.2.91"
+        "edition": "2021",
+        "version": "0.2.95"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -18986,14 +23749,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-streams 0.4.0": {
+    "wasm-streams 0.4.1": {
       "name": "wasm-streams",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "package_url": "https://github.com/MattiasBuelens/wasm-streams/",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-streams/0.4.0/download",
-          "sha256": "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+          "url": "https://static.crates.io/crates/wasm-streams/0.4.1/download",
+          "sha256": "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
         }
       },
       "targets": [
@@ -19018,30 +23781,30 @@
         "deps": {
           "common": [
             {
-              "id": "futures-util 0.3.30",
+              "id": "futures-util 0.3.31",
               "target": "futures_util"
             },
             {
-              "id": "js-sys 0.3.68",
+              "id": "js-sys 0.3.72",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.91",
+              "id": "wasm-bindgen 0.2.95",
               "target": "wasm_bindgen"
             },
             {
-              "id": "wasm-bindgen-futures 0.4.41",
+              "id": "wasm-bindgen-futures 0.4.45",
               "target": "wasm_bindgen_futures"
             },
             {
-              "id": "web-sys 0.3.68",
+              "id": "web-sys 0.3.72",
               "target": "web_sys"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.0"
+        "version": "0.4.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19050,14 +23813,88 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "web-sys 0.3.68": {
+    "wasm-timer 0.2.5": {
+      "name": "wasm-timer",
+      "version": "0.2.5",
+      "package_url": "https://github.com/tomaka/wasm-timer",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-timer/0.2.5/download",
+          "sha256": "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasm_timer",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_timer",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "futures 0.3.31",
+              "target": "futures"
+            },
+            {
+              "id": "parking_lot 0.11.2",
+              "target": "parking_lot"
+            },
+            {
+              "id": "pin-utils 0.1.0",
+              "target": "pin_utils"
+            }
+          ],
+          "selects": {
+            "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))": [
+              {
+                "id": "js-sys 0.3.72",
+                "target": "js_sys"
+              },
+              {
+                "id": "wasm-bindgen 0.2.95",
+                "target": "wasm_bindgen"
+              },
+              {
+                "id": "wasm-bindgen-futures 0.4.45",
+                "target": "wasm_bindgen_futures"
+              },
+              {
+                "id": "web-sys 0.3.72",
+                "target": "web_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.2.5"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "web-sys 0.3.72": {
       "name": "web-sys",
-      "version": "0.3.68",
+      "version": "0.3.72",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/web-sys/0.3.68/download",
-          "sha256": "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+          "url": "https://static.crates.io/crates/web-sys/0.3.72/download",
+          "sha256": "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
         }
       },
       "targets": [
@@ -19119,23 +23956,28 @@
             "WritableStreamDefaultController",
             "WritableStreamDefaultWriter"
           ],
-          "selects": {}
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "Performance",
+              "PerformanceTiming"
+            ]
+          }
         },
         "deps": {
           "common": [
             {
-              "id": "js-sys 0.3.68",
+              "id": "js-sys 0.3.72",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.91",
+              "id": "wasm-bindgen 0.2.95",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.3.68"
+        "edition": "2021",
+        "version": "0.3.72"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19221,11 +24063,21 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "regex"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "either 1.9.0",
+              "id": "either 1.13.0",
               "target": "either"
+            },
+            {
+              "id": "regex 1.11.1",
+              "target": "regex"
             }
           ],
           "selects": {
@@ -19301,17 +24153,15 @@
         ],
         "crate_features": {
           "common": [
-            "consoleapi",
-            "errhandlingapi",
             "fileapi",
-            "minwindef",
-            "processenv",
+            "handleapi",
+            "libloaderapi",
+            "processthreadsapi",
             "std",
             "sysinfoapi",
             "winbase",
-            "wincon",
             "winerror",
-            "winnt"
+            "winver"
           ],
           "selects": {}
         },
@@ -19423,14 +24273,14 @@
       ],
       "license_file": null
     },
-    "winapi-util 0.1.6": {
+    "winapi-util 0.1.9": {
       "name": "winapi-util",
-      "version": "0.1.6",
+      "version": "0.1.9",
       "package_url": "https://github.com/BurntSushi/winapi-util",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/winapi-util/0.1.6/download",
-          "sha256": "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+          "url": "https://static.crates.io/crates/winapi-util/0.1.9/download",
+          "sha256": "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
         }
       },
       "targets": [
@@ -19457,16 +24307,16 @@
           "selects": {
             "cfg(windows)": [
               {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.1.6"
+        "version": "0.1.9"
       },
-      "license": "Unlicense/MIT",
+      "license": "Unlicense OR MIT",
       "license_ids": [
         "MIT",
         "Unlicense"
@@ -19541,14 +24391,14 @@
       ],
       "license_file": null
     },
-    "windows 0.52.0": {
+    "windows 0.58.0": {
       "name": "windows",
-      "version": "0.52.0",
+      "version": "0.58.0",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows/0.52.0/download",
-          "sha256": "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+          "url": "https://static.crates.io/crates/windows/0.58.0/download",
+          "sha256": "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
         }
       },
       "targets": [
@@ -19580,14 +24430,15 @@
             "Win32_System_IO",
             "Win32_System_Ioctl",
             "Win32_System_SystemServices",
-            "default"
+            "default",
+            "std"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "windows-core 0.52.0",
+              "id": "windows-core 0.58.0",
               "target": "windows_core"
             },
             {
@@ -19598,7 +24449,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.58.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19607,14 +24458,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows-core 0.52.0": {
+    "windows-core 0.58.0": {
       "name": "windows-core",
-      "version": "0.52.0",
+      "version": "0.58.0",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows-core/0.52.0/download",
-          "sha256": "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+          "url": "https://static.crates.io/crates/windows-core/0.58.0/download",
+          "sha256": "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
         }
       },
       "targets": [
@@ -19638,12 +24489,21 @@
         ],
         "crate_features": {
           "common": [
-            "default"
+            "default",
+            "std"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
+            {
+              "id": "windows-result 0.2.0",
+              "target": "windows_result"
+            },
+            {
+              "id": "windows-strings 0.1.0",
+              "target": "windows_strings"
+            },
             {
               "id": "windows-targets 0.52.6",
               "target": "windows_targets"
@@ -19652,7 +24512,132 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "windows-implement 0.58.0",
+              "target": "windows_implement"
+            },
+            {
+              "id": "windows-interface 0.58.0",
+              "target": "windows_interface"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.58.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "license-apache-2.0"
+    },
+    "windows-implement 0.58.0": {
+      "name": "windows-implement",
+      "version": "0.58.0",
+      "package_url": "https://github.com/microsoft/windows-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-implement/0.58.0/download",
+          "sha256": "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "windows_implement",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_implement",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.58.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "license-apache-2.0"
+    },
+    "windows-interface 0.58.0": {
+      "name": "windows-interface",
+      "version": "0.58.0",
+      "package_url": "https://github.com/microsoft/windows-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-interface/0.58.0/download",
+          "sha256": "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "windows_interface",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_interface",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.37",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.85",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.58.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19864,13 +24849,20 @@
           "common": [
             "Win32",
             "Win32_Foundation",
+            "Win32_Globalization",
             "Win32_Networking",
             "Win32_Networking_WinSock",
+            "Win32_Security",
+            "Win32_Storage",
+            "Win32_Storage_FileSystem",
             "Win32_System",
+            "Win32_System_Com",
             "Win32_System_Console",
             "Win32_System_IO",
+            "Win32_System_Pipes",
             "Win32_System_Threading",
-            "Win32_System_WindowsProgramming",
+            "Win32_UI",
+            "Win32_UI_Shell",
             "default"
           ],
           "selects": {}
@@ -19942,6 +24934,7 @@
             "Win32_System_Com",
             "Win32_System_Console",
             "Win32_System_IO",
+            "Win32_System_Ioctl",
             "Win32_System_Pipes",
             "Win32_System_SystemServices",
             "Win32_System_Threading",
@@ -20004,8 +24997,21 @@
           "common": [
             "Win32",
             "Win32_Foundation",
+            "Win32_Security",
+            "Win32_Security_Authentication",
+            "Win32_Security_Authentication_Identity",
+            "Win32_Security_Credentials",
+            "Win32_Security_Cryptography",
             "Win32_Storage",
             "Win32_Storage_FileSystem",
+            "Win32_System",
+            "Win32_System_Console",
+            "Win32_System_IO",
+            "Win32_System_Ioctl",
+            "Win32_System_LibraryLoader",
+            "Win32_System_Memory",
+            "Win32_System_SystemInformation",
+            "Win32_System_Time",
             "default"
           ],
           "selects": {}
@@ -21227,14 +26233,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "winnow 0.5.39": {
+    "winnow 0.6.20": {
       "name": "winnow",
-      "version": "0.5.39",
+      "version": "0.6.20",
       "package_url": "https://github.com/winnow-rs/winnow",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/winnow/0.5.39/download",
-          "sha256": "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+          "url": "https://static.crates.io/crates/winnow/0.6.20/download",
+          "sha256": "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
         }
       },
       "targets": [
@@ -21265,7 +26271,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.5.39"
+        "version": "0.6.20"
       },
       "license": "MIT",
       "license_ids": [
@@ -21317,20 +26323,20 @@
       ],
       "license_file": "LICENSE.md"
     },
-    "wyz 0.5.1": {
-      "name": "wyz",
-      "version": "0.5.1",
-      "package_url": "https://github.com/myrrlyn/wyz",
+    "winsafe 0.0.22": {
+      "name": "winsafe",
+      "version": "0.0.22",
+      "package_url": "https://github.com/rodrigocfd/winsafe",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wyz/0.5.1/download",
-          "sha256": "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+          "url": "https://static.crates.io/crates/winsafe/0.0.22/download",
+          "sha256": "7d6ad6cbd9c6e5144971e326303f0e453b61d82e4f72067fccf23106bccd8437"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "wyz",
+            "crate_name": "winsafe",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -21341,28 +26347,25 @@
           }
         }
       ],
-      "library_target_name": "wyz",
+      "library_target_name": "winsafe",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "deps": {
+        "crate_features": {
           "common": [
-            {
-              "id": "tap 1.0.1",
-              "target": "tap"
-            }
+            "kernel"
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.5.1"
+        "edition": "2021",
+        "version": "0.0.22"
       },
       "license": "MIT",
       "license_ids": [
         "MIT"
       ],
-      "license_file": "LICENSE.txt"
+      "license_file": "LICENSE.md"
     },
     "xattr 1.3.1": {
       "name": "xattr",
@@ -21432,20 +26435,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "xxhash-rust 0.8.8": {
-      "name": "xxhash-rust",
-      "version": "0.8.8",
-      "package_url": "https://github.com/DoumanAsh/xxhash-rust",
+    "xz2 0.1.7": {
+      "name": "xz2",
+      "version": "0.1.7",
+      "package_url": "https://github.com/alexcrichton/xz2-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/xxhash-rust/0.8.8/download",
-          "sha256": "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
+          "url": "https://static.crates.io/crates/xz2/0.1.7/download",
+          "sha256": "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "xxhash_rust",
+            "crate_name": "xz2",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -21456,25 +26459,29 @@
           }
         }
       ],
-      "library_target_name": "xxhash_rust",
+      "library_target_name": "xz2",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
+        "deps": {
           "common": [
-            "xxh3"
+            {
+              "id": "lzma-sys 0.1.20",
+              "target": "lzma_sys"
+            }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.8"
+        "version": "0.1.7"
       },
-      "license": "BSL-1.0",
+      "license": "MIT/Apache-2.0",
       "license_ids": [
-        "BSL-1.0"
+        "Apache-2.0",
+        "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": "LICENSE-APACHE"
     },
     "zerocopy 0.7.35": {
       "name": "zerocopy",
@@ -21505,17 +26512,34 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "byteorder",
+            "default",
+            "derive",
+            "simd",
+            "zerocopy-derive"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "byteorder 1.5.0",
+              "target": "byteorder"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
         "proc_macro_deps": {
-          "common": [],
-          "selects": {
-            "cfg(any())": [
-              {
-                "id": "zerocopy-derive 0.7.35",
-                "target": "zerocopy_derive"
-              }
-            ]
-          }
+          "common": [
+            {
+              "id": "zerocopy-derive 0.7.35",
+              "target": "zerocopy_derive"
+            }
+          ],
+          "selects": {}
         },
         "version": "0.7.35"
       },
@@ -21563,11 +26587,11 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.35",
+              "id": "quote 1.0.37",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.82",
+              "id": "syn 2.0.85",
               "target": "syn"
             }
           ],
@@ -21661,72 +26685,30 @@
         ],
         "crate_features": {
           "common": [
-            "aes",
-            "aes-crypto",
-            "bzip2",
-            "constant_time_eq",
-            "default",
             "deflate",
-            "flate2",
-            "hmac",
-            "pbkdf2",
-            "sha1",
-            "time",
-            "zstd"
+            "flate2"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "aes 0.8.3",
-              "target": "aes"
-            },
-            {
               "id": "byteorder 1.5.0",
               "target": "byteorder"
             },
             {
-              "id": "bzip2 0.4.4",
-              "target": "bzip2"
-            },
-            {
-              "id": "constant_time_eq 0.1.5",
-              "target": "constant_time_eq"
-            },
-            {
-              "id": "crc32fast 1.3.2",
+              "id": "crc32fast 1.4.2",
               "target": "crc32fast"
             },
             {
-              "id": "flate2 1.0.28",
+              "id": "flate2 1.0.34",
               "target": "flate2"
-            },
-            {
-              "id": "hmac 0.12.1",
-              "target": "hmac"
-            },
-            {
-              "id": "pbkdf2 0.11.0",
-              "target": "pbkdf2"
-            },
-            {
-              "id": "sha1 0.10.6",
-              "target": "sha1"
-            },
-            {
-              "id": "time 0.3.36",
-              "target": "time"
-            },
-            {
-              "id": "zstd 0.11.2+zstd.1.5.2",
-              "target": "zstd"
             }
           ],
           "selects": {
             "cfg(any(all(target_arch = \"arm\", target_pointer_width = \"32\"), target_arch = \"mips\", target_arch = \"powerpc\"))": [
               {
-                "id": "crossbeam-utils 0.8.19",
+                "id": "crossbeam-utils 0.8.20",
                 "target": "crossbeam_utils"
               }
             ]
@@ -21741,14 +26723,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "zstd 0.11.2+zstd.1.5.2": {
+    "zstd 0.13.2": {
       "name": "zstd",
-      "version": "0.11.2+zstd.1.5.2",
+      "version": "0.13.2",
       "package_url": "https://github.com/gyscos/zstd-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/zstd/0.11.2+zstd.1.5.2/download",
-          "sha256": "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+          "url": "https://static.crates.io/crates/zstd/0.13.2/download",
+          "sha256": "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
         }
       },
       "targets": [
@@ -21770,26 +26752,17 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "arrays",
-            "default",
-            "legacy",
-            "zdict_builder"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
-              "id": "zstd-safe 5.0.2+zstd.1.5.2",
+              "id": "zstd-safe 7.2.1",
               "target": "zstd_safe"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.11.2+zstd.1.5.2"
+        "version": "0.13.2"
       },
       "license": "MIT",
       "license_ids": [
@@ -21797,14 +26770,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "zstd-safe 5.0.2+zstd.1.5.2": {
+    "zstd-safe 7.2.1": {
       "name": "zstd-safe",
-      "version": "5.0.2+zstd.1.5.2",
+      "version": "7.2.1",
       "package_url": "https://github.com/gyscos/zstd-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/zstd-safe/5.0.2+zstd.1.5.2/download",
-          "sha256": "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+          "url": "https://static.crates.io/crates/zstd-safe/7.2.1/download",
+          "sha256": "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
         }
       },
       "targets": [
@@ -21840,32 +26813,25 @@
         ],
         "crate_features": {
           "common": [
-            "arrays",
-            "legacy",
-            "std",
-            "zdict_builder"
+            "std"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.161",
-              "target": "libc"
-            },
-            {
-              "id": "zstd-safe 5.0.2+zstd.1.5.2",
+              "id": "zstd-safe 7.2.1",
               "target": "build_script_build"
             },
             {
-              "id": "zstd-sys 2.0.9+zstd.1.5.5",
+              "id": "zstd-sys 2.0.13+zstd.1.5.6",
               "target": "zstd_sys"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "5.0.2+zstd.1.5.2"
+        "version": "7.2.1"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -21877,7 +26843,7 @@
         "link_deps": {
           "common": [
             {
-              "id": "zstd-sys 2.0.9+zstd.1.5.5",
+              "id": "zstd-sys 2.0.13+zstd.1.5.6",
               "target": "zstd_sys"
             }
           ],
@@ -21891,14 +26857,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "zstd-sys 2.0.9+zstd.1.5.5": {
+    "zstd-sys 2.0.13+zstd.1.5.6": {
       "name": "zstd-sys",
-      "version": "2.0.9+zstd.1.5.5",
+      "version": "2.0.13+zstd.1.5.6",
       "package_url": "https://github.com/gyscos/zstd-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/zstd-sys/2.0.9+zstd.1.5.5/download",
-          "sha256": "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+          "url": "https://static.crates.io/crates/zstd-sys/2.0.13+zstd.1.5.6/download",
+          "sha256": "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
         }
       },
       "targets": [
@@ -21934,23 +26900,21 @@
         ],
         "crate_features": {
           "common": [
-            "legacy",
-            "std",
-            "zdict_builder"
+            "std"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "zstd-sys 2.0.9+zstd.1.5.5",
+              "id": "zstd-sys 2.0.13+zstd.1.5.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.0.9+zstd.1.5.5"
+        "version": "2.0.13+zstd.1.5.6"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -21962,11 +26926,11 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.83",
+              "id": "cc 1.1.31",
               "target": "cc"
             },
             {
-              "id": "pkg-config 0.3.29",
+              "id": "pkg-config 0.3.31",
               "target": "pkg_config"
             }
           ],
@@ -22097,6 +27061,9 @@
       "aarch64-apple-ios-sim"
     ],
     "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [],
+    "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))": [
+      "wasm32-unknown-unknown"
+    ],
     "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
       "i686-unknown-linux-gnu"
     ],
@@ -22113,7 +27080,29 @@
     "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
       "x86_64-pc-windows-msvc"
     ],
-    "cfg(any())": [],
+    "cfg(all(unix, not(target_os = \"macos\")))": [
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-linux-android",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
+    ],
     "cfg(any(all(target_arch = \"arm\", target_pointer_width = \"32\"), target_arch = \"mips\", target_arch = \"powerpc\"))": [
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
@@ -22142,31 +27131,6 @@
       "i686-unknown-linux-gnu",
       "thumbv7em-none-eabi",
       "thumbv8m.main-none-eabi",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios",
-      "x86_64-fuchsia",
-      "x86_64-linux-android",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
-      "x86_64-unknown-none"
-    ],
-    "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-fuchsia",
-      "aarch64-linux-android",
-      "aarch64-pc-windows-msvc",
-      "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
-      "i686-apple-darwin",
-      "i686-linux-android",
-      "i686-pc-windows-msvc",
-      "i686-unknown-freebsd",
-      "i686-unknown-linux-gnu",
       "x86_64-apple-darwin",
       "x86_64-apple-ios",
       "x86_64-fuchsia",
@@ -22220,14 +27184,6 @@
       "x86_64-linux-android",
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
-    ],
-    "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "i686-apple-darwin",
-      "x86_64-apple-darwin",
-      "x86_64-apple-ios"
     ],
     "cfg(any(unix, target_os = \"wasi\"))": [
       "aarch64-apple-darwin",
@@ -22379,6 +27335,39 @@
       "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
+    "cfg(not(target_os = \"windows\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "riscv64gc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
+      "thumbv7em-none-eabi",
+      "thumbv8m.main-none-eabi",
+      "wasm32-unknown-unknown",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
+      "x86_64-unknown-none"
+    ],
     "cfg(not(windows))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -22412,19 +27401,11 @@
       "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
-    "cfg(target_arch = \"spirv\")": [],
     "cfg(target_arch = \"wasm32\")": [
       "wasm32-unknown-unknown",
       "wasm32-wasi"
     ],
     "cfg(target_feature = \"atomics\")": [],
-    "cfg(target_os = \"android\")": [
-      "aarch64-linux-android",
-      "armv7-linux-androideabi",
-      "i686-linux-android",
-      "x86_64-linux-android"
-    ],
-    "cfg(target_os = \"haiku\")": [],
     "cfg(target_os = \"hermit\")": [],
     "cfg(target_os = \"linux\")": [
       "aarch64-unknown-linux-gnu",
@@ -22436,6 +27417,11 @@
       "s390x-unknown-linux-gnu",
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
+    ],
+    "cfg(target_os = \"macos\")": [
+      "aarch64-apple-darwin",
+      "i686-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(target_os = \"redox\")": [],
     "cfg(target_os = \"wasi\")": [
@@ -22552,8 +27538,17 @@
   },
   "direct_deps": [
     "clap 4.5.20",
+    "itertools 0.13.0",
     "miette 7.2.0",
-    "rattler_installs_packages 0.9.0"
+    "tempfile 3.13.0",
+    "thiserror 1.0.65",
+    "uv-cache 0.0.1",
+    "uv-distribution-filename 0.0.1",
+    "uv-extract 0.0.1",
+    "uv-install-wheel 0.0.1",
+    "uv-pypi-types 0.0.1",
+    "uv-python 0.0.1",
+    "uv-virtualenv 0.0.4"
   ],
   "direct_dev_deps": []
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,65 +4,40 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aes"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -74,27 +49,27 @@ checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -102,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "async-compression"
@@ -112,28 +87,16 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
 dependencies = [
+ "bzip2",
  "flate2",
  "futures-core",
  "futures-io",
  "memchr",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-once-cell"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "tokio",
+ "xz2",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -149,15 +112,15 @@ dependencies = [
 
 [[package]]
 name = "async_http_range_reader"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8561e6613f8361df8bed11c0eef05b98384643bc81f6b753eec7c1d91f097509"
+checksum = "f1a0e0571c5d724d17fbe0b608d31a91e94938722c141877d3a2982216b084c2"
 dependencies = [
  "bisection",
  "futures",
  "http-content-range",
  "itertools 0.12.1",
- "memmap2 0.9.4",
+ "memmap2",
  "reqwest",
  "reqwest-middleware",
  "thiserror",
@@ -169,9 +132,8 @@ dependencies = [
 
 [[package]]
 name = "async_zip"
-version = "0.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527207465fb6dcafbf661b0d4a51d0d2306c9d0c2975423079a6caa807930daf"
+version = "0.0.17"
+source = "git+https://github.com/charliermarsh/rs-async-zip?rev=011b24604fa7bc223daaad7712c0694bac8f0a87#011b24604fa7bc223daaad7712c0694bac8f0a87"
 dependencies = [
  "async-compression",
  "crc32fast",
@@ -183,24 +145,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -214,21 +196,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bisection"
@@ -244,30 +214,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest",
-]
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -279,10 +228,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.14.0"
+name = "boxcar"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "fba19c552ee63cb6646b75e1166d1bdb8a6d34a6d19e319dec88c8adadff2db3"
+
+[[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523363cbe1df49b68215efdf500b103ac3b0fb4836aed6d15689a076eadb8fff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -318,40 +306,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "cacache"
-version = "13.0.0"
+name = "cachedir"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7"
+checksum = "4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873"
 dependencies = [
- "digest",
- "either",
- "futures",
- "hex",
- "libc",
- "memmap2 0.5.10",
- "miette 5.10.0",
- "reflink-copy",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "sha2",
- "ssri",
  "tempfile",
- "thiserror",
- "tokio",
- "tokio-stream",
+]
+
+[[package]]
+name = "cargo-util"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dd67a24439ca5260a08128b6cbf4b0f4453497a2f60508163ab9d5b534b122"
+dependencies = [
+ "anyhow",
+ "core-foundation",
+ "filetime",
+ "hex",
+ "ignore",
+ "jobserver",
+ "libc",
+ "miow",
+ "same-file",
+ "sha2",
+ "shell-escape",
+ "tempfile",
+ "tracing",
  "walkdir",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -361,53 +355,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.33"
+name = "charset"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "serde",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
+ "base64",
+ "encoding_rs",
 ]
 
 [[package]]
@@ -429,7 +383,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -452,66 +406,74 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "configparser"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec6d3da8e550377a85339063af6e3735f4b1d9392108da4e083a1b3b9820288"
+checksum = "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
+name = "core-foundation"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
+name = "crossbeam-deque"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
+name = "crossbeam-epoch"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -545,55 +507,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.5"
+name = "dashmap"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
- "serde",
-]
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "digest"
@@ -603,28 +534,63 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "elsa"
-version = "1.10.0"
+name = "encoding_rs"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "stable_deref_trait",
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -634,24 +600,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.8"
+name = "erased-serde"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.3.1"
+name = "etcetera"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -662,27 +638,21 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "filetime"
-version = "0.2.23"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
- "windows-sys 0.52.0",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -710,35 +680,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+ "tokio",
 ]
 
 [[package]]
-name = "fs4"
-version = "0.8.4"
+name = "fs2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
- "rustix",
- "windows-sys 0.52.0",
+ "libc",
+ "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -751,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -761,15 +720,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -778,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -797,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -808,21 +767,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -842,43 +801,88 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "half"
-version = "2.3.1"
+name = "globset"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
- "cfg-if",
- "crunchy",
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.6.0",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -903,15 +907,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "home"
@@ -966,39 +961,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-cache-semantics"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
-dependencies = [
- "http",
- "http-serde",
- "reqwest",
- "serde",
- "time",
-]
-
-[[package]]
 name = "http-content-range"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0d1a8ef218a86416107794b34cc446958d9203556c312bb41eab4c924c1d2e"
-
-[[package]]
-name = "http-serde"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
-dependencies = [
- "http",
- "serde",
-]
+checksum = "aa7929c876417cd3ece616950474c7dff5b0150a2b53bd7e7fda55afa086c22b"
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "hyper"
@@ -1009,6 +981,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1030,6 +1003,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1057,35 +1031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,33 +1041,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.3"
+name = "ignore"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1137,25 +1068,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
+name = "instant"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "generic-array",
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1177,26 +1117,78 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jiff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb"
+dependencies = [
+ "jiff-tzdb-platform",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "junction"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "krata-tokio-tar"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8bd5fee9b96acb5fc36b401896d601e6fdcce52b0e651ce24a3b21fb524e79f"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -1206,6 +1198,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall 0.5.7",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,9 +1216,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1223,9 +1226,31 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "mailparse"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da03d5980411a724e8aaf7b61a7b5e386ec55a7fb49ee3d0ff79efc7e5e7c7e"
+dependencies = [
+ "charset",
+ "data-encoding",
+ "quoted_printable",
+]
 
 [[package]]
 name = "md-5"
@@ -1239,38 +1264,17 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "miette"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
-dependencies = [
- "miette-derive 5.10.0",
- "once_cell",
- "thiserror",
- "unicode-width",
 ]
 
 [[package]]
@@ -1282,7 +1286,7 @@ dependencies = [
  "backtrace",
  "backtrace-ext",
  "cfg-if",
- "miette-derive 7.2.0",
+ "miette-derive",
  "owo-colors",
  "supports-color",
  "supports-hyperlinks",
@@ -1291,17 +1295,6 @@ dependencies = [
  "textwrap",
  "thiserror",
  "unicode-width",
-]
-
-[[package]]
-name = "miette-derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1322,12 +1315,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.2"
+name = "mime_guess"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
- "adler",
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -1343,40 +1346,84 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
+name = "miow"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "owo-colors"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "parking"
@@ -1386,110 +1433,59 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
+ "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.7",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
+name = "paste"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pathdiff"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
-]
-
-[[package]]
-name = "peg"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400bcab7d219c38abf8bd7cc2054eb9bbbd4312d66f6a5557d572a203f646f61"
-dependencies = [
- "peg-macros",
- "peg-runtime",
-]
-
-[[package]]
-name = "peg-macros"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e61cce859b76d19090f62da50a9fe92bab7c2a5f09e183763559a2ac392c90"
-dependencies = [
- "peg-runtime",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "peg-runtime"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36bae92c60fa2398ce4678b98b2c4b5a7c61099961ca1fa305aec04a9ad28922"
-
-[[package]]
-name = "pep440_rs"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c29f9c43de378b4e4e0cd7dbcce0e5cfb80443de8c05620368b2948bc936a1"
-dependencies = [
- "once_cell",
- "regex",
- "serde",
- "unicode-width",
-]
-
-[[package]]
-name = "pep508_rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910c513bea0f4f833122321c0f20e8c704e01de98692f6989c2ec21f43d88b1e"
-dependencies = [
- "once_cell",
- "pep440_rs",
- "regex",
- "serde",
- "thiserror",
- "tracing",
- "unicode-width",
- "url",
-]
+checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
 
 [[package]]
 name = "percent-encoding"
@@ -1498,29 +1494,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.6.0",
-]
-
-[[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1529,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -1541,15 +1527,31 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
+name = "plain"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "platform-info"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91077ffd05d058d70d79eefcd7d7f6aac34980860a7519960f7913b6563a8c3a"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "ppv-lite86"
@@ -1558,6 +1560,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "priority-queue"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
+dependencies = [
+ "autocfg",
+ "equivalent",
+ "indexmap",
 ]
 
 [[package]]
@@ -1570,24 +1583,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "py"
-version = "0.1.0"
+name = "ptr_meta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
 dependencies = [
- "miette 7.2.0",
- "rattler_installs_packages",
+ "ptr_meta_derive",
 ]
 
 [[package]]
-name = "pyproject-toml"
-version = "0.9.0"
+name = "ptr_meta_derive"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c3dd745f99aa3c554b7bb00859f7d18c2f1d6afd749ccc86d60b61e702abd9"
+checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
- "indexmap 2.6.0",
- "pep440_rs",
- "pep508_rs",
- "serde",
- "toml",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pubgrub"
+version = "0.2.1"
+source = "git+https://github.com/astral-sh/pubgrub?rev=388685a8711092971930986644cfed152d1a1f6c#388685a8711092971930986644cfed152d1a1f6c"
+dependencies = [
+ "indexmap",
+ "log",
+ "priority-queue",
+ "rustc-hash",
+ "thiserror",
+]
+
+[[package]]
+name = "py"
+version = "0.1.0"
+dependencies = [
+ "itertools 0.13.0",
+ "miette",
+ "tempfile",
+ "thiserror",
+ "uv-cache",
+ "uv-distribution-filename",
+ "uv-extract",
+ "uv-install-wheel",
+ "uv-pypi-types",
+ "uv-python",
+ "uv-virtualenv",
 ]
 
 [[package]]
@@ -1640,18 +1681,27 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
+name = "quoted_printable"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
+
+[[package]]
+name = "rancor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -1684,95 +1734,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "rattler_digest"
-version = "0.19.5"
+name = "rayon"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb0228f734983274fb6938844123e88aa55158d53ead37e8ae3deb641fe05aa"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
- "blake2",
- "digest",
- "generic-array",
- "hex",
- "md-5",
- "serde",
- "serde_with",
- "sha2",
+ "either",
+ "rayon-core",
 ]
 
 [[package]]
-name = "rattler_installs_packages"
-version = "0.9.0"
-source = "git+https://github.com/prefix-dev/rip?rev=1b4d909496f68c292800ebbd3667c8682b01d218#1b4d909496f68c292800ebbd3667c8682b01d218"
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "async-once-cell",
- "async-recursion",
- "async-trait",
- "async_http_range_reader",
- "async_zip",
- "bytes",
- "cacache",
- "ciborium",
- "configparser",
- "csv",
- "data-encoding",
- "dunce",
- "elsa",
- "flate2",
- "fs-err",
- "fs4",
- "fs_extra",
- "futures",
- "html-escape",
- "http",
- "http-cache-semantics",
- "include_dir",
- "indexmap 2.6.0",
- "itertools 0.12.1",
- "miette 7.2.0",
- "mime",
- "once_cell",
- "parking_lot",
- "pathdiff",
- "peg",
- "pep440_rs",
- "pep508_rs",
- "pin-project-lite",
- "pyproject-toml",
- "rattler_digest",
- "regex",
- "reqwest",
- "reqwest-middleware",
- "resolvo",
- "serde",
- "serde_json",
- "serde_with",
- "smallvec",
- "tar",
- "tempfile",
- "thiserror",
- "tl",
- "tokio",
- "tokio-util",
- "tracing",
- "url",
- "which",
- "zip",
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
-name = "reflink-copy"
-version = "0.1.14"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767be24c0da52e7448d495b8d162506a9aa125426651d547d545d6c2b4b65b62"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc31414597d1cd7fdd2422798b7652a6329dda0fe0219e6335a13d5bcaa9aeb6"
 dependencies = [
  "cfg-if",
  "rustix",
@@ -1781,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1809,15 +1832,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rend"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
- "base64 0.22.1",
+ "async-compression",
+ "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1828,11 +1863,13 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -1841,6 +1878,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower-service",
  "url",
@@ -1855,8 +1893,7 @@ dependencies = [
 [[package]]
 name = "reqwest-middleware"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+source = "git+https://github.com/astral-sh/reqwest-middleware?rev=5e3eaf254b5bd481c75d2710eed055f95b756913#5e3eaf254b5bd481c75d2710eed055f95b756913"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1868,40 +1905,115 @@ dependencies = [
 ]
 
 [[package]]
-name = "resolvo"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d299d168910c5d71f3c0f5441abe38ca4a6ae21f70fae909bfc6bead28f6620f"
+name = "reqwest-retry"
+version = "0.7.1"
+source = "git+https://github.com/astral-sh/reqwest-middleware?rev=5e3eaf254b5bd481c75d2710eed055f95b756913#5e3eaf254b5bd481c75d2710eed055f95b756913"
 dependencies = [
- "bitvec",
- "elsa",
- "event-listener",
+ "anyhow",
+ "async-trait",
  "futures",
- "itertools 0.13.0",
- "petgraph",
+ "getrandom",
+ "http",
+ "hyper",
+ "parking_lot",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror",
  "tokio",
  "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395027076c569819ea6035ee62e664f5e03d74e281744f55261dd1afd939212b"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cb82b74b4810f07e460852c32f522e979787691b0b7b7439fe473e49d49b2f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rust-netrc"
+version = "0.1.1"
+source = "git+https://github.com/gribouille/netrc?rev=544f3890b621f0dc30fcefb4f804269c160ce2e9#544f3890b621f0dc30fcefb4f804269c160ce2e9"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -1915,7 +2027,7 @@ version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1934,6 +2046,19 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1964,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -1978,10 +2103,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1993,10 +2201,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2676ba99bd82f75cae5cbd2c8eda6fa0b8760f18978ea840e980dd5567b5c5b6"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2017,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -2037,58 +2267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.6.0",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,13 +2278,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
+name = "shell-escape"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2131,12 +2327,12 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2146,35 +2342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "ssri"
-version = "9.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
-dependencies = [
- "base64 0.21.7",
- "digest",
- "hex",
- "miette 5.10.0",
- "serde",
- "sha-1",
- "sha2",
- "thiserror",
- "xxhash-rust",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,15 +2349,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
+checksum = "8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77"
 dependencies = [
  "is_ci",
 ]
@@ -2209,9 +2376,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2228,21 +2395,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
+name = "sys-info"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
-name = "tar"
-version = "0.4.40"
+name = "target-lexicon"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -2299,41 +2465,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2347,8 +2482,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tl"
 version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
+source = "git+https://github.com/charliermarsh/tl.git?rev=6e25b2ee2513d75385101a8ff9f591ef51f314ec#6e25b2ee2513d75385101a8ff9f591ef51f314ec"
 
 [[package]]
 name = "tokio"
@@ -2390,10 +2524,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.14"
+name = "tokio-socks"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2403,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2413,14 +2559,13 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2430,20 +2575,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.4"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2452,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2462,7 +2607,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2495,22 +2639,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
+name = "unicase"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2520,27 +2676,33 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unpack_bin"
 version = "0.1.0"
 dependencies = [
  "clap",
- "miette 7.2.0",
+ "miette",
  "py",
 ]
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"
@@ -2550,15 +2712,21 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-width"
@@ -2568,30 +2736,539 @@ checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+
+[[package]]
+name = "uv-auth"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "futures",
+ "http",
+ "reqwest",
+ "reqwest-middleware",
+ "rust-netrc",
+ "rustc-hash",
+ "tokio",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uv-once-map",
+]
+
+[[package]]
+name = "uv-cache"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "directories",
+ "etcetera",
+ "fs-err",
+ "nanoid",
+ "rmp-serde",
+ "rustc-hash",
+ "serde",
+ "tempfile",
+ "tracing",
+ "url",
+ "uv-cache-info",
+ "uv-cache-key",
+ "uv-distribution-types",
+ "uv-fs",
+ "uv-normalize",
+ "uv-pypi-types",
+ "uv-static",
+ "walkdir",
+]
+
+[[package]]
+name = "uv-cache-info"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "fs-err",
+ "globwalk",
+ "serde",
+ "thiserror",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "uv-cache-key"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "hex",
+ "seahash",
+ "url",
+]
+
+[[package]]
+name = "uv-client"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "async_http_range_reader",
+ "async_zip",
+ "bytecheck",
+ "fs-err",
+ "futures",
+ "html-escape",
+ "http",
+ "itertools 0.13.0",
+ "jiff",
+ "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "rkyv",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "sys-info",
+ "thiserror",
+ "tl",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uv-auth",
+ "uv-cache",
+ "uv-cache-key",
+ "uv-configuration",
+ "uv-distribution-filename",
+ "uv-distribution-types",
+ "uv-fs",
+ "uv-metadata",
+ "uv-normalize",
+ "uv-pep440",
+ "uv-pep508",
+ "uv-platform-tags",
+ "uv-pypi-types",
+ "uv-static",
+ "uv-version",
+ "uv-warnings",
+]
+
+[[package]]
+name = "uv-configuration"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "either",
+ "fs-err",
+ "rustc-hash",
+ "serde",
+ "serde-untagged",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "uv-auth",
+ "uv-cache",
+ "uv-cache-info",
+ "uv-cache-key",
+ "uv-normalize",
+ "uv-pep508",
+ "uv-platform-tags",
+ "uv-pypi-types",
+ "uv-static",
+ "which",
+]
+
+[[package]]
+name = "uv-distribution-filename"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "rkyv",
+ "serde",
+ "thiserror",
+ "url",
+ "uv-normalize",
+ "uv-pep440",
+ "uv-platform-tags",
+]
+
+[[package]]
+name = "uv-distribution-types"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "anyhow",
+ "fs-err",
+ "itertools 0.13.0",
+ "jiff",
+ "rkyv",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uv-cache-info",
+ "uv-cache-key",
+ "uv-distribution-filename",
+ "uv-fs",
+ "uv-git",
+ "uv-normalize",
+ "uv-pep440",
+ "uv-pep508",
+ "uv-platform-tags",
+ "uv-pypi-types",
+]
+
+[[package]]
+name = "uv-extract"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "async-compression",
+ "async_zip",
+ "fs-err",
+ "futures",
+ "krata-tokio-tar",
+ "md-5",
+ "rayon",
+ "reqwest",
+ "rustc-hash",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uv-distribution-filename",
+ "uv-pypi-types",
+ "xz2",
+ "zip",
+]
+
+[[package]]
+name = "uv-fs"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "backoff",
+ "cachedir",
+ "dunce",
+ "either",
+ "encoding_rs_io",
+ "fs-err",
+ "fs2",
+ "junction",
+ "path-slash",
+ "rustix",
+ "serde",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "urlencoding",
+ "winsafe 0.0.22",
+]
+
+[[package]]
+name = "uv-git"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "anyhow",
+ "cargo-util",
+ "dashmap",
+ "fs-err",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "uv-auth",
+ "uv-cache-key",
+ "uv-fs",
+ "uv-static",
+]
+
+[[package]]
+name = "uv-install-wheel"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "configparser",
+ "csv",
+ "data-encoding",
+ "fs-err",
+ "mailparse",
+ "pathdiff",
+ "platform-info",
+ "reflink-copy",
+ "regex",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "uv-cache-info",
+ "uv-distribution-filename",
+ "uv-fs",
+ "uv-normalize",
+ "uv-pep440",
+ "uv-platform-tags",
+ "uv-pypi-types",
+ "uv-warnings",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
+name = "uv-metadata"
+version = "0.1.0"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "async_zip",
+ "fs-err",
+ "futures",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "uv-distribution-filename",
+ "uv-normalize",
+ "uv-pypi-types",
+ "zip",
+]
+
+[[package]]
+name = "uv-normalize"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "rkyv",
+ "serde",
+]
+
+[[package]]
+name = "uv-once-map"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "dashmap",
+ "futures",
+ "tokio",
+]
+
+[[package]]
+name = "uv-pep440"
+version = "0.7.0"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "rkyv",
+ "serde",
+ "tracing",
+ "unicode-width",
+ "unscanny",
+]
+
+[[package]]
+name = "uv-pep508"
+version = "0.6.0"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "boxcar",
+ "indexmap",
+ "itertools 0.13.0",
+ "pubgrub",
+ "regex",
+ "rustc-hash",
+ "schemars",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "unicode-width",
+ "url",
+ "uv-fs",
+ "uv-normalize",
+ "uv-pep440",
+ "uv-pubgrub",
+]
+
+[[package]]
+name = "uv-platform-tags"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "uv-pubgrub"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "itertools 0.13.0",
+ "pubgrub",
+ "thiserror",
+ "uv-pep440",
+]
+
+[[package]]
+name = "uv-pypi-types"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "indexmap",
+ "itertools 0.13.0",
+ "jiff",
+ "mailparse",
+ "regex",
+ "rkyv",
+ "serde",
+ "serde-untagged",
+ "thiserror",
+ "toml",
+ "toml_edit",
+ "tracing",
+ "url",
+ "uv-distribution-filename",
+ "uv-fs",
+ "uv-git",
+ "uv-normalize",
+ "uv-pep440",
+ "uv-pep508",
+]
+
+[[package]]
+name = "uv-python"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "anyhow",
+ "configparser",
+ "fs-err",
+ "futures",
+ "goblin",
+ "itertools 0.13.0",
+ "owo-colors",
+ "regex",
+ "reqwest",
+ "reqwest-middleware",
+ "rmp-serde",
+ "same-file",
+ "serde",
+ "serde_json",
+ "target-lexicon",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uv-cache",
+ "uv-cache-info",
+ "uv-cache-key",
+ "uv-client",
+ "uv-distribution-filename",
+ "uv-extract",
+ "uv-fs",
+ "uv-install-wheel",
+ "uv-pep440",
+ "uv-pep508",
+ "uv-platform-tags",
+ "uv-pypi-types",
+ "uv-state",
+ "uv-static",
+ "uv-warnings",
+ "which",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "uv-state"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "directories",
+ "etcetera",
+ "fs-err",
+ "tempfile",
+]
+
+[[package]]
+name = "uv-static"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+
+[[package]]
+name = "uv-version"
+version = "0.4.21"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+
+[[package]]
+name = "uv-virtualenv"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "fs-err",
+ "itertools 0.13.0",
+ "pathdiff",
+ "thiserror",
+ "tracing",
+ "uv-fs",
+ "uv-platform-tags",
+ "uv-pypi-types",
+ "uv-python",
+ "uv-version",
+]
+
+[[package]]
+name = "uv-warnings"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?rev=855c1917e1e0e2b48c38de71bebc845af016afae#855c1917e1e0e2b48c38de71bebc845af016afae"
+dependencies = [
+ "anstream",
+ "owo-colors",
+ "rustc-hash",
+]
 
 [[package]]
 name = "venv_bin"
 version = "0.1.0"
 dependencies = [
  "clap",
- "miette 7.2.0",
+ "miette",
  "py",
 ]
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -2614,19 +3291,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -2639,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2651,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2661,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2674,15 +3352,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2692,10 +3370,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.68"
+name = "wasm-timer"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2718,8 +3411,9 @@ checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
+ "regex",
  "rustix",
- "winsafe",
+ "winsafe 0.0.19",
 ]
 
 [[package]]
@@ -2740,11 +3434,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2755,9 +3449,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
  "windows-targets 0.52.6",
@@ -2765,11 +3459,37 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2952,9 +3672,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -2966,13 +3686,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
+name = "winsafe"
+version = "0.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
+checksum = "7d6ad6cbd9c6e5144971e326303f0e453b61d82e4f72067fccf23106bccd8437"
 
 [[package]]
 name = "xattr"
@@ -2986,10 +3703,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "xxhash-rust"
-version = "0.8.8"
+name = "xz2"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "zerocopy"
@@ -3024,44 +3744,35 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes",
  "byteorder",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,22 @@ readme = "README.md"
 rust-version = "1.81.0"
 
 [workspace.dependencies]
+clap = { version = "4.5.20", features = ["derive"] }
+itertools = "0.13.0"
 miette = { version = "7.2", features = ["fancy"] }
+tempfile = "3.13.0"
+thiserror = "1.0.64"
+uv-cache = { git = "https://github.com/astral-sh/uv", rev = "855c1917e1e0e2b48c38de71bebc845af016afae" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv.git", rev = "855c1917e1e0e2b48c38de71bebc845af016afae" }
+uv-extract = { git = "https://github.com/astral-sh/uv.git", rev = "855c1917e1e0e2b48c38de71bebc845af016afae" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", rev = "855c1917e1e0e2b48c38de71bebc845af016afae" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv.git", rev = "855c1917e1e0e2b48c38de71bebc845af016afae" }
+uv-python = { git = "https://github.com/astral-sh/uv", rev = "855c1917e1e0e2b48c38de71bebc845af016afae" }
+uv-virtualenv = { git = "https://github.com/astral-sh/uv", rev = "855c1917e1e0e2b48c38de71bebc845af016afae" }
+
+[patch.crates-io]
+reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913", features = ["multipart"] }
+reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
 
 [profile.release]
 strip = true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,6 +49,14 @@ load("@aspect_bazel_lib//lib:repositories.bzl", "register_coreutils_toolchains")
 
 register_coreutils_toolchains()
 
+load("@musl_toolchains//:repositories.bzl", "load_musl_toolchains")
+
+load_musl_toolchains(extra_target_compatible_with = ["@//tools/linkers:musl"])
+
+load("@musl_toolchains//:toolchains.bzl", "register_musl_toolchains")
+
+register_musl_toolchains()
+
 ############################################
 ## CC toolchain using llvm
 load("@toolchains_llvm//toolchain:deps.bzl", "bazel_toolchain_dependencies")
@@ -156,34 +164,123 @@ RUST_EDITION = "2021"
 
 RUST_VERSION = "1.81.0"
 
-rust_register_toolchains(
+# Declare cross-compilation toolchains
+rust_repository_set(
+    name = "apple_darwin_aarch64",
     edition = RUST_EDITION,
-    extra_target_triples = [
-        "x86_64-apple-darwin",
-    ],
+    exec_triple = "aarch64-apple-darwin",
+    # and cross-compile to these platforms:
+    extra_target_triples = {
+        "aarch64-apple-darwin": [
+            "@platforms//cpu:arm64",
+            "@platforms//os:macos",
+        ],
+        "aarch64-unknown-linux-musl": [
+            "@platforms//cpu:arm64",
+            "@platforms//os:linux",
+            "@//tools/linkers:musl",
+        ],
+        "x86_64-apple-darwin": [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:macos",
+        ],
+        "x86_64-unknown-linux-musl": [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+            "@//tools/linkers:musl",
+        ],
+    },
     versions = [RUST_VERSION],
 )
 
-# Declare cross-compilation toolchains
 rust_repository_set(
-    name = "apple_darwin_86_64",
+    name = "apple_darwin_x86_64",
     edition = RUST_EDITION,
     exec_triple = "x86_64-apple-darwin",
     # and cross-compile to these platforms:
-    extra_target_triples = [
-        "aarch64-apple-darwin",
-    ],
+    extra_target_triples = {
+        "aarch64-apple-darwin": [
+            "@platforms//cpu:arm64",
+            "@platforms//os:macos",
+        ],
+        "aarch64-unknown-linux-musl": [
+            "@platforms//cpu:arm64",
+            "@platforms//os:linux",
+            "@//tools/linkers:musl",
+        ],
+        "x86_64-apple-darwin": [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:macos",
+        ],
+        "x86_64-unknown-linux-musl": [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+            "@//tools/linkers:musl",
+        ],
+    },
     versions = [RUST_VERSION],
 )
 
 rust_repository_set(
-    name = "linux_x86_64",
+    name = "rust_linux_x86_64",
     edition = RUST_EDITION,
     exec_triple = "x86_64-unknown-linux-gnu",
-    # and cross-compile to these platforms:
-    extra_target_triples = [
-        "aarch64-unknown-linux-gnu",
-    ],
+    extra_target_triples = {
+        "aarch64-unknown-linux-gnu": [
+            "@platforms//cpu:arm64",
+            "@platforms//os:linux",
+            "@//tools/linkers:unknown",
+        ],
+        "aarch64-unknown-linux-musl": [
+            "@platforms//cpu:arm64",
+            "@platforms//os:linux",
+            "@//tools/linkers:musl",
+        ],
+        "x86_64-unknown-linux-gnu": [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+            "@//tools/linkers:unknown",
+        ],
+        "x86_64-unknown-linux-musl": [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+            "@//tools/linkers:musl",
+        ],
+    },
+    versions = [RUST_VERSION],
+)
+
+rust_repository_set(
+    name = "rust_linux_aarch64",
+    edition = RUST_EDITION,
+    exec_triple = "aarch64-unknown-linux-gnu",
+    extra_target_triples = {
+        "aarch64-unknown-linux-gnu": [
+            "@platforms//cpu:arm64",
+            "@platforms//os:linux",
+            "@//tools/linkers:unknown",
+        ],
+        "aarch64-unknown-linux-musl": [
+            "@platforms//cpu:arm64",
+            "@platforms//os:linux",
+            "@//tools/linkers:musl",
+        ],
+        "x86_64-unknown-linux-gnu": [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+            "@//tools/linkers:unknown",
+        ],
+        "x86_64-unknown-linux-musl": [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+            "@//tools/linkers:musl",
+        ],
+    },
+    versions = [RUST_VERSION],
+)
+
+rust_register_toolchains(
+    edition = RUST_EDITION,
     versions = [RUST_VERSION],
 )
 

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -73,11 +73,6 @@ def _py_binary_rule_impl(ctx):
             "{{ARG_COLLISION_STRATEGY}}": ctx.attr.package_collisions,
             "{{ARG_PYTHON}}": to_rlocation_path(ctx, py_toolchain.python) if py_toolchain.runfiles_interpreter else py_toolchain.python.path,
             "{{ARG_VENV_NAME}}": ".{}.venv".format(ctx.attr.name),
-            "{{ARG_VENV_PYTHON_VERSION}}": "{}.{}.{}".format(
-                py_toolchain.interpreter_version_info.major,
-                py_toolchain.interpreter_version_info.minor,
-                py_toolchain.interpreter_version_info.micro,
-            ),
             "{{ARG_PTH_FILE}}": to_rlocation_path(ctx, site_packages_pth_file),
             "{{ENTRYPOINT}}": to_rlocation_path(ctx, ctx.file.main),
             "{{PYTHON_ENV}}": "\n".join(_dict_to_exports(env)).strip(),

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -18,16 +18,12 @@ def _py_unpacked_wheel_impl(ctx):
         unpack_directory.path,
         "--wheel",
         ctx.file.src.path,
-        "--python",
-        py_toolchain.python,
         "--python-version",
         "{}.{}.{}".format(
             py_toolchain.interpreter_version_info.major,
             py_toolchain.interpreter_version_info.minor,
             py_toolchain.interpreter_version_info.micro,
         ),
-        "--package-name",
-        ctx.attr.py_package_name,
     ])
 
     ctx.actions.run(
@@ -70,9 +66,6 @@ _attrs = {
     "src": attr.label(
         doc = "The Wheel file, as defined by https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format",
         allow_single_file = [".whl"],
-        mandatory = True,
-    ),
-    "py_package_name": attr.string(
         mandatory = True,
     ),
     # NB: this is read by _resolve_toolchain in py_semantics.

--- a/py/private/py_venv.bzl
+++ b/py/private/py_venv.bzl
@@ -54,11 +54,7 @@ def _py_venv_rule_imp(ctx):
             "{{ARG_PYTHON}}": to_rlocation_path(ctx, py_toolchain.python) if py_toolchain.runfiles_interpreter else py_toolchain.python.path,
             "{{ARG_COLLISION_STRATEGY}}": ctx.attr.package_collisions,
             "{{ARG_VENV_LOCATION}}": paths.join(ctx.attr.location, ctx.attr.venv_name),
-            "{{ARG_VENV_PYTHON_VERSION}}": "{}.{}.{}".format(
-                py_toolchain.interpreter_version_info.major,
-                py_toolchain.interpreter_version_info.minor,
-                py_toolchain.interpreter_version_info.micro,
-            ),
+            "{{ARG_VENV_NAME}}": ".{}.venv".format(ctx.attr.name),
             "{{ARG_PTH_FILE}}": to_rlocation_path(ctx, site_packages_pth_file),
             "{{EXEC_PYTHON_BIN}}": "python{}".format(
                 py_toolchain.interpreter_version_info.major,

--- a/py/private/run.tmpl.sh
+++ b/py/private/run.tmpl.sh
@@ -41,9 +41,9 @@ export VIRTUAL_ENV
 "${VENV_TOOL}" \
     --location "${VIRTUAL_ENV}" \
     --python "$(python_location)" \
-    --python-version "{{ARG_VENV_PYTHON_VERSION}}" \
     --pth-file "$(rlocation {{ARG_PTH_FILE}})" \
-    --collision-strategy "{{ARG_COLLISION_STRATEGY}}"
+    --collision-strategy "{{ARG_COLLISION_STRATEGY}}" \
+    --venv-name "{{ARG_VENV_NAME}}"
 
 PATH="${VIRTUAL_ENV}/bin:${PATH}"
 export PATH

--- a/py/private/toolchain/tools.bzl
+++ b/py/private/toolchain/tools.bzl
@@ -30,7 +30,7 @@ TOOLCHAIN_PLATFORMS = {
     ),
     "linux_amd64": struct(
         arch = "x86_64",
-        vendor_os_abi = "unknown-linux-gnu",
+        vendor_os_abi = "unknown-linux-musl",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
@@ -38,7 +38,7 @@ TOOLCHAIN_PLATFORMS = {
     ),
     "linux_arm64": struct(
         arch = "aarch64",
-        vendor_os_abi = "unknown-linux-gnu",
+        vendor_os_abi = "unknown-linux-musl",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",

--- a/py/private/venv.tmpl.sh
+++ b/py/private/venv.tmpl.sh
@@ -27,9 +27,9 @@ VIRTUAL_ENV="$(alocation "${VENV_ROOT}/{{ARG_VENV_LOCATION}}")"
 "${VENV_TOOL}" \
     --location "${VIRTUAL_ENV}" \
     --python "$(alocation $(rlocation {{ARG_PYTHON}}))" \
-    --python-version "{{ARG_VENV_PYTHON_VERSION}}" \
     --pth-file "$(rlocation {{ARG_PTH_FILE}})" \
     --pth-entry-prefix "${RUNFILES_DIR}" \
-    --collision-strategy "{{ARG_COLLISION_STRATEGY}}"
+    --collision-strategy "{{ARG_COLLISION_STRATEGY}}" \
+    --venv-name "{{ARG_VENV_NAME}}"
 
 echo "Created virtualenv in ${VIRTUAL_ENV}"

--- a/py/tests/virtual/django/BUILD.bazel
+++ b/py/tests/virtual/django/BUILD.bazel
@@ -7,7 +7,6 @@ django_resolutions = resolutions.from_requirements(all_whl_requirements_by_packa
 py_unpacked_wheel(
     name = "django_wheel",
     src = "@django_4_2_4//file",
-    py_package_name = "Django",
 )
 
 compile_pip_requirements(

--- a/py/tools/pex/BUILD.bazel
+++ b/py/tools/pex/BUILD.bazel
@@ -3,13 +3,12 @@ load("//py:defs.bzl", "py_binary", "py_unpacked_wheel")
 py_unpacked_wheel(
     name = "pex_unpacked",
     src = "@rules_py_pex_2_3_1//file",
-    py_package_name = "pex"
 )
 
 py_binary(
     name = "pex",
     srcs = ["main.py"],
     main = "main.py",
+    visibility = ["//visibility:public"],
     deps = [":pex_unpacked"],
-    visibility = ["//visibility:public"]
 )

--- a/py/tools/py/BUILD.bazel
+++ b/py/tools/py/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 rust_library(
     name = "py",
     srcs = [
-        "src/interpreter.rs",
         "src/lib.rs",
         "src/pth.rs",
         "src/unpack.rs",
@@ -14,7 +13,16 @@ rust_library(
         "//py/tools/venv_bin:__pkg__",
     ],
     deps = [
+        "@crate_index//:itertools",
         "@crate_index//:miette",
-        "@crate_index//:rattler_installs_packages",
+        "@crate_index//:tempfile",
+        "@crate_index//:thiserror",
+        "@crate_index//:uv-cache",
+        "@crate_index//:uv-distribution-filename",
+        "@crate_index//:uv-extract",
+        "@crate_index//:uv-install-wheel",
+        "@crate_index//:uv-pypi-types",
+        "@crate_index//:uv-python",
+        "@crate_index//:uv-virtualenv",
     ],
 )

--- a/py/tools/py/Cargo.toml
+++ b/py/tools/py/Cargo.toml
@@ -12,5 +12,14 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+itertools = { workspace = true }
 miette = { workspace = true }
-rattler_installs_packages = { git = "https://github.com/prefix-dev/rip", rev = "1b4d909496f68c292800ebbd3667c8682b01d218", default-features = false, features = ["rustls-tls"] }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+uv-cache = { workspace = true }
+uv-distribution-filename = { workspace = true }
+uv-extract = { workspace = true }
+uv-install-wheel = { workspace = true }
+uv-pypi-types = { workspace = true }
+uv-python = { workspace = true }
+uv-virtualenv = { workspace = true }

--- a/py/tools/py/src/lib.rs
+++ b/py/tools/py/src/lib.rs
@@ -1,4 +1,3 @@
-mod interpreter;
 mod pth;
 mod unpack;
 mod venv;
@@ -6,5 +5,4 @@ mod venv;
 pub use unpack::unpack_wheel;
 pub use venv::create_venv;
 
-pub(crate) use interpreter::Interpreter;
 pub use pth::{PthFile, SymlinkCollisionResolutionStrategy};

--- a/py/tools/py/src/unpack.rs
+++ b/py/tools/py/src/unpack.rs
@@ -1,39 +1,67 @@
-use std::path::Path;
-
-use miette::{miette, IntoDiagnostic, Result};
-use rattler_installs_packages::{
-    artifacts::Wheel, install::install_wheel, install::InstallWheelOptions, types::PackageName,
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
 };
 
-use crate::Interpreter;
+use miette::{miette, IntoDiagnostic, Result};
 
-pub fn unpack_wheel(
-    python: &Path,
-    version: &str,
-    location: &Path,
-    pkg_name: &str,
-    wheel: &Path,
-) -> Result<()> {
-    let interpreter = Interpreter::new(python, version)?;
-    let python_executable = interpreter.executable()?;
-    let install_paths = interpreter.install_paths(false);
+pub fn unpack_wheel(version: &str, location: &Path, wheel: &Path) -> Result<()> {
+    let python_version: uv_python::PythonVersion = version
+        .parse()
+        .map_err(|_| miette!("Failed to parse Python version"))?;
 
-    let install_options = InstallWheelOptions {
-        installer: Some("Aspect Build rules_py".to_string()),
-        // launcher_arch:
-        ..InstallWheelOptions::default()
+    let wheel_file_reader = fs::File::open(wheel).into_diagnostic()?;
+
+    let temp = tempfile::tempdir().into_diagnostic()?;
+
+    let _ = uv_extract::unzip(wheel_file_reader, temp.path()).into_diagnostic()?;
+
+    let site_packages_dir = location
+        .join("lib")
+        .join(format!(
+            "python{}.{}",
+            python_version.major(),
+            python_version.minor()
+        ))
+        .join("site-packages");
+
+    let scheme = uv_pypi_types::Scheme {
+        purelib: site_packages_dir.to_path_buf(),
+        platlib: site_packages_dir.to_path_buf(),
+        // No windows support.
+        scripts: location.join("bin"),
+        data: site_packages_dir.to_path_buf(),
+        include: location.join("lib").join("include"),
     };
 
-    let package_name: PackageName = pkg_name.parse().unwrap();
-    let wheel = Wheel::from_path(wheel, &package_name.into())
-        .map_err(|_| miette!("Failed to create wheel from path"))?;
+    let layout = uv_install_wheel::Layout {
+        sys_executable: PathBuf::new(),
+        python_version: (python_version.major(), python_version.minor()),
+        // Don't stamp in the path to the interpreter into the generated bins
+        // as we don't want an absolute path here.
+        // Perhaps this should be set to just "python" so it picks up the one in the venv path?
+        os_name: "/bin/false".to_string(),
+        scheme,
+    };
 
-    install_wheel(
-        &wheel,
-        &location,
-        &install_paths,
-        &python_executable,
-        &install_options,
+    let filename = wheel
+        .file_name()
+        .and_then(|f| f.to_str())
+        .expect("Exepected to get filename from wheel path");
+    let wheel_file_name =
+        uv_distribution_filename::WheelFilename::from_str(filename).into_diagnostic()?;
+
+    uv_install_wheel::linker::install_wheel(
+        &layout,
+        false,
+        temp.path(),
+        &wheel_file_name,
+        None,
+        None,
+        Some("aspect_rule_py"),
+        uv_install_wheel::linker::LinkMode::Copy,
+        &uv_install_wheel::linker::Locks::default(),
     )
     .into_diagnostic()?;
 

--- a/py/tools/unpack_bin/BUILD.bazel
+++ b/py/tools/unpack_bin/BUILD.bazel
@@ -1,13 +1,9 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//tools/release:defs.bzl", "multi_arch_rust_binary_release")
+load("//tools/release:defs.bzl", "rust_binary")
 
 rust_binary(
-    name = "unpack_bin",
+    name = "unpack",
     srcs = [
         "src/main.rs",
-    ],
-    visibility = [
-        "//visibility:public",
     ],
     deps = [
         "//py/tools/py",
@@ -17,20 +13,9 @@ rust_binary(
 )
 
 alias(
-    name = "unpack",
-    actual = ":unpack_bin",
-)
-
-multi_arch_rust_binary_release(
-    name = "macos",
-    src = ":unpack",
-    os = "macos",
-    visibility = ["//tools/release:__pkg__"],
-)
-
-multi_arch_rust_binary_release(
-    name = "linux",
-    src = ":unpack",
-    os = "linux",
-    visibility = ["//tools/release:__pkg__"],
+    name = "unpack_bin",
+    actual = ":unpack",
+    visibility = [
+        "//visibility:public",
+    ],
 )

--- a/py/tools/unpack_bin/Cargo.toml
+++ b/py/tools/unpack_bin/Cargo.toml
@@ -16,6 +16,6 @@ name = "unpack"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.5.20", features = ["derive"] }
+clap = { workspace = true }
 miette = { workspace = true }
 py = { path = "../py" }

--- a/py/tools/unpack_bin/src/main.rs
+++ b/py/tools/unpack_bin/src/main.rs
@@ -15,14 +15,6 @@ struct UnpackArgs {
     #[arg(long)]
     wheel: PathBuf,
 
-    /// The package name of the wheel to unpack.
-    #[arg(long)]
-    package_name: String,
-
-    /// Python interpreter to do something with.
-    #[arg(long)]
-    python: PathBuf,
-
     /// Python version, eg 3.8.12
     /// Must be seperated by dots.
     #[arg(long)]
@@ -30,13 +22,7 @@ struct UnpackArgs {
 }
 
 fn unpack_cmd_handler(args: UnpackArgs) -> miette::Result<()> {
-    py::unpack_wheel(
-        &args.python,
-        &args.python_version,
-        &args.into,
-        &args.package_name,
-        &args.wheel,
-    )
+    py::unpack_wheel(&args.python_version, &args.into, &args.wheel)
 }
 
 fn main() -> miette::Result<()> {

--- a/py/tools/venv_bin/BUILD.bazel
+++ b/py/tools/venv_bin/BUILD.bazel
@@ -1,13 +1,9 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//tools/release:defs.bzl", "multi_arch_rust_binary_release")
+load("//tools/release:defs.bzl", "rust_binary")
 
 rust_binary(
-    name = "venv_bin",
+    name = "venv",
     srcs = [
         "src/main.rs",
-    ],
-    visibility = [
-        "//visibility:public",
     ],
     deps = [
         "//py/tools/py",
@@ -17,20 +13,9 @@ rust_binary(
 )
 
 alias(
-    name = "venv",
-    actual = ":venv_bin",
-)
-
-multi_arch_rust_binary_release(
-    name = "macos",
-    src = ":venv",
-    os = "macos",
-    visibility = ["//tools/release:__pkg__"],
-)
-
-multi_arch_rust_binary_release(
-    name = "linux",
-    src = ":venv",
-    os = "linux",
-    visibility = ["//tools/release:__pkg__"],
+    name = "venv_bin",
+    actual = ":venv",
+    visibility = [
+        "//visibility:public",
+    ],
 )

--- a/py/tools/venv_bin/Cargo.toml
+++ b/py/tools/venv_bin/Cargo.toml
@@ -16,6 +16,6 @@ name = "venv"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.1.11", features = ["derive"] }
+clap = { workspace = true }
 miette = { workspace = true }
 py = { path = "../py" }

--- a/py/tools/venv_bin/src/main.rs
+++ b/py/tools/venv_bin/src/main.rs
@@ -37,11 +37,6 @@ struct VenvArgs {
     #[arg(long)]
     location: PathBuf,
 
-    /// Python version string to use, eg 3.8.12
-    /// Must be seperated by dots.
-    #[arg(long)]
-    python_version: String,
-
     /// Path to a .pth file to add to the site-packages of the generated venv.
     #[arg(long)]
     pth_file: PathBuf,
@@ -55,16 +50,21 @@ struct VenvArgs {
     /// If none is given, an error will be thrown.
     #[arg(long)]
     collision_strategy: Option<SymlinkCollisionStrategy>,
+
+    /// Name to apply to the venv in the terminal when using
+    /// activate scripts.
+    #[arg(long)]
+    venv_name: String,
 }
 
 fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
     let pth_file = py::PthFile::new(&args.pth_file, args.pth_entry_prefix);
     py::create_venv(
         &args.python,
-        &args.python_version,
         &args.location,
         Some(pth_file),
         args.collision_strategy.unwrap_or_default().into(),
+        &args.venv_name,
     )
 }
 

--- a/tools/linkers/BUILD.bazel
+++ b/tools/linkers/BUILD.bazel
@@ -1,0 +1,29 @@
+constraint_setting(
+    name = "linker",
+    default_constraint_value = ":unknown",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "musl",
+    constraint_setting = ":linker",
+    visibility = ["//visibility:public"],
+)
+
+# Default linker for anyone not setting the linker to `musl`.
+# You shouldn't ever need to set this value manually.
+constraint_value(
+    name = "unknown",
+    constraint_setting = ":linker",
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "linux_x86_64_musl",
+    constraint_values = [
+        ":musl",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/platforms/BUILD.bazel
+++ b/tools/platforms/BUILD.bazel
@@ -1,0 +1,35 @@
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:linux",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "macos_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "macos_aarch64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:macos",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/release/BUILD.bazel
+++ b/tools/release/BUILD.bazel
@@ -4,6 +4,7 @@
         constraint_values = [
             "@platforms//os:" + os,
             "@platforms//cpu:" + cpu,
+            "//tools/linkers:musl" if os == "linux" else "//tools/linkers:unknown",
         ],
         visibility = ["//py/tools:__subpackages__"],
     )
@@ -18,13 +19,13 @@
 ]
 
 LINUX_ARTIFACTS = [
-    "//py/tools/unpack_bin:linux",
-    "//py/tools/venv_bin:linux",
+    "//py/tools/unpack_bin:unpack_linux",
+    "//py/tools/venv_bin:venv_linux",
 ]
 
 MACOS_ARTIFACTS = [
-    "//py/tools/unpack_bin:macos",
-    "//py/tools/venv_bin:macos",
+    "//py/tools/unpack_bin:unpack_macos",
+    "//py/tools/venv_bin:venv_macos",
 ]
 
 sh_binary(

--- a/tools/release/defs.bzl
+++ b/tools/release/defs.bzl
@@ -1,51 +1,74 @@
 "Make releases for platforms supported by rules_py"
 
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
-load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@aspect_bazel_lib//tools/release:hashes.bzl", "hashes")
+load("@rules_rust//rust:defs.bzl", _rust_binary = "rust_binary")
+
+DEFAULT_OS = ["linux", "macos"]
+DEFAULT_ARCHS = ["aarch64", "x86_64"]
 
 def _map_os_to_triple(os):
     if os == "linux":
-        # TODO: when we produce musl-linked binaries, this should change to unknown-linux-musl
-        return "unknown-linux-gnu"
+        return "unknown-linux-musl"
     if os == "macos":
         return "apple-darwin"
-    fail("unrecognized os", os)
+    fail("Unrecognized os", os)
 
 # buildozer: disable=function-docstring
-def multi_arch_rust_binary_release(name, src, os, archs = ["aarch64", "x86_64"], **kwargs):
-    outs = []
-    for arch in archs:
-        bin = Label(src).name
-        platform_transition_filegroup(
-            name = "{}_{}_{}_build".format(bin, os, arch),
-            srcs = [src],
-            target_platform = "//tools/release:{}_{}".format(os, arch),
-            target_compatible_with = ["@platforms//os:{}".format(os)],
+def rust_binary(name, visibility = [], **kwargs):
+    selection = {}
+    for os in DEFAULT_OS:
+        outs = []
+
+        target_suffix = "{}_{}".format(name, os)
+        target_compatible_with = ["@platforms//os:{}".format(os)]
+
+        for arch in DEFAULT_ARCHS:
+            arch_target_suffix = "{}_{}".format(target_suffix, arch)
+            binary_name = "{}_build".format(arch_target_suffix)
+            platform = "//tools/platforms:{}_{}".format(os, arch)
+            release_platform = "//tools/release:{}_{}".format(os, arch)
+
+            # Artifact naming follows typical Rust "triples" convention.
+            artifact = "{}-{}-{}".format(name, arch, _map_os_to_triple(os))
+            outs.append(artifact)
+
+            selection.update([[platform, binary_name]])
+
+            _rust_binary(
+                name = binary_name,
+                crate_name = name,
+                platform = release_platform,
+                target_compatible_with = target_compatible_with,
+                tags = ["manual"],
+                **kwargs
+            )
+
+            copy_file(
+                name = "copy_{}".format(arch_target_suffix),
+                src = binary_name,
+                out = artifact,
+                target_compatible_with = target_compatible_with,
+            )
+
+            hash_file = "{}.sha256".format(arch_target_suffix)
+            outs.append(hash_file)
+            hashes(
+                name = hash_file,
+                src = artifact,
+                target_compatible_with = target_compatible_with,
+            )
+
+        native.filegroup(
+            name = target_suffix,
+            srcs = outs,
+            target_compatible_with = target_compatible_with,
+            tags = ["manual"],
+            visibility = ["//tools/release:__pkg__"],
         )
 
-        # Artifact naming follows typical Rust "triples" convention.
-        artifact = "{}-{}-{}".format(bin, arch, _map_os_to_triple(os))
-        outs.append(artifact)
-        copy_file(
-            name = "copy_{}_{}_{}".format(bin, os, arch),
-            src = "{}_{}_{}_build".format(bin, os, arch),
-            out = artifact,
-            target_compatible_with = ["@platforms//os:{}".format(os)],
-        )
-
-        hash_file = "{}_{}_{}.sha256".format(bin, os, arch)
-        outs.append(hash_file)
-        hashes(
-            name = hash_file,
-            src = artifact,
-            target_compatible_with = ["@platforms//os:{}".format(os)],
-        )
-
-    native.filegroup(
+    native.alias(
         name = name,
-        srcs = outs,
-        target_compatible_with = ["@platforms//os:{}".format(os)],
-        tags = ["manual"],
-        **kwargs
+        actual = select(selection),
+        visibility = visibility,
     )

--- a/tools/release/fetch.bzl
+++ b/tools/release/fetch.bzl
@@ -47,6 +47,12 @@ def fetch_deps():
     )
 
     http_archive(
+        name = "musl_toolchains",
+        sha256 = "86bf928e6b11e81d2d33ca8e044b875f1ed7c7016b607376dd5575db7342c31e",
+        urls = ["https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.20/musl_toolchain-v0.1.20.tar.gz"],
+    )
+
+    http_archive(
         name = "sysroot_darwin_universal",
         build_file_content = _SYSROOT_DARWIN_BUILD_FILE,
         sha256 = "11870a4a3d382b78349861081264921bb883440a7e0b3dd4a007373d87324a38",


### PR DESCRIPTION
Drops the dependency on `rattler_installs_packages` in favour of the uv crates.

Note that while this works, the creates of uv do not officially support depending directly on the crates, however there is little overhead here, and is pinned to a fixed SHA.

Closes #307
Closes #344
Closes #345

Due to compilation issues under llvm, this diff also switches to musl for the toolchain binaries. We need to keep llvm for proc macros, unfortunately. 

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Drop dependency on `rattler_installs_packages` in favour of the uv crates.
Produce statically linked toolchain binaries via musl.

### Test plan

- New test cases added