### PR TITLE
fix: fix bcr rust dev patch

### DIFF
--- a/.bcr/patches/rust_dev_dep.patch
+++ b/.bcr/patches/rust_dev_dep.patch
@@ -1,36 +1,36 @@
 diff --git a/MODULE.bazel b/MODULE.bazel
-index 841aed7..e1a1d6d 100644
+index 967dad2..5022390 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -41,13 +41,13 @@ register_toolchains(
+@@ -45,13 +45,13 @@ register_toolchains(
  bazel_dep(
      name = "rules_rust",
      version = "0.53.0",
 -    # In released versions: dev_dependency = True
-+    dev_dependency = True
++    dev_dependency = True,
  )
  
  rust = use_extension(
      "@rules_rust//rust:extensions.bzl",
      "rust",
 -    # In released versions: dev_dependency = True
-+    dev_dependency = True
++    dev_dependency = True,
  )
- 
  rust.toolchain(
-@@ -58,13 +58,13 @@ use_repo(rust, "rust_toolchains")
+     edition = "2021",
+@@ -61,13 +61,13 @@ use_repo(rust, "rust_toolchains")
  
  register_toolchains(
      "@rust_toolchains//:all",
 -    # In released versions: dev_dependency = True
-+    dev_dependency = True
++    dev_dependency = True,
  )
  
  crate = use_extension(
      "@rules_rust//crate_universe:extension.bzl",
      "crate",
 -    # In released versions: dev_dependency = True
-+    dev_dependency = True
++    dev_dependency = True,
  )
- 
  crate.from_cargo(
+     name = "crate_index",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
     # Will need to bump this version in the future when there are breaking changes.
     # NB: update tools/integrity.bzl at the same time!
     env:
-      RULES_PY_RELEASE_VERSION: 1.1.0
+      RULES_PY_RELEASE_VERSION: 1.2.0
     steps:
       - uses: actions/checkout@v4
       - run: ./minimal_download_test.sh

--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -63,5 +63,4 @@ bazel test --test_output=streamed //...
 (
     cd ../..
     rm MODULE.bazel
-    mv MODULE.bazel.orig MODULE.bazel
 )

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -4,14 +4,14 @@ This file contents are entirely replaced during release publishing.
 The checked in content is only here to allow load() statements in the sources to resolve.
 """
 
-# TEST DATA extracted from tools/integrity.bzl file within https://github.com/aspect-build/rules_py/releases/download/v1.1.0/rules_py-v1.1.0.tar.gz
+# TEST DATA extracted from tools/integrity.bzl file within https://github.com/aspect-build/rules_py/releases/download/v1.2.0/rules_py-v1.2.0.tar.gz
 RELEASED_BINARY_INTEGRITY = {
     "unpack-aarch64-apple-darwin": "e973717a34f3bc19a111d2326ca573bd310660851024217e057d276346fc0f6a",
     "unpack-x86_64-apple-darwin": "3ebb392cd01b43804bee638b3e12c19d61a07487367e801bc936bd5fd469fc81",
     "venv-aarch64-apple-darwin": "2f07120fc0a8bbc1ca7ce8b10d5df1b0637c235f66d2f7ad95105ada0792acb1",
     "venv-x86_64-apple-darwin": "134269ced40240e757e2f6705e546d4f905b6e125fec775afe8bd3bfd8aac495",
     "unpack-aarch64-unknown-linux-musl": "0f58e2ae3b29a9884f23eb48ded26b3d5aebf2cedb99461a291c9b4f533d2e64",
-    "unpack-x86_64-unknown-linux-musl": "a2bf95fa8ca2401e348f403a1d2dbc435da219fcaa546e0161bb516ac0e7494e",
+    "unpack-x86_64-unknown-linux-musl": "88623e315e885c1eca10574425448a5b3dc1ca5ac34c8b55f0eb8c7f7fa2dd40 ",
     "venv-aarch64-unknown-linux-musl": "5249e68cc18aaa93bf60c74c927a02d55b7f89722adbc0352d5c144f88ee637e",
     "venv-x86_64-unknown-linux-musl": "ec524c9f9e5cf7f31168a1f74eddd8fa98033ecc229580f69990cd6f65d164dd",
 }

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -11,7 +11,7 @@ RELEASED_BINARY_INTEGRITY = {
     "venv-aarch64-apple-darwin": "2f07120fc0a8bbc1ca7ce8b10d5df1b0637c235f66d2f7ad95105ada0792acb1",
     "venv-x86_64-apple-darwin": "134269ced40240e757e2f6705e546d4f905b6e125fec775afe8bd3bfd8aac495",
     "unpack-aarch64-unknown-linux-musl": "0f58e2ae3b29a9884f23eb48ded26b3d5aebf2cedb99461a291c9b4f533d2e64",
-    "unpack-x86_64-unknown-linux-musl": "88623e315e885c1eca10574425448a5b3dc1ca5ac34c8b55f0eb8c7f7fa2dd40 ",
+    "unpack-x86_64-unknown-linux-musl": "88623e315e885c1eca10574425448a5b3dc1ca5ac34c8b55f0eb8c7f7fa2dd40",
     "venv-aarch64-unknown-linux-musl": "5249e68cc18aaa93bf60c74c927a02d55b7f89722adbc0352d5c144f88ee637e",
     "venv-x86_64-unknown-linux-musl": "ec524c9f9e5cf7f31168a1f74eddd8fa98033ecc229580f69990cd6f65d164dd",
 }


### PR DESCRIPTION
Closes https://github.com/aspect-build/rules_py/issues/506

I think this was introduced by https://github.com/aspect-build/rules_py/pull/480. We should maybe double check the `verify-bcr-patches` job and why this was not found by CI.