### PR TITLE
Make mypy happy with pytest_main

### DIFF
--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     if test_filter is not None:
         args.append(f"-k={test_filter}")
 
-    user_args = [$$FLAGS$$]
+    user_args: list[str] = [$$FLAGS$$]
     if len(user_args) > 0:
         args.extend(user_args)
 


### PR DESCRIPTION
### Changes are visible to end-users: yes

* `rules_mypy` runs on py_library/py_test and would try to type check this file
* it would then fail with something like:
```
bazel-out/k8-fastbuild/.../__test__.py:42: error: Need type annotation for "user_args" (hint: "user_args: list[<type>] = ...")  [var-annotated]
bazel-out/k8-fastbuild/.../__test__.py:43: error: Expression type contains "Any" (has type "list[Any]")  [misc]
bazel-out/k8-fastbuild/.../__test__.py:44: error: Expression type contains "Any" (has type "list[Any]")  [misc]
```
* make `mypy` happy
