### PR TITLE
Add types to file generated by __test__.py

### DIFF
--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     if test_filter is not None:
         args.append(f"-k={test_filter}")
 
-    user_args = [$$FLAGS$$]
+    user_args: list[str] = [$$FLAGS$$]
     if len(user_args) > 0:
         args.extend(user_args)
 


### PR DESCRIPTION
I am adding types to user_args otherwise mypy complains when running `bazel test`.

I am trying to automatically run `mypy` when building my bazel targets. I am using [rules_mypy](https://github.com/theoremlp/rules_mypy) for this. 
I am also using the `py_pytest_main` rule: 

```python
py_pytest_main(
    name = "__test__",
    deps = ["@pip//pytest"],
)

py_test(
    name = "mytest",
    size = "small",
    srcs = [
        "mytest.py",
        ":__test__",
    ],
    main = ":__test__.py",
    package_collisions = "warning",
    deps = [
        ":__test__",
        ":mylib",
    ],
)
```

However, if I run `bazel test mytest`, mypy complains: `bazel-out/k8-fastbuild/bin/src/backend2/__test__.py:42: error: Need type annotation for "user_args" (hint: "user_args: list[<type>] = ...")  [var-annotated]`.
I haven't found a way to remove the `__test__` file from `mypy` analysis, and this is actually a simple fix, so I thought we could patch this in. 

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes/no

