### PR TITLE
Add an owner arg to py_image_layer

### DIFF
--- a/docs/py_image_layer.md
+++ b/docs/py_image_layer.md
@@ -38,7 +38,7 @@ oci_image(
 
 <pre>
 py_image_layer(<a href="#py_image_layer-name">name</a>, <a href="#py_image_layer-binary">binary</a>, <a href="#py_image_layer-root">root</a>, <a href="#py_image_layer-layer_groups">layer_groups</a>, <a href="#py_image_layer-compress">compress</a>, <a href="#py_image_layer-tar_args">tar_args</a>, <a href="#py_image_layer-compute_unused_inputs">compute_unused_inputs</a>,
-               <a href="#py_image_layer-platform">platform</a>, <a href="#py_image_layer-kwargs">kwargs</a>)
+               <a href="#py_image_layer-platform">platform</a>, <a href="#py_image_layer-owner">owner</a>, <a href="#py_image_layer-kwargs">kwargs</a>)
 </pre>
 
 Produce a separate tar output for each layer of a python app
@@ -75,6 +75,7 @@ The default layer groups are:
 | <a id="py_image_layer-tar_args"></a>tar_args |  Additional arguments to pass to the tar rule. Default is <code>[]</code>. See: https://github.com/bazel-contrib/bazel-lib/blob/main/docs/tar.md#tar_rule-args   |  <code>[]</code> |
 | <a id="py_image_layer-compute_unused_inputs"></a>compute_unused_inputs |  Whether to compute unused inputs. Default is 1. See: https://github.com/bazel-contrib/bazel-lib/blob/main/docs/tar.md#tar_rule-compute_unused_inputs   |  <code>1</code> |
 | <a id="py_image_layer-platform"></a>platform |  The platform to use for the transition. Default is None. See: https://github.com/bazel-contrib/bazel-lib/blob/main/docs/transitions.md#platform_transition_binary-target_platform   |  <code>None</code> |
+| <a id="py_image_layer-owner"></a>owner |  An owner uid for the uncompressed files. See mtree_mutate: https://github.com/bazel-contrib/bazel-lib/blob/main/docs/tar.md#mutating-the-tar-contents   |  <code>None</code> |
 | <a id="py_image_layer-kwargs"></a>kwargs |  attribute that apply to all targets expanded by the macro   |  none |
 
 **RETURNS**

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -30,7 +30,7 @@ oci_image(
 ```
 """
 
-load("@aspect_bazel_lib//lib:tar.bzl", "mtree_spec", "tar", "mtree_mutate")
+load("@aspect_bazel_lib//lib:tar.bzl", "mtree_mutate", "mtree_spec", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 
 default_layer_groups = {
@@ -91,17 +91,16 @@ awk < $< 'BEGIN {
     )
 
 def py_image_layer(
-    name,
-    binary,
-    root = "/",
-    layer_groups = {},
-    compress = "gzip",
-    tar_args = [],
-    compute_unused_inputs = 1,
-    platform = None,
-    owner = None,
-    **kwargs
-    ):
+        name,
+        binary,
+        root = "/",
+        layer_groups = {},
+        compress = "gzip",
+        tar_args = [],
+        compute_unused_inputs = 1,
+        platform = None,
+        owner = None,
+        **kwargs):
     """Produce a separate tar output for each layer of a python app
 
     > Requires `awk` to be installed on the host machine/rbe runner.

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -141,22 +141,23 @@ def py_image_layer(
 
     # Produce the manifest for a tar file of our py_binary, but don't tar it up yet, so we can split
     # into fine-grained layers for better pull, push and remote cache performance.
-    mtree_spec(
-        name = name + ".manifest.preprocessed",
-        srcs = [binary],
-        **kwargs
-    )
-
+    manifest_name = name + ".manifest"
     if owner:
+        mtree_spec(
+            name = manifest_name + ".preprocessed",
+            srcs = [binary],
+            **kwargs
+        )
         mtree_mutate(
-            name = name + ".manifest",
+            name = manifest_name,
             mtree = name + ".manifest.preprocessed",
             owner = owner,
         )
     else:
-        native.alias(
-            name = name + ".manifest",
-            actual = name + ".manifest.preprocessed",
+        mtree_spec(
+            name = manifest_name,
+            srcs = [binary],
+            **kwargs
         )
 
     groups = dict(**layer_groups)


### PR DESCRIPTION
I needed to be able to change the owner of some files in the final oci image. `mtree_mutate` seemed the right way to do it, but I couldn't control the mtree while using `py_image_layer` , so this adds an `owner` option to handle the `mtree_mutate`

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

<!-- Delete any which do not apply -->

I tested by adding an `owner` attribute to an image I was generating.
I did not update any tests, but if this change is approved, I can go back and add if we think its necessary.
