### PR TITLE
chore: gitignore node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 **/*.whl
 .venv/
 
+node_modules/
+
 !third_party/**
 
 # TODO: enable when it is more stable, maybe Bazel 7.1


### PR DESCRIPTION
One of the tools, maybe `prettier` creates a `node_modules` folder locally which should be ignored.

---

### Changes are visible to end-users: no

### Test plan

no testing required