### PR TITLE
Disable typing in `py/private/pytest.py.tmpl`

### DIFF
--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# type: ignore
+
 import sys
 import os
 from pathlib import Path


### PR DESCRIPTION
Disable type checking in generated code.

This fixes a regression that occurred after upgrading to the latest version of the rules.  There, our tooling started producing the following typing errors.

```
bazel-out/k8-fastbuild/bin/packages/cmk-agent-based/__test__.py:35: error: Cannot find implementation or library stub for module named "coverage"  [import-not-found]
bazel-out/k8-fastbuild/bin/packages/cmk-agent-based/__test__.py:35: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
bazel-out/k8-fastbuild/bin/packages/cmk-agent-based/__test__.py:37: error: Argument 1 to "open" has incompatible type "str | None"; expected "int | str | bytes | PathLike[str] | PathLike[bytes]"  [arg-type]
bazel-out/k8-fastbuild/bin/packages/cmk-agent-based/__test__.py:78: error: Argument 1 to "int" has incompatible type "str | None"; expected "str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc"  [arg-type]
bazel-out/k8-fastbuild/bin/packages/cmk-agent-based/__test__.py:84: error: Argument 1 to "Path" has incompatible type "str | None"; expected "str | PathLike[str]"  [arg-type]
bazel-out/k8-fastbuild/bin/packages/cmk-agent-based/__test__.py:109: error: Unsupported left operand type for + ("None")  [operator]
bazel-out/k8-fastbuild/bin/packages/cmk-agent-based/__test__.py:109: note: Left operand is of type "str | None"
bazel-out/k8-fastbuild/bin/packages/cmk-agent-based/__test__.py:114: error: Argument 1 to "open" has incompatible type "str | None"; expected "int | str | bytes | PathLike[str] | PathLike[bytes]"  [arg-type]
Found 6 errors in 1 file (checked 1 source file)
```

Related:
 * https://github.com/aspect-build/rules_py/pull/428

---

### Changes are visible to end-users: yes

This patch fixes a regression.