### PR TITLE
chore(ci): make it 8min faster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,18 +25,17 @@ jobs:
   test:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@646899086d7aaee8e532540480f3e91e00596234 # 11 Dec 2024
     with:
-      folders: '[".", "e2e/smoke", "e2e/repository-rule-deps", "e2e/system-interpreter", "examples/uv_pip_compile"]'
+      # NB: the root folder is tested with Aspect Workflows on BuildKite, see /.aspect/workflows/config.yaml
+      folders: '["e2e/smoke", "e2e/repository-rule-deps", "e2e/system-interpreter", "examples/uv_pip_compile"]'
       # TODO: Build Windows tools and add to toolchain
       # TODO(alex): switch the root folder to bzlmod
       # TODO: fix remaining folders on Bazel 8
       exclude: |
         [
           {"os": "windows-latest"},
-          {"folder": ".", "bzlmodEnabled": true},
           {"folder": "e2e/repository-rule-deps", "bzlmodEnabled": false},
           {"folder": "e2e/system-interpreter", "bzlmodEnabled": false},
           {"folder": "examples/uv_pip_compile", "bzlmodEnabled": false},
-          {"folder": ".", "bazelversion": "8.0.0"},
           {"folder": "e2e/smoke", "bazelversion": "8.0.0"}
         ]
 


### PR DESCRIPTION
The GHA job for the root folder is taking 12min while all the rest are 4min. We setup Aspect Workflows recently which gives us test coverage.

Note, we'll have to adjust the branch protection to gate PRs on AW passing
