### PR TITLE
Only remove the venv_root directory if it has contents

### DIFF
--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -21,7 +21,7 @@ pub fn create_venv(
         // With readOnlyRootFilesystem (k8s), we mount a writable volume here with an empty directory.
         // In that case, we cannot delete that directory.
         let is_empty = location.read_dir()?.next().is_none();
-        if is_empty.not() {
+        if !is_empty {
             // Clear down the an old venv if there is one present.
             fs::remove_dir_all(location)
                 .into_diagnostic()

--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -26,7 +26,7 @@ pub fn create_venv(
             fs::remove_dir_all(location)
                 .into_diagnostic()
                 .wrap_err("Unable to remove venv_root directory")?;
-            }
+        }
     }
 
     // Create all the dirs down to the venv base

--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -18,10 +18,15 @@ pub fn create_venv(
     venv_name: &str,
 ) -> miette::Result<()> {
     if location.exists() {
-        // Clear down the an old venv if there is one present.
-        fs::remove_dir_all(location)
-            .into_diagnostic()
-            .wrap_err("Unable to remove venv_root directory")?;
+        // With readOnlyRootFilesystem (k8s), we mount a writable volume here with an empty directory.
+        // In that case, we cannot delete that directory.
+        let is_empty = location.read_dir()?.next().is_none();
+        if is_empty.not() {
+            // Clear down the an old venv if there is one present.
+            fs::remove_dir_all(location)
+                .into_diagnostic()
+                .wrap_err("Unable to remove venv_root directory")?;
+            }
     }
 
     // Create all the dirs down to the venv base


### PR DESCRIPTION
When a k8s pod is configured with readOnlyRootFilesystem, we hit the following error:
```
Unable to create base venv directory
Read-only file system.
```

We then mounted a volume under the path where the venv directory was being created. We then hit:
```
Unable to remove venv_root directory
Read-only file system.
```

I think this should solve the issue. Basically, only try to delete the existing venv directory if it is non-empty. In our case, it is empty (when we are mounting an empty directory as a volume).

However, I'm not totally sure how I can actually test this in our environment without a release. I tried adding a patch for `py/tools/py/src/venv.rs` but that didn't work because I guess this actually gets bundled as a binary as part of the release. Do you have any hints for us to test this change? 


<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
