### PR TITLE
fix(shim): Apply path canonicalization

### DIFF
--- a/e2e/use_release/minimal_download_test.sh
+++ b/e2e/use_release/minimal_download_test.sh
@@ -66,3 +66,14 @@ bazel test --test_output=streamed //...
     rm MODULE.bazel
     mv MODULE.bazel.orig MODULE.bazel
 )
+
+#############
+# Smoke test py_venv examples
+(
+  cd ../..
+  bazel run //examples/py_venv:venv -- -c 'print("Hello, world")'
+  bazel run //examples/py_venv:internal_venv
+  bazel run --stamp //examples/py_venv:internal_venv
+  bazel run //examples/py_venv:external_venv
+  bazel run --stamp //examples/py_venv:external_venv
+)

--- a/py/tests/py_venv_image_layer/my_app_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_layers_listing.yaml
@@ -2511,9 +2511,9 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
   - -rwxr-xr-x  0 0      0        1918 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
-  - -rwxr-xr-x  0 0      0     5183072 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
-  - -rwxr-xr-x  0 0      0     5183072 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
-  - -rwxr-xr-x  0 0      0     5183072 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
+  - -rwxr-xr-x  0 0      0     5118056 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
+  - -rwxr-xr-x  0 0      0     5118056 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
+  - -rwxr-xr-x  0 0      0     5118056 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
   - -rwxr-xr-x  0 0      0         323 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg

--- a/py/tests/py_venv_image_layer/my_app_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_layers_listing.yaml
@@ -2511,9 +2511,9 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
   - -rwxr-xr-x  0 0      0        1918 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
-  - -rwxr-xr-x  0 0      0     5118056 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
-  - -rwxr-xr-x  0 0      0     5118056 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
-  - -rwxr-xr-x  0 0      0     5118056 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
+  - -rwxr-xr-x  0 0      0     5118072 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
+  - -rwxr-xr-x  0 0      0     5118072 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
+  - -rwxr-xr-x  0 0      0     5118072 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
   - -rwxr-xr-x  0 0      0         323 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg

--- a/py/tools/venv_shim/BUILD.bazel
+++ b/py/tools/venv_shim/BUILD.bazel
@@ -1,10 +1,30 @@
 load("//tools/release:defs.bzl", "rust_binary")
 
+config_setting(
+    name = "debug_build",
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
+
 rust_binary(
     name = "shim",
     srcs = [
         "src/main.rs",
     ],
+    crate_features = select({
+        ":debug_build": [
+            "debug",
+        ],
+        "//conditions:default": [],
+    }),
+    rustc_flags = select({
+        ":debug_build": [],
+        "//conditions:default": [
+            "-C",
+            "opt-level=3",
+        ],
+    }),
     deps = [
         "@crate_index//:miette",
     ],

--- a/py/tools/venv_shim/src/main.rs
+++ b/py/tools/venv_shim/src/main.rs
@@ -64,7 +64,7 @@ fn find_python_executables(version_from_cfg: &str, exclude_dir: &Path) -> Option
                 None
             }
         })
-        .filter_map(|path| match path.canonicalize() {
+        .filter_map(|path| path.canonicalize().ok()
             Ok(p) => Some(p),
             _ => None,
         })

--- a/py/tools/venv_shim/src/main.rs
+++ b/py/tools/venv_shim/src/main.rs
@@ -1,4 +1,4 @@
-use miette::miette;
+use miette::{miette, Context, IntoDiagnostic};
 use std::env;
 use std::fs;
 use std::io::{self, BufRead};
@@ -86,119 +86,111 @@ fn main() -> miette::Result<()> {
     #[cfg(feature = "debug")]
     eprintln!("[aspect] Current executable path: {:?}", current_exe);
 
-    let pyvenv_cfg_path = match find_pyvenv_cfg(&current_exe) {
-        Some(path) => {
-            #[cfg(feature = "debug")]
-            eprintln!("[aspect] Found pyvenv.cfg at: {:?}", path);
-            path
-        }
-        None => {
-            return Err(miette!("pyvenv.cfg not found one directory level up."));
-        }
+    let Some(pyvenv_cfg_path) = find_pyvenv_cfg(&current_exe) else {
+        return Err(miette!("pyvenv.cfg not found one directory level up."));
+    };
+    #[cfg(feature = "debug")]
+    eprintln!("[aspect] Found pyvenv.cfg at: {:?}", &pyvenv_cfg_path);
+
+    let version_info_result = extract_pyvenv_version_info(&pyvenv_cfg_path)
+        .into_diagnostic()
+        .wrap_err(format!(
+            "Failed to parse pyvenv.cfg {}",
+            &pyvenv_cfg_path.to_str().unwrap(),
+        ))
+        .unwrap();
+
+    let Some(version_info) = version_info_result else {
+        return Err(miette!("version_info key not found in pyvenv.cfg."));
     };
 
-    let version_info_result = extract_pyvenv_version_info(&pyvenv_cfg_path).unwrap();
-    let version_info = match version_info_result {
-        Some(v) => {
-            #[cfg(feature = "debug")]
-            eprintln!("[aspect] version_info from pyvenv.cfg: {}", v);
-            v
-        }
-        None => {
-            return Err(miette!("version_info key not found in pyvenv.cfg."));
-        }
+    #[cfg(feature = "debug")]
+    eprintln!("[aspect] version_info from pyvenv.cfg: {}", &version_info);
+
+    let Some(target_python_version) = parse_version_info(&version_info) else {
+        return Err(miette!("Could not parse version_info as x.y."));
     };
 
-    let target_python_version = match parse_version_info(&version_info) {
-        Some(v) => {
-            #[cfg(feature = "debug")]
-            eprintln!("[aspect] Parsed target Python version (major.minor): {}", v);
-            v
-        }
-        None => {
-            return Err(miette!("Could not parse version_info as x.y."));
-        }
-    };
+    #[cfg(feature = "debug")]
+    eprintln!(
+        "[aspect] Parsed target Python version (major.minor): {}",
+        &target_python_version
+    );
 
     let exclude_dir = current_exe.parent().unwrap().canonicalize().unwrap();
 
     #[cfg(feature = "debug")]
-    eprintln!("[aspect] Ignoring dir {:?}", exclude_dir);
+    eprintln!("[aspect] Ignoring dir {:?}", &exclude_dir);
 
-    if let Some(python_executables) = find_python_executables(&target_python_version, &exclude_dir)
-    {
-        #[cfg(feature = "debug")]
-        {
-            eprintln!(
-                "[aspect] Found potential Python interpreters in PATH with matching version:"
-            );
-            for exe in &python_executables {
-                println!("[aspect] - {:?}", exe);
-            }
-        }
-
-        // Attempt to break infinite recursion through this shim by counting up
-        // the number of times we've come back to this shim and incrementing it
-        // until we hit something on the path that DOESN'T come back here, or we
-        // run out of path entries.
-        let index: usize = {
-            match env::var(COUNTER_VAR) {
-                // Whatever the previous value was didn't work because we're
-                // back here, so increment.
-                Ok(it) => it.parse::<usize>().unwrap() + 1,
-                _ => 0,
-            }
-        };
-
-        let interpreter_path = match python_executables.get(index) {
-            Some(it) => it,
-            None => {
-                return Err(miette!(
-                    "Unable to find another interpreter at index {}",
-                    index
-                ))
-            }
-        };
-
-        let exe_path = current_exe.to_string_lossy().into_owned();
-        let exec_args = &args[1..];
-
-        #[cfg(feature = "debug")]
-        eprintln!(
-            "[aspect] Attempting to execute: {:?} with argv[0] as {:?} and args as {:?}",
-            interpreter_path, exe_path, exec_args,
-        );
-
-        let mut cmd = Command::new(interpreter_path);
-        cmd.args(exec_args);
-
-        // Lie about the value of argv0 to hoodwink the interpreter as to its
-        // location on Linux-based platforms.
-        if cfg!(target_os = "linux") {
-            cmd.arg0(&exe_path);
-        }
-
-        // On MacOS however, there are facilities for asking the C runtime/OS
-        // what the real name of the interpreter executable is, and that value
-        // is preferred while argv[0] is ignored. So we need to use a different
-        // mechanism to lie to the target interpreter about its own path.
-        //
-        // https://github.com/python/cpython/blob/68e72cf3a80362d0a2d57ff0c9f02553c378e537/Modules/getpath.c#L778
-        // https://docs.python.org/3/using/cmdline.html#envvar-PYTHONEXECUTABLE
-        if cfg!(target_os = "macos") {
-            cmd.env("PYTHONEXECUTABLE", exe_path);
-        }
-
-        // Re-export the counter so it'll go up
-        cmd.env(COUNTER_VAR, index.to_string());
-
-        let _ = cmd.exec();
-
-        return Ok(());
-    } else {
+    let Some(python_executables) = find_python_executables(&target_python_version, &exclude_dir)
+    else {
         return Err(miette!(
             "No suitable Python interpreter found in PATH matching version '{}'.",
             &version_info,
         ));
+    };
+
+    #[cfg(feature = "debug")]
+    {
+        eprintln!("[aspect] Found potential Python interpreters in PATH with matching version:");
+        for exe in &python_executables {
+            println!("[aspect] - {:?}", exe);
+        }
     }
+
+    // Attempt to break infinite recursion through this shim by counting up
+    // the number of times we've come back to this shim and incrementing it
+    // until we hit something on the path that DOESN'T come back here, or we
+    // run out of path entries.
+    let index: usize = {
+        match env::var(COUNTER_VAR) {
+            // Whatever the previous value was didn't work because we're
+            // back here, so increment.
+            Ok(it) => it.parse::<usize>().unwrap() + 1,
+            _ => 0,
+        }
+    };
+
+    let Some(interpreter_path) = python_executables.get(index) else {
+        return Err(miette!(
+            "Unable to find another interpreter at index {}",
+            index
+        ));
+    };
+
+    let exe_path = current_exe.to_string_lossy().into_owned();
+    let exec_args = &args[1..];
+
+    #[cfg(feature = "debug")]
+    eprintln!(
+        "[aspect] Attempting to execute: {:?} with argv[0] as {:?} and args as {:?}",
+        interpreter_path, exe_path, exec_args,
+    );
+
+    let mut cmd = Command::new(&interpreter_path);
+    cmd.args(exec_args);
+
+    // Lie about the value of argv0 to hoodwink the interpreter as to its
+    // location on Linux-based platforms.
+    if cfg!(target_os = "linux") {
+        cmd.arg0(&exe_path);
+    }
+
+    // On MacOS however, there are facilities for asking the C runtime/OS
+    // what the real name of the interpreter executable is, and that value
+    // is preferred while argv[0] is ignored. So we need to use a different
+    // mechanism to lie to the target interpreter about its own path.
+    //
+    // https://github.com/python/cpython/blob/68e72cf3a80362d0a2d57ff0c9f02553c378e537/Modules/getpath.c#L778
+    // https://docs.python.org/3/using/cmdline.html#envvar-PYTHONEXECUTABLE
+    if cfg!(target_os = "macos") {
+        cmd.env("PYTHONEXECUTABLE", &exe_path);
+    }
+
+    // Re-export the counter so it'll go up
+    cmd.env(COUNTER_VAR, index.to_string());
+
+    let _ = cmd.exec();
+
+    return Ok(());
 }

--- a/py/tools/venv_shim/src/main.rs
+++ b/py/tools/venv_shim/src/main.rs
@@ -64,10 +64,7 @@ fn find_python_executables(version_from_cfg: &str, exclude_dir: &Path) -> Option
                 None
             }
         })
-        .filter_map(|path| path.canonicalize().ok()
-            Ok(p) => Some(p),
-            _ => None,
-        })
+        .filter_map(|path| path.canonicalize().ok())
         .filter(|potential_executable| potential_executable.parent() != Some(exclude_dir))
         .filter(|potential_executable| compare_versions(version_from_cfg, &potential_executable))
         .collect();


### PR DESCRIPTION
Fixes a user-visible bug present in v1.5.0 which could cause the Python shim to skip over viable interpreters and fail to resolve an appropriate one.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes/no

### Details
The Python interpreter shim exists to inspect the `pyvenv.cfg` sentinel file which defines a virtualenv, extract the interpreter version for the virtualenv and then traverse the `$PATH` attempting to identify a viable interpreter of the required version which it will chainload.

As a reminder a venv will look something like

```
|-- .venv
|   |-- bin
|   |   |-- activate
|   |   |-- pip
|   |   |-- pip3
|   |   |-- pip3.12
|   |   |-- python <- our shim
|   |   |-- python3 -> python
|   |   `-- python3.12 -> python
|   |-- include
|   |   `-- python3.12
|   |-- lib
|   |   `-- python3.12
|   |       `-- site-packages
|   |           |-- pip
|   |           `-- pip-24.0.dist-info
|   |-- lib64 -> lib
|   `-- pyvenv.cfg
`-- src
    `-- app
        `-- __main__.py
```

The trick is that since the interpreter shim is emplaced in the venv as `bin/python` and symlinked to by the other versioned Python files we can't simply `exec python${VERSION}` since when the venv is activated and `$VIRTUAL_ENV/bin` is prepended to the `$PATH` that would cause an infinite self-loop.

Enabling the `debug` config on the shim crate and running the internal_venv example @ v1.5.0 produces the following (simplified) output

```shellsession
$ bazel run //examples/py_venv:internal_venv
INFO: Analyzed target //examples/py_venv:internal_venv (457 packages loaded, 56604 targets configured).
INFO: Found 1 target...
Target //examples/py_venv:internal_venv up-to-date:
  bazel-bin/examples/py_venv/internal_venv
INFO: Elapsed time: 15.549s, Critical Path: 4.20s
INFO: 4 processes: 2 internal, 2 darwin-sandbox.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-bin/examples/py_venv/internal_venv

# First attempt
[aspect] Current executable path: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/python"
[aspect] Found pyvenv.cfg at: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/pyvenv.cfg"
[aspect] version_info from pyvenv.cfg: 3.9.0
[aspect] Parsed target Python version (major.minor): 3.9
[aspect] Found potential Python interpreters in PATH with matching version:
[aspect] - "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/bin/python3.9"
[aspect] - "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/python_toolchain_aarch64-apple-darwin/bin/python3.9"
[aspect] - "${HOME}/.local/pyenv/shims/python3.9"
[aspect] Attempting to execute: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/bin/python3.9" with argv[0] as "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/python" and args as ["-B", "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/say.py"]

# Second attempt
[aspect] Current executable path: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/bin/python3.9"
[aspect] Found pyvenv.cfg at: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/pyvenv.cfg"
[aspect] version_info from pyvenv.cfg: 3.9.0
[aspect] Parsed target Python version (major.minor): 3.9
[aspect] Found potential Python interpreters in PATH with matching version:
[aspect] - "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/python_toolchain_aarch64-apple-darwin/bin/python3.9"
[aspect] - "${HOME}/.local/pyenv/shims/python3.9"
[aspect] Attempting to execute: "${HOME}/.local/pyenv/shims/python3.9" with argv[0] as "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/bin/python3.9" and args as ["-B", "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/say.py"]

# Third attempt
[aspect] Current executable path: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/bin/python3.9"
[aspect] Found pyvenv.cfg at: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/pyvenv.cfg"
[aspect] version_info from pyvenv.cfg: 3.9.0
[aspect] Parsed target Python version (major.minor): 3.9
[aspect] Found potential Python interpreters in PATH with matching version:
[aspect] - "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/python_toolchain_aarch64-apple-darwin/bin/python3.9"
[aspect] - "${HOME}/.local/pyenv/shims/python3.9"
Error:   × Unable to find another interpreter at index 2
```

The key detail of which is

```
# First attempt
[aspect] Found pyvenv.cfg at: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/pyvenv.cfg"
# Second attempt
[aspect] Found pyvenv.cfg at: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/pyvenv.cfg"
# Third attempt
[aspect] Found pyvenv.cfg at: "${EXECROOT}/aspect_rules_py/bazel-out/fastbuild/bin/examples/py_venv/.internal_venv/pyvenv.cfg"
```

What's happening here is that under `bazel run` the first `exec()` invocation is of the interpreter as it exists in a `.runfiles` tree under `bazel-out`. However that runfiles tree consists of symlinks to actual outputs elsewhere, so the observed path of the `pyvenv.cfg` (which is _not_ canonicalized and is located relative to the nominal interpreter path) appears to change between attempts going from the non-canonicalized `.runfiles/` entry to the "actual" build output dir.

This causes the second attempt to change its filtering rules, and skip the viable toolchain-provided interpreter present in the `$PATH`.

The fix is to canonicalize both the `$PATH` entries and the `pyvenv.cfg`'s paths when filtering out possibilities to ensure that the filtering behavior is stable between attempts.

With that fix applied the shim correctly identifies the required interpreter on the first try.

```shellsession
$ bazel run -c dbg //examples/py_venv:internal_venv
INFO: Analyzed target //examples/py_venv:internal_venv (0 packages loaded, 56606 targets configured).
INFO: From Compiling Rust rlib py (4 files):
INFO: Found 1 target...
Target //examples/py_venv:internal_venv up-to-date:
  bazel-bin/examples/py_venv/internal_venv
INFO: Elapsed time: 129.494s, Critical Path: 75.62s
INFO: 472 processes: 166 internal, 306 darwin-sandbox.
INFO: Build completed successfully, 472 total actions
INFO: Running command line: bazel-bin/examples/py_venv/internal_venv
[aspect] Current executable path: "/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-dbg/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/python"
[aspect] Found pyvenv.cfg at: "/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-dbg/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/pyvenv.cfg"
[aspect] version_info from pyvenv.cfg: 3.9.0
[aspect] Parsed target Python version (major.minor): 3.9
[aspect] Ignoring dir "/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-dbg/bin/examples/py_venv/.internal_venv/bin"
[aspect] Found potential Python interpreters in PATH with matching version:
[aspect] - "/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/external/python_toolchain_aarch64-apple-darwin/bin/python3.9"
[aspect] - "/Users/arrdem/.local/pyenv/shims/python3.9"
[aspect] Attempting to execute: "/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/external/python_toolchain_aarch64-apple-darwin/bin/python3.9" with argv[0] as "/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-dbg/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/python" and args as ["-B", "/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-dbg/bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/say.py"]
---
virtualenv: ${RUNFILES}/aspect_rules_py/examples/py_venv/.internal_venv/lib/python3.9/site-packages/_virtualenv.py
sys.prefix: ${RUNFILES}/aspect_rules_py/examples/py_venv/.internal_venv
sys.path:
 - ${BAZEL_EXECROOT}/aspect_rules_py/bazel-out/darwin_arm64-dbg/bin/examples/py_venv
 - ${RUNFILES}/python_toolchain_aarch64-apple-darwin/lib/python39.zip
 - ${RUNFILES}/python_toolchain_aarch64-apple-darwin/lib/python3.9
 - ${RUNFILES}/python_toolchain_aarch64-apple-darwin/lib/python3.9/lib-dynload
 - ${RUNFILES}/aspect_rules_py/examples/py_venv/.internal_venv/lib/python3.9/site-packages
 - ${RUNFILES}/aspect_rules_py
 - ${RUNFILES}/aspect_rules_py/examples/py_venv
 - /Users/arrdem/.local/lib/python3.9/site-packages
 - ${RUNFILES}/python_toolchain_aarch64-apple-darwin/lib/python3.9/site-packages
site.PREFIXES:
 - ${RUNFILES}/aspect_rules_py/examples/py_venv/.internal_venv
 - ${RUNFILES}/python_toolchain_aarch64-apple-darwin
 - ${RUNFILES}/python_toolchain_aarch64-apple-darwin
  ___________________________________________
| hello py_venv! (built at <BUILD_TIMESTAMP>) |
  ===========================================
                                           \
                                            \
                                              ^__^
                                              (oo)\_______
                                              (__)\       )\/\
                                                  ||----w |
                                                  ||     ||
```

### Test plan

- [x] The examples now actually work (sigh)
- [x] The examples are now exercised in our release integration testing