### PR TITLE
chore: bump rust version to 1.81.0

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "42d98484f551a064e2a08fed772e5ed9e6ec222b9d64e5fc11f90721ef981a01",
+  "checksum": "d106312d2f6264156c52e22eaf1d544f39fa5380fa99cb923f75c2320aaafd25",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -274,7 +274,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.153",
+              "id": "libc 0.2.161",
               "target": "libc"
             }
           ],
@@ -330,7 +330,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstyle 1.0.6",
+              "id": "anstyle 1.0.8",
               "target": "anstyle"
             },
             {
@@ -381,14 +381,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "anstyle 1.0.6": {
+    "anstyle 1.0.8": {
       "name": "anstyle",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "package_url": "https://github.com/rust-cli/anstyle.git",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anstyle/1.0.6/download",
-          "sha256": "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+          "url": "https://static.crates.io/crates/anstyle/1.0.8/download",
+          "sha256": "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
         }
       },
       "targets": [
@@ -418,7 +418,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.6"
+        "version": "1.0.8"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -564,7 +564,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstyle 1.0.6",
+              "id": "anstyle 1.0.8",
               "target": "anstyle"
             }
           ],
@@ -662,14 +662,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "async-compression 0.3.15": {
+    "async-compression 0.4.17": {
       "name": "async-compression",
-      "version": "0.3.15",
-      "package_url": "https://github.com/Nemo157/async-compression",
+      "version": "0.4.17",
+      "package_url": "https://github.com/Nullus157/async-compression",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/async-compression/0.3.15/download",
-          "sha256": "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+          "url": "https://static.crates.io/crates/async-compression/0.4.17/download",
+          "sha256": "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
         }
       },
       "targets": [
@@ -718,14 +718,14 @@
               "target": "memchr"
             },
             {
-              "id": "pin-project-lite 0.2.13",
+              "id": "pin-project-lite 0.2.14",
               "target": "pin_project_lite"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.15"
+        "version": "0.4.17"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -773,14 +773,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "async-recursion 1.0.5": {
+    "async-recursion 1.1.1": {
       "name": "async-recursion",
-      "version": "1.0.5",
+      "version": "1.1.1",
       "package_url": "https://github.com/dcchut/async-recursion",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/async-recursion/1.0.5/download",
-          "sha256": "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+          "url": "https://static.crates.io/crates/async-recursion/1.1.1/download",
+          "sha256": "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
         }
       },
       "targets": [
@@ -805,7 +805,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -813,14 +813,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.5"
+        "version": "1.1.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -829,14 +829,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "async-trait 0.1.77": {
+    "async-trait 0.1.83": {
       "name": "async-trait",
-      "version": "0.1.77",
+      "version": "0.1.83",
       "package_url": "https://github.com/dtolnay/async-trait",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/async-trait/0.1.77/download",
-          "sha256": "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+          "url": "https://static.crates.io/crates/async-trait/0.1.83/download",
+          "sha256": "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
         }
       },
       "targets": [
@@ -844,18 +844,6 @@
           "ProcMacro": {
             "crate_name": "async_trait",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -873,11 +861,7 @@
         "deps": {
           "common": [
             {
-              "id": "async-trait 0.1.77",
-              "target": "build_script_build"
-            },
-            {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -885,22 +869,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.77"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ]
+        "version": "0.1.83"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -909,14 +885,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "async_http_range_reader 0.6.0": {
+    "async_http_range_reader 0.7.1": {
       "name": "async_http_range_reader",
-      "version": "0.6.0",
+      "version": "0.7.1",
       "package_url": "https://github.com/prefix-dev/async_http_range_reader",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/async_http_range_reader/0.6.0/download",
-          "sha256": "809a79b508f86b02136fc5aab935ef777d03e5d377dda04e6736a081add9287c"
+          "url": "https://static.crates.io/crates/async_http_range_reader/0.7.1/download",
+          "sha256": "8561e6613f8361df8bed11c0eef05b98384643bc81f6b753eec7c1d91f097509"
         }
       },
       "targets": [
@@ -961,19 +937,19 @@
               "target": "memmap2"
             },
             {
-              "id": "reqwest 0.11.24",
+              "id": "reqwest 0.12.8",
               "target": "reqwest"
             },
             {
-              "id": "reqwest-middleware 0.2.4",
+              "id": "reqwest-middleware 0.3.3",
               "target": "reqwest_middleware"
             },
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "tokio 1.41.0",
               "target": "tokio"
             },
             {
@@ -992,7 +968,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.6.0"
+        "version": "0.7.1"
       },
       "license": "MIT",
       "license_ids": [
@@ -1000,14 +976,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "async_zip 0.0.15": {
+    "async_zip 0.0.16": {
       "name": "async_zip",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "package_url": "https://github.com/Majored/rs-async-zip",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/async_zip/0.0.15/download",
-          "sha256": "795310de3218cde15219fc98c1cf7d8fe9db4865aab27fcf1d535d6cb61c6b54"
+          "url": "https://static.crates.io/crates/async_zip/0.0.16/download",
+          "sha256": "527207465fb6dcafbf661b0d4a51d0d2306c9d0c2975423079a6caa807930daf"
         }
       },
       "targets": [
@@ -1041,7 +1017,7 @@
         "deps": {
           "common": [
             {
-              "id": "async-compression 0.3.15",
+              "id": "async-compression 0.4.17",
               "target": "async_compression"
             },
             {
@@ -1049,23 +1025,19 @@
               "target": "crc32fast"
             },
             {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "log 0.4.20",
-              "target": "log"
+              "id": "futures-lite 2.3.0",
+              "target": "futures_lite"
             },
             {
               "id": "pin-project 1.1.4",
               "target": "pin_project"
             },
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "tokio 1.41.0",
               "target": "tokio"
             },
             {
@@ -1076,7 +1048,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.0.15"
+        "version": "0.0.16"
       },
       "license": "MIT",
       "license_ids": [
@@ -1193,7 +1165,7 @@
                 "target": "addr2line"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -1329,6 +1301,53 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "base64 0.22.1": {
+      "name": "base64",
+      "version": "0.22.1",
+      "package_url": "https://github.com/marshallpierce/rust-base64",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/base64/0.22.1/download",
+          "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "base64",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "base64",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.22.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "base64ct 1.6.0": {
       "name": "base64ct",
       "version": "1.6.0",
@@ -1435,12 +1454,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "1.3.2"
       },
@@ -1758,14 +1771,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "bytes 1.5.0": {
+    "bytes 1.8.0": {
       "name": "bytes",
-      "version": "1.5.0",
+      "version": "1.8.0",
       "package_url": "https://github.com/tokio-rs/bytes",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/bytes/1.5.0/download",
-          "sha256": "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+          "url": "https://static.crates.io/crates/bytes/1.8.0/download",
+          "sha256": "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
         }
       },
       "targets": [
@@ -1795,7 +1808,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.5.0"
+        "version": "1.8.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -1839,7 +1852,7 @@
               "target": "bzip2_sys"
             },
             {
-              "id": "libc 0.2.153",
+              "id": "libc 0.2.161",
               "target": "libc"
             }
           ],
@@ -1903,7 +1916,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "libc 0.2.153",
+              "id": "libc 0.2.161",
               "target": "libc"
             }
           ],
@@ -1941,14 +1954,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cacache 12.0.0": {
+    "cacache 13.0.0": {
       "name": "cacache",
-      "version": "12.0.0",
+      "version": "13.0.0",
       "package_url": "https://github.com/zkat/cacache-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cacache/12.0.0/download",
-          "sha256": "142316461ed3a3dfcba10417317472da5bfd0461e4d276bf7c07b330766d9490"
+          "url": "https://static.crates.io/crates/cacache/13.0.0/download",
+          "sha256": "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7"
         }
       },
       "targets": [
@@ -2013,11 +2026,11 @@
               "target": "reflink_copy"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.113",
+              "id": "serde_json 1.0.132",
               "target": "serde_json"
             },
             {
@@ -2033,15 +2046,15 @@
               "target": "ssri"
             },
             {
-              "id": "tempfile 3.10.0",
+              "id": "tempfile 3.13.0",
               "target": "tempfile"
             },
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "tokio 1.41.0",
               "target": "tokio"
             },
             {
@@ -2056,55 +2069,55 @@
           "selects": {
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "aarch64-unknown-nixos-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "arm-unknown-linux-gnueabi": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "armv7-unknown-linux-gnueabi": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "i686-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "powerpc-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "s390x-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "x86_64-unknown-nixos-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ]
@@ -2114,13 +2127,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.196",
+              "id": "serde_derive 1.0.213",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "12.0.0"
+        "version": "13.0.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -2174,7 +2187,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ]
@@ -2324,7 +2337,7 @@
               "target": "ciborium_ll"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
@@ -2487,14 +2500,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap 4.4.18": {
+    "clap 4.5.20": {
       "name": "clap",
-      "version": "4.4.18",
+      "version": "4.5.20",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap/4.4.18/download",
-          "sha256": "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+          "url": "https://static.crates.io/crates/clap/4.5.20/download",
+          "sha256": "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
         }
       },
       "targets": [
@@ -2532,7 +2545,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.4.18",
+              "id": "clap_builder 4.5.20",
               "target": "clap_builder"
             }
           ],
@@ -2542,13 +2555,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "clap_derive 4.4.7",
+              "id": "clap_derive 4.5.18",
               "target": "clap_derive"
             }
           ],
           "selects": {}
         },
-        "version": "4.4.18"
+        "version": "4.5.20"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2557,14 +2570,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_builder 4.4.18": {
+    "clap_builder 4.5.20": {
       "name": "clap_builder",
-      "version": "4.4.18",
+      "version": "4.5.20",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_builder/4.4.18/download",
-          "sha256": "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+          "url": "https://static.crates.io/crates/clap_builder/4.5.20/download",
+          "sha256": "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
         }
       },
       "targets": [
@@ -2604,22 +2617,22 @@
               "target": "anstream"
             },
             {
-              "id": "anstyle 1.0.6",
+              "id": "anstyle 1.0.8",
               "target": "anstyle"
             },
             {
-              "id": "clap_lex 0.6.0",
+              "id": "clap_lex 0.7.2",
               "target": "clap_lex"
             },
             {
-              "id": "strsim 0.10.0",
+              "id": "strsim 0.11.1",
               "target": "strsim"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.4.18"
+        "version": "4.5.20"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2628,14 +2641,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_derive 4.4.7": {
+    "clap_derive 4.5.18": {
       "name": "clap_derive",
-      "version": "4.4.7",
-      "package_url": "https://github.com/clap-rs/clap/tree/master/clap_derive",
+      "version": "4.5.18",
+      "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_derive/4.4.7/download",
-          "sha256": "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+          "url": "https://static.crates.io/crates/clap_derive/4.5.18/download",
+          "sha256": "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
         }
       },
       "targets": [
@@ -2666,11 +2679,11 @@
         "deps": {
           "common": [
             {
-              "id": "heck 0.4.1",
+              "id": "heck 0.5.0",
               "target": "heck"
             },
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -2678,14 +2691,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.4.7"
+        "version": "4.5.18"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2694,14 +2707,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_lex 0.6.0": {
+    "clap_lex 0.7.2": {
       "name": "clap_lex",
-      "version": "0.6.0",
-      "package_url": "https://github.com/clap-rs/clap/tree/master/clap_lex",
+      "version": "0.7.2",
+      "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_lex/0.6.0/download",
-          "sha256": "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+          "url": "https://static.crates.io/crates/clap_lex/0.7.2/download",
+          "sha256": "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
         }
       },
       "targets": [
@@ -2724,7 +2737,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.6.0"
+        "version": "0.7.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -2766,6 +2779,60 @@
         "version": "1.0.0"
       },
       "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "concurrent-queue 2.5.0": {
+      "name": "concurrent-queue",
+      "version": "2.5.0",
+      "package_url": "https://github.com/smol-rs/concurrent-queue",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/concurrent-queue/2.5.0/download",
+          "sha256": "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "concurrent_queue",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "concurrent_queue",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "crossbeam-utils 0.8.19",
+              "target": "crossbeam_utils"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.5.0"
+      },
+      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -2849,65 +2916,6 @@
       ],
       "license_file": "LICENSE.txt"
     },
-    "core-foundation 0.9.4": {
-      "name": "core-foundation",
-      "version": "0.9.4",
-      "package_url": "https://github.com/servo/core-foundation-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/core-foundation/0.9.4/download",
-          "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "core_foundation",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "core_foundation",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "link"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "core-foundation-sys 0.8.6",
-              "target": "core_foundation_sys"
-            },
-            {
-              "id": "libc 0.2.153",
-              "target": "libc"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.9.4"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "core-foundation-sys 0.8.6": {
       "name": "core-foundation-sys",
       "version": "0.8.6",
@@ -2937,13 +2945,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "link"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "0.8.6"
       },
@@ -2988,25 +2989,25 @@
           "selects": {
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ]
@@ -3143,11 +3144,33 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "armv7-linux-androideabi": [
+              "default",
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "thumbv7em-none-eabi": [
+              "default",
+              "std"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "default",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -3345,7 +3368,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
@@ -3525,7 +3548,7 @@
               "target": "ident_case"
             },
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -3537,7 +3560,7 @@
               "target": "strsim"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
@@ -3592,7 +3615,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
@@ -3917,62 +3940,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "encoding_rs 0.8.33": {
-      "name": "encoding_rs",
-      "version": "0.8.33",
-      "package_url": "https://github.com/hsivonen/encoding_rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/encoding_rs/0.8.33/download",
-          "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "encoding_rs",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "encoding_rs",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.8.33"
-      },
-      "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause",
-      "license_ids": [
-        "Apache-2.0",
-        "BSD-3-Clause",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "equivalent 1.0.1": {
       "name": "equivalent",
       "version": "1.0.1",
@@ -4052,19 +4019,19 @@
           "selects": {
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -4086,14 +4053,267 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "fastrand 2.0.1": {
+    "event-listener 5.3.1": {
+      "name": "event-listener",
+      "version": "5.3.1",
+      "package_url": "https://github.com/smol-rs/event-listener",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/event-listener/5.3.1/download",
+          "sha256": "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "event_listener",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "event_listener",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "parking",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "concurrent-queue 2.5.0",
+              "target": "concurrent_queue"
+            },
+            {
+              "id": "pin-project-lite 0.2.14",
+              "target": "pin_project_lite"
+            }
+          ],
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "aarch64-apple-ios": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "aarch64-apple-ios-sim": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "aarch64-fuchsia": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "aarch64-linux-android": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "armv7-linux-androideabi": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "i686-apple-darwin": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "i686-linux-android": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "i686-unknown-freebsd": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "riscv32imc-unknown-none-elf": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "riscv64gc-unknown-none-elf": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "thumbv7em-none-eabi": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "thumbv8m.main-none-eabi": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-apple-ios": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-fuchsia": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-linux-android": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ],
+            "x86_64-unknown-none": [
+              {
+                "id": "parking 2.2.1",
+                "target": "parking"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "5.3.1"
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "fastrand 2.1.1": {
       "name": "fastrand",
-      "version": "2.0.1",
+      "version": "2.1.1",
       "package_url": "https://github.com/smol-rs/fastrand",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/fastrand/2.0.1/download",
-          "sha256": "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+          "url": "https://static.crates.io/crates/fastrand/2.1.1/download",
+          "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
         }
       },
       "targets": [
@@ -4124,7 +4344,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.0.1"
+        "version": "2.1.1"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -4178,7 +4398,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -4479,14 +4699,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "fs4 0.6.6": {
+    "fs4 0.8.4": {
       "name": "fs4",
-      "version": "0.6.6",
+      "version": "0.8.4",
       "package_url": "https://github.com/al8n/fs4-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/fs4/0.6.6/download",
-          "sha256": "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
+          "url": "https://static.crates.io/crates/fs4/0.8.4/download",
+          "sha256": "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
         }
       },
       "targets": [
@@ -4520,22 +4740,22 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "rustix 0.38.31",
+                "id": "rustix 0.38.37",
                 "target": "rustix"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.6.6"
+        "version": "0.8.4"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -5014,6 +5234,80 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "futures-lite 2.3.0": {
+      "name": "futures-lite",
+      "version": "2.3.0",
+      "package_url": "https://github.com/smol-rs/futures-lite",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/futures-lite/2.3.0/download",
+          "sha256": "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "futures_lite",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "futures_lite",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "fastrand",
+            "futures-io",
+            "parking",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "fastrand 2.1.1",
+              "target": "fastrand"
+            },
+            {
+              "id": "futures-core 0.3.30",
+              "target": "futures_core"
+            },
+            {
+              "id": "futures-io 0.3.30",
+              "target": "futures_io"
+            },
+            {
+              "id": "parking 2.2.1",
+              "target": "parking"
+            },
+            {
+              "id": "pin-project-lite 0.2.14",
+              "target": "pin_project_lite"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.3.0"
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "futures-macro 0.3.30": {
       "name": "futures-macro",
       "version": "0.3.30",
@@ -5046,7 +5340,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -5054,7 +5348,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
@@ -5198,7 +5492,6 @@
             "async-await",
             "async-await-macro",
             "channel",
-            "default",
             "futures-channel",
             "futures-io",
             "futures-macro",
@@ -5209,7 +5502,14 @@
             "slab",
             "std"
           ],
-          "selects": {}
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "default"
+            ],
+            "wasm32-wasi": [
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -5238,7 +5538,7 @@
               "target": "memchr"
             },
             {
-              "id": "pin-project-lite 0.2.13",
+              "id": "pin-project-lite 0.2.14",
               "target": "pin_project_lite"
             },
             {
@@ -5314,7 +5614,8 @@
         ],
         "crate_features": {
           "common": [
-            "more_lengths"
+            "more_lengths",
+            "serde"
           ],
           "selects": {}
         },
@@ -5323,6 +5624,10 @@
             {
               "id": "generic-array 0.14.7",
               "target": "build_script_build"
+            },
+            {
+              "id": "serde 1.0.213",
+              "target": "serde"
             },
             {
               "id": "typenum 1.17.0",
@@ -5402,7 +5707,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ]
@@ -5463,93 +5768,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "h2 0.3.24": {
-      "name": "h2",
-      "version": "0.3.24",
-      "package_url": "https://github.com/hyperium/h2",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/h2/0.3.24/download",
-          "sha256": "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "h2",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "h2",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.5.0",
-              "target": "bytes"
-            },
-            {
-              "id": "fnv 1.0.7",
-              "target": "fnv"
-            },
-            {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
-              "id": "futures-sink 0.3.30",
-              "target": "futures_sink"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "http 0.2.11",
-              "target": "http"
-            },
-            {
-              "id": "indexmap 2.2.2",
-              "target": "indexmap"
-            },
-            {
-              "id": "slab 0.4.9",
-              "target": "slab"
-            },
-            {
-              "id": "tokio 1.36.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tokio-util 0.7.10",
-              "target": "tokio_util"
-            },
-            {
-              "id": "tracing 0.1.40",
-              "target": "tracing"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.3.24"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
     },
     "half 2.3.1": {
       "name": "half",
@@ -5645,14 +5863,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "hashbrown 0.14.3": {
+    "hashbrown 0.15.0": {
       "name": "hashbrown",
-      "version": "0.14.3",
+      "version": "0.15.0",
       "package_url": "https://github.com/rust-lang/hashbrown",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/hashbrown/0.14.3/download",
-          "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+          "url": "https://static.crates.io/crates/hashbrown/0.15.0/download",
+          "sha256": "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
         }
       },
       "targets": [
@@ -5674,14 +5892,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "raw"
-          ],
-          "selects": {}
-        },
         "edition": "2021",
-        "version": "0.14.3"
+        "version": "0.15.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5690,14 +5902,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "heck 0.4.1": {
+    "heck 0.5.0": {
       "name": "heck",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "package_url": "https://github.com/withoutboats/heck",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/heck/0.4.1/download",
-          "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+          "url": "https://static.crates.io/crates/heck/0.5.0/download",
+          "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
         }
       },
       "targets": [
@@ -5719,14 +5931,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.4.1"
+        "edition": "2021",
+        "version": "0.5.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5735,14 +5941,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "hermit-abi 0.3.5": {
+    "hermit-abi 0.3.9": {
       "name": "hermit-abi",
-      "version": "0.3.5",
-      "package_url": "https://github.com/hermitcore/hermit-rs",
+      "version": "0.3.9",
+      "package_url": "https://github.com/hermit-os/hermit-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/hermit-abi/0.3.5/download",
-          "sha256": "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+          "url": "https://static.crates.io/crates/hermit-abi/0.3.9/download",
+          "sha256": "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
         }
       },
       "targets": [
@@ -5765,7 +5971,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.3.5"
+        "version": "0.3.9"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5875,6 +6081,56 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "home 0.5.9": {
+      "name": "home",
+      "version": "0.5.9",
+      "package_url": "https://github.com/rust-lang/cargo",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/home/0.5.9/download",
+          "sha256": "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "home",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "home",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.52.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.5.9"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "html-escape 0.2.13": {
       "name": "html-escape",
       "version": "0.2.13",
@@ -5929,14 +6185,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "http 0.2.11": {
+    "http 1.1.0": {
       "name": "http",
-      "version": "0.2.11",
+      "version": "1.1.0",
       "package_url": "https://github.com/hyperium/http",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/http/0.2.11/download",
-          "sha256": "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+          "url": "https://static.crates.io/crates/http/1.1.0/download",
+          "sha256": "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
         }
       },
       "targets": [
@@ -5958,10 +6214,17 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "bytes 1.5.0",
+              "id": "bytes 1.8.0",
               "target": "bytes"
             },
             {
@@ -5976,7 +6239,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.11"
+        "version": "1.1.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5985,14 +6248,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "http-body 0.4.6": {
+    "http-body 1.0.1": {
       "name": "http-body",
-      "version": "0.4.6",
+      "version": "1.0.1",
       "package_url": "https://github.com/hyperium/http-body",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/http-body/0.4.6/download",
-          "sha256": "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+          "url": "https://static.crates.io/crates/http-body/1.0.1/download",
+          "sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
         }
       },
       "targets": [
@@ -6017,22 +6280,18 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.5.0",
+              "id": "bytes 1.8.0",
               "target": "bytes"
             },
             {
-              "id": "http 0.2.11",
+              "id": "http 1.1.0",
               "target": "http"
-            },
-            {
-              "id": "pin-project-lite 0.2.13",
-              "target": "pin_project_lite"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.6"
+        "version": "1.0.1"
       },
       "license": "MIT",
       "license_ids": [
@@ -6040,14 +6299,77 @@
       ],
       "license_file": "LICENSE"
     },
-    "http-cache-semantics 1.0.2": {
+    "http-body-util 0.1.2": {
+      "name": "http-body-util",
+      "version": "0.1.2",
+      "package_url": "https://github.com/hyperium/http-body",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/http-body-util/0.1.2/download",
+          "sha256": "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "http_body_util",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "http_body_util",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.8.0",
+              "target": "bytes"
+            },
+            {
+              "id": "futures-util 0.3.30",
+              "target": "futures_util"
+            },
+            {
+              "id": "http 1.1.0",
+              "target": "http"
+            },
+            {
+              "id": "http-body 1.0.1",
+              "target": "http_body"
+            },
+            {
+              "id": "pin-project-lite 0.2.14",
+              "target": "pin_project_lite"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.2"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "http-cache-semantics 2.1.0": {
       "name": "http-cache-semantics",
-      "version": "1.0.2",
+      "version": "2.1.0",
       "package_url": "https://github.com/kornelski/rusty-http-cache-semantics",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/http-cache-semantics/1.0.2/download",
-          "sha256": "7aec9f678bca3f4a15194b980f20ed9bfe0dd38e8d298c65c559a93dfbd6380a"
+          "url": "https://static.crates.io/crates/http-cache-semantics/2.1.0/download",
+          "sha256": "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
         }
       },
       "targets": [
@@ -6072,37 +6394,37 @@
         "crate_features": {
           "common": [
             "reqwest",
-            "with_serde"
+            "serde"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "http 0.2.11",
+              "id": "http 1.1.0",
               "target": "http"
             },
             {
-              "id": "http-serde 1.1.3",
+              "id": "http-serde 2.1.1",
               "target": "http_serde"
             },
             {
-              "id": "reqwest 0.11.24",
+              "id": "reqwest 0.12.8",
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
-              "id": "time 0.3.34",
+              "id": "time 0.3.36",
               "target": "time"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.2"
+        "version": "2.1.0"
       },
       "license": "BSD-2-Clause",
       "license_ids": [
@@ -6149,14 +6471,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "http-serde 1.1.3": {
+    "http-serde 2.1.1": {
       "name": "http-serde",
-      "version": "1.1.3",
+      "version": "2.1.1",
       "package_url": "https://gitlab.com/kornelski/http-serde",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/http-serde/1.1.3/download",
-          "sha256": "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
+          "url": "https://static.crates.io/crates/http-serde/2.1.1/download",
+          "sha256": "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
         }
       },
       "targets": [
@@ -6181,18 +6503,18 @@
         "deps": {
           "common": [
             {
-              "id": "http 0.2.11",
+              "id": "http 1.1.0",
               "target": "http"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.3"
+        "version": "2.1.1"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -6276,53 +6598,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "httpdate 1.0.3": {
-      "name": "httpdate",
-      "version": "1.0.3",
-      "package_url": "https://github.com/pyfisch/httpdate",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/httpdate/1.0.3/download",
-          "sha256": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "httpdate",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "httpdate",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "1.0.3"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "hyper 0.14.28": {
+    "hyper 1.5.0": {
       "name": "hyper",
-      "version": "0.14.28",
+      "version": "1.5.0",
       "package_url": "https://github.com/hyperium/hyper",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/hyper/0.14.28/download",
-          "sha256": "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+          "url": "https://static.crates.io/crates/hyper/1.5.0/download",
+          "sha256": "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
         }
       },
       "targets": [
@@ -6347,19 +6630,15 @@
         "crate_features": {
           "common": [
             "client",
-            "h2",
-            "http1",
-            "http2",
-            "runtime",
-            "socket2",
-            "tcp"
+            "default",
+            "http1"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "bytes 1.5.0",
+              "id": "bytes 1.8.0",
               "target": "bytes"
             },
             {
@@ -6367,23 +6646,15 @@
               "target": "futures_channel"
             },
             {
-              "id": "futures-core 0.3.30",
-              "target": "futures_core"
-            },
-            {
               "id": "futures-util 0.3.30",
               "target": "futures_util"
             },
             {
-              "id": "h2 0.3.24",
-              "target": "h2"
-            },
-            {
-              "id": "http 0.2.11",
+              "id": "http 1.1.0",
               "target": "http"
             },
             {
-              "id": "http-body 0.4.6",
+              "id": "http-body 1.0.1",
               "target": "http_body"
             },
             {
@@ -6391,32 +6662,20 @@
               "target": "httparse"
             },
             {
-              "id": "httpdate 1.0.3",
-              "target": "httpdate"
-            },
-            {
               "id": "itoa 1.0.10",
               "target": "itoa"
             },
             {
-              "id": "pin-project-lite 0.2.13",
+              "id": "pin-project-lite 0.2.14",
               "target": "pin_project_lite"
             },
             {
-              "id": "socket2 0.5.5",
-              "target": "socket2"
+              "id": "smallvec 1.13.2",
+              "target": "smallvec"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "tokio 1.41.0",
               "target": "tokio"
-            },
-            {
-              "id": "tower-service 0.3.2",
-              "target": "tower_service"
-            },
-            {
-              "id": "tracing 0.1.40",
-              "target": "tracing"
             },
             {
               "id": "want 0.3.1",
@@ -6425,8 +6684,8 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.14.28"
+        "edition": "2021",
+        "version": "1.5.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -6434,14 +6693,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "hyper-rustls 0.24.2": {
+    "hyper-rustls 0.27.3": {
       "name": "hyper-rustls",
-      "version": "0.24.2",
+      "version": "0.27.3",
       "package_url": "https://github.com/rustls/hyper-rustls",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/hyper-rustls/0.24.2/download",
-          "sha256": "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+          "url": "https://static.crates.io/crates/hyper-rustls/0.27.3/download",
+          "sha256": "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
         }
       },
       "targets": [
@@ -6463,6 +6722,16 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "http1",
+            "ring",
+            "tls12",
+            "webpki-roots",
+            "webpki-tokio"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -6470,35 +6739,149 @@
               "target": "futures_util"
             },
             {
-              "id": "http 0.2.11",
+              "id": "http 1.1.0",
               "target": "http"
             },
             {
-              "id": "hyper 0.14.28",
+              "id": "hyper 1.5.0",
               "target": "hyper"
             },
             {
-              "id": "rustls 0.21.10",
+              "id": "hyper-util 0.1.9",
+              "target": "hyper_util"
+            },
+            {
+              "id": "rustls 0.23.15",
               "target": "rustls"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "rustls-pki-types 1.10.0",
+              "target": "rustls_pki_types",
+              "alias": "pki_types"
+            },
+            {
+              "id": "tokio 1.41.0",
               "target": "tokio"
             },
             {
-              "id": "tokio-rustls 0.24.1",
+              "id": "tokio-rustls 0.26.0",
               "target": "tokio_rustls"
+            },
+            {
+              "id": "tower-service 0.3.2",
+              "target": "tower_service"
+            },
+            {
+              "id": "webpki-roots 0.26.6",
+              "target": "webpki_roots"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.24.2"
+        "version": "0.27.3"
       },
       "license": "Apache-2.0 OR ISC OR MIT",
       "license_ids": [
         "Apache-2.0",
         "ISC",
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "hyper-util 0.1.9": {
+      "name": "hyper-util",
+      "version": "0.1.9",
+      "package_url": "https://github.com/hyperium/hyper-util",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/hyper-util/0.1.9/download",
+          "sha256": "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "hyper_util",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "hyper_util",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "client",
+            "client-legacy",
+            "default",
+            "http1",
+            "tokio"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.8.0",
+              "target": "bytes"
+            },
+            {
+              "id": "futures-channel 0.3.30",
+              "target": "futures_channel"
+            },
+            {
+              "id": "futures-util 0.3.30",
+              "target": "futures_util"
+            },
+            {
+              "id": "http 1.1.0",
+              "target": "http"
+            },
+            {
+              "id": "http-body 1.0.1",
+              "target": "http_body"
+            },
+            {
+              "id": "hyper 1.5.0",
+              "target": "hyper"
+            },
+            {
+              "id": "pin-project-lite 0.2.14",
+              "target": "pin_project_lite"
+            },
+            {
+              "id": "socket2 0.5.5",
+              "target": "socket2"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tower-service 0.3.2",
+              "target": "tower_service"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.9"
+      },
+      "license": "MIT",
+      "license_ids": [
         "MIT"
       ],
       "license_file": "LICENSE"
@@ -6842,7 +7225,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -6942,14 +7325,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "indexmap 2.2.2": {
+    "indexmap 2.6.0": {
       "name": "indexmap",
-      "version": "2.2.2",
+      "version": "2.6.0",
       "package_url": "https://github.com/indexmap-rs/indexmap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/indexmap/2.2.2/download",
-          "sha256": "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+          "url": "https://static.crates.io/crates/indexmap/2.6.0/download",
+          "sha256": "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
         }
       },
       "targets": [
@@ -6986,18 +7369,18 @@
               "target": "equivalent"
             },
             {
-              "id": "hashbrown 0.14.3",
+              "id": "hashbrown 0.15.0",
               "target": "hashbrown"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.2.2"
+        "version": "2.6.0"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -7138,62 +7521,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "itertools 0.11.0": {
-      "name": "itertools",
-      "version": "0.11.0",
-      "package_url": "https://github.com/rust-itertools/itertools",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/itertools/0.11.0/download",
-          "sha256": "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "itertools",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "itertools",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "use_alloc",
-            "use_std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "either 1.9.0",
-              "target": "either"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.11.0"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "itertools 0.12.1": {
       "name": "itertools",
       "version": "0.12.1",
@@ -7242,6 +7569,62 @@
         },
         "edition": "2018",
         "version": "0.12.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "itertools 0.13.0": {
+      "name": "itertools",
+      "version": "0.13.0",
+      "package_url": "https://github.com/rust-itertools/itertools",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/itertools/0.13.0/download",
+          "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "itertools",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "itertools",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "use_alloc",
+            "use_std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "either 1.9.0",
+              "target": "either"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.13.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -7323,7 +7706,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ]
@@ -7387,14 +7770,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "libc 0.2.153": {
+    "libc 0.2.161": {
       "name": "libc",
-      "version": "0.2.153",
+      "version": "0.2.161",
       "package_url": "https://github.com/rust-lang/libc",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/libc/0.2.153/download",
-          "sha256": "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+          "url": "https://static.crates.io/crates/libc/0.2.161/download",
+          "sha256": "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
         }
       },
       "targets": [
@@ -7511,14 +7894,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.153",
+              "id": "libc 0.2.161",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.153"
+        "version": "0.2.161"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -7535,14 +7918,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "linux-raw-sys 0.4.13": {
+    "linux-raw-sys 0.4.14": {
       "name": "linux-raw-sys",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "package_url": "https://github.com/sunfishcode/linux-raw-sys",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/linux-raw-sys/0.4.13/download",
-          "sha256": "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+          "url": "https://static.crates.io/crates/linux-raw-sys/0.4.14/download",
+          "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
         }
       },
       "targets": [
@@ -7615,7 +7998,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.4.13"
+        "version": "0.4.14"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -7891,7 +8274,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ]
@@ -7941,7 +8324,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ]
@@ -7999,7 +8382,7 @@
               "target": "once_cell"
             },
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -8114,7 +8497,7 @@
               "target": "textwrap"
             },
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -8174,7 +8557,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -8182,7 +8565,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
@@ -8229,7 +8612,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -8237,7 +8620,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
@@ -8290,90 +8673,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "mime_guess 2.0.4": {
-      "name": "mime_guess",
-      "version": "2.0.4",
-      "package_url": "https://github.com/abonander/mime_guess",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/mime_guess/2.0.4/download",
-          "sha256": "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "mime_guess",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "mime_guess",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "mime 0.3.17",
-              "target": "mime"
-            },
-            {
-              "id": "mime_guess 2.0.4",
-              "target": "build_script_build"
-            },
-            {
-              "id": "unicase 2.7.0",
-              "target": "unicase"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "2.0.4"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "unicase 2.7.0",
-              "target": "unicase"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
     },
     "miniz_oxide 0.7.2": {
       "name": "miniz_oxide",
@@ -8430,14 +8729,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "mio 0.8.10": {
+    "mio 1.0.2": {
       "name": "mio",
-      "version": "0.8.10",
+      "version": "1.0.2",
       "package_url": "https://github.com/tokio-rs/mio",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/mio/0.8.10/download",
-          "sha256": "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+          "url": "https://static.crates.io/crates/mio/1.0.2/download",
+          "sha256": "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
         }
       },
       "targets": [
@@ -8470,9 +8769,16 @@
         "deps": {
           "common": [],
           "selects": {
+            "cfg(target_os = \"hermit\")": [
+              {
+                "id": "hermit-abi 0.3.9",
+                "target": "hermit_abi",
+                "alias": "libc"
+              }
+            ],
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -8482,20 +8788,20 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
-        "edition": "2018",
-        "version": "0.8.10"
+        "edition": "2021",
+        "version": "1.0.2"
       },
       "license": "MIT",
       "license_ids": [
@@ -8611,62 +8917,6 @@
           ],
           "selects": {}
         }
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "num_cpus 1.16.0": {
-      "name": "num_cpus",
-      "version": "1.16.0",
-      "package_url": "https://github.com/seanmonstar/num_cpus",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/num_cpus/1.16.0/download",
-          "sha256": "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "num_cpus",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "num_cpus",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(not(windows))": [
-              {
-                "id": "libc 0.2.153",
-                "target": "libc"
-              }
-            ],
-            "cfg(target_os = \"hermit\")": [
-              {
-                "id": "hermit-abi 0.3.5",
-                "target": "hermit_abi"
-              }
-            ]
-          }
-        },
-        "edition": "2015",
-        "version": "1.16.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -8821,6 +9071,45 @@
       ],
       "license_file": "LICENSE"
     },
+    "parking 2.2.1": {
+      "name": "parking",
+      "version": "2.2.1",
+      "package_url": "https://github.com/smol-rs/parking",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/parking/2.2.1/download",
+          "sha256": "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "parking",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "parking",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "2.2.1"
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "parking_lot 0.12.1": {
       "name": "parking_lot",
       "version": "0.12.1",
@@ -8931,7 +9220,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "smallvec 1.13.1",
+              "id": "smallvec 1.13.2",
               "target": "smallvec"
             }
           ],
@@ -8944,7 +9233,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -9244,7 +9533,7 @@
               "target": "peg_runtime"
             },
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -9349,11 +9638,11 @@
               "target": "once_cell"
             },
             {
-              "id": "regex 1.10.3",
+              "id": "regex 1.11.0",
               "target": "regex"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
@@ -9373,14 +9662,14 @@
       ],
       "license_file": "License-Apache"
     },
-    "pep508_rs 0.2.4": {
+    "pep508_rs 0.3.0": {
       "name": "pep508_rs",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "package_url": "https://github.com/konstin/pep508_rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pep508_rs/0.2.4/download",
-          "sha256": "aa9d1320b78f4a5715b3ec914f32b5e85a50287ad923730e3cbf0255259432eb"
+          "url": "https://static.crates.io/crates/pep508_rs/0.3.0/download",
+          "sha256": "910c513bea0f4f833122321c0f20e8c704e01de98692f6989c2ec21f43d88b1e"
         }
       },
       "targets": [
@@ -9420,15 +9709,15 @@
               "target": "pep440_rs"
             },
             {
-              "id": "regex 1.10.3",
+              "id": "regex 1.11.0",
               "target": "regex"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -9447,7 +9736,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.4"
+        "version": "0.3.0"
       },
       "license": "Apache-2.0 OR BSD-2-Clause",
       "license_ids": [
@@ -9503,14 +9792,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "petgraph 0.6.4": {
+    "petgraph 0.6.5": {
       "name": "petgraph",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "package_url": "https://github.com/petgraph/petgraph",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/petgraph/0.6.4/download",
-          "sha256": "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+          "url": "https://static.crates.io/crates/petgraph/0.6.5/download",
+          "sha256": "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
         }
       },
       "targets": [
@@ -9548,14 +9837,14 @@
               "target": "fixedbitset"
             },
             {
-              "id": "indexmap 2.2.2",
+              "id": "indexmap 2.6.0",
               "target": "indexmap"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.6.4"
+        "version": "0.6.5"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -9644,7 +9933,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -9652,7 +9941,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
@@ -9668,14 +9957,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pin-project-lite 0.2.13": {
+    "pin-project-lite 0.2.14": {
       "name": "pin-project-lite",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "package_url": "https://github.com/taiki-e/pin-project-lite",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pin-project-lite/0.2.13/download",
-          "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+          "url": "https://static.crates.io/crates/pin-project-lite/0.2.14/download",
+          "sha256": "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
         }
       },
       "targets": [
@@ -9698,7 +9987,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.2.13"
+        "version": "0.2.14"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -9824,14 +10113,62 @@
       ],
       "license_file": "LICENSE-Apache"
     },
-    "proc-macro2 1.0.78": {
+    "ppv-lite86 0.2.20": {
+      "name": "ppv-lite86",
+      "version": "0.2.20",
+      "package_url": "https://github.com/cryptocorrosion/cryptocorrosion",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ppv-lite86/0.2.20/download",
+          "sha256": "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ppv_lite86",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ppv_lite86",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "zerocopy 0.7.35",
+              "target": "zerocopy"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.20"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "proc-macro2 1.0.89": {
       "name": "proc-macro2",
-      "version": "1.0.78",
+      "version": "1.0.89",
       "package_url": "https://github.com/dtolnay/proc-macro2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/proc-macro2/1.0.78/download",
-          "sha256": "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+          "url": "https://static.crates.io/crates/proc-macro2/1.0.89/download",
+          "sha256": "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
         }
       },
       "targets": [
@@ -9875,7 +10212,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "build_script_build"
             },
             {
@@ -9886,7 +10223,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.78"
+        "version": "1.0.89"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -9934,7 +10271,7 @@
               "target": "miette"
             },
             {
-              "id": "rattler_installs_packages 0.6.0",
+              "id": "rattler_installs_packages 0.9.0",
               "target": "rattler_installs_packages"
             }
           ],
@@ -9947,14 +10284,14 @@
       "license_ids": [],
       "license_file": null
     },
-    "pyproject-toml 0.8.2": {
+    "pyproject-toml 0.9.0": {
       "name": "pyproject-toml",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "package_url": "https://github.com/PyO3/pyproject-toml-rs.git",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pyproject-toml/0.8.2/download",
-          "sha256": "ef61ae096a2f8c8b49eca360679dbc25f57c99145f6634b6bc18fedb1f9c6c30"
+          "url": "https://static.crates.io/crates/pyproject-toml/0.9.0/download",
+          "sha256": "95c3dd745f99aa3c554b7bb00859f7d18c2f1d6afd749ccc86d60b61e702abd9"
         }
       },
       "targets": [
@@ -9979,7 +10316,7 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.2",
+              "id": "indexmap 2.6.0",
               "target": "indexmap"
             },
             {
@@ -9987,11 +10324,11 @@
               "target": "pep440_rs"
             },
             {
-              "id": "pep508_rs 0.2.4",
+              "id": "pep508_rs 0.3.0",
               "target": "pep508_rs"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
@@ -10002,13 +10339,230 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.2"
+        "version": "0.9.0"
       },
       "license": "MIT",
       "license_ids": [
         "MIT"
       ],
       "license_file": "LICENSE"
+    },
+    "quinn 0.11.5": {
+      "name": "quinn",
+      "version": "0.11.5",
+      "package_url": "https://github.com/quinn-rs/quinn",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn/0.11.5/download",
+          "sha256": "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "quinn",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "quinn",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.8.0",
+              "target": "bytes"
+            },
+            {
+              "id": "pin-project-lite 0.2.14",
+              "target": "pin_project_lite"
+            },
+            {
+              "id": "quinn-proto 0.11.8",
+              "target": "quinn_proto",
+              "alias": "proto"
+            },
+            {
+              "id": "quinn-udp 0.5.5",
+              "target": "quinn_udp",
+              "alias": "udp"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "socket2 0.5.5",
+              "target": "socket2"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.11.5"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "quinn-proto 0.11.8": {
+      "name": "quinn-proto",
+      "version": "0.11.8",
+      "package_url": "https://github.com/quinn-rs/quinn",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn-proto/0.11.8/download",
+          "sha256": "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "quinn_proto",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "quinn_proto",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.8.0",
+              "target": "bytes"
+            },
+            {
+              "id": "rand 0.8.5",
+              "target": "rand"
+            },
+            {
+              "id": "rustc-hash 2.0.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "slab 0.4.9",
+              "target": "slab"
+            },
+            {
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
+            },
+            {
+              "id": "tinyvec 1.6.0",
+              "target": "tinyvec"
+            },
+            {
+              "id": "tracing 0.1.40",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.11.8"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "quinn-udp 0.5.5": {
+      "name": "quinn-udp",
+      "version": "0.5.5",
+      "package_url": "https://github.com/quinn-rs/quinn",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/quinn-udp/0.5.5/download",
+          "sha256": "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "quinn_udp",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "quinn_udp",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "libc 0.2.161",
+              "target": "libc"
+            },
+            {
+              "id": "socket2 0.5.5",
+              "target": "socket2"
+            }
+          ],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "once_cell 1.19.0",
+                "target": "once_cell"
+              },
+              {
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.5.5"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "quote 1.0.35": {
       "name": "quote",
@@ -10049,7 +10603,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             }
           ],
@@ -10132,6 +10686,106 @@
       ],
       "license_file": "LICENSE.txt"
     },
+    "rand 0.8.5": {
+      "name": "rand",
+      "version": "0.8.5",
+      "package_url": "https://github.com/rust-random/rand",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rand/0.8.5/download",
+          "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rand",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rand",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rand_core 0.6.4",
+              "target": "rand_core"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.8.5"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "rand_chacha 0.3.1": {
+      "name": "rand_chacha",
+      "version": "0.3.1",
+      "package_url": "https://github.com/rust-random/rand",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rand_chacha/0.3.1/download",
+          "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rand_chacha",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rand_chacha",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "ppv-lite86 0.2.20",
+              "target": "ppv_lite86"
+            },
+            {
+              "id": "rand_core 0.6.4",
+              "target": "rand_core"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "rand_core 0.6.4": {
       "name": "rand_core",
       "version": "0.6.4",
@@ -10171,14 +10825,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rattler_digest 0.9.0": {
+    "rattler_digest 0.19.5": {
       "name": "rattler_digest",
-      "version": "0.9.0",
+      "version": "0.19.5",
       "package_url": "https://github.com/mamba-org/rattler",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rattler_digest/0.9.0/download",
-          "sha256": "881d6040b07c00070386bc7d98f21b71474a0b7847fa5b32a7c5a0a01d028f8f"
+          "url": "https://static.crates.io/crates/rattler_digest/0.19.5/download",
+          "sha256": "eeb0228f734983274fb6938844123e88aa55158d53ead37e8ae3deb641fe05aa"
         }
       },
       "targets": [
@@ -10202,6 +10856,7 @@
         ],
         "crate_features": {
           "common": [
+            "generic-array",
             "serde"
           ],
           "selects": {}
@@ -10217,6 +10872,10 @@
               "target": "digest"
             },
             {
+              "id": "generic-array 0.14.7",
+              "target": "generic_array"
+            },
+            {
               "id": "hex 0.4.3",
               "target": "hex"
             },
@@ -10225,11 +10884,11 @@
               "target": "md5"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
-              "id": "serde_with 3.6.0",
+              "id": "serde_with 3.11.0",
               "target": "serde_with"
             },
             {
@@ -10240,7 +10899,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.9.0"
+        "version": "0.19.5"
       },
       "license": "BSD-3-Clause",
       "license_ids": [
@@ -10248,15 +10907,15 @@
       ],
       "license_file": null
     },
-    "rattler_installs_packages 0.6.0": {
+    "rattler_installs_packages 0.9.0": {
       "name": "rattler_installs_packages",
-      "version": "0.6.0",
+      "version": "0.9.0",
       "package_url": "https://github.com/prefix-dev/rip",
       "repository": {
         "Git": {
           "remote": "https://github.com/prefix-dev/rip",
           "commitish": {
-            "Rev": "b047c9ec0b42125a67d35346f08b7e7848ac24f4"
+            "Rev": "1b4d909496f68c292800ebbd3667c8682b01d218"
           },
           "strip_prefix": "crates/rattler_installs_packages"
         }
@@ -10293,19 +10952,19 @@
               "target": "async_once_cell"
             },
             {
-              "id": "async_http_range_reader 0.6.0",
+              "id": "async_http_range_reader 0.7.1",
               "target": "async_http_range_reader"
             },
             {
-              "id": "async_zip 0.0.15",
+              "id": "async_zip 0.0.16",
               "target": "async_zip"
             },
             {
-              "id": "bytes 1.5.0",
+              "id": "bytes 1.8.0",
               "target": "bytes"
             },
             {
-              "id": "cacache 12.0.0",
+              "id": "cacache 13.0.0",
               "target": "cacache"
             },
             {
@@ -10341,7 +11000,7 @@
               "target": "fs_err"
             },
             {
-              "id": "fs4 0.6.6",
+              "id": "fs4 0.8.4",
               "target": "fs4"
             },
             {
@@ -10357,11 +11016,11 @@
               "target": "html_escape"
             },
             {
-              "id": "http 0.2.11",
+              "id": "http 1.1.0",
               "target": "http"
             },
             {
-              "id": "http-cache-semantics 1.0.2",
+              "id": "http-cache-semantics 2.1.0",
               "target": "http_cache_semantics"
             },
             {
@@ -10369,7 +11028,7 @@
               "target": "include_dir"
             },
             {
-              "id": "indexmap 2.2.2",
+              "id": "indexmap 2.6.0",
               "target": "indexmap"
             },
             {
@@ -10377,7 +11036,7 @@
               "target": "itertools"
             },
             {
-              "id": "miette 5.10.0",
+              "id": "miette 7.2.0",
               "target": "miette"
             },
             {
@@ -10405,51 +11064,51 @@
               "target": "pep440_rs"
             },
             {
-              "id": "pep508_rs 0.2.4",
+              "id": "pep508_rs 0.3.0",
               "target": "pep508_rs"
             },
             {
-              "id": "pin-project-lite 0.2.13",
+              "id": "pin-project-lite 0.2.14",
               "target": "pin_project_lite"
             },
             {
-              "id": "pyproject-toml 0.8.2",
+              "id": "pyproject-toml 0.9.0",
               "target": "pyproject_toml"
             },
             {
-              "id": "rattler_digest 0.9.0",
+              "id": "rattler_digest 0.19.5",
               "target": "rattler_digest"
             },
             {
-              "id": "regex 1.10.3",
+              "id": "regex 1.11.0",
               "target": "regex"
             },
             {
-              "id": "reqwest 0.11.24",
+              "id": "reqwest 0.12.8",
               "target": "reqwest"
             },
             {
-              "id": "reqwest-middleware 0.2.4",
+              "id": "reqwest-middleware 0.3.3",
               "target": "reqwest_middleware"
             },
             {
-              "id": "resolvo 0.3.0",
+              "id": "resolvo 0.4.1",
               "target": "resolvo"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.113",
+              "id": "serde_json 1.0.132",
               "target": "serde_json"
             },
             {
-              "id": "serde_with 3.6.0",
+              "id": "serde_with 3.11.0",
               "target": "serde_with"
             },
             {
-              "id": "smallvec 1.13.1",
+              "id": "smallvec 1.13.2",
               "target": "smallvec"
             },
             {
@@ -10457,11 +11116,11 @@
               "target": "tar"
             },
             {
-              "id": "tempfile 3.10.0",
+              "id": "tempfile 3.13.0",
               "target": "tempfile"
             },
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -10469,7 +11128,7 @@
               "target": "tl"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "tokio 1.41.0",
               "target": "tokio"
             },
             {
@@ -10485,6 +11144,10 @@
               "target": "url"
             },
             {
+              "id": "which 6.0.3",
+              "target": "which"
+            },
+            {
               "id": "zip 0.6.6",
               "target": "zip"
             }
@@ -10495,17 +11158,17 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-recursion 1.0.5",
+              "id": "async-recursion 1.1.1",
               "target": "async_recursion"
             },
             {
-              "id": "async-trait 0.1.77",
+              "id": "async-trait 0.1.83",
               "target": "async_trait"
             }
           ],
           "selects": {}
         },
-        "version": "0.6.0"
+        "version": "0.9.0"
       },
       "license": "BSD-3-Clause",
       "license_ids": [
@@ -10599,7 +11262,7 @@
           "selects": {
             "cfg(any(target_os = \"linux\", target_os = \"android\"))": [
               {
-                "id": "rustix 0.38.31",
+                "id": "rustix 0.38.37",
                 "target": "rustix"
               }
             ],
@@ -10621,14 +11284,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "regex 1.10.3": {
+    "regex 1.11.0": {
       "name": "regex",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "package_url": "https://github.com/rust-lang/regex",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex/1.10.3/download",
-          "sha256": "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+          "url": "https://static.crates.io/crates/regex/1.11.0/download",
+          "sha256": "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
         }
       },
       "targets": [
@@ -10683,18 +11346,18 @@
               "target": "memchr"
             },
             {
-              "id": "regex-automata 0.4.5",
+              "id": "regex-automata 0.4.8",
               "target": "regex_automata"
             },
             {
-              "id": "regex-syntax 0.8.2",
+              "id": "regex-syntax 0.8.5",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.10.3"
+        "version": "1.11.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -10703,14 +11366,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "regex-automata 0.4.5": {
+    "regex-automata 0.4.8": {
       "name": "regex-automata",
-      "version": "0.4.5",
+      "version": "0.4.8",
       "package_url": "https://github.com/rust-lang/regex/tree/master/regex-automata",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex-automata/0.4.5/download",
-          "sha256": "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+          "url": "https://static.crates.io/crates/regex-automata/0.4.8/download",
+          "sha256": "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
         }
       },
       "targets": [
@@ -10770,14 +11433,14 @@
               "target": "memchr"
             },
             {
-              "id": "regex-syntax 0.8.2",
+              "id": "regex-syntax 0.8.5",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.5"
+        "version": "0.4.8"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -10786,14 +11449,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "regex-syntax 0.8.2": {
+    "regex-syntax 0.8.5": {
       "name": "regex-syntax",
-      "version": "0.8.2",
+      "version": "0.8.5",
       "package_url": "https://github.com/rust-lang/regex/tree/master/regex-syntax",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex-syntax/0.8.2/download",
-          "sha256": "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+          "url": "https://static.crates.io/crates/regex-syntax/0.8.5/download",
+          "sha256": "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
         }
       },
       "targets": [
@@ -10831,7 +11494,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.2"
+        "version": "0.8.5"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -10840,14 +11503,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "reqwest 0.11.24": {
+    "reqwest 0.12.8": {
       "name": "reqwest",
-      "version": "0.11.24",
+      "version": "0.12.8",
       "package_url": "https://github.com/seanmonstar/reqwest",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/reqwest/0.11.24/download",
-          "sha256": "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+          "url": "https://static.crates.io/crates/reqwest/0.12.8/download",
+          "sha256": "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
         }
       },
       "targets": [
@@ -10872,31 +11535,23 @@
         "crate_features": {
           "common": [
             "__rustls",
+            "__rustls-ring",
             "__tls",
-            "hyper-rustls",
             "json",
-            "mime_guess",
-            "multipart",
-            "rustls",
             "rustls-tls",
             "rustls-tls-webpki-roots",
-            "serde_json",
-            "stream",
-            "tokio-rustls",
-            "tokio-util",
-            "wasm-streams",
-            "webpki-roots"
+            "stream"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.7",
+              "id": "base64 0.22.1",
               "target": "base64"
             },
             {
-              "id": "bytes 1.5.0",
+              "id": "bytes 1.8.0",
               "target": "bytes"
             },
             {
@@ -10908,19 +11563,15 @@
               "target": "futures_util"
             },
             {
-              "id": "http 0.2.11",
+              "id": "http 1.1.0",
               "target": "http"
             },
             {
-              "id": "mime_guess 2.0.4",
-              "target": "mime_guess"
-            },
-            {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.113",
+              "id": "serde_json 1.0.132",
               "target": "serde_json"
             },
             {
@@ -10928,7 +11579,7 @@
               "target": "serde_urlencoded"
             },
             {
-              "id": "sync_wrapper 0.1.2",
+              "id": "sync_wrapper 1.0.1",
               "target": "sync_wrapper"
             },
             {
@@ -10943,19 +11594,23 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -10963,25 +11618,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "aarch64-apple-ios": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -10989,25 +11648,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "aarch64-apple-ios-sim": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11015,25 +11678,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "aarch64-fuchsia": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11041,25 +11708,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "aarch64-linux-android": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11067,25 +11738,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "aarch64-pc-windows-msvc": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11093,25 +11768,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11119,25 +11798,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "aarch64-unknown-nixos-gnu": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11145,25 +11828,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "aarch64-unknown-nto-qnx710": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11171,25 +11858,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "arm-unknown-linux-gnueabi": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11197,25 +11888,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "armv7-linux-androideabi": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11223,25 +11918,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "armv7-unknown-linux-gnueabi": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11249,26 +11948,26 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "cfg(not(target_arch = \"wasm32\"))": [
               {
-                "id": "encoding_rs 0.8.33",
-                "target": "encoding_rs"
-              },
-              {
-                "id": "h2 0.3.24",
-                "target": "h2"
-              },
-              {
-                "id": "http-body 0.4.6",
+                "id": "http-body 1.0.1",
                 "target": "http_body"
               },
               {
-                "id": "hyper 0.14.28",
+                "id": "http-body-util 0.1.2",
+                "target": "http_body_util"
+              },
+              {
+                "id": "hyper 1.5.0",
                 "target": "hyper"
+              },
+              {
+                "id": "hyper-util 0.1.9",
+                "target": "hyper_util"
               },
               {
                 "id": "ipnet 2.9.0",
@@ -11291,11 +11990,11 @@
                 "target": "percent_encoding"
               },
               {
-                "id": "pin-project-lite 0.2.13",
+                "id": "pin-project-lite 0.2.14",
                 "target": "pin_project_lite"
               },
               {
-                "id": "tokio 1.36.0",
+                "id": "tokio 1.41.0",
                 "target": "tokio"
               }
             ],
@@ -11317,33 +12016,31 @@
                 "target": "web_sys"
               }
             ],
-            "cfg(target_os = \"macos\")": [
-              {
-                "id": "system-configuration 0.5.1",
-                "target": "system_configuration"
-              }
-            ],
             "cfg(windows)": [
               {
-                "id": "winreg 0.50.0",
-                "target": "winreg"
+                "id": "windows-registry 0.2.0",
+                "target": "windows_registry"
               }
             ],
             "i686-apple-darwin": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11351,25 +12048,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "i686-linux-android": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11377,25 +12078,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "i686-pc-windows-msvc": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11403,25 +12108,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "i686-unknown-freebsd": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11429,25 +12138,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "i686-unknown-linux-gnu": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11455,25 +12168,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "powerpc-unknown-linux-gnu": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11481,25 +12198,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "riscv32imc-unknown-none-elf": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11507,25 +12228,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "riscv64gc-unknown-none-elf": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11533,25 +12258,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "s390x-unknown-linux-gnu": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11559,25 +12288,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "thumbv7em-none-eabi": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11585,25 +12318,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "thumbv8m.main-none-eabi": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11611,7 +12348,7 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
@@ -11629,19 +12366,23 @@
             ],
             "x86_64-apple-darwin": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11649,25 +12390,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-apple-ios": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11675,25 +12420,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-fuchsia": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11701,25 +12450,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-linux-android": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11727,25 +12480,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-pc-windows-msvc": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11753,25 +12510,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-unknown-freebsd": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11779,25 +12540,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11805,25 +12570,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-unknown-nixos-gnu": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11831,25 +12600,29 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-unknown-none": [
               {
-                "id": "hyper-rustls 0.24.2",
+                "id": "hyper-rustls 0.27.3",
                 "target": "hyper_rustls"
               },
               {
-                "id": "rustls 0.21.10",
+                "id": "rustls 0.23.15",
                 "target": "rustls"
               },
               {
-                "id": "rustls-pemfile 1.0.4",
+                "id": "rustls-pemfile 2.2.0",
                 "target": "rustls_pemfile"
               },
               {
-                "id": "tokio-rustls 0.24.1",
+                "id": "rustls-pki-types 1.10.0",
+                "target": "rustls_pki_types"
+              },
+              {
+                "id": "tokio-rustls 0.26.0",
                 "target": "tokio_rustls"
               },
               {
@@ -11857,14 +12630,14 @@
                 "target": "tokio_util"
               },
               {
-                "id": "webpki-roots 0.25.4",
+                "id": "webpki-roots 0.26.6",
                 "target": "webpki_roots"
               }
             ]
           }
         },
-        "edition": "2018",
-        "version": "0.11.24"
+        "edition": "2021",
+        "version": "0.12.8"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11873,14 +12646,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "reqwest-middleware 0.2.4": {
+    "reqwest-middleware 0.3.3": {
       "name": "reqwest-middleware",
-      "version": "0.2.4",
+      "version": "0.3.3",
       "package_url": "https://github.com/TrueLayer/reqwest-middleware",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/reqwest-middleware/0.2.4/download",
-          "sha256": "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
+          "url": "https://static.crates.io/crates/reqwest-middleware/0.3.3/download",
+          "sha256": "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
         }
       },
       "targets": [
@@ -11909,24 +12682,24 @@
               "target": "anyhow"
             },
             {
-              "id": "http 0.2.11",
+              "id": "http 1.1.0",
               "target": "http"
             },
             {
-              "id": "reqwest 0.11.24",
+              "id": "reqwest 0.12.8",
               "target": "reqwest"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
-              "id": "task-local-extensions 0.1.4",
-              "target": "task_local_extensions"
+              "id": "thiserror 1.0.65",
+              "target": "thiserror"
             },
             {
-              "id": "thiserror 1.0.56",
-              "target": "thiserror"
+              "id": "tower-service 0.3.2",
+              "target": "tower_service"
             }
           ],
           "selects": {}
@@ -11935,29 +12708,29 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.77",
+              "id": "async-trait 0.1.83",
               "target": "async_trait"
             }
           ],
           "selects": {}
         },
-        "version": "0.2.4"
+        "version": "0.3.3"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
-      "license_file": null
+      "license_file": "LICENSE-APACHE"
     },
-    "resolvo 0.3.0": {
+    "resolvo 0.4.1": {
       "name": "resolvo",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "package_url": "https://github.com/mamba-org/resolvo",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/resolvo/0.3.0/download",
-          "sha256": "acd163bc7df01195423c83a7a391fecf319ff41d3de899694a9ccb698e790b29"
+          "url": "https://static.crates.io/crates/resolvo/0.4.1/download",
+          "sha256": "d299d168910c5d71f3c0f5441abe38ca4a6ae21f70fae909bfc6bead28f6620f"
         }
       },
       "targets": [
@@ -11979,6 +12752,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "tokio"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -11990,12 +12769,24 @@
               "target": "elsa"
             },
             {
-              "id": "itertools 0.11.0",
+              "id": "event-listener 5.3.1",
+              "target": "event_listener"
+            },
+            {
+              "id": "futures 0.3.30",
+              "target": "futures"
+            },
+            {
+              "id": "itertools 0.13.0",
               "target": "itertools"
             },
             {
-              "id": "petgraph 0.6.4",
+              "id": "petgraph 0.6.5",
               "target": "petgraph"
+            },
+            {
+              "id": "tokio 1.41.0",
+              "target": "tokio"
             },
             {
               "id": "tracing 0.1.40",
@@ -12005,7 +12796,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.0"
+        "version": "0.4.1"
       },
       "license": "BSD-3-Clause",
       "license_ids": [
@@ -12080,7 +12871,7 @@
           "selects": {
             "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12162,14 +12953,53 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustix 0.38.31": {
+    "rustc-hash 2.0.0": {
+      "name": "rustc-hash",
+      "version": "2.0.0",
+      "package_url": "https://github.com/rust-lang/rustc-hash",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rustc-hash/2.0.0/download",
+          "sha256": "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustc_hash",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustc_hash",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "2.0.0"
+      },
+      "license": "Apache-2.0/MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "rustix 0.38.37": {
       "name": "rustix",
-      "version": "0.38.31",
+      "version": "0.38.37",
       "package_url": "https://github.com/bytecodealliance/rustix",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustix/0.38.31/download",
-          "sha256": "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+          "url": "https://static.crates.io/crates/rustix/0.38.37/download",
+          "sha256": "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
         }
       },
       "targets": [
@@ -12208,6 +13038,7 @@
             "alloc",
             "default",
             "fs",
+            "libc-extra-traits",
             "std",
             "termios",
             "use-libc-auxv"
@@ -12221,7 +13052,7 @@
               "target": "bitflags"
             },
             {
-              "id": "rustix 0.38.31",
+              "id": "rustix 0.38.37",
               "target": "build_script_build"
             }
           ],
@@ -12233,7 +13064,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12244,7 +13075,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12255,7 +13086,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12266,7 +13097,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12277,7 +13108,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12288,7 +13119,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12299,19 +13130,19 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "linux-raw-sys 0.4.13",
+                "id": "linux-raw-sys 0.4.14",
                 "target": "linux_raw_sys"
               }
             ],
             "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
               {
-                "id": "linux-raw-sys 0.4.13",
+                "id": "linux-raw-sys 0.4.14",
                 "target": "linux_raw_sys"
               }
             ],
@@ -12322,7 +13153,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12344,7 +13175,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12355,7 +13186,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12366,7 +13197,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12377,7 +13208,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12388,7 +13219,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12399,7 +13230,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12410,7 +13241,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12421,7 +13252,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12432,7 +13263,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12443,7 +13274,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12454,7 +13285,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12465,7 +13296,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12476,7 +13307,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12487,7 +13318,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12498,7 +13329,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12509,7 +13340,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -12520,14 +13351,14 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.38.31"
+        "version": "0.38.37"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -12544,14 +13375,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustls 0.21.10": {
+    "rustls 0.23.15": {
       "name": "rustls",
-      "version": "0.21.10",
+      "version": "0.23.15",
       "package_url": "https://github.com/rustls/rustls",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls/0.21.10/download",
-          "sha256": "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+          "url": "https://static.crates.io/crates/rustls/0.23.15/download",
+          "sha256": "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
         }
       },
       "targets": [
@@ -12587,10 +13418,8 @@
         ],
         "crate_features": {
           "common": [
-            "dangerous_configuration",
-            "default",
-            "log",
-            "logging",
+            "ring",
+            "std",
             "tls12"
           ],
           "selects": {}
@@ -12598,30 +13427,39 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.20",
-              "target": "log"
+              "id": "once_cell 1.19.0",
+              "target": "once_cell"
             },
             {
               "id": "ring 0.17.7",
               "target": "ring"
             },
             {
-              "id": "rustls 0.21.10",
+              "id": "rustls 0.23.15",
               "target": "build_script_build"
             },
             {
-              "id": "rustls-webpki 0.101.7",
+              "id": "rustls-pki-types 1.10.0",
+              "target": "rustls_pki_types",
+              "alias": "pki_types"
+            },
+            {
+              "id": "rustls-webpki 0.102.8",
               "target": "webpki"
             },
             {
-              "id": "sct 0.7.1",
-              "target": "sct"
+              "id": "subtle 2.5.0",
+              "target": "subtle"
+            },
+            {
+              "id": "zeroize 1.8.1",
+              "target": "zeroize"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.21.10"
+        "version": "0.23.15"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -12648,14 +13486,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustls-pemfile 1.0.4": {
+    "rustls-pemfile 2.2.0": {
       "name": "rustls-pemfile",
-      "version": "1.0.4",
+      "version": "2.2.0",
       "package_url": "https://github.com/rustls/pemfile",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls-pemfile/1.0.4/download",
-          "sha256": "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+          "url": "https://static.crates.io/crates/rustls-pemfile/2.2.0/download",
+          "sha256": "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
         }
       },
       "targets": [
@@ -12677,17 +13515,25 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.7",
-              "target": "base64"
+              "id": "rustls-pki-types 1.10.0",
+              "target": "rustls_pki_types",
+              "alias": "pki_types"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.4"
+        "version": "2.2.0"
       },
       "license": "Apache-2.0 OR ISC OR MIT",
       "license_ids": [
@@ -12697,14 +13543,61 @@
       ],
       "license_file": "LICENSE"
     },
-    "rustls-webpki 0.101.7": {
+    "rustls-pki-types 1.10.0": {
+      "name": "rustls-pki-types",
+      "version": "1.10.0",
+      "package_url": "https://github.com/rustls/pki-types",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rustls-pki-types/1.10.0/download",
+          "sha256": "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustls_pki_types",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustls_pki_types",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.10.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "rustls-webpki 0.102.8": {
       "name": "rustls-webpki",
-      "version": "0.101.7",
+      "version": "0.102.8",
       "package_url": "https://github.com/rustls/webpki",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls-webpki/0.101.7/download",
-          "sha256": "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+          "url": "https://static.crates.io/crates/rustls-webpki/0.102.8/download",
+          "sha256": "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
         }
       },
       "targets": [
@@ -12729,7 +13622,7 @@
         "crate_features": {
           "common": [
             "alloc",
-            "default",
+            "ring",
             "std"
           ],
           "selects": {}
@@ -12741,6 +13634,11 @@
               "target": "ring"
             },
             {
+              "id": "rustls-pki-types 1.10.0",
+              "target": "rustls_pki_types",
+              "alias": "pki_types"
+            },
+            {
               "id": "untrusted 0.9.0",
               "target": "untrusted"
             }
@@ -12748,7 +13646,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.101.7"
+        "version": "0.102.8"
       },
       "license": "ISC",
       "license_ids": [
@@ -12884,67 +13782,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "sct 0.7.1": {
-      "name": "sct",
-      "version": "0.7.1",
-      "package_url": "https://github.com/rustls/sct.rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/sct/0.7.1/download",
-          "sha256": "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "sct",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "sct",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "ring 0.17.7",
-              "target": "ring"
-            },
-            {
-              "id": "untrusted 0.9.0",
-              "target": "untrusted"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.1"
-      },
-      "license": "Apache-2.0 OR ISC OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "ISC",
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "serde 1.0.196": {
+    "serde 1.0.213": {
       "name": "serde",
-      "version": "1.0.196",
+      "version": "1.0.213",
       "package_url": "https://github.com/serde-rs/serde",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde/1.0.196/download",
-          "sha256": "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+          "url": "https://static.crates.io/crates/serde/1.0.213/download",
+          "sha256": "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
         }
       },
       "targets": [
@@ -12991,7 +13836,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "build_script_build"
             }
           ],
@@ -13001,13 +13846,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.196",
+              "id": "serde_derive 1.0.213",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.196"
+        "version": "1.0.213"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -13024,14 +13869,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_derive 1.0.196": {
+    "serde_derive 1.0.213": {
       "name": "serde_derive",
-      "version": "1.0.196",
+      "version": "1.0.213",
       "package_url": "https://github.com/serde-rs/serde",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_derive/1.0.196/download",
-          "sha256": "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+          "url": "https://static.crates.io/crates/serde_derive/1.0.213/download",
+          "sha256": "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
         }
       },
       "targets": [
@@ -13062,7 +13907,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -13070,14 +13915,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.196"
+        "version": "1.0.213"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13086,14 +13931,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_json 1.0.113": {
+    "serde_json 1.0.132": {
       "name": "serde_json",
-      "version": "1.0.113",
+      "version": "1.0.132",
       "package_url": "https://github.com/serde-rs/json",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_json/1.0.113/download",
-          "sha256": "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+          "url": "https://static.crates.io/crates/serde_json/1.0.132/download",
+          "sha256": "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
         }
       },
       "targets": [
@@ -13141,22 +13986,26 @@
               "target": "itoa"
             },
             {
+              "id": "memchr 2.7.1",
+              "target": "memchr"
+            },
+            {
               "id": "ryu 1.0.16",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.113",
+              "id": "serde_json 1.0.132",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.113"
+        "version": "1.0.132"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -13211,7 +14060,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
@@ -13271,7 +14120,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
@@ -13287,14 +14136,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_with 3.6.0": {
+    "serde_with 3.11.0": {
       "name": "serde_with",
-      "version": "3.6.0",
+      "version": "3.11.0",
       "package_url": "https://github.com/jonasbb/serde_with/",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_with/3.6.0/download",
-          "sha256": "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+          "url": "https://static.crates.io/crates/serde_with/3.11.0/download",
+          "sha256": "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
         }
       },
       "targets": [
@@ -13328,7 +14177,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
@@ -13338,13 +14187,17 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_with_macros 3.6.0",
+              "id": "serde_derive 1.0.213",
+              "target": "serde_derive"
+            },
+            {
+              "id": "serde_with_macros 3.11.0",
               "target": "serde_with_macros"
             }
           ],
           "selects": {}
         },
-        "version": "3.6.0"
+        "version": "3.11.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13353,14 +14206,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_with_macros 3.6.0": {
+    "serde_with_macros 3.11.0": {
       "name": "serde_with_macros",
-      "version": "3.6.0",
+      "version": "3.11.0",
       "package_url": "https://github.com/jonasbb/serde_with/",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_with_macros/3.6.0/download",
-          "sha256": "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+          "url": "https://static.crates.io/crates/serde_with_macros/3.11.0/download",
+          "sha256": "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
         }
       },
       "targets": [
@@ -13389,7 +14242,7 @@
               "target": "darling"
             },
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -13397,14 +14250,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "3.6.0"
+        "version": "3.11.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13643,7 +14496,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.153",
+              "id": "libc 0.2.161",
               "target": "libc"
             }
           ],
@@ -13742,14 +14595,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "smallvec 1.13.1": {
+    "smallvec 1.13.2": {
       "name": "smallvec",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "package_url": "https://github.com/servo/rust-smallvec",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/smallvec/1.13.1/download",
-          "sha256": "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+          "url": "https://static.crates.io/crates/smallvec/1.13.2/download",
+          "sha256": "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
         }
       },
       "targets": [
@@ -13779,7 +14632,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.13.1"
+        "version": "1.13.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13866,7 +14719,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -13987,7 +14840,7 @@
               "target": "miette"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
@@ -13999,7 +14852,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "thiserror"
             },
             {
@@ -14096,6 +14949,44 @@
         ],
         "edition": "2015",
         "version": "0.10.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "strsim 0.11.1": {
+      "name": "strsim",
+      "version": "0.11.1",
+      "package_url": "https://github.com/rapidfuzz/strsim-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/strsim/0.11.1/download",
+          "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "strsim",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "strsim",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.11.1"
       },
       "license": "MIT",
       "license_ids": [
@@ -14264,14 +15155,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "syn 2.0.48": {
+    "syn 2.0.82": {
       "name": "syn",
-      "version": "2.0.48",
+      "version": "2.0.82",
       "package_url": "https://github.com/dtolnay/syn",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/syn/2.0.48/download",
-          "sha256": "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+          "url": "https://static.crates.io/crates/syn/2.0.82/download",
+          "sha256": "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
         }
       },
       "targets": [
@@ -14303,7 +15194,6 @@
             "parsing",
             "printing",
             "proc-macro",
-            "quote",
             "visit",
             "visit-mut"
           ],
@@ -14312,7 +15202,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -14327,7 +15217,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.48"
+        "version": "2.0.82"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -14336,14 +15226,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "sync_wrapper 0.1.2": {
+    "sync_wrapper 1.0.1": {
       "name": "sync_wrapper",
-      "version": "0.1.2",
+      "version": "1.0.1",
       "package_url": "https://github.com/Actyx/sync_wrapper",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/sync_wrapper/0.1.2/download",
-          "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+          "url": "https://static.crates.io/crates/sync_wrapper/1.0.1/download",
+          "sha256": "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
         }
       },
       "targets": [
@@ -14365,146 +15255,30 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "futures",
+            "futures-core"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "futures-core 0.3.30",
+              "target": "futures_core"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
-        "version": "0.1.2"
+        "version": "1.0.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
         "Apache-2.0"
       ],
       "license_file": "LICENSE"
-    },
-    "system-configuration 0.5.1": {
-      "name": "system-configuration",
-      "version": "0.5.1",
-      "package_url": "https://github.com/mullvad/system-configuration-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/system-configuration/0.5.1/download",
-          "sha256": "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "system_configuration",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "system_configuration",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 1.3.2",
-              "target": "bitflags"
-            },
-            {
-              "id": "core-foundation 0.9.4",
-              "target": "core_foundation"
-            },
-            {
-              "id": "system-configuration-sys 0.5.0",
-              "target": "system_configuration_sys"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.5.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "system-configuration-sys 0.5.0": {
-      "name": "system-configuration-sys",
-      "version": "0.5.0",
-      "package_url": "https://github.com/mullvad/system-configuration-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/system-configuration-sys/0.5.0/download",
-          "sha256": "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "system_configuration_sys",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "system_configuration_sys",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "core-foundation-sys 0.8.6",
-              "target": "core_foundation_sys"
-            },
-            {
-              "id": "libc 0.2.153",
-              "target": "libc"
-            },
-            {
-              "id": "system-configuration-sys 0.5.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.5.0"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
     },
     "tap 1.0.1": {
       "name": "tap",
@@ -14656,7 +15430,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
@@ -14750,62 +15524,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "task-local-extensions 0.1.4": {
-      "name": "task-local-extensions",
-      "version": "0.1.4",
-      "package_url": "https://github.com/TrueLayer/task-local-extensions",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/task-local-extensions/0.1.4/download",
-          "sha256": "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "task_local_extensions",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "task_local_extensions",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "pin-utils 0.1.0",
-              "target": "pin_utils"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.4"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "tempfile 3.10.0": {
+    "tempfile 3.13.0": {
       "name": "tempfile",
-      "version": "3.10.0",
+      "version": "3.13.0",
       "package_url": "https://github.com/Stebalien/tempfile",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tempfile/3.10.0/download",
-          "sha256": "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+          "url": "https://static.crates.io/crates/tempfile/3.13.0/download",
+          "sha256": "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
         }
       },
       "targets": [
@@ -14834,27 +15560,31 @@
               "target": "cfg_if"
             },
             {
-              "id": "fastrand 2.0.1",
+              "id": "fastrand 2.1.1",
               "target": "fastrand"
+            },
+            {
+              "id": "once_cell 1.19.0",
+              "target": "once_cell"
             }
           ],
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "rustix 0.38.31",
+                "id": "rustix 0.38.37",
                 "target": "rustix"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.52.0",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
-        "edition": "2018",
-        "version": "3.10.0"
+        "edition": "2021",
+        "version": "3.13.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -14897,7 +15627,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "rustix 0.38.31",
+                "id": "rustix 0.38.37",
                 "target": "rustix"
               }
             ],
@@ -14983,14 +15713,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "thiserror 1.0.56": {
+    "thiserror 1.0.65": {
       "name": "thiserror",
-      "version": "1.0.56",
+      "version": "1.0.65",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror/1.0.56/download",
-          "sha256": "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+          "url": "https://static.crates.io/crates/thiserror/1.0.65/download",
+          "sha256": "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
         }
       },
       "targets": [
@@ -15027,7 +15757,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.56",
+              "id": "thiserror 1.0.65",
               "target": "build_script_build"
             }
           ],
@@ -15037,13 +15767,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.56",
+              "id": "thiserror-impl 1.0.65",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.56"
+        "version": "1.0.65"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -15060,14 +15790,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror-impl 1.0.56": {
+    "thiserror-impl 1.0.65": {
       "name": "thiserror-impl",
-      "version": "1.0.56",
+      "version": "1.0.65",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror-impl/1.0.56/download",
-          "sha256": "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+          "url": "https://static.crates.io/crates/thiserror-impl/1.0.65/download",
+          "sha256": "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
         }
       },
       "targets": [
@@ -15092,7 +15822,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -15100,14 +15830,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.56"
+        "version": "1.0.65"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -15116,14 +15846,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "time 0.3.34": {
+    "time 0.3.36": {
       "name": "time",
-      "version": "0.3.34",
+      "version": "0.3.36",
       "package_url": "https://github.com/time-rs/time",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/time/0.3.34/download",
-          "sha256": "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+          "url": "https://static.crates.io/crates/time/0.3.36/download",
+          "sha256": "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
         }
       },
       "targets": [
@@ -15181,7 +15911,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.34"
+        "version": "0.3.36"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -15229,14 +15959,14 @@
       ],
       "license_file": "LICENSE-Apache"
     },
-    "time-macros 0.2.17": {
+    "time-macros 0.2.18": {
       "name": "time-macros",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "package_url": "https://github.com/time-rs/time",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/time-macros/0.2.17/download",
-          "sha256": "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+          "url": "https://static.crates.io/crates/time-macros/0.2.18/download",
+          "sha256": "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
         }
       },
       "targets": [
@@ -15272,7 +16002,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.17"
+        "version": "0.2.18"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -15416,14 +16146,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "tokio 1.36.0": {
+    "tokio 1.41.0": {
       "name": "tokio",
-      "version": "1.36.0",
+      "version": "1.41.0",
       "package_url": "https://github.com/tokio-rs/tokio",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tokio/1.36.0/download",
-          "sha256": "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+          "url": "https://static.crates.io/crates/tokio/1.41.0/download",
+          "sha256": "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
         }
       },
       "targets": [
@@ -15454,7 +16184,6 @@
             "libc",
             "macros",
             "mio",
-            "num_cpus",
             "process",
             "rt",
             "rt-multi-thread",
@@ -15600,26 +16329,22 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.5.0",
+              "id": "bytes 1.8.0",
               "target": "bytes"
             },
             {
-              "id": "mio 0.8.10",
+              "id": "mio 1.0.2",
               "target": "mio"
             },
             {
-              "id": "num_cpus 1.16.0",
-              "target": "num_cpus"
-            },
-            {
-              "id": "pin-project-lite 0.2.13",
+              "id": "pin-project-lite 0.2.14",
               "target": "pin_project_lite"
             }
           ],
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15633,7 +16358,7 @@
             ],
             "aarch64-apple-ios": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15647,7 +16372,7 @@
             ],
             "aarch64-apple-ios-sim": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15661,7 +16386,7 @@
             ],
             "aarch64-fuchsia": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15675,7 +16400,7 @@
             ],
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15693,13 +16418,13 @@
                 "target": "socket2"
               },
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ],
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15713,7 +16438,7 @@
             ],
             "aarch64-unknown-nixos-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15727,7 +16452,7 @@
             ],
             "aarch64-unknown-nto-qnx710": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15741,7 +16466,7 @@
             ],
             "arm-unknown-linux-gnueabi": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15755,7 +16480,7 @@
             ],
             "armv7-linux-androideabi": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15769,7 +16494,7 @@
             ],
             "armv7-unknown-linux-gnueabi": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15789,7 +16514,7 @@
             ],
             "i686-apple-darwin": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15803,7 +16528,7 @@
             ],
             "i686-linux-android": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15821,13 +16546,13 @@
                 "target": "socket2"
               },
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ],
             "i686-unknown-freebsd": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15841,7 +16566,7 @@
             ],
             "i686-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15855,7 +16580,7 @@
             ],
             "powerpc-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15881,7 +16606,7 @@
             ],
             "s390x-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15907,7 +16632,7 @@
             ],
             "x86_64-apple-darwin": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15921,7 +16646,7 @@
             ],
             "x86_64-apple-ios": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15935,7 +16660,7 @@
             ],
             "x86_64-fuchsia": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15949,7 +16674,7 @@
             ],
             "x86_64-linux-android": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15967,13 +16692,13 @@
                 "target": "socket2"
               },
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ],
             "x86_64-unknown-freebsd": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -15987,7 +16712,7 @@
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -16001,7 +16726,7 @@
             ],
             "x86_64-unknown-nixos-gnu": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               },
               {
@@ -16025,13 +16750,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tokio-macros 2.2.0",
+              "id": "tokio-macros 2.4.0",
               "target": "tokio_macros"
             }
           ],
           "selects": {}
         },
-        "version": "1.36.0"
+        "version": "1.41.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -16039,14 +16764,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "tokio-macros 2.2.0": {
+    "tokio-macros 2.4.0": {
       "name": "tokio-macros",
-      "version": "2.2.0",
+      "version": "2.4.0",
       "package_url": "https://github.com/tokio-rs/tokio",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tokio-macros/2.2.0/download",
-          "sha256": "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+          "url": "https://static.crates.io/crates/tokio-macros/2.4.0/download",
+          "sha256": "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
         }
       },
       "targets": [
@@ -16071,7 +16796,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -16079,14 +16804,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.2.0"
+        "version": "2.4.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -16094,14 +16819,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "tokio-rustls 0.24.1": {
+    "tokio-rustls 0.26.0": {
       "name": "tokio-rustls",
-      "version": "0.24.1",
+      "version": "0.26.0",
       "package_url": "https://github.com/rustls/tokio-rustls",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tokio-rustls/0.24.1/download",
-          "sha256": "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+          "url": "https://static.crates.io/crates/tokio-rustls/0.26.0/download",
+          "sha256": "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
         }
       },
       "targets": [
@@ -16125,8 +16850,7 @@
         ],
         "crate_features": {
           "common": [
-            "default",
-            "logging",
+            "ring",
             "tls12"
           ],
           "selects": {}
@@ -16134,18 +16858,23 @@
         "deps": {
           "common": [
             {
-              "id": "rustls 0.21.10",
+              "id": "rustls 0.23.15",
               "target": "rustls"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "rustls-pki-types 1.10.0",
+              "target": "rustls_pki_types",
+              "alias": "pki_types"
+            },
+            {
+              "id": "tokio 1.41.0",
               "target": "tokio"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.24.1"
+        "edition": "2021",
+        "version": "0.26.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -16200,11 +16929,11 @@
               "target": "futures_core"
             },
             {
-              "id": "pin-project-lite 0.2.13",
+              "id": "pin-project-lite 0.2.14",
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "tokio 1.41.0",
               "target": "tokio"
             },
             {
@@ -16424,7 +17153,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.5.0",
+              "id": "bytes 1.8.0",
               "target": "bytes"
             },
             {
@@ -16440,11 +17169,11 @@
               "target": "futures_sink"
             },
             {
-              "id": "pin-project-lite 0.2.13",
+              "id": "pin-project-lite 0.2.14",
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.36.0",
+              "id": "tokio 1.41.0",
               "target": "tokio"
             }
           ],
@@ -16690,7 +17419,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
@@ -16756,7 +17485,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
@@ -16811,11 +17540,11 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.2.2",
+              "id": "indexmap 2.6.0",
               "target": "indexmap"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             },
             {
@@ -16927,7 +17656,7 @@
               "target": "log"
             },
             {
-              "id": "pin-project-lite 0.2.13",
+              "id": "pin-project-lite 0.2.14",
               "target": "pin_project_lite"
             },
             {
@@ -16987,7 +17716,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -16995,7 +17724,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             }
           ],
@@ -17169,83 +17898,6 @@
         "MIT"
       ],
       "license_file": "LICENSE"
-    },
-    "unicase 2.7.0": {
-      "name": "unicase",
-      "version": "2.7.0",
-      "package_url": "https://github.com/seanmonstar/unicase",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/unicase/2.7.0/download",
-          "sha256": "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "unicase",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "unicase",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "unicase 2.7.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "2.7.0"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
     },
     "unicode-bidi 0.3.15": {
       "name": "unicode-bidi",
@@ -17484,7 +18136,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.4.18",
+              "id": "clap 4.5.20",
               "target": "clap"
             },
             {
@@ -17590,7 +18242,7 @@
               "target": "percent_encoding"
             },
             {
-              "id": "serde 1.0.196",
+              "id": "serde 1.0.213",
               "target": "serde"
             }
           ],
@@ -17703,7 +18355,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.4.18",
+              "id": "clap 4.5.20",
               "target": "clap"
             },
             {
@@ -18046,7 +18698,7 @@
               "target": "once_cell"
             },
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -18054,7 +18706,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             },
             {
@@ -18233,7 +18885,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.78",
+              "id": "proc-macro2 1.0.89",
               "target": "proc_macro2"
             },
             {
@@ -18241,7 +18893,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.48",
+              "id": "syn 2.0.82",
               "target": "syn"
             },
             {
@@ -18492,14 +19144,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "webpki-roots 0.25.4": {
+    "webpki-roots 0.26.6": {
       "name": "webpki-roots",
-      "version": "0.25.4",
+      "version": "0.26.6",
       "package_url": "https://github.com/rustls/webpki-roots",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/webpki-roots/0.25.4/download",
-          "sha256": "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+          "url": "https://static.crates.io/crates/webpki-roots/0.26.6/download",
+          "sha256": "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
         }
       },
       "targets": [
@@ -18521,14 +19173,90 @@
         "compile_data_glob": [
           "**"
         ],
+        "deps": {
+          "common": [
+            {
+              "id": "rustls-pki-types 1.10.0",
+              "target": "rustls_pki_types",
+              "alias": "pki_types"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
-        "version": "0.25.4"
+        "version": "0.26.6"
       },
       "license": "MPL-2.0",
       "license_ids": [
         "MPL-2.0"
       ],
       "license_file": "LICENSE"
+    },
+    "which 6.0.3": {
+      "name": "which",
+      "version": "6.0.3",
+      "package_url": "https://github.com/harryfei/which-rs.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/which/6.0.3/download",
+          "sha256": "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "which",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "which",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "either 1.9.0",
+              "target": "either"
+            }
+          ],
+          "selects": {
+            "cfg(any(unix, target_os = \"wasi\", target_os = \"redox\"))": [
+              {
+                "id": "rustix 0.38.37",
+                "target": "rustix"
+              }
+            ],
+            "cfg(any(windows, unix, target_os = \"redox\"))": [
+              {
+                "id": "home 0.5.9",
+                "target": "home"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "winsafe 0.0.19",
+                "target": "winsafe"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "6.0.3"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.txt"
     },
     "winapi 0.3.9": {
       "name": "winapi",
@@ -18863,7 +19591,7 @@
               "target": "windows_core"
             },
             {
-              "id": "windows-targets 0.52.0",
+              "id": "windows-targets 0.52.6",
               "target": "windows_targets"
             }
           ],
@@ -18917,7 +19645,7 @@
         "deps": {
           "common": [
             {
-              "id": "windows-targets 0.52.0",
+              "id": "windows-targets 0.52.6",
               "target": "windows_targets"
             }
           ],
@@ -18925,6 +19653,176 @@
         },
         "edition": "2021",
         "version": "0.52.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "license-apache-2.0"
+    },
+    "windows-registry 0.2.0": {
+      "name": "windows-registry",
+      "version": "0.2.0",
+      "package_url": "https://github.com/microsoft/windows-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-registry/0.2.0/download",
+          "sha256": "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_registry",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_registry",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows-result 0.2.0",
+              "target": "windows_result"
+            },
+            {
+              "id": "windows-strings 0.1.0",
+              "target": "windows_strings"
+            },
+            {
+              "id": "windows-targets 0.52.6",
+              "target": "windows_targets"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "license-apache-2.0"
+    },
+    "windows-result 0.2.0": {
+      "name": "windows-result",
+      "version": "0.2.0",
+      "package_url": "https://github.com/microsoft/windows-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-result/0.2.0/download",
+          "sha256": "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_result",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_result",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "windows-targets 0.52.6",
+              "target": "windows_targets"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "license-apache-2.0"
+    },
+    "windows-strings 0.1.0": {
+      "name": "windows-strings",
+      "version": "0.1.0",
+      "package_url": "https://github.com/microsoft/windows-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-strings/0.1.0/download",
+          "sha256": "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_strings",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_strings",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "windows-result 0.2.0",
+              "target": "windows_result"
+            },
+            {
+              "id": "windows-targets 0.52.6",
+              "target": "windows_targets"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -18968,19 +19866,10 @@
             "Win32_Foundation",
             "Win32_Networking",
             "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
             "Win32_System",
             "Win32_System_Console",
-            "Win32_System_Diagnostics",
-            "Win32_System_Diagnostics_Debug",
             "Win32_System_IO",
-            "Win32_System_Pipes",
-            "Win32_System_Registry",
-            "Win32_System_SystemServices",
             "Win32_System_Threading",
-            "Win32_System_Time",
             "Win32_System_WindowsProgramming",
             "default"
           ],
@@ -19036,12 +19925,29 @@
         ],
         "crate_features": {
           "common": [
+            "Wdk",
+            "Wdk_Foundation",
+            "Wdk_Storage",
+            "Wdk_Storage_FileSystem",
+            "Wdk_System",
+            "Wdk_System_IO",
             "Win32",
             "Win32_Foundation",
+            "Win32_Networking",
+            "Win32_Networking_WinSock",
+            "Win32_Security",
             "Win32_Storage",
             "Win32_Storage_FileSystem",
             "Win32_System",
+            "Win32_System_Com",
             "Win32_System_Console",
+            "Win32_System_IO",
+            "Win32_System_Pipes",
+            "Win32_System_SystemServices",
+            "Win32_System_Threading",
+            "Win32_System_WindowsProgramming",
+            "Win32_UI",
+            "Win32_UI_Shell",
             "default"
           ],
           "selects": {}
@@ -19049,7 +19955,7 @@
         "deps": {
           "common": [
             {
-              "id": "windows-targets 0.52.0",
+              "id": "windows-targets 0.52.6",
               "target": "windows_targets"
             }
           ],
@@ -19057,6 +19963,64 @@
         },
         "edition": "2021",
         "version": "0.52.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "license-apache-2.0"
+    },
+    "windows-sys 0.59.0": {
+      "name": "windows-sys",
+      "version": "0.59.0",
+      "package_url": "https://github.com/microsoft/windows-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-sys/0.59.0/download",
+          "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "Win32",
+            "Win32_Foundation",
+            "Win32_Storage",
+            "Win32_Storage_FileSystem",
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "windows-targets 0.52.6",
+              "target": "windows_targets"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.59.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19151,14 +20115,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows-targets 0.52.0": {
+    "windows-targets 0.52.6": {
       "name": "windows-targets",
-      "version": "0.52.0",
+      "version": "0.52.6",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows-targets/0.52.0/download",
-          "sha256": "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+          "url": "https://static.crates.io/crates/windows-targets/0.52.6/download",
+          "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
         }
       },
       "targets": [
@@ -19185,50 +20149,56 @@
           "selects": {
             "aarch64-pc-windows-gnullvm": [
               {
-                "id": "windows_aarch64_gnullvm 0.52.0",
+                "id": "windows_aarch64_gnullvm 0.52.6",
                 "target": "windows_aarch64_gnullvm"
+              }
+            ],
+            "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [
+              {
+                "id": "windows_x86_64_msvc 0.52.6",
+                "target": "windows_x86_64_msvc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
               {
-                "id": "windows_aarch64_msvc 0.52.0",
+                "id": "windows_aarch64_msvc 0.52.6",
                 "target": "windows_aarch64_msvc"
               }
             ],
-            "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [
+            "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
               {
-                "id": "windows_i686_gnu 0.52.0",
+                "id": "windows_i686_gnu 0.52.6",
                 "target": "windows_i686_gnu"
               }
             ],
             "cfg(all(target_arch = \"x86\", target_env = \"msvc\", not(windows_raw_dylib)))": [
               {
-                "id": "windows_i686_msvc 0.52.0",
+                "id": "windows_i686_msvc 0.52.6",
                 "target": "windows_i686_msvc"
               }
             ],
             "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
               {
-                "id": "windows_x86_64_gnu 0.52.0",
+                "id": "windows_x86_64_gnu 0.52.6",
                 "target": "windows_x86_64_gnu"
               }
             ],
-            "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
+            "i686-pc-windows-gnullvm": [
               {
-                "id": "windows_x86_64_msvc 0.52.0",
-                "target": "windows_x86_64_msvc"
+                "id": "windows_i686_gnullvm 0.52.6",
+                "target": "windows_i686_gnullvm"
               }
             ],
             "x86_64-pc-windows-gnullvm": [
               {
-                "id": "windows_x86_64_gnullvm 0.52.0",
+                "id": "windows_x86_64_gnullvm 0.52.6",
                 "target": "windows_x86_64_gnullvm"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.52.6"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19305,14 +20275,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows_aarch64_gnullvm 0.52.0": {
+    "windows_aarch64_gnullvm 0.52.6": {
       "name": "windows_aarch64_gnullvm",
-      "version": "0.52.0",
+      "version": "0.52.6",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.0/download",
-          "sha256": "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+          "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download",
+          "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
         }
       },
       "targets": [
@@ -19349,14 +20319,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_aarch64_gnullvm 0.52.0",
+              "id": "windows_aarch64_gnullvm 0.52.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.52.6"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -19441,14 +20411,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows_aarch64_msvc 0.52.0": {
+    "windows_aarch64_msvc 0.52.6": {
       "name": "windows_aarch64_msvc",
-      "version": "0.52.0",
+      "version": "0.52.6",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows_aarch64_msvc/0.52.0/download",
-          "sha256": "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+          "url": "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download",
+          "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
         }
       },
       "targets": [
@@ -19485,14 +20455,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_aarch64_msvc 0.52.0",
+              "id": "windows_aarch64_msvc 0.52.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.52.6"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -19577,14 +20547,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows_i686_gnu 0.52.0": {
+    "windows_i686_gnu 0.52.6": {
       "name": "windows_i686_gnu",
-      "version": "0.52.0",
+      "version": "0.52.6",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows_i686_gnu/0.52.0/download",
-          "sha256": "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+          "url": "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download",
+          "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
         }
       },
       "targets": [
@@ -19621,14 +20591,82 @@
         "deps": {
           "common": [
             {
-              "id": "windows_i686_gnu 0.52.0",
+              "id": "windows_i686_gnu 0.52.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.52.6"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "license-apache-2.0"
+    },
+    "windows_i686_gnullvm 0.52.6": {
+      "name": "windows_i686_gnullvm",
+      "version": "0.52.6",
+      "package_url": "https://github.com/microsoft/windows-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download",
+          "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_i686_gnullvm",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_i686_gnullvm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "windows_i686_gnullvm 0.52.6",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.52.6"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -19713,14 +20751,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows_i686_msvc 0.52.0": {
+    "windows_i686_msvc 0.52.6": {
       "name": "windows_i686_msvc",
-      "version": "0.52.0",
+      "version": "0.52.6",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows_i686_msvc/0.52.0/download",
-          "sha256": "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+          "url": "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download",
+          "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
         }
       },
       "targets": [
@@ -19757,14 +20795,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_i686_msvc 0.52.0",
+              "id": "windows_i686_msvc 0.52.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.52.6"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -19849,14 +20887,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows_x86_64_gnu 0.52.0": {
+    "windows_x86_64_gnu 0.52.6": {
       "name": "windows_x86_64_gnu",
-      "version": "0.52.0",
+      "version": "0.52.6",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows_x86_64_gnu/0.52.0/download",
-          "sha256": "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+          "url": "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download",
+          "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
         }
       },
       "targets": [
@@ -19893,14 +20931,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_gnu 0.52.0",
+              "id": "windows_x86_64_gnu 0.52.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.52.6"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -19985,14 +21023,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows_x86_64_gnullvm 0.52.0": {
+    "windows_x86_64_gnullvm 0.52.6": {
       "name": "windows_x86_64_gnullvm",
-      "version": "0.52.0",
+      "version": "0.52.6",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.0/download",
-          "sha256": "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+          "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download",
+          "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
         }
       },
       "targets": [
@@ -20029,14 +21067,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_gnullvm 0.52.0",
+              "id": "windows_x86_64_gnullvm 0.52.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.52.6"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -20121,14 +21159,14 @@
       ],
       "license_file": "license-apache-2.0"
     },
-    "windows_x86_64_msvc 0.52.0": {
+    "windows_x86_64_msvc 0.52.6": {
       "name": "windows_x86_64_msvc",
-      "version": "0.52.0",
+      "version": "0.52.6",
       "package_url": "https://github.com/microsoft/windows-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/windows_x86_64_msvc/0.52.0/download",
-          "sha256": "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+          "url": "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download",
+          "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
         }
       },
       "targets": [
@@ -20165,14 +21203,14 @@
         "deps": {
           "common": [
             {
-              "id": "windows_x86_64_msvc 0.52.0",
+              "id": "windows_x86_64_msvc 0.52.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.52.0"
+        "version": "0.52.6"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -20235,20 +21273,20 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "winreg 0.50.0": {
-      "name": "winreg",
-      "version": "0.50.0",
-      "package_url": "https://github.com/gentoo90/winreg-rs",
+    "winsafe 0.0.19": {
+      "name": "winsafe",
+      "version": "0.0.19",
+      "package_url": "https://github.com/rodrigocfd/winsafe",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/winreg/0.50.0/download",
-          "sha256": "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+          "url": "https://static.crates.io/crates/winsafe/0.0.19/download",
+          "sha256": "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "winreg",
+            "crate_name": "winsafe",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -20259,32 +21297,25 @@
           }
         }
       ],
-      "library_target_name": "winreg",
+      "library_target_name": "winsafe",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "deps": {
+        "crate_features": {
           "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "windows-sys 0.48.0",
-              "target": "windows_sys"
-            }
+            "kernel"
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.50.0"
+        "edition": "2021",
+        "version": "0.0.19"
       },
       "license": "MIT",
       "license_ids": [
         "MIT"
       ],
-      "license_file": "LICENSE"
+      "license_file": "LICENSE.md"
     },
     "wyz 0.5.1": {
       "name": "wyz",
@@ -20372,20 +21403,20 @@
         "deps": {
           "common": [
             {
-              "id": "rustix 0.38.31",
+              "id": "rustix 0.38.37",
               "target": "rustix"
             }
           ],
           "selects": {
             "cfg(any(target_os = \"freebsd\", target_os = \"netbsd\"))": [
               {
-                "id": "libc 0.2.153",
+                "id": "libc 0.2.161",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"linux\")": [
               {
-                "id": "linux-raw-sys 0.4.13",
+                "id": "linux-raw-sys 0.4.14",
                 "target": "linux_raw_sys"
               }
             ]
@@ -20444,6 +21475,160 @@
         "BSL-1.0"
       ],
       "license_file": "LICENSE"
+    },
+    "zerocopy 0.7.35": {
+      "name": "zerocopy",
+      "version": "0.7.35",
+      "package_url": "https://github.com/google/zerocopy",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/zerocopy/0.7.35/download",
+          "sha256": "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "zerocopy",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "zerocopy",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [],
+          "selects": {
+            "cfg(any())": [
+              {
+                "id": "zerocopy-derive 0.7.35",
+                "target": "zerocopy_derive"
+              }
+            ]
+          }
+        },
+        "version": "0.7.35"
+      },
+      "license": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "zerocopy-derive 0.7.35": {
+      "name": "zerocopy-derive",
+      "version": "0.7.35",
+      "package_url": "https://github.com/google/zerocopy",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/zerocopy-derive/0.7.35/download",
+          "sha256": "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "zerocopy_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "zerocopy_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.89",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.35",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.82",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.7.35"
+      },
+      "license": "BSD-2-Clause OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "zeroize 1.8.1": {
+      "name": "zeroize",
+      "version": "1.8.1",
+      "package_url": "https://github.com/RustCrypto/utils/tree/master/zeroize",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/zeroize/1.8.1/download",
+          "sha256": "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "zeroize",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "zeroize",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.8.1"
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "zip 0.6.6": {
       "name": "zip",
@@ -20530,7 +21715,7 @@
               "target": "sha1"
             },
             {
-              "id": "time 0.3.34",
+              "id": "time 0.3.36",
               "target": "time"
             },
             {
@@ -20665,7 +21850,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.153",
+              "id": "libc 0.2.161",
               "target": "libc"
             },
             {
@@ -20842,6 +22027,9 @@
     "armv7-unknown-linux-gnueabi": [
       "armv7-unknown-linux-gnueabi"
     ],
+    "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [
+      "x86_64-pc-windows-msvc"
+    ],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-linux-android",
       "armv7-linux-androideabi",
@@ -20909,6 +22097,9 @@
       "aarch64-apple-ios-sim"
     ],
     "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [],
+    "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
+      "i686-unknown-linux-gnu"
+    ],
     "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [
       "i686-unknown-linux-gnu"
     ],
@@ -20922,6 +22113,7 @@
     "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
       "x86_64-pc-windows-msvc"
     ],
+    "cfg(any())": [],
     "cfg(any(all(target_arch = \"arm\", target_pointer_width = \"32\"), target_arch = \"mips\", target_arch = \"powerpc\"))": [
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
@@ -21064,6 +22256,62 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
     ],
+    "cfg(any(unix, target_os = \"wasi\", target_os = \"redox\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
+    ],
+    "cfg(any(windows, unix, target_os = \"redox\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
+    ],
     "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -21189,11 +22437,6 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
     ],
-    "cfg(target_os = \"macos\")": [
-      "aarch64-apple-darwin",
-      "i686-apple-darwin",
-      "x86_64-apple-darwin"
-    ],
     "cfg(target_os = \"redox\")": [],
     "cfg(target_os = \"wasi\")": [
       "wasm32-wasi"
@@ -21242,6 +22485,7 @@
       "i686-linux-android"
     ],
     "i686-pc-windows-gnu": [],
+    "i686-pc-windows-gnullvm": [],
     "i686-pc-windows-msvc": [
       "i686-pc-windows-msvc"
     ],
@@ -21307,9 +22551,9 @@
     ]
   },
   "direct_deps": [
-    "clap 4.4.18",
+    "clap 4.5.20",
     "miette 7.2.0",
-    "rattler_installs_packages 0.6.0"
+    "rattler_installs_packages 0.9.0"
   ],
   "direct_dev_deps": []
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -108,9 +108,9 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "async-compression"
-version = "0.3.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
 dependencies = [
  "flate2",
  "futures-core",
@@ -127,9 +127,9 @@ checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
 
 [[package]]
 name = "async-recursion"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "async_http_range_reader"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809a79b508f86b02136fc5aab935ef777d03e5d377dda04e6736a081add9287c"
+checksum = "8561e6613f8361df8bed11c0eef05b98384643bc81f6b753eec7c1d91f097509"
 dependencies = [
  "bisection",
  "futures",
@@ -169,14 +169,13 @@ dependencies = [
 
 [[package]]
 name = "async_zip"
-version = "0.0.15"
+version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795310de3218cde15219fc98c1cf7d8fe9db4865aab27fcf1d535d6cb61c6b54"
+checksum = "527207465fb6dcafbf661b0d4a51d0d2306c9d0c2975423079a6caa807930daf"
 dependencies = [
  "async-compression",
  "crc32fast",
- "futures-util",
- "log",
+ "futures-lite",
  "pin-project",
  "thiserror",
  "tokio",
@@ -218,6 +217,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -287,9 +292,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bzip2"
@@ -314,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "cacache"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142316461ed3a3dfcba10417317472da5bfd0461e4d276bf7c07b330766d9490"
+checksum = "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7"
 dependencies = [
  "digest",
  "either",
@@ -365,7 +370,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -407,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -417,21 +422,21 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -441,15 +446,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "configparser"
@@ -462,16 +476,6 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -560,7 +564,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -624,15 +628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,10 +644,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.0.1"
+name = "event-listener"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "filetime"
@@ -708,12 +714,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.6.6"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
 dependencies = [
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -777,6 +783,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +842,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
+ "serde",
  "typenum",
  "version_check",
 ]
@@ -845,25 +865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "h2"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap 2.2.2",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,21 +882,21 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -913,6 +914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -934,20 +944,32 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-cache-semantics"
-version = "1.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aec9f678bca3f4a15194b980f20ed9bfe0dd38e8d298c65c559a93dfbd6380a"
+checksum = "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
 dependencies = [
  "http",
  "http-serde",
@@ -964,9 +986,9 @@ checksum = "9f0d1a8ef218a86416107794b34cc446958d9203556c312bb41eab4c924c1d2e"
 
 [[package]]
 name = "http-serde"
-version = "1.1.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
 dependencies = [
  "http",
  "serde",
@@ -979,47 +1001,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http",
  "hyper",
+ "hyper-util",
  "rustls",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1093,12 +1127,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -1125,18 +1159,18 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1167,15 +1201,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1288,16 +1322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,13 +1332,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1330,16 +1355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1362,6 +1377,12 @@ name = "owo-colors"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1456,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "pep508_rs"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9d1320b78f4a5715b3ec914f32b5e85a50287ad923730e3cbf0255259432eb"
+checksum = "910c513bea0f4f833122321c0f20e8c704e01de98692f6989c2ec21f43d88b1e"
 dependencies = [
  "once_cell",
  "pep440_rs",
@@ -1478,12 +1499,12 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -1508,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1531,10 +1552,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.78"
+name = "ppv-lite86"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1549,15 +1579,63 @@ dependencies = [
 
 [[package]]
 name = "pyproject-toml"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef61ae096a2f8c8b49eca360679dbc25f57c99145f6634b6bc18fedb1f9c6c30"
+checksum = "95c3dd745f99aa3c554b7bb00859f7d18c2f1d6afd749ccc86d60b61e702abd9"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.6.0",
  "pep440_rs",
  "pep508_rs",
  "serde",
  "toml",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1576,19 +1654,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rattler_digest"
-version = "0.9.0"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881d6040b07c00070386bc7d98f21b71474a0b7847fa5b32a7c5a0a01d028f8f"
+checksum = "eeb0228f734983274fb6938844123e88aa55158d53ead37e8ae3deb641fe05aa"
 dependencies = [
  "blake2",
  "digest",
+ "generic-array",
  "hex",
  "md-5",
  "serde",
@@ -1598,8 +1701,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_installs_packages"
-version = "0.6.0"
-source = "git+https://github.com/prefix-dev/rip?rev=b047c9ec0b42125a67d35346f08b7e7848ac24f4#b047c9ec0b42125a67d35346f08b7e7848ac24f4"
+version = "0.9.0"
+source = "git+https://github.com/prefix-dev/rip?rev=1b4d909496f68c292800ebbd3667c8682b01d218#1b4d909496f68c292800ebbd3667c8682b01d218"
 dependencies = [
  "async-once-cell",
  "async-recursion",
@@ -1623,9 +1726,9 @@ dependencies = [
  "http",
  "http-cache-semantics",
  "include_dir",
- "indexmap 2.2.2",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
- "miette 5.10.0",
+ "miette 7.2.0",
  "mime",
  "once_cell",
  "parking_lot",
@@ -1652,6 +1755,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "which",
  "zip",
 ]
 
@@ -1677,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1689,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1700,41 +1804,41 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1745,34 +1849,37 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.2.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",
  "http",
  "reqwest",
  "serde",
- "task-local-extensions",
  "thiserror",
+ "tower-service",
 ]
 
 [[package]]
 name = "resolvo"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd163bc7df01195423c83a7a391fecf319ff41d3de899694a9ccb698e790b29"
+checksum = "d299d168910c5d71f3c0f5441abe38ca4a6ae21f70fae909bfc6bead28f6620f"
 dependencies = [
  "bitvec",
  "elsa",
- "itertools 0.11.0",
+ "event-listener",
+ "futures",
+ "itertools 0.13.0",
  "petgraph",
+ "tokio",
  "tracing",
 ]
 
@@ -1797,10 +1904,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustix"
-version = "0.38.31"
+name = "rustc-hash"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -1811,32 +1924,41 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -1862,29 +1984,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1893,11 +2005,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1925,16 +2038,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.2",
+ "indexmap 2.6.0",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -1942,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2005,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smawk"
@@ -2037,7 +2151,7 @@ version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "digest",
  "hex",
  "miette 5.10.0",
@@ -2059,6 +2173,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2089,9 +2209,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2100,29 +2220,11 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "futures-core",
 ]
 
 [[package]]
@@ -2143,24 +2245,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2186,18 +2280,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2206,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -2227,9 +2321,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2258,27 +2352,26 @@ checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2287,11 +2380,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -2349,7 +2443,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2405,15 +2499,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -2618,9 +2703,24 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
 
 [[package]]
 name = "winapi"
@@ -2660,7 +2760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2669,7 +2769,37 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2687,7 +2817,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2707,17 +2846,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2728,9 +2868,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2740,9 +2880,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2752,9 +2892,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2764,9 +2910,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2776,9 +2922,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2788,9 +2934,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2800,9 +2946,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2814,14 +2960,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "winsafe"
+version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wyz"
@@ -2848,6 +2990,33 @@ name = "xxhash-rust"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/aspect-build/rules_py"
 license = "Apache 2"
 edition = "2021"
 readme = "README.md"
-rust-version = "1.74.1"
+rust-version = "1.81.0"
 
 [workspace.dependencies]
 miette = { version = "7.2", features = ["fancy"] }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,7 +52,7 @@ rust = use_extension(
 
 rust.toolchain(
     edition = "2021",
-    versions = ["1.74.1"],
+    versions = ["1.81.0"],
 )
 use_repo(rust, "rust_toolchains")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ python_register_toolchains(
     name = "python_toolchain_3_8",
     python_version = "3.8.12",
     # Setting `set_python_version_constraint` will set special constraints on the registered toolchain.
-    # This means that this toolchain registration will only be selected for `py_binary` / `py_test` targets 
+    # This means that this toolchain registration will only be selected for `py_binary` / `py_test` targets
     # that have the `python_version = "3.8.12"` attribute set. Targets that have no `python_attribute` will use
     # the default toolchain resolved which can be seen below.
     set_python_version_constraint = True,
@@ -154,7 +154,7 @@ rules_rust_dependencies()
 
 RUST_EDITION = "2021"
 
-RUST_VERSION = "1.77.2"
+RUST_VERSION = "1.81.0"
 
 rust_register_toolchains(
     edition = RUST_EDITION,

--- a/e2e/repository-rule-deps/MODULE.bazel
+++ b/e2e/repository-rule-deps/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_rust", version = "0.53.0")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
-    versions = ["1.74.1"],
+    versions = ["1.81.0"],
 )
 use_repo(rust, "rust_toolchains")
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_rust", version = "0.53.0")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
-    versions = ["1.74.1"],
+    versions = ["1.81.0"],
 )
 use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -21,7 +21,7 @@ rules_rust_dependencies()
 
 rust_register_toolchains(
     edition = "2021",
-    versions = ["1.74.1"],
+    versions = ["1.81.0"],
 )
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")

--- a/e2e/system-interpreter/MODULE.bazel
+++ b/e2e/system-interpreter/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_rust", version = "0.53.0")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
-    versions = ["1.74.1"],
+    versions = ["1.81.0"],
 )
 use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")

--- a/py/tools/py/Cargo.toml
+++ b/py/tools/py/Cargo.toml
@@ -13,4 +13,4 @@ rust-version.workspace = true
 
 [dependencies]
 miette = { workspace = true }
-rattler_installs_packages = { git = "https://github.com/prefix-dev/rip", rev = "b047c9ec0b42125a67d35346f08b7e7848ac24f4", default-features = false, features = ["rustls-tls"] }
+rattler_installs_packages = { git = "https://github.com/prefix-dev/rip", rev = "1b4d909496f68c292800ebbd3667c8682b01d218", default-features = false, features = ["rustls-tls"] }

--- a/py/tools/py/src/interpreter.rs
+++ b/py/tools/py/src/interpreter.rs
@@ -5,7 +5,7 @@ use std::{
 
 use miette::{Context, IntoDiagnostic};
 use rattler_installs_packages::{
-    artifacts::wheel::InstallPaths,
+    install::InstallPaths,
     python_env::{PythonInterpreterVersion, PythonLocation},
 };
 

--- a/py/tools/py/src/unpack.rs
+++ b/py/tools/py/src/unpack.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use miette::{miette, IntoDiagnostic, Result};
 use rattler_installs_packages::{
-    artifacts::wheel::UnpackWheelOptions, artifacts::Wheel, types::PackageName,
+    artifacts::Wheel, install::install_wheel, install::InstallWheelOptions, types::PackageName,
 };
 
 use crate::Interpreter;
@@ -18,24 +18,24 @@ pub fn unpack_wheel(
     let python_executable = interpreter.executable()?;
     let install_paths = interpreter.install_paths(false);
 
-    let unpack_options = UnpackWheelOptions {
+    let install_options = InstallWheelOptions {
         installer: Some("Aspect Build rules_py".to_string()),
         // launcher_arch:
-        ..UnpackWheelOptions::default()
+        ..InstallWheelOptions::default()
     };
 
     let package_name: PackageName = pkg_name.parse().unwrap();
     let wheel = Wheel::from_path(wheel, &package_name.into())
         .map_err(|_| miette!("Failed to create wheel from path"))?;
 
-    wheel
-        .unpack(
-            &location,
-            &install_paths,
-            &python_executable,
-            &unpack_options,
-        )
-        .into_diagnostic()?;
+    install_wheel(
+        &wheel,
+        &location,
+        &install_paths,
+        &python_executable,
+        &install_options,
+    )
+    .into_diagnostic()?;
 
     Ok(())
 }

--- a/py/tools/unpack_bin/Cargo.toml
+++ b/py/tools/unpack_bin/Cargo.toml
@@ -16,6 +16,6 @@ name = "unpack"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.1.11", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive"] }
 miette = { workspace = true }
 py = { path = "../py" }


### PR DESCRIPTION
Bumps the Rust version to 1.81.0 and updates required dependencies.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases