### PR TITLE
docs: fix example of py_image_layer

### DIFF
--- a/docs/py_image_layer.md
+++ b/docs/py_image_layer.md
@@ -22,7 +22,7 @@ py_binary(
 oci_image(
     tars = py_image_layer(
         name = "my_app",
-        py_binary = ":my_app_bin",
+        binary = ":my_app_bin",
         layer_groups = {
             "torch": "pip_deps_torch.*",
             "numpy": "pip_deps_numpy.*",

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -20,7 +20,7 @@ py_binary(
 oci_image(
     tars = py_image_layer(
         name = "my_app",
-        py_binary = ":my_app_bin",
+        binary = ":my_app_bin",
         layer_groups = {
             "torch": "pip_deps_torch.*",
             "numpy": "pip_deps_numpy.*",


### PR DESCRIPTION
It's named `binary` rather than `py_binary`
