### PR TITLE
fix(py_venv): Activate embedded interpreters

### DIFF
--- a/docs/venv.md
+++ b/docs/venv.md
@@ -2,95 +2,6 @@
 
 Implementation for the py_binary and py_test rules.
 
-<a id="py_venv"></a>
-
-## py_venv
-
-<pre>
-py_venv(<a href="#py_venv-name">name</a>, <a href="#py_venv-data">data</a>, <a href="#py_venv-deps">deps</a>, <a href="#py_venv-env">env</a>, <a href="#py_venv-imports">imports</a>, <a href="#py_venv-interpreter_options">interpreter_options</a>, <a href="#py_venv-package_collisions">package_collisions</a>, <a href="#py_venv-python_version">python_version</a>,
-        <a href="#py_venv-resolutions">resolutions</a>, <a href="#py_venv-srcs">srcs</a>)
-</pre>
-
-Build a Python virtual environment and execute its interpreter.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="py_venv-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="py_venv-data"></a>data |  Runtime dependencies of the program.<br><br>        The transitive closure of the <code>data</code> dependencies will be available in the <code>.runfiles</code>         folder for this binary/test. The program may optionally use the Runfiles lookup library to         locate the data files, see https://pypi.org/project/bazel-runfiles/.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_venv-deps"></a>deps |  Targets that produce Python code, commonly <code>py_library</code> rules.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_venv-env"></a>env |  Environment variables to set when running the binary.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
-| <a id="py_venv-imports"></a>imports |  List of import directories to be added to the PYTHONPATH.   | List of strings | optional | <code>[]</code> |
-| <a id="py_venv-interpreter_options"></a>interpreter_options |  Additional options to pass to the Python interpreter.   | List of strings | optional | <code>[]</code> |
-| <a id="py_venv-package_collisions"></a>package_collisions |  The action that should be taken when a symlink collision is encountered when creating the venv. A collision can occur when multiple packages providing the same file are installed into the venv. The possible values are:<br><br>* "error": When conflicting symlinks are found, an error is reported and venv creation halts. * "warning": When conflicting symlinks are found, an warning is reported, however venv creation continues. * "ignore": When conflicting symlinks are found, no message is reported and venv creation continues.   | String | optional | <code>"error"</code> |
-| <a id="py_venv-python_version"></a>python_version |  Whether to build this target and its transitive deps for a specific python version.   | String | optional | <code>""</code> |
-| <a id="py_venv-resolutions"></a>resolutions |  Satisfy a virtual_dep with a mapping from external package name to the label of an installed package that provides it.         See [virtual dependencies](/docs/virtual_deps.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional | <code>{}</code> |
-| <a id="py_venv-srcs"></a>srcs |  Python source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-
-
-<a id="py_venv_binary"></a>
-
-## py_venv_binary
-
-<pre>
-py_venv_binary(<a href="#py_venv_binary-name">name</a>, <a href="#py_venv_binary-data">data</a>, <a href="#py_venv_binary-deps">deps</a>, <a href="#py_venv_binary-env">env</a>, <a href="#py_venv_binary-imports">imports</a>, <a href="#py_venv_binary-interpreter_options">interpreter_options</a>, <a href="#py_venv_binary-main">main</a>, <a href="#py_venv_binary-package_collisions">package_collisions</a>,
-               <a href="#py_venv_binary-python_version">python_version</a>, <a href="#py_venv_binary-resolutions">resolutions</a>, <a href="#py_venv_binary-srcs">srcs</a>, <a href="#py_venv_binary-venv">venv</a>)
-</pre>
-
-Run a Python program under Bazel using a virtualenv.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="py_venv_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="py_venv_binary-data"></a>data |  Runtime dependencies of the program.<br><br>        The transitive closure of the <code>data</code> dependencies will be available in the <code>.runfiles</code>         folder for this binary/test. The program may optionally use the Runfiles lookup library to         locate the data files, see https://pypi.org/project/bazel-runfiles/.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_venv_binary-deps"></a>deps |  Targets that produce Python code, commonly <code>py_library</code> rules.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_venv_binary-env"></a>env |  Environment variables to set when running the binary.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
-| <a id="py_venv_binary-imports"></a>imports |  List of import directories to be added to the PYTHONPATH.   | List of strings | optional | <code>[]</code> |
-| <a id="py_venv_binary-interpreter_options"></a>interpreter_options |  Additional options to pass to the Python interpreter.   | List of strings | optional | <code>[]</code> |
-| <a id="py_venv_binary-main"></a>main |  Script to execute with the Python interpreter.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="py_venv_binary-package_collisions"></a>package_collisions |  The action that should be taken when a symlink collision is encountered when creating the venv. A collision can occur when multiple packages providing the same file are installed into the venv. The possible values are:<br><br>* "error": When conflicting symlinks are found, an error is reported and venv creation halts. * "warning": When conflicting symlinks are found, an warning is reported, however venv creation continues. * "ignore": When conflicting symlinks are found, no message is reported and venv creation continues.   | String | optional | <code>"error"</code> |
-| <a id="py_venv_binary-python_version"></a>python_version |  Whether to build this target and its transitive deps for a specific python version.   | String | optional | <code>""</code> |
-| <a id="py_venv_binary-resolutions"></a>resolutions |  Satisfy a virtual_dep with a mapping from external package name to the label of an installed package that provides it.         See [virtual dependencies](/docs/virtual_deps.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional | <code>{}</code> |
-| <a id="py_venv_binary-srcs"></a>srcs |  Python source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_venv_binary-venv"></a>venv |  A virtualenv; if provided all 3rdparty deps are assumed to come via the venv.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-
-
-<a id="py_venv_test"></a>
-
-## py_venv_test
-
-<pre>
-py_venv_test(<a href="#py_venv_test-name">name</a>, <a href="#py_venv_test-data">data</a>, <a href="#py_venv_test-deps">deps</a>, <a href="#py_venv_test-env">env</a>, <a href="#py_venv_test-env_inherit">env_inherit</a>, <a href="#py_venv_test-imports">imports</a>, <a href="#py_venv_test-interpreter_options">interpreter_options</a>, <a href="#py_venv_test-main">main</a>,
-             <a href="#py_venv_test-package_collisions">package_collisions</a>, <a href="#py_venv_test-python_version">python_version</a>, <a href="#py_venv_test-resolutions">resolutions</a>, <a href="#py_venv_test-srcs">srcs</a>, <a href="#py_venv_test-venv">venv</a>)
-</pre>
-
-Run a Python program under Bazel using a virtualenv.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="py_venv_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="py_venv_test-data"></a>data |  Runtime dependencies of the program.<br><br>        The transitive closure of the <code>data</code> dependencies will be available in the <code>.runfiles</code>         folder for this binary/test. The program may optionally use the Runfiles lookup library to         locate the data files, see https://pypi.org/project/bazel-runfiles/.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_venv_test-deps"></a>deps |  Targets that produce Python code, commonly <code>py_library</code> rules.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_venv_test-env"></a>env |  Environment variables to set when running the binary.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
-| <a id="py_venv_test-env_inherit"></a>env_inherit |  Specifies additional environment variables to inherit from the external environment when the test is executed by bazel test.   | List of strings | optional | <code>[]</code> |
-| <a id="py_venv_test-imports"></a>imports |  List of import directories to be added to the PYTHONPATH.   | List of strings | optional | <code>[]</code> |
-| <a id="py_venv_test-interpreter_options"></a>interpreter_options |  Additional options to pass to the Python interpreter.   | List of strings | optional | <code>[]</code> |
-| <a id="py_venv_test-main"></a>main |  Script to execute with the Python interpreter.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="py_venv_test-package_collisions"></a>package_collisions |  The action that should be taken when a symlink collision is encountered when creating the venv. A collision can occur when multiple packages providing the same file are installed into the venv. The possible values are:<br><br>* "error": When conflicting symlinks are found, an error is reported and venv creation halts. * "warning": When conflicting symlinks are found, an warning is reported, however venv creation continues. * "ignore": When conflicting symlinks are found, no message is reported and venv creation continues.   | String | optional | <code>"error"</code> |
-| <a id="py_venv_test-python_version"></a>python_version |  Whether to build this target and its transitive deps for a specific python version.   | String | optional | <code>""</code> |
-| <a id="py_venv_test-resolutions"></a>resolutions |  Satisfy a virtual_dep with a mapping from external package name to the label of an installed package that provides it.         See [virtual dependencies](/docs/virtual_deps.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional | <code>{}</code> |
-| <a id="py_venv_test-srcs"></a>srcs |  Python source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="py_venv_test-venv"></a>venv |  A virtualenv; if provided all 3rdparty deps are assumed to come via the venv.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-
-
 <a id="VirtualenvInfo"></a>
 
 ## VirtualenvInfo
@@ -111,6 +22,42 @@ VirtualenvInfo(<a href="#VirtualenvInfo-home">home</a>)
 | <a id="VirtualenvInfo-home"></a>home |  Path of the virtualenv    |
 
 
+<a id="py_venv"></a>
+
+## py_venv
+
+<pre>
+py_venv(<a href="#py_venv-kwargs">kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_venv-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a id="py_venv_binary"></a>
+
+## py_venv_binary
+
+<pre>
+py_venv_binary(<a href="#py_venv_binary-kwargs">kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_venv_binary-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
 <a id="py_venv_link"></a>
 
 ## py_venv_link
@@ -128,5 +75,23 @@ Build a Python virtual environment and produce a script to link it into the buil
 | :------------- | :------------- | :------------- |
 | <a id="py_venv_link-venv_name"></a>venv_name |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="py_venv_link-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a id="py_venv_test"></a>
+
+## py_venv_test
+
+<pre>
+py_venv_test(<a href="#py_venv_test-kwargs">kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_venv_test-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 

--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -10,6 +10,13 @@ exports_files([
     "link.py",
 ])
 
+config_setting(
+    name = "debug_build",
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
+
 bzl_library(
     name = "py_venv",
     srcs = [

--- a/py/private/py_venv/entrypoint.tmpl.sh
+++ b/py/private/py_venv/entrypoint.tmpl.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
+if {{DEBUG}}; then
+    set -x
+fi
+
 {{BASH_RLOCATION_FN}}
 
 runfiles_export_envvars
 
 set -o errexit -o nounset -o pipefail
 
-{{PRELUDE}}
-
 source "$(rlocation "{{VENV}}")"/bin/activate
-
-{{PREEXEC}}
 
 exec "$(rlocation "{{VENV}}")"/bin/python {{INTERPRETER_FLAGS}} "$@"

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -36,30 +36,6 @@ def _interpreter_flags(ctx):
 
     return args
 
-def _venv_preexec(ctx):
-    py_toolchain = _py_semantics.resolve_toolchain(ctx)
-    lines = []
-
-    if py_toolchain.runfiles_interpreter:
-        lines.extend([
-            """\
-# HACK: Override PYTHONHOME after bin/activate to support embedded standalone interpreter
-PYTHONHOME="$(dirname "$(dirname "$(rlocation {})")")"
-export PYTHONHOME
-""".format(to_rlocation_path(ctx, py_toolchain.python)),
-            """\
-# HACK: Shove the PYTHONHOME's bin/ _second_ on the path.
-# First on the path will be VIRTUALENV/bin which we want to stay there.
-# But we also need the interpreter's bin/ to be on the path so that it can be found.
-IFS=: read -a _arr <<< "$PATH"
-_arr=(\"${_arr[@]:0:1}\" \"${PYTHONHOME}/bin\" \"${_arr[@]:1}\")
-_ifs=\"$IFS\"; IFS=:; PATH=\"${_arr[*]}\"; IFS=\"$_ifs\"
-export PATH
-""",
-        ])
-
-    return "\n".join(lines)
-
 # FIXME: This is derived directly from the py_binary.bzl rule and should really
 # be a layer on top of it if we can figure out flowing the data around. This is
 # PoC quality.
@@ -147,7 +123,8 @@ def _py_venv_base_impl(ctx):
         executable = venv_tool,
         arguments = [
             "--location=" + venv_dir.path,
-            "--python=" + py_shim.bin.bin.path,
+            "--venv-shim=" + py_shim.bin.bin.path,
+            "--python=" + to_rlocation_path(ctx, py_toolchain.python) if py_toolchain.runfiles_interpreter else py_toolchain.python.path,
             "--pth-file=" + site_packages_pth_file.path,
             "--env-file=" + env_file.path,
             "--bin-dir=" + ctx.bin_dir.path,
@@ -158,13 +135,13 @@ def _py_venv_base_impl(ctx):
                 py_toolchain.interpreter_version_info.major,
                 py_toolchain.interpreter_version_info.minor,
             ),
-        ],
+        ] + (["--debug"] if ctx.attr.debug else []),
         inputs = rfs.merge_all([
             ctx.runfiles(files = [
                 site_packages_pth_file,
                 env_file,
                 venv_tool,
-            ]),
+            ] + py_toolchain.files.to_list()),
             py_shim.default_info.default_runfiles,
         ]).files,
         outputs = [
@@ -175,7 +152,7 @@ def _py_venv_base_impl(ctx):
     return venv_dir, rfs.merge_all([
         ctx.runfiles(files = [
             venv_dir,
-        ]),
+        ] + py_toolchain.files.to_list()),
     ])
 
 def _py_venv_rule_impl(ctx):
@@ -193,9 +170,8 @@ def _py_venv_rule_impl(ctx):
             "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION.strip(),
             "{{INTERPRETER_FLAGS}}": " ".join(_interpreter_flags(ctx)),
             "{{ENTRYPOINT}}": "${VIRTUAL_ENV}/bin/python",
-            "{{PRELUDE}}": "",
-            "{{PREEXEC}}": _venv_preexec(ctx),
             "{{VENV}}": to_rlocation_path(ctx, venv_dir),
+            "{{DEBUG}}": str(ctx.attr.debug).lower(),
         },
         is_executable = True,
     )
@@ -261,9 +237,8 @@ def _py_venv_binary_impl(ctx):
         substitutions = {
             "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION.strip(),
             "{{INTERPRETER_FLAGS}}": " ".join(_interpreter_flags(ctx)),
-            "{{PRELUDE}}": "",
-            "{{PREEXEC}}": _venv_preexec(ctx),
             "{{VENV}}": to_rlocation_path(ctx, venv_dir),
+            "{{DEBUG}}": str(ctx.attr.debug).lower(),
         },
         is_executable = True,
     )
@@ -320,6 +295,9 @@ A collision can occur when multiple packages providing the same file are install
         default = "//py/private/toolchain:resolved_venv_toolchain",
         cfg = "exec",
     ),
+    "debug": attr.bool(
+        default = False,
+    ),
 })
 
 _attrs.update(**_py_library.attrs)
@@ -370,7 +348,7 @@ py_venv_base = struct(
     cfg = python_version_transition,
 )
 
-py_venv = rule(
+_py_venv = rule(
     doc = """Build a Python virtual environment and execute its interpreter.""",
     implementation = _py_venv_rule_impl,
     attrs = py_venv_base.attrs,
@@ -379,17 +357,14 @@ py_venv = rule(
     cfg = py_venv_base.cfg,
 )
 
-def py_venv_link(venv_name = None, **kwargs):
-    """Build a Python virtual environment and produce a script to link it into the build directory."""
-    link_script = str(Label("//py/private/py_venv:link.py"))
-    py_venv_binary(
-        args = [] + (["--venv-name=" + venv_name] if venv_name else []),
-        main = link_script,
-        srcs = [link_script],
-        **kwargs
-    )
+def _wrap_with_debug(rule):
+    def helper(**kwargs):
+        kwargs["debug"] = select({Label(":debug_build"): True, "//conditions:default": False})
+        return rule(**kwargs)
 
-py_venv_binary = rule(
+    return helper
+
+_py_venv_binary = rule(
     doc = """Run a Python program under Bazel using a virtualenv.""",
     implementation = _py_venv_binary_impl,
     attrs = py_venv_base.attrs | py_venv_base.binary_attrs,
@@ -398,7 +373,7 @@ py_venv_binary = rule(
     cfg = py_venv_base.cfg,
 )
 
-py_venv_test = rule(
+_py_venv_test = rule(
     doc = """Run a Python program under Bazel using a virtualenv.""",
     implementation = _py_venv_binary_impl,
     attrs = py_venv_base.attrs | py_venv_base.binary_attrs | py_venv_base.test_attrs,
@@ -406,3 +381,20 @@ py_venv_test = rule(
     test = True,
     cfg = py_venv_base.cfg,
 )
+
+py_venv = _wrap_with_debug(_py_venv)
+py_venv_binary = _wrap_with_debug(_py_venv_binary)
+py_venv_test = _wrap_with_debug(_py_venv_test)
+
+def py_venv_link(venv_name = None, **kwargs):
+    """Build a Python virtual environment and produce a script to link it into the build directory."""
+
+    # Note that the binary is already wrapped with debug
+    link_script = str(Label("//py/private/py_venv:link.py"))
+    kwargs["debug"] = select({Label(":debug_build"): True, "//conditions:default": False})
+    py_venv_binary(
+        args = [] + (["--venv-name=" + venv_name] if venv_name else []),
+        main = link_script,
+        srcs = [link_script],
+        **kwargs
+    )

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -153,6 +153,7 @@ def _py_venv_base_impl(ctx):
         ctx.runfiles(files = [
             venv_dir,
         ] + py_toolchain.files.to_list()),
+        ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
     ])
 
 def _py_venv_rule_impl(ctx):
@@ -185,9 +186,9 @@ def _py_venv_rule_impl(ctx):
                 venv_dir,
             ]),
             executable = ctx.outputs.executable,
-            runfiles = rfs.merge(ctx.runfiles(files = [
-                venv_dir,
-            ])),
+            runfiles = rfs.merge(
+                ctx.runfiles(files = [venv_dir]),
+            ),
         ),
         # FIXME: Does not provide PyInfo because venvs are supposed to be terminal artifacts.
         VirtualenvInfo(
@@ -216,9 +217,6 @@ def _py_venv_binary_impl(ctx):
             py_toolchain.files,
             srcs_depset,
         ] + virtual_resolution.srcs + virtual_resolution.runfiles,
-        extra_runfiles_depsets = [
-            ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
-        ],
     )
 
     if not ctx.attr.venv:

--- a/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
@@ -2495,7 +2495,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/
-  - -rwxr-xr-x  0 0      0        1832 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin
+  - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/
@@ -2510,7 +2510,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        1918 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        7526 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
@@ -2518,7 +2518,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
   - -rwxr-xr-x  0 0      0         323 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         299 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        1832 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
+  - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/tools/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/tools/bash/

--- a/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
@@ -2510,7 +2510,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        7526 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        7558 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9

--- a/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
@@ -2510,7 +2510,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        7558 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        7827 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      813320 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2476,7 +2476,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/
-  - -rwxr-xr-x  0 0      0        1833 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin
+  - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/
@@ -2491,7 +2491,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        1918 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        7527 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
@@ -2499,7 +2499,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
   - -rwxr-xr-x  0 0      0         323 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         299 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        1833 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
+  - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/tools/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/tools/bash/

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2491,7 +2491,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        7559 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        7828 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2491,7 +2491,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        7527 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        7559 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      693968 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9

--- a/py/tools/py/BUILD.bazel
+++ b/py/tools/py/BUILD.bazel
@@ -12,6 +12,7 @@ rust_library(
         "src/_virtualenv.py",
         "src/activate.tmpl",
         "src/pyvenv.cfg.tmpl",
+        "src/runfiles_interpreter.tmpl",
     ],
     visibility = [
         "//py/tools/unpack_bin:__pkg__",

--- a/py/tools/py/src/activate.tmpl
+++ b/py/tools/py/src/activate.tmpl
@@ -7,31 +7,39 @@ deactivate () {
     if [ -n "${_OLD_VIRTUAL_PATH:-}" ] ; then
         PATH="${_OLD_VIRTUAL_PATH:-}"
         export PATH
-        unset _OLD_VIRTUAL_PATH
     fi
 
-    if [ "${_OLD_VIRTUAL_PYTHONHOME:-}" == "_activate_undef" ]; then
-       unset _OLD_VIRTUAL_PYTHONHOME
-       unset PYTHONHOME
+    if [ "${_OLD_VIRTUAL_PYTHONHOME:-}" = "_activate_undef" ]; then
+        unset _OLD_VIRTUAL_PYTHONHOME
+        unset PYTHONHOME
     elif [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
         PYTHONHOME="${_OLD_VIRTUAL_PYTHONHOME:-}"
         export PYTHONHOME
-        unset _OLD_VIRTUAL_PYTHONHOME
     fi
 
-    # Call hash to forget past locations. Without forgetting
-    # past locations the $PATH changes we made may not be respected.
-    # See "man bash" for more details. hash is usually a builtin of your shell
+    # Call hash to forget past locations. Without forgetting past locations the
+    # $PATH changes we made may not be respected. See "man bash" for more
+    # details. hash is usually a builtin of your shell
     hash -r 2> /dev/null
 
     if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
         PS1="${_OLD_VIRTUAL_PS1:-}"
         export PS1
-        unset _OLD_VIRTUAL_PS1
     fi
 
+    unset _OLD_VIRTUAL_PS1
+    unset _OLD_VIRTUAL_PATH
+    unset _OLD_VIRTUAL_PYTHONHOME
     unset VIRTUAL_ENV
     unset VIRTUAL_ENV_PROMPT
+
+    # Unset Bazel-injected vars
+{{ENVVARS_UNSET}}
+
+    # Unset vars we set with the runfiles interpreter
+    unset RUNFILES_DIR
+    unset RUNFILES_MANIFEST_FILE
+
     if [ ! "${1:-}" = "nondestructive" ] ; then
     # Self destruct!
         unset -f deactivate

--- a/py/tools/py/src/activate.tmpl
+++ b/py/tools/py/src/activate.tmpl
@@ -53,15 +53,8 @@ export VIRTUAL_ENV
 # unset PYTHONHOME if set
 # this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
 # could use `if (set -u; : $PYTHONHOME) ;` in bash.
-#
-# Note that since we are going to set PYTHONHOME ourselves in the case of a
-# hermetic interpreter, we need to explicitly unset that when deactivating.
-if [ -n "${PYTHONHOME:-}" ] ; then
-    _OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-}"
-    unset PYTHONHOME
-else
-    _OLD_VIRTUAL_PYTHONHOME="_activate_undef"
-fi
+_OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-}"
+unset PYTHONHOME
 
 _OLD_VIRTUAL_PATH="$PATH"
 
@@ -71,7 +64,8 @@ _OLD_VIRTUAL_PATH="$PATH"
 
 # Initialize the runfiles interpreter if we're using one. Note that this happens
 # AFTER unsetting the PYTHONHOME so that we can set PYTHONHOME if we're using a
-# full bundled interpreter.
+# full bundled interpreter, and after we set the Bazel-specific envvars so we
+# can provide some fallback handling around runfiles too.
 {{RUNFILES_INTERPRETER}}
 
 PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/py/tools/py/src/activate.tmpl
+++ b/py/tools/py/src/activate.tmpl
@@ -1,7 +1,6 @@
 # Adapted from CPython Lib/venv/scripts/common/activate
-#
-# This file must be used with "source bin/activate" *from bash*
-# You cannot run it directly
+
+set -eu -o pipefail
 
 deactivate () {
     # reset old environment variables
@@ -10,7 +9,11 @@ deactivate () {
         export PATH
         unset _OLD_VIRTUAL_PATH
     fi
-    if [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
+
+    if [ "${_OLD_VIRTUAL_PYTHONHOME:-}" == "_activate_undef" ]; then
+       unset _OLD_VIRTUAL_PYTHONHOME
+       unset PYTHONHOME
+    elif [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
         PYTHONHOME="${_OLD_VIRTUAL_PYTHONHOME:-}"
         export PYTHONHOME
         unset _OLD_VIRTUAL_PYTHONHOME
@@ -35,29 +38,47 @@ deactivate () {
     fi
 }
 
+{{DEBUG}}
+
 # unset irrelevant variables
 deactivate nondestructive
 
-# use the path as-is
-# HACK: $BASH_SOURCE works on real bashes, $0 works on zsh
-VIRTUAL_ENV="$(realpath "$(dirname "$(dirname "${BASH_SOURCE-$0}")")")"
-export VIRTUAL_ENV
+# For ZSH, emulate BASH_SOURCE.
+# The runfiles library code has some deps on this so we just set it :/
+: "${BASH_SOURCE:=$0}"
 
-_OLD_VIRTUAL_PATH="$PATH"
-PATH="$VIRTUAL_ENV/bin:$PATH"
-export PATH
+VIRTUAL_ENV="$(realpath "$(dirname "$(dirname "${BASH_SOURCE}")")")"
+export VIRTUAL_ENV
 
 # unset PYTHONHOME if set
 # this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
-# could use `if (set -u; : $PYTHONHOME) ;` in bash
+# could use `if (set -u; : $PYTHONHOME) ;` in bash.
+#
+# Note that since we are going to set PYTHONHOME ourselves in the case of a
+# hermetic interpreter, we need to explicitly unset that when deactivating.
 if [ -n "${PYTHONHOME:-}" ] ; then
     _OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-}"
     unset PYTHONHOME
+else
+    _OLD_VIRTUAL_PYTHONHOME="_activate_undef"
 fi
+
+_OLD_VIRTUAL_PATH="$PATH"
+
+# Aspect additions
+# We set these before runfiles initialization so that we can use it as part of a fallback path
+{{ENVVARS}}
+
+# Initialize the runfiles interpreter if we're using one. Note that this happens
+# AFTER unsetting the PYTHONHOME so that we can set PYTHONHOME if we're using a
+# full bundled interpreter.
+{{RUNFILES_INTERPRETER}}
+
+PATH="$VIRTUAL_ENV/bin:$PATH"
+export PATH
 
 # Call hash to forget past commands. Without forgetting
 # past commands the $PATH changes we made may not be respected
 hash -r 2> /dev/null
 
-# Aspect additions
-{{ENVVARS}}
+set +eu +o pipefail

--- a/py/tools/py/src/activate.tmpl
+++ b/py/tools/py/src/activate.tmpl
@@ -36,9 +36,12 @@ deactivate () {
     # Unset Bazel-injected vars
 {{ENVVARS_UNSET}}
 
-    # Unset vars we set with the runfiles interpreter
-    unset RUNFILES_DIR
-    unset RUNFILES_MANIFEST_FILE
+    # Unset vars we set with the runfiles interpreter. Note that this needs to
+    # be conditional so we don't throw this state out under tests or run.
+    if [ "${_OLD_RUNFILES_DIR:-}" = "_activate_undef" ]; then
+        unset RUNFILES_DIR
+        unset RUNFILES_MANIFEST_FILE
+    fi
 
     if [ ! "${1:-}" = "nondestructive" ] ; then
     # Self destruct!

--- a/py/tools/py/src/runfiles_interpreter.tmpl
+++ b/py/tools/py/src/runfiles_interpreter.tmpl
@@ -11,59 +11,51 @@
 #   launcher binary in which case the manifest would be obvious
 #
 # So we need to try and find the runfiles manifest by other means.
-if [ -z "${RUNFILES_DIR:-}" ] \
-    && [ -z "${RUNFILES_MANIFEST_FILE:-}" ] \
-    && [ ! -e "${BASH_SOURCE}.runfiles" ] \
-    && [ ! -e "${BASH_SOURCE}.runfiles_manifest" ]; then
 
-   # There are two cases here.
-   # 1. In development, the realpath will be in a /execroot/ somewhere
-   # 2. If copied to "production", the realpath will be in a .runfiles/ somewhere
-
-   AEXE="$(realpath "${BASH_SOURCE}")"
-   RUNFILES_PATH="$(echo "${BAZEL_TARGET}" | sed 's/^.*\/\/\(.*\):\(.*\)$/\1\/\2/' ).runfiles"
-
-   if [[ "${BASH_SOURCE}" == */execroot/*/bin/* ]]; then
-      # Examples:
-      # - ${BAZEL_HOME}/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/
-      #
-      # We can grab the execroot prefix, and then use the Bazel target info to
-      # find the manifest file and runfiles tree relative to the execroot.
-
-      # HACK: We can't lazy-match to the first /bin/, so we have to manually count four groups
-      EXECROOT="$(echo "${BASH_SOURCE}" | sed 's/\(execroot\/[^\/]*\/[^\/]*\/[^\/]*\/[^\/]*\/\).*$/\1/' )"
-      RUNFILES_DIR="${EXECROOT}/${RUNFILES_PATH}"
-
-   elif [[ "${BASH_SOURCE}" == *.runfiles/* ]]; then
-      # Examples:
-      # - bazel-bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/activate
-      #
-      # We are within the runfiles tree, so we just need to capture its root
-      RUNFILES_DIR="$(echo "${BASH_SOURCE}" | sed 's/\(.runfiles\).*$/\1/')"
-
-   elif [[ "${AEXE}" == */execroot/*/bin/* ]]; then
-      # Examples:
-      # - ${BAZEL_HOME}/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/
-      #
-      # We can grab the execroot prefix, and then use the Bazel target info to
-      # find the manifest file and runfiles tree relative to the execroot.
-      EXECROOT="$(echo "${AEXE}" | sed 's/\(execroot\/[^\/]*\/[^\/]*\/[^\/]*\/[^\/]*\/\).*$/\1/' )"
-      RUNFILES_DIR="${EXECROOT}/${RUNFILES_PATH}"
-
-   elif [[ "${AEXE}" == *.runfiles/* ]]; then
-      # Examples:
-      # - bazel-bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/activate
-      #
-      # We are within the runfiles tree, so we just need to capture its root
-      RUNFILES_DIR="$(echo "${AEXE}" | sed 's/\(.runfiles\).*$/\1/')"
-
-   else
+_activate_find_runfiles() {
+    # $1 -- an executable path
+    if [[ "${1}" == */execroot/*/bin/* ]]; then
+       # Examples:
+       # - ${BAZEL_HOME}/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/
        #
-       echo>&2 "ERROR: activate[.sh] cannot identify a fallback runfiles manifest!"
-       exit 1
-   fi
+       # We can grab the execroot prefix, and then use the Bazel target info to
+       # find the manifest file and runfiles tree relative to the execroot.
 
-   export RUNFILES_DIR
+       # HACK: We can't lazy-match to the first /bin/, so we have to manually count four groups
+       EXECROOT="$(echo "${1}" | sed 's/\(execroot\/[^\/]*\/[^\/]*\/[^\/]*\/[^\/]*\/\).*$/\1/' )"
+       export RUNFILES_DIR="${EXECROOT}/${RUNFILES_PATH}"
+    elif [[ "${1}" == *.runfiles/* ]]; then
+       # Examples:
+       # - bazel-bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/activate
+       #
+       # We are within the runfiles tree, so we just need to capture its root
+       export RUNFILES_DIR="$(echo "${1}" | sed 's/\(.runfiles\).*$/\1/')"
+    else
+        return 1
+    fi
+}
+
+if [ -z "${RUNFILES_DIR:-}" ] && \
+    [ -z "${RUNFILES_MANIFEST_FILE:-}" ] && \
+    [ ! -e "${BASH_SOURCE:-}.runfiles" ] && \
+    [ ! -e "${BASH_SOURCE:-}.runfiles_manifest" ]; then
+
+    # There are two cases here.
+    # 1. In development, the realpath will be in a /execroot/ somewhere
+    # 2. If copied to "production", the realpath will be in a .runfiles/ somewhere
+
+    RUNFILES_PATH="$(echo "${BAZEL_TARGET}" | sed 's/^.*\/\/\(.*\):\(.*\)$/\1\/\2/' ).runfiles"
+
+    set -uo pipefail;
+    _activate_find_runfiles "${BASH_SOURCE}" || \
+        _activate_find_runfiles "$(realpath "${BASH_SOURCE}")" || \
+        { echo>&2 "ERROR: activate[.sh] cannot identify a fallback runfiles manifest!"; exit 1; };
+
+    # FIXME: This should always be true, when is it not?
+    if [ -e "${RUNFILES_DIR}/MANIFEST" ]; then
+       RUNFILES_MANIFEST_FILE="${RUNFILES_DIR}/MANIFEST"
+       export RUNFILES_MANIFEST_FILE
+    fi
 fi
 
 # As a workaround for export -f under zsh, we fence this whole thing off and pipe it to /dev/null
@@ -95,18 +87,22 @@ INTERPRETER="$(realpath $(rlocation {{INTERPRETER_TARGET}}))"
 if [ "$(basename "$(dirname "$INTERPRETER")")" = "bin" ] && [ -e "$(dirname "$(dirname "$INTERPRETER")")/lib" ]; then
   # We also want to set PYTHONHOME
   # This should help avoid leakages and help us load libraries hermetically
-  export PYTHONHOME="$(dirname "$(dirname "$INTERPRETER")")"
+  PYTHONHOME="$(dirname "$(dirname "$INTERPRETER")")"
+  export PYTHONHOME
 
   # Note that since we are going to set PYTHONHOME ourselves in the case of a
   # hermetic interpreter, we need to explicitly unset that when deactivating.
   # If there was a previous PYTHONHOME, we want to reset to that.
   if [ -z "${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
-     export _OLD_VIRTUAL_PYTHONHOME="_activate_undef"
+     _OLD_VIRTUAL_PYTHONHOME="_activate_undef"
+     export _OLD_VIRTUAL_PYTHONHOME
   fi
 
   # If we've got a real interpreter, we want to put its bindir on the path.
   # We'll put the venv's bindir in front of this one eventually.
-  export PATH="$PYTHONHOME/bin:$PATH"
+  PATH="$PYTHONHOME/bin:$PATH"
+  export PATH
 fi
 
-# FIXME: Need to handle a nominal interpreter (eg. some random script, not named as "python3.X")
+# FIXME: Need to handle a nominal interpreter (eg. some random script, not named
+# as "python3.X" or an absolute path)

--- a/py/tools/py/src/runfiles_interpreter.tmpl
+++ b/py/tools/py/src/runfiles_interpreter.tmpl
@@ -56,6 +56,9 @@ if [ -z "${RUNFILES_DIR:-}" ] && \
        RUNFILES_MANIFEST_FILE="${RUNFILES_DIR}/MANIFEST"
        export RUNFILES_MANIFEST_FILE
     fi
+
+    # Set our magic flag to unset the runfiles vars
+    _OLD_RUNFILES_DIR="_activate_undef"
 fi
 
 # As a workaround for export -f under zsh, we fence this whole thing off and pipe it to /dev/null

--- a/py/tools/py/src/runfiles_interpreter.tmpl
+++ b/py/tools/py/src/runfiles_interpreter.tmpl
@@ -1,0 +1,105 @@
+# --- Runfiles-based interpreter setup --
+
+# If the runfiles dir is unset AND we will fail to find a runfiles manifest
+# based on inspecting $0, we need to try something different.
+#
+# What this means is that:
+#
+# - This script isn't being loaded from `bazel run`
+#
+# - The script is likely being loaded directly as "activate" rather than via a
+#   launcher binary in which case the manifest would be obvious
+#
+# So we need to try and find the runfiles manifest by other means.
+if [ -z "${RUNFILES_DIR:-}" ] \
+    && [ -z "${RUNFILES_MANIFEST_FILE:-}" ] \
+    && [ ! -e "${BASH_SOURCE}.runfiles" ] \
+    && [ ! -e "${BASH_SOURCE}.runfiles_manifest" ]; then
+
+   # There are two cases here.
+   # 1. In development, the realpath will be in a /execroot/ somewhere
+   # 2. If copied to "production", the realpath will be in a .runfiles/ somewhere
+
+   AEXE="$(realpath "${BASH_SOURCE}")"
+   RUNFILES_PATH="$(echo "${BAZEL_TARGET}" | sed 's/^.*\/\/\(.*\):\(.*\)$/\1\/\2/' ).runfiles"
+
+   if [[ "${BASH_SOURCE}" == */execroot/*/bin/* ]]; then
+      # Examples:
+      # - ${BAZEL_HOME}/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/
+      #
+      # We can grab the execroot prefix, and then use the Bazel target info to
+      # find the manifest file and runfiles tree relative to the execroot.
+
+      # HACK: We can't lazy-match to the first /bin/, so we have to manually count four groups
+      EXECROOT="$(echo "${BASH_SOURCE}" | sed 's/\(execroot\/[^\/]*\/[^\/]*\/[^\/]*\/[^\/]*\/\).*$/\1/' )"
+      RUNFILES_DIR="${EXECROOT}/${RUNFILES_PATH}"
+
+   elif [[ "${BASH_SOURCE}" == *.runfiles/* ]]; then
+      # Examples:
+      # - bazel-bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/activate
+      #
+      # We are within the runfiles tree, so we just need to capture its root
+      RUNFILES_DIR="$(echo "${BASH_SOURCE}" | sed 's/\(.runfiles\).*$/\1/')"
+
+   elif [[ "${AEXE}" == */execroot/*/bin/* ]]; then
+      # Examples:
+      # - ${BAZEL_HOME}/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/
+      #
+      # We can grab the execroot prefix, and then use the Bazel target info to
+      # find the manifest file and runfiles tree relative to the execroot.
+      EXECROOT="$(echo "${AEXE}" | sed 's/\(execroot\/[^\/]*\/[^\/]*\/[^\/]*\/[^\/]*\/\).*$/\1/' )"
+      RUNFILES_DIR="${EXECROOT}/${RUNFILES_PATH}"
+
+   elif [[ "${AEXE}" == *.runfiles/* ]]; then
+      # Examples:
+      # - bazel-bin/examples/py_venv/internal_venv.runfiles/aspect_rules_py/examples/py_venv/.internal_venv/bin/activate
+      #
+      # We are within the runfiles tree, so we just need to capture its root
+      RUNFILES_DIR="$(echo "${AEXE}" | sed 's/\(.runfiles\).*$/\1/')"
+
+   else
+       #
+       echo>&2 "ERROR: activate[.sh] cannot identify a fallback runfiles manifest!"
+       exit 1
+   fi
+
+   export RUNFILES_DIR
+fi
+
+# As a workaround for export -f under zsh, we fence this whole thing off and pipe it to /dev/null
+# HACK: Note that this is adjusted to use $BASH_SOURCE not $0; this works around other zsh vs bash issues
+{
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+# https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/${f}" 2>/dev/null || \
+    source "$(grep -sm1 "^${f} " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+    source "${BASH_SOURCE}.runfiles/${f}" 2>/dev/null || \
+    source "$(grep -sm1 "^${f} " "${BASH_SOURCE}.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+    source "$(grep -sm1 "^${f} " "${BASH_SOURCE}.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+    { echo>&2 "ERROR: runfiles.bash initializer cannot find ${f}. An executable rule may have forgotten to expose it in the runfiles, or the binary may require RUNFILES_DIR to be set."; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+} >/dev/null
+
+# Look up the runfiles-based interpreter and put its dir _first_ on the path.
+INTERPRETER="$(realpath $(rlocation {{INTERPRETER_TARGET}}))"
+
+# Figure out if we're dealing with just some program or a real install
+# <SOMEDIR> <- possible $PYTHONHOME
+#   bin/<SOMETHING> <- probably our interpreter
+#   lib/...         <- site-packages, etc.
+#
+if [ "$(basename "$(dirname "$INTERPRETER")")" = "bin" ] && [ -e "$(dirname "$(dirname "$INTERPRETER")")/lib" ]; then
+  # We also want to set PYTHONHOME
+  # This should help avoid leakages and help us load libraries hermetically
+  export PYTHONHOME="$(dirname "$(dirname "$INTERPRETER")")"
+
+  # If we've got a real interpreter, we want to put its bindir on the path.
+  # We'll put the venv's bindir in front of this one eventually.
+  export PATH="$PYTHONHOME/bin:$PATH"
+fi
+
+# FIXME: Need to handle a nominal interpreter (eg. some random script, not named as "python3.X")

--- a/py/tools/py/src/runfiles_interpreter.tmpl
+++ b/py/tools/py/src/runfiles_interpreter.tmpl
@@ -97,6 +97,13 @@ if [ "$(basename "$(dirname "$INTERPRETER")")" = "bin" ] && [ -e "$(dirname "$(d
   # This should help avoid leakages and help us load libraries hermetically
   export PYTHONHOME="$(dirname "$(dirname "$INTERPRETER")")"
 
+  # Note that since we are going to set PYTHONHOME ourselves in the case of a
+  # hermetic interpreter, we need to explicitly unset that when deactivating.
+  # If there was a previous PYTHONHOME, we want to reset to that.
+  if [ -z "${_OLD_VIRTUAL_PYTHONHOME:-}" ]; then
+     export _OLD_VIRTUAL_PYTHONHOME="_activate_undef"
+  fi
+
   # If we've got a real interpreter, we want to put its bindir on the path.
   # We'll put the venv's bindir in front of this one eventually.
   export PATH="$PYTHONHOME/bin:$PATH"

--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -329,6 +329,13 @@ pub fn create_empty_venv<'a>(
             None => "".to_string(),
         };
 
+        let envvars_unset = &envvars
+            .lines()
+            .filter_map(|line| line.find('=').map(|idx| line[..idx].trim()))
+            .map(|var| format!("    unset {}", var))
+            .collect::<Vec<_>>()
+            .join("\n");
+
         let runfiles_activation: String = match venv_shim {
             Some(_) => include_str!("runfiles_interpreter.tmpl")
                 .replace("{{INTERPRETER_TARGET}}", &python.to_str().unwrap()),
@@ -339,6 +346,7 @@ pub fn create_empty_venv<'a>(
             venv.bin_dir.join("activate"),
             include_str!("activate.tmpl")
                 .replace("{{ENVVARS}}", &envvars)
+                .replace("{{ENVVARS_UNSET}}", envvars_unset)
                 .replace("{{RUNFILES_INTERPRETER}}", &runfiles_activation)
                 .replace("{{DEBUG}}", if debug { &"set -x\n" } else { &"\n" }),
         )

--- a/py/tools/venv_bin/src/main.rs
+++ b/py/tools/venv_bin/src/main.rs
@@ -41,6 +41,10 @@ struct VenvArgs {
     #[arg(long)]
     python: PathBuf,
 
+    /// A shim we may want to use in place of the interpreter
+    #[arg(long)]
+    venv_shim: Option<PathBuf>,
+
     /// Destination path of the venv.
     #[arg(long)]
     location: PathBuf,
@@ -83,6 +87,9 @@ struct VenvArgs {
     /// PyRuntimeInfo.
     #[arg(long)]
     version: Option<String>,
+
+    #[arg(long, default_value_t = false)]
+    debug: bool,
 }
 
 fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
@@ -106,6 +113,8 @@ fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
                 py::venv::PythonVersionInfo::from_str(&version)?,
                 &args.location,
                 &args.env_file,
+                &args.venv_shim,
+                args.debug,
             )?;
 
             py::venv::populate_venv_with_copies(
@@ -128,6 +137,8 @@ fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
                 py::venv::PythonVersionInfo::from_str(&version)?,
                 &args.location,
                 &args.env_file,
+                &args.venv_shim,
+                args.debug,
             )?;
 
             py::venv::populate_venv_with_pth(


### PR DESCRIPTION
Previously the `bin/activate` script relied on Bazel (specifically `bazel run`) defined envvars, or being sourced directly from the binary entrypoint. This meant that if the user created a link (eg via the venv link verb or manually) to the venv defined by a given target, sourcing that venv's activate script would fail to locate a runfiles-based interpreter. On systems where there is no appropriately versioned non-hermetic interpreter available, this meant that venvs which should run with the Bazel-managed interpreter instead failed.

The fix is to harden venv initialization so that if the `activate` script is directly used AND the runfiles preconditions are not met an effort will be made to satisfy them.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- [x] Updated script works on BASH
```shellsession
$ /bin/bash
$ bazel run //examples/py_binary:py_binary.venv
INFO: Analyzed target //examples/py_binary:py_binary.venv (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/py_binary:py_binary.venv up-to-date:
  bazel-bin/examples/py_binary/py_binary.venv
INFO: Elapsed time: 1.224s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/examples/py_binary/py_binary.venv
Linking: /private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv -> /Users/arrdem/Documents/work/aspect/rules_py/.py_binary.venv

To activate the virtualenv run:
    source /Users/arrdem/Documents/work/aspect/rules_py/.py_binary.venv/bin/activate

Link is up to date!
$ ( source .py_binary.venv/bin/activate; echo $VIRTUAL_ENV; which python; which python3; echo $PYTHONHOME; deactivate; echo $VIRTUAL_ENV; which python; which python3 )
/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv
/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv/bin/python
/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv/bin/python3
/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/external/python_toolchain_aarch64-apple-darwin

/Users/arrdem/.local/pyenv/shims/python
/Users/arrdem/.local/pyenv/shims/python3
```

- [x] Updated script works on ZSH
```shellsession
$ /bin/zsh
$ bazel run //examples/py_binary:py_binary.venv
INFO: Analyzed target //examples/py_binary:py_binary.venv (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/py_binary:py_binary.venv up-to-date:
  bazel-bin/examples/py_binary/py_binary.venv
INFO: Elapsed time: 1.224s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/examples/py_binary/py_binary.venv
Linking: /private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv -> /Users/arrdem/Documents/work/aspect/rules_py/.py_binary.venv

To activate the virtualenv run:
    source /Users/arrdem/Documents/work/aspect/rules_py/.py_binary.venv/bin/activate

Link is up to date!
$ ( source .py_binary.venv/bin/activate; echo $VIRTUAL_ENV; which python; which python3; echo $PYTHONHOME; deactivate; echo $VIRTUAL_ENV; which python; which python3 )
/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv
/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv/bin/python
/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv/bin/python3
/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/external/python_toolchain_aarch64-apple-darwin

/Users/arrdem/.local/pyenv/shims/python
/Users/arrdem/.local/pyenv/shims/python3
```