### PR TITLE
fix(ci): assert that patches apply exactly

### DIFF
--- a/.bcr/patches/rust_dev_dep.patch
+++ b/.bcr/patches/rust_dev_dep.patch
@@ -1,36 +1,36 @@
 diff --git a/MODULE.bazel b/MODULE.bazel
-index 841aed7..e1a1d6d 100644
+index 967dad2..5022390 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -41,13 +41,13 @@ register_toolchains(
+@@ -45,13 +45,13 @@ register_toolchains(
  bazel_dep(
      name = "rules_rust",
      version = "0.53.0",
 -    # In released versions: dev_dependency = True
-+    dev_dependency = True
++    dev_dependency = True,
  )
  
  rust = use_extension(
      "@rules_rust//rust:extensions.bzl",
      "rust",
 -    # In released versions: dev_dependency = True
-+    dev_dependency = True
++    dev_dependency = True,
  )
- 
  rust.toolchain(
-@@ -58,13 +58,13 @@ use_repo(rust, "rust_toolchains")
+     edition = "2021",
+@@ -61,13 +61,13 @@ use_repo(rust, "rust_toolchains")
  
  register_toolchains(
      "@rust_toolchains//:all",
 -    # In released versions: dev_dependency = True
-+    dev_dependency = True
++    dev_dependency = True,
  )
  
  crate = use_extension(
      "@rules_rust//crate_universe:extension.bzl",
      "crate",
 -    # In released versions: dev_dependency = True
-+    dev_dependency = True
++    dev_dependency = True,
  )
- 
  crate.from_cargo(
+     name = "crate_index",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: patch --dry-run -p1 < .bcr/patches/*.patch
+      - run: patch --dry-run -p1 --fuzz 0 < .bcr/patches/*.patch
 
   test-release:
     runs-on: ubuntu-latest

--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -13,7 +13,8 @@ fi
 # Test bzlmod
 (
     cd ../..
-    patch -p1 < .bcr/patches/*.patch
+    # Create the .orig file, whether there's a mismatch or not
+    patch -p1 --backup < .bcr/patches/*.patch
 )
 OUTPUT_BASE=$(mktemp -d)
 output=$(bazel "--output_base=$OUTPUT_BASE" run --enable_bzlmod //src:main)


### PR DESCRIPTION
From `man patch`

```
     -F max-fuzz, --fuzz max-fuzz
             Sets the maximum fuzz factor.  This option only applies to
             context diffs, and causes patch to ignore up to that many lines
             in looking for places to install a hunk.  Note that a larger fuzz
             factor increases the odds of a faulty patch.  The default fuzz
             factor is 2, and it may not be set to more than the number of
             lines of context in the context diff, ordinarily 3.
```

The hint was in our CI job which passes but prints 

```
Run patch --dry-run -p1 < .bcr/patches/*.patch
checking file MODULE.bazel
Hunk #1 succeeded at 45 with fuzz 2 (offset 4 lines).
Hunk #2 succeeded at 61 with fuzz 2 (offset 3 lines).
```

When Bazel or the Publish to BCR app apply the patches, they don't use the `patch` tool so they don't allow any variation in the patch lines. Our assertion needs to be strict.

Fixes #506 