### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Pin to runner releases since our Rust compile is fiddly with system libs
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-13]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
macos-12 is deprecated, last release failed to build.
See https://github.com/aspect-build/rules_py/actions/runs/12833660494