### PR TITLE
Add backwards compatible types to file generated by __test__.py

### DIFF
--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -14,6 +14,7 @@
 
 import sys
 import os
+from typing import List
 
 import pytest
 
@@ -39,7 +40,7 @@ if __name__ == "__main__":
     if test_filter is not None:
         args.append(f"-k={test_filter}")
 
-    user_args = [$$FLAGS$$]
+    user_args: List[str] = [$$FLAGS$$]
     if len(user_args) > 0:
         args.extend(user_args)
 


### PR DESCRIPTION
As suggested in https://github.com/aspect-build/rules_py/pull/435#issuecomment-2482658330 a backwards compatible (< Python 3.9) type hint.

Regardless of merging this PR or not, the current 1.0.0 release is broken for < Python 3.9. Since Python 3.8 is already EOL, this is in theory valid, but I guess there are still a few people using Python 3.8 because of Ubuntu 20.04.

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
