### PR TITLE
ci(pre-commit): Autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+    rev: "v3.1.0"
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,18 +9,18 @@ default_stages: [commit]
 repos:
   # Check formatting and lint for starlark code
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 4.0.1.1
+    rev: 7.3.1.1
     hooks:
       - id: buildifier
       - id: buildifier-lint
   # Enforce that commit messages allow for later changelog generation
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.18.0
+    rev: v4.1.0
     hooks:
       # Requires that commitizen is already installed
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.4.0"
+    rev: "v4.0.0-alpha.8"
     hooks:
       - id: prettier

--- a/e2e/repository-rule-deps/README.md
+++ b/e2e/repository-rule-deps/README.md
@@ -30,7 +30,6 @@ The `:test` test case imports two modules from `@myrepo` ("flat" using `imports=
 
 The second test case `:all_direct` skips the `repository_rule` to demonstrate that the `test.py` itself is correctly implemented and can actually pass when the bug is not present.
 
-
 ```console
 $ bazel test ...
 ...


### PR DESCRIPTION
The pre-commit hooks are quite old in this repo. This PR run `pre-commit autoupdate`. Since the hooks are not enfored by CI, buildifier is already broken. I will create a follow up PR similar to https://github.com/bazel-contrib/bazel-lib/pull/1002 that adds it to CI and fix all errors.