### PR TITLE
refactor(ci): re-enable testing against prior release artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,13 +46,20 @@ jobs:
       - uses: actions/checkout@v4
       - run: patch --dry-run -p1 < .bcr/patches/*.patch
 
-  # TODO(alexeagle): re-enable after greening up
-  # test-release:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - working-directory: e2e/use_release
-  #       run: ./minimal_download_test.sh
+  test-release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: e2e/use_release
+    # This test references pre-built artifacts from a prior release.
+    # See py/private/toolchain/tools.bzl where this is referenced from rctx.os.environ.
+    # Will need to bump this version in the future when there are breaking changes.
+    # NB: update tools/integrity.bzl at the same time!
+    env:
+      RULES_PY_RELEASE_VERSION: 1.1.0
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./minimal_download_test.sh
 
   # For branch protection settings, this job provides a "stable" name that can be used to gate PR merges
   # on "all matrix jobs were successful".

--- a/e2e/use_release/MODULE.bazel
+++ b/e2e/use_release/MODULE.bazel
@@ -1,5 +1,4 @@
-bazel_dep(name = "aspect_rules_py", version = "0.7.0")
-
+bazel_dep(name = "aspect_rules_py", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_py",
     path = "../..",

--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -9,10 +9,6 @@ if [ "$ARCH" == "x86_64" ]; then
     ALLOWED="rules_py_tools.${OS}_amd64"
 fi
 
-# This test references pre-built artifacts from a prior release.
-# Will need to bump this version in the future when there are breaking changes.
-export RULES_PY_RELEASE_VERSION=0.7.4
-
 #############
 # Test bzlmod
 (

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -4,14 +4,14 @@ This file contents are entirely replaced during release publishing.
 The checked in content is only here to allow load() statements in the sources to resolve.
 """
 
-# TEST DATA extracted from tools/integrity.bzl file within https://github.com/aspect-build/rules_py/releases/download/v0.7.4/rules_py-v0.7.4.tar.gz
+# TEST DATA extracted from tools/integrity.bzl file within https://github.com/aspect-build/rules_py/releases/download/v1.1.0/rules_py-v1.1.0.tar.gz
 RELEASED_BINARY_INTEGRITY = {
-    "unpack-aarch64-apple-darwin": "791c711bba95829118920553489537d156c320163876f2435e017c07bfcbd30a",
-    "unpack-x86_64-apple-darwin": "2a060c679e376e951877c4179824fa3bb8edd8674b7ec430585a4f83650ad910",
-    "venv-aarch64-apple-darwin": "a355e4338e7c2312d8366386ad981ed6864a65214d38ed6bd756ba19b532aa05",
-    "venv-x86_64-apple-darwin": "af56a742e79d64a30bae422c46a9d6c7edc77df107a8bb96f826967059eff96b",
-    "unpack-aarch64-unknown-linux-gnu": "84a2603b5c521346c22431f73af54c54ebed50ddcb19740fa958c8ad870723dc",
-    "unpack-x86_64-unknown-linux-gnu": "4e21607baa25108b7ca322b57dcf5fd94545e0960e8d7f2b449e84c5e68ec9cc",
-    "venv-aarch64-unknown-linux-gnu": "56be3172bbb95007120a2183dff0dcb204b7e0464bd0197397bb86198bb5d7ba",
-    "venv-x86_64-unknown-linux-gnu": "c09b7f8d0af9cde213f658e9b43444709f687e4d7e1d67941c661525432092a4",
+    "unpack-aarch64-apple-darwin": "e973717a34f3bc19a111d2326ca573bd310660851024217e057d276346fc0f6a",
+    "unpack-x86_64-apple-darwin": "3ebb392cd01b43804bee638b3e12c19d61a07487367e801bc936bd5fd469fc81",
+    "venv-aarch64-apple-darwin": "2f07120fc0a8bbc1ca7ce8b10d5df1b0637c235f66d2f7ad95105ada0792acb1",
+    "venv-x86_64-apple-darwin": "134269ced40240e757e2f6705e546d4f905b6e125fec775afe8bd3bfd8aac495",
+    "unpack-aarch64-unknown-linux-musl": "0f58e2ae3b29a9884f23eb48ded26b3d5aebf2cedb99461a291c9b4f533d2e64",
+    "unpack-x86_64-unknown-linux-musl": "a2bf95fa8ca2401e348f403a1d2dbc435da219fcaa546e0161bb516ac0e7494e",
+    "venv-aarch64-unknown-linux-musl": "5249e68cc18aaa93bf60c74c927a02d55b7f89722adbc0352d5c144f88ee637e",
+    "venv-x86_64-unknown-linux-musl": "ec524c9f9e5cf7f31168a1f74eddd8fa98033ecc229580f69990cd6f65d164dd",
 }


### PR DESCRIPTION
May be useful to assert that coverage support is working, since we have a hard time compiling rust tools under --collect_code_coverage


---

### Changes are visible to end-users: no
