### PR TITLE
pytest - add suite name to junit.xml report

### DIFF
--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -23,6 +23,7 @@ if __name__ == "__main__":
     $$CHDIR$$
 
     os.environ["ENV"] = "testing"
+    suite_name = os.environ.get("BAZEL_TARGET")
 
     args = [
         "--verbose",
@@ -31,6 +32,9 @@ if __name__ == "__main__":
         "-p",
         "no:cacheprovider",
     ]
+
+    if suite_name:
+        args.extend(["-o", f"junit_suite_name={suite_name}"])
 
     junit_xml_out = os.environ.get("XML_OUTPUT_FILE")
     if junit_xml_out is not None:

--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -23,7 +23,6 @@ if __name__ == "__main__":
     $$CHDIR$$
 
     os.environ["ENV"] = "testing"
-    suite_name = os.environ.get("BAZEL_TARGET")
 
     args = [
         "--verbose",
@@ -33,12 +32,13 @@ if __name__ == "__main__":
         "no:cacheprovider",
     ]
 
-    if suite_name:
-        args.extend(["-o", f"junit_suite_name={suite_name}"])
-
     junit_xml_out = os.environ.get("XML_OUTPUT_FILE")
     if junit_xml_out is not None:
         args.append(f"--junitxml={junit_xml_out}")
+
+        suite_name = os.environ.get("BAZEL_TARGET")
+        if suite_name:
+            args.extend(["-o", f"junit_suite_name={suite_name}"])
 
     test_filter = os.environ.get("TESTBRIDGE_TEST_ONLY")
     if test_filter is not None:


### PR DESCRIPTION
<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

The `junit.xml` files generated by pytest use the name `pytest` by default. For any tools that consume the xml files like IDEs or CI system UIs, this makes the output unfriendly because every test case rolls up the the same test suite named `pytest`.

The changes here add the `BAZEL_TARGET` name to the suite using standard pytest command line args.

Here is an example before and after when running the tests with and without the change in IntelliJ. The example only runs two test targets. The issue becomes more apparent as the number of targets scales up.

<img width="333" alt="Screenshot 2024-12-18 at 5 13 47 PM" src="https://github.com/user-attachments/assets/21cd041e-ef8e-4cb6-9a5a-d60c9dd6caaf" />

<img width="334" alt="Screenshot 2024-12-18 at 5 12 37 PM" src="https://github.com/user-attachments/assets/a4bdf396-aa55-471e-92c5-96f230fb6190" />


---

### Changes are visible to end-users: yes/no

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

Run a `py_test` target that uses `py_pytest_main` and observe the test suite name.
