### PR TITLE
chore(py_pytest_main): Refactor to allow for linting

### DIFF
--- a/py/private/py_pytest_main.bzl
+++ b/py/private/py_pytest_main.bzl
@@ -19,7 +19,7 @@ load(":py_library.bzl", default_py_library = "py_library")
 
 def _py_pytest_main_impl(ctx):
     substitutions = {
-        "$$FLAGS$$": ", ".join(['"{}"'.format(f) for f in ctx.attr.args]).strip(),
+        "user_args: List[str] = []": "user_args: List[str] = " + repr(['"{}"'.format(f) for f in ctx.attr.args]),
         # Leaving CHDIR empty results in potentially user facing issues w/
         # black and flake8, so we'll just assign something trivial as a no-op.
         "$$CHDIR$$": "os.chdir('{}')".format(ctx.attr.chdir) if ctx.attr.chdir else "_ = 0",

--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -1,3 +1,4 @@
+# -*- mode: python -*-
 # Copyright 2022 Aspect Build Systems, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,7 +89,8 @@ if __name__ == "__main__":
     if test_filter is not None:
         args.append(f"-k={test_filter}")
 
-    user_args: List[str] = [$$FLAGS$$]
+    # This list will be replaced if the user provides args to bake in
+    user_args: List[str] = []
     if len(user_args) > 0:
         args.extend(user_args)
 


### PR DESCRIPTION
The pytest driver template isn't valid Python, which makes it unlintable, which is part of why it has unmitigated typing issues which become visible when users adopt `rules_mypy` and equivalents.

Rework the driver template so that in its pre-expansion form it's valid Python and impose linting on it.

---

### Changes are visible to end-users: no

### Test plan

TBD