### PR TITLE
chore(release): upgrade Ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Pin to runner releases since our Rust compile is fiddly with system libs
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
GitHub will force us soon:

The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:


March 4 14:00 UTC – 22:00 UTC
March 11 13:00 UTC – 21:00 UTC
March 18 13:00 UTC – 21:00 UTC
March 25 13:00 UTC – 21:00 UTC


Note, the only way I know to test this is to land it and 🤞🏻 a release
