### PR TITLE
Add CcInfo to allowed providers of py_library deps.

### DIFF
--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -205,7 +205,7 @@ _attrs = dict({
     ),
     "deps": attr.label_list(
         doc = "Targets that produce Python code, commonly `py_library` rules.",
-        providers = [[PyInfo], [PyVirtualInfo]],
+        providers = [[PyInfo], [PyVirtualInfo], [CcInfo]],
     ),
     "data": attr.label_list(
         doc = """Runtime dependencies of the program.

--- a/py/tests/cc-deps/BUILD.bazel
+++ b/py/tests/cc-deps/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//py:defs.bzl", "py_test")
+
+# Test that cc targets can be used as deps for py targets.
+# We only add a very simple test to not pull in all the deps
+# to build proper py-bindings.
+cc_library(
+    name = "example_library",
+    srcs = ["example_library.cpp"],
+)
+
+py_test(
+    name = "test_smoke",
+    srcs = ["test_smoke.py"],
+    deps = [":example_library"],
+)

--- a/py/tests/cc-deps/example_library.cpp
+++ b/py/tests/cc-deps/example_library.cpp
@@ -1,0 +1,3 @@
+
+int add(int i, int j) { return i + j; }
+

--- a/py/tests/cc-deps/test_smoke.py
+++ b/py/tests/cc-deps/test_smoke.py
@@ -1,0 +1,5 @@
+def main():
+    print("Running successfully!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi Aspect Team

This PR enables better compatibility with pybind11_bazel and makes the aspect py rules more of a drop-in replacement of the official rules_python. Please let me know if you are open to this contribution, then I can also add tests for it.

More specifically: This change is useful when using a
[pybind_extension](https://github.com/pybind/pybind11_bazel/blob/2b6082a4d9d163a52299718113fa41e4b7978db5/build_defs.bzl#L28) in the `deps` of a `py_libary` as the `pybind_extension` is just a `cc_binary` under the hood. This PR enables using it like so:
```py
load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
load("@aspect_rules_python//python:defs.bzl", aspect_py_library="py_library")


pybind_extension(
    name = "my_pybind_extension",
    srcs = ["my_binding.cpp"],
)

aspect_py_library(
    name = "my_python_library",
    srcs = [":my_python_library.py"],
    deps = [":my_pybind_extension"],
)
```

The `py_libary` from the official `rules_python` also already supports using `CcInfo` providers in the `deps` attribute.

Without this change a workaround is to wrap the `pybind_extension` in a `py_library` from the official `rules_python`:
```py
load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
load("@rules_python//python:defs.bzl", official_py_library="py_library")
load("@aspect_rules_python//python:defs.bzl", aspect_py_library="py_library")


pybind_extension(
    name = "my_pybind_extension",
    srcs = ["my_binding.cpp"],
)

official_py_library(
    name = "my_pybind_extension_wrapper",
    srcs = [],
    deps = [":my_pybind_extension"],
)

aspect_py_library(
    name = "my_python_library",
    srcs = [":my_python_library.py"],
    deps = [":my_pybind_extension_wrapper"],
)
```

---

### Changes are visible to end-users: no

### Test plan

TODO
