### PR TITLE
Canonicalize target link in venv

### DIFF
--- a/py/tools/py/src/pth.rs
+++ b/py/tools/py/src/pth.rs
@@ -212,7 +212,12 @@ fn create_symlink(
         };
     }
 
-    std::os::unix::fs::symlink(&tgt, &link)
+    let canonical_tgt = tgt.canonicalize().into_diagnostic().wrap_err(format!(
+        "Unable to get full path for symlink target: {}",
+        tgt.to_string_lossy()
+    ))?;
+
+    std::os::unix::fs::symlink(&canonical_tgt, &link)
         .into_diagnostic()
         .wrap_err(format!(
             "Unable to create symlink: {} -> {}",


### PR DESCRIPTION
This way the created venv can be stable across sandboxes.

Internally we implement a test daemon that reuses the same venv (and python process) across tests whenever possible. Hence, if the target link is canonicalized, the same venv can be used across different targets.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
