### PR TITLE
Remove extra files from py_binary DefaultInfo

### DIFF
--- a/examples/py_pex_binary/BUILD.bazel
+++ b/examples/py_pex_binary/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 load("//py:defs.bzl", "py_binary", "py_pex_binary")
 
 py_binary(
@@ -5,11 +6,11 @@ py_binary(
     srcs = ["say.py"],
     data = ["data.txt"],
     env = {
-        "TEST": "1"
+        "TEST": "1",
     },
     deps = [
-        "@pypi_cowsay//:pkg",
         "@bazel_tools//tools/python/runfiles",
+        "@pypi_cowsay//:pkg",
     ],
 )
 
@@ -17,6 +18,20 @@ py_pex_binary(
     name = "py_pex_binary",
     binary = ":binary",
     inject_env = {
-        "TEST": "1"
-    }
+        "TEST": "1",
+    },
+)
+
+genrule(
+    name = "execute_pex",
+    srcs = [],
+    outs = ["pex.out"],
+    cmd = "$(execpath py_pex_binary) >$@",
+    tools = ["py_pex_binary"],
+)
+
+assert_contains(
+    name = "smoke_test_pex",
+    actual = "pex.out",
+    expected = "Mooo!",
 )

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -108,11 +108,7 @@ def _py_binary_rule_impl(ctx):
 
     return [
         DefaultInfo(
-            files = depset([
-                executable_launcher,
-                ctx.file.main,
-                site_packages_pth_file,
-            ]),
+            files = depset([executable_launcher]),
             executable = executable_launcher,
             runfiles = runfiles,
         ),

--- a/py/tests/py_image_layer/my_app_layers.listing
+++ b/py/tests/py_image_layer/my_app_layers.listing
@@ -2439,8 +2439,6 @@ drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/
 drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/
 drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_image_layer/
 -rwxr-xr-x  0 0      0        2887 Jan  1  2023 ./py/tests/py_image_layer/my_app_bin
--rwxr-xr-x  0 0      0          16 Jan  1  2023 ./py/tests/py_image_layer/main.py
--rwxr-xr-x  0 0      0          40 Jan  1  2023 ./py/tests/py_image_layer/my_app_bin.venv.pth
 drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_image_layer/my_app_bin.runfiles/
 drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_image_layer/my_app_bin.runfiles/aspect_rules_py/
 drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_image_layer/my_app_bin.runfiles/aspect_rules_py/py/


### PR DESCRIPTION
This mirrors rules_python to ensure that users can use `execpath` with a
py_binary target.

Fixes https://github.com/aspect-build/rules_py/issues/455
