### PR TITLE
Fix bash runfiles with rules_shell

### DIFF
--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -97,8 +97,9 @@ def _py_binary_rule_impl(ctx):
         ] + virtual_resolution.srcs + virtual_resolution.runfiles,
         extra_runfiles = [
             site_packages_pth_file,
-        ] + ctx.files._runfiles_lib,
+        ],
         extra_runfiles_depsets = [
+            ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
             venv_toolchain.default_info.default_runfiles,
         ],
     )

--- a/py/private/py_venv.bzl
+++ b/py/private/py_venv.bzl
@@ -71,8 +71,9 @@ def _py_venv_rule_imp(ctx):
         ] + virtual_resolution.srcs + virtual_resolution.runfiles,
         extra_runfiles = [
             site_packages_pth_file,
-        ] + ctx.files._runfiles_lib,
+        ],
         extra_runfiles_depsets = [
+            ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
             venv_toolchain.default_info.default_runfiles,
         ],
     )


### PR DESCRIPTION
Bazel @ HEAD moved the bash runfiles to rules_shell. In this case
accessing just the single file was no longer valid.
