### PR TITLE
fix: Compatibility with symbolic macros

### DIFF
--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -61,7 +61,7 @@ resolutions = _resolutions
 
 def _py_binary_or_test(name, rule, srcs, main, deps = [], resolutions = {}, **kwargs):
     # Compatibility with rules_python, see docs in py_executable.bzl
-    main_target = "_{}.find_main".format(name)
+    main_target = "{}.find_main".format(name)
     determine_main(
         name = main_target,
         target_name = name,

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -80,7 +80,7 @@ awk < $< 'BEGIN {
 """ % (mtree_begin_blocks, root, ifs, name)
 
     native.genrule(
-        name = "_{}_manifests".format(name),
+        name = "{}_manifests".format(name),
         srcs = [name + ".manifest"],
         outs = [
             "{}.{}.manifest.spec".format(name, group_name)
@@ -146,7 +146,7 @@ def py_image_layer(name, binary, root = "/", layer_groups = {}, compress = "gzip
     # Finally create layers using the tar rule
     srcs = []
     for group_name in group_names:
-        tar_target = "_{}_{}".format(name, group_name)
+        tar_target = "{}_{}".format(name, group_name)
         tar(
             name = tar_target,
             srcs = [binary],

--- a/py/tests/py_image_layer/asserts.bzl
+++ b/py/tests/py_image_layer/asserts.bzl
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_file")
 
 # buildifier: disable=function-docstring
 def assert_tar_listing(name, actual, expected):
-    actual_listing = "_{}_listing".format(name)
+    actual_listing = "{}_listing".format(name)
     native.genrule(
         name = actual_listing,
         srcs = actual,


### PR DESCRIPTION
### Changes are visible to end-users: yes/no

See https://bazel.build/extending/macros#naming, these naming conventions are violated by this legacy macro (and thus by a symbolic macro wrapping this legacy macro)

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
