### PR TITLE
fix `java.io.IOException: ... Argument list too long` during pex generation.

### DIFF
--- a/py/private/py_pex_binary.bzl
+++ b/py/private/py_pex_binary.bzl
@@ -113,10 +113,18 @@ def _py_python_pex_impl(ctx):
     )
     args.add(output, format = "--output-file=%s")
 
+    # The argument list can become quite long which can throw java.io.IOException Argument list too long.
+    # Instead write the args to a file and read that file at runtime
+    args_file = ctx.actions.declare_file("args.txt")
+    ctx.actions.write(
+        output = args_file,
+        content = args,
+    )
+
     ctx.actions.run(
         executable = ctx.executable._pex,
-        inputs = runfiles.files,
-        arguments = [args],
+        inputs = runfiles.files.to_list() + [args_file],
+        arguments = [args_file.path],
         outputs = [output],
         mnemonic = "PyPex",
         progress_message = "Building PEX binary %{label}",

--- a/py/tools/pex/main.py
+++ b/py/tools/pex/main.py
@@ -107,7 +107,10 @@ parser.add_argument(
     action="append",
 )
 
-options = parser.parse_args(args = sys.argv[1:])
+options = None
+with open(sys.argv[1], "r") as args_file:
+    args = [arg[1:-1] for arg in args_file.read().splitlines()]
+    options = parser.parse_args(args)
 
 # Monkey patch bootstrap template to inject some templated environment variables.
 # Unfortunately we can't use `preamble` feature because it runs before any initialization code.


### PR DESCRIPTION
In certain circumstance, a large number of `--source` args are passed to the `_pex` script which causes an IOException to be thrown by bazel. This refactors the rule to write the args to a file and pass that single path as an arg to the `_pex` script. The script then opens that file and feeds it into the arg parser instead.

fixes #542

---

### Test plan

- Covered by existing test cases - `py/tests/py-pex-binary`
- I also tested it with my project that I originally found the bug in.  
