### PR TITLE
Fix absolute label use in main attribute of py_test

### DIFF
--- a/examples/pytest/BUILD.bazel
+++ b/examples/pytest/BUILD.bazel
@@ -21,3 +21,13 @@ py_test(
         "@pypi_pytest//:pkg",
     ],
 )
+
+py_test(
+    name = "absolute_main_test",
+    srcs = [
+        # 2 files required
+        "__init__.py",
+        "main_test.py",
+    ],
+    main = "//examples/pytest:main_test.py",
+)

--- a/examples/pytest/main_test.py
+++ b/examples/pytest/main_test.py
@@ -1,0 +1,1 @@
+print("loaded as main!")

--- a/py/private/py_executable.bzl
+++ b/py/private/py_executable.bzl
@@ -26,7 +26,7 @@ def _determine_main(ctx):
     """
     if ctx.attr.main:
         # Deviation from rules_python: allow a leading colon, e.g. `main = ":my_target"`
-        proposed_main = ctx.attr.main.removeprefix(":")
+        proposed_main = ctx.attr.main.label.name.removeprefix(":")
         if not proposed_main.endswith(".py"):
             fail("main {} must end in '.py'".format(proposed_main))
     else:
@@ -87,7 +87,7 @@ determine_main = rule(
     implementation = _determine_main_impl,
     attrs = {
         "target_name": attr.string(mandatory = True, doc = "The name of the py_binary or py_test we are finding a main for"),
-        "main": attr.string(doc = "Hint the user supplied as the main"),
+        "main": attr.label(doc = "Hint the user supplied as the main", allow_single_file = True),
         "srcs": attr.label_list(allow_files = True),
     },
 )


### PR DESCRIPTION
In rules_python you can specify a file from another package like:

```bzl
main = "//path/to:file.py",
```

This didn't work in rules_py since it was taking the main as a string to
manipulate. This appears closer to me to the upstream logic that was
mirrored, so maybe this was changed for another reason
