### PR TITLE
Revert "Add types to file generated by __test__.py"

### DIFF
--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     if test_filter is not None:
         args.append(f"-k={test_filter}")
 
-    user_args: list[str] = [$$FLAGS$$]
+    user_args = [$$FLAGS$$]
     if len(user_args) > 0:
         args.extend(user_args)
 


### PR DESCRIPTION
Reverts aspect-build/rules_py#428

Revert as it's causing a failure on CI for older versions of Python.