### PR TITLE
Add data to py_venv rule

### DIFF
--- a/docs/venv.md
+++ b/docs/venv.md
@@ -14,7 +14,7 @@ Using `py_venv` directly is only required for cases where those defaults do not 
 ## py_venv_rule
 
 <pre>
-py_venv_rule(<a href="#py_venv_rule-name">name</a>, <a href="#py_venv_rule-deps">deps</a>, <a href="#py_venv_rule-imports">imports</a>, <a href="#py_venv_rule-location">location</a>, <a href="#py_venv_rule-package_collisions">package_collisions</a>, <a href="#py_venv_rule-resolutions">resolutions</a>, <a href="#py_venv_rule-venv_name">venv_name</a>)
+py_venv_rule(<a href="#py_venv_rule-name">name</a>, <a href="#py_venv_rule-data">data</a>, <a href="#py_venv_rule-deps">deps</a>, <a href="#py_venv_rule-imports">imports</a>, <a href="#py_venv_rule-location">location</a>, <a href="#py_venv_rule-package_collisions">package_collisions</a>, <a href="#py_venv_rule-resolutions">resolutions</a>, <a href="#py_venv_rule-venv_name">venv_name</a>)
 </pre>
 
 Create a Python virtual environment with the dependencies listed.
@@ -25,6 +25,7 @@ Create a Python virtual environment with the dependencies listed.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="py_venv_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_venv_rule-data"></a>data |  Runtime dependencies of the program.<br><br>        The transitive closure of the <code>data</code> dependencies will be available in the <code>.runfiles</code>         folder for this binary/test. The program may optionally use the Runfiles lookup library to         locate the data files, see https://pypi.org/project/bazel-runfiles/.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="py_venv_rule-deps"></a>deps |  Targets that produce Python code, commonly <code>py_library</code> rules.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="py_venv_rule-imports"></a>imports |  List of import directories to be added to the PYTHONPATH.   | List of strings | optional | <code>[]</code> |
 | <a id="py_venv_rule-location"></a>location |  Path from the workspace root for where to root the virtial environment   | String | optional | <code>""</code> |

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -59,7 +59,7 @@ py_image_layer = _py_image_layer
 
 resolutions = _resolutions
 
-def _py_binary_or_test(name, rule, srcs, main, deps = [], resolutions = {}, **kwargs):
+def _py_binary_or_test(name, rule, srcs, main, data = [], deps = [], resolutions = {}, **kwargs):
     # Compatibility with rules_python, see docs in py_executable.bzl
     main_target = "{}.find_main".format(name)
     determine_main(
@@ -76,6 +76,7 @@ def _py_binary_or_test(name, rule, srcs, main, deps = [], resolutions = {}, **kw
         name = name,
         srcs = srcs,
         main = main_target,
+        data = data,
         deps = deps,
         resolutions = resolutions,
         package_collisions = package_collisions,
@@ -84,6 +85,7 @@ def _py_binary_or_test(name, rule, srcs, main, deps = [], resolutions = {}, **kw
 
     _py_venv(
         name = "{}.venv".format(name),
+        data = data,
         deps = deps,
         imports = kwargs.get("imports"),
         resolutions = resolutions,

--- a/py/private/py_venv.bzl
+++ b/py/private/py_venv.bzl
@@ -97,6 +97,15 @@ py_venv_rule = rule(
             allow_files = True,
             providers = [[PyInfo], [PyVirtualInfo]],
         ),
+        "data": attr.label_list(
+            doc = """Runtime dependencies of the program.
+
+        The transitive closure of the `data` dependencies will be available in the `.runfiles`
+        folder for this binary/test. The program may optionally use the Runfiles lookup library to
+        locate the data files, see https://pypi.org/project/bazel-runfiles/.
+        """,
+            allow_files = True,
+        ),
         "imports": attr.string_list(
             doc = "List of import directories to be added to the PYTHONPATH.",
             default = [],


### PR DESCRIPTION
If your venv requires runtime dependencies in the build, these
previously weren't built
