### PR TITLE
chore: switch to upstream release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+# Publish new releases to Bazel Central Registry.
+name: Publish
+on:
+  # Run the publish workflow after a successful release
+  # Will be triggered from the release.yaml workflow
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: true
+  # In case of problems, let release engineers retry by manually dispatching
+  # the workflow from the GitHub UI
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.4
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
+      registry_fork: aspect-build/bazel-central-registry
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      # Necessary to push to the BCR fork, and to open a pull request against a registry
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,13 @@
 name: Release
 
 on:
-  workflow_dispatch: # allow trigger through Web UI
   push:
     tags:
       - "v*.*.*"
-
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
 jobs:
   build:
     # We don't attempt to cross-compile rust binaries from one OS to another.
@@ -40,26 +42,17 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # Fetch the built artifacts from build jobs above and extract into
-      # ${GITHUB_WORKSPACE}/artifacts-macos-latest/*
-      # ${GITHUB_WORKSPACE}/artifacts-ubuntu-latest/*
-      - uses: actions/download-artifact@v4
-
-      - name: Prepare release
-        run: .github/workflows/release_prep.sh > release_notes.txt
-
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          prerelease: false
-          # Use GH feature to populate the changelog automatically
-          generate_release_notes: true
-          body_path: release_notes.txt
-          files: |
-            artifacts-*/*
-            rules_py-*.tar.gz
-          fail_on_unmatched_files: true
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
+    with:
+      prerelease: false
+      release_files: |
+        artifacts-*/*
+        rules_py-*.tar.gz
+      tag_name: ${{ github.ref_name }}
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
This includes provenance attestations for our rust binaries and the release artifact

Note, I've already disabled the Publish to BCR GH App for this repo, and added the BCR_PUBLISH_TOKEN as an org-wide secret
