### PR TITLE
fix(coverage): produce combined coverage report

### DIFF
--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -175,6 +175,13 @@ A collision can occur when multiple packages providing the same file are install
     "_allowlist_function_transition": attr.label(
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
     ),
+    # Magic attribute to make coverage work. There's no
+    # docs about this; see TestActionBuilder.java
+    "_lcov_merger": attr.label(
+        default = configuration_field(fragment = "coverage", name = "output_generator"),
+        executable = True,
+        cfg = "exec",
+    ),
 })
 
 _attrs.update(**_py_library.attrs)


### PR DESCRIPTION
Bazel is not producing combined coverage report for targets that don't define the `_lcov_merger` attribute, the `collect_coverage.sh` script just exits silently in this case: https://github.com/bazelbuild/bazel/blob/fde4b67009d377a3543a3dc8481147307bd37d36/tools/test/collect_coverage.sh#L186-L194

 Since `rules_python` defines this attribute both for `py_binary` and `py_test`, we're mirroring this behavior by modifying `py_base.attrs`.

Tested by applying the patch and verifying that `bazel-out/_coverage/_coverage_report.dat` is not empty after running `bazel coverage --combined_report=lcov [target]`.