### PR TITLE
chore(rollforward): example: Add example for pybind11

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -85,3 +85,5 @@ crate.from_cargo(
 )
 
 use_repo(crate, "crate_index")
+
+bazel_dep(name = "pybind11_bazel", version = "2.12.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ module(
 # py_image_layer requires 2.x for the `tar` rule.
 # py_image_layer needs compute_unused_inputs attribute
 # py_image_layer needs repo_mapping fix.
-bazel_dep(name = "aspect_bazel_lib", version = "2.9.4") 
+bazel_dep(name = "aspect_bazel_lib", version = "2.9.4")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_python", version = "0.29.0")
 bazel_dep(name = "platforms", version = "0.0.7")
@@ -86,4 +86,4 @@ crate.from_cargo(
 
 use_repo(crate, "crate_index")
 
-bazel_dep(name = "pybind11_bazel", version = "2.12.0", dev_dependency = True)
+bazel_dep(name = "pybind11_bazel", version = "2.13.6", dev_dependency = True)

--- a/examples/pybind11/BUILD.bazel
+++ b/examples/pybind11/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library", "py_test")
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
+
+pybind_extension(
+    name = "basic",
+    srcs = ["basic.cpp"],
+)
+
+py_library(
+    name = "basic_lib",
+    data = [":basic"],
+    imports = ["."],
+)
+
+py_test(
+    name = "basic_test",
+    srcs = ["basic_test.py"],
+    deps = [":basic_lib"],
+)

--- a/examples/pybind11/basic.cpp
+++ b/examples/pybind11/basic.cpp
@@ -1,0 +1,10 @@
+#include <pybind11/pybind11.h>
+
+int add(int i, int j) {
+  return i + j;
+}
+
+PYBIND11_MODULE(basic, module) {
+  module.doc() = "A basic pybind11 extension";
+  module.def("add", &add, "A function that adds two numbers");
+}

--- a/examples/pybind11/basic_test.py
+++ b/examples/pybind11/basic_test.py
@@ -1,0 +1,14 @@
+import unittest
+
+import basic
+
+
+class TestBasic(unittest.TestCase):
+
+  def test_add(self):
+    self.assertEqual(basic.add(1, 2), 3)
+    self.assertEqual(basic.add(2, 2), 4)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -118,3 +118,19 @@ def rules_py_internal_deps():
         sha256 = "0523026398aea9c8b5f7a4a6d5c0829c285b4fbd960c17b5967a369342e21e01",
         downloaded_file_path = "sqlparse-0.4.0-py3-none-any.whl",
     )
+
+    http_archive(
+        name = "pybind11_bazel",
+        strip_prefix = "pybind11_bazel-2.13.6",
+        sha256 = "9df284330336958c837fb70dc34c0a6254dac52a5c983b3373a8c2bbb79ac35e",
+        urls = ["https://github.com/pybind/pybind11_bazel/archive/v2.13.6.zip"],
+    )
+
+    # We still require the pybind library.
+    http_archive(
+        name = "pybind11",
+        build_file = "@pybind11_bazel//:pybind11-BUILD.bazel",
+        strip_prefix = "pybind11-2.13.6",
+        urls = ["https://github.com/pybind/pybind11/archive/v2.13.6.zip"],
+        sha256 = "d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6",
+    )


### PR DESCRIPTION
Reverts #444 and adds pybind dependency to `WORKSPACE` file as mention in #446.