### PR TITLE
feat(py_test): Allows passing tags to generated py_pytest_main.

### DIFF
--- a/docs/py_test.md
+++ b/docs/py_test.md
@@ -109,7 +109,7 @@ Identical to [py_binary](./py_binary.md), but produces a target that can be used
 | <a id="py_test-srcs"></a>srcs |  Python source files.   |  <code>[]</code> |
 | <a id="py_test-main"></a>main |  Entry point. Like rules_python, this is treated as a suffix of a file that should appear among the srcs. If absent, then <code>[name].py</code> is tried. As a final fallback, if the srcs has a single file, that is used as the main.   |  <code>None</code> |
 | <a id="py_test-pytest_main"></a>pytest_main |  If set, generate a [py_pytest_main](#py_pytest_main) script and use it as the main. The deps should include the pytest package (as well as the coverage package if desired).   |  <code>False</code> |
-| <a id="py_test-tags"></a>tags |  Tags to passed to generated rules (e.g. [py_pytest_main](#py_pytest_main))   |  <code>[]</code> |
+| <a id="py_test-tags"></a>tags |  If set, tags to be passed to generated targets (e.g. [py_pytest_main](#py_pytest_main)).   |  <code>[]</code> |
 | <a id="py_test-kwargs"></a>kwargs |  additional named parameters to <code>py_binary_rule</code>.   |  none |
 
 

--- a/docs/py_test.md
+++ b/docs/py_test.md
@@ -95,7 +95,7 @@ py_pytest_main wraps the template rendering target and the final py_library.
 ## py_test
 
 <pre>
-py_test(<a href="#py_test-name">name</a>, <a href="#py_test-srcs">srcs</a>, <a href="#py_test-main">main</a>, <a href="#py_test-pytest_main">pytest_main</a>, <a href="#py_test-kwargs">kwargs</a>)
+py_test(<a href="#py_test-name">name</a>, <a href="#py_test-srcs">srcs</a>, <a href="#py_test-main">main</a>, <a href="#py_test-pytest_main">pytest_main</a>, <a href="#py_test-tags">tags</a>, <a href="#py_test-kwargs">kwargs</a>)
 </pre>
 
 Identical to [py_binary](./py_binary.md), but produces a target that can be used with `bazel test`.
@@ -109,6 +109,7 @@ Identical to [py_binary](./py_binary.md), but produces a target that can be used
 | <a id="py_test-srcs"></a>srcs |  Python source files.   |  <code>[]</code> |
 | <a id="py_test-main"></a>main |  Entry point. Like rules_python, this is treated as a suffix of a file that should appear among the srcs. If absent, then <code>[name].py</code> is tried. As a final fallback, if the srcs has a single file, that is used as the main.   |  <code>None</code> |
 | <a id="py_test-pytest_main"></a>pytest_main |  If set, generate a [py_pytest_main](#py_pytest_main) script and use it as the main. The deps should include the pytest package (as well as the coverage package if desired).   |  <code>False</code> |
+| <a id="py_test-tags"></a>tags |  Tags to passed to generated rules (e.g. [py_pytest_main](#py_pytest_main))   |  <code>[]</code> |
 | <a id="py_test-kwargs"></a>kwargs |  additional named parameters to <code>py_binary_rule</code>.   |  none |
 
 

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -146,6 +146,7 @@ def py_test(name, srcs = [], main = None, pytest_main = False, tags = [], **kwar
             that is used as the main.
         pytest_main: If set, generate a [py_pytest_main](#py_pytest_main) script and use it as the main.
             The deps should include the pytest package (as well as the coverage package if desired).
+        tags: If set, tags to be passed to generated targets (e.g. [py_pytest_main](#py_pytest_main)).
         **kwargs: additional named parameters to `py_binary_rule`.
     """
 

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -134,7 +134,7 @@ def py_binary(name, srcs = [], main = None, **kwargs):
         **kwargs
     )
 
-def py_test(name, srcs = [], main = None, pytest_main = False, **kwargs):
+def py_test(name, srcs = [], main = None, pytest_main = False, tags = [], **kwargs):
     """Identical to [py_binary](./py_binary.md), but produces a target that can be used with `bazel test`.
 
     Args:
@@ -164,7 +164,7 @@ def py_test(name, srcs = [], main = None, pytest_main = False, **kwargs):
             fail("When pytest_main is set, the main attribute should not be set.")
         pytest_main_target = name + ".pytest_main"
         main = pytest_main_target + ".py"
-        py_pytest_main(name = pytest_main_target)
+        py_pytest_main(name = pytest_main_target, tags=tags)
         srcs.append(main)
         deps.append(pytest_main_target)
 
@@ -175,5 +175,6 @@ def py_test(name, srcs = [], main = None, pytest_main = False, **kwargs):
         deps = deps,
         main = main,
         resolutions = resolutions,
+		tags = tags,
         **kwargs
     )


### PR DESCRIPTION
Passing `tags` to `py_pytest_main` allows them to be excluded from mypy type checking. 


Current implementation of `pytest`-generated code does not adhere to strict type safety and gives the following mypy errors:
```
bazel-out/.../my_test.pytest_main.py:37: error: Argument 1 to "open" has incompatible type "str | None"; expected "int | str | bytes | PathLike[str] | PathLike[bytes]"  [arg-type]
bazel-out/.../my_test.pytest_main.py:78: error: Argument 1 to "int" has incompatible type "str | None"; expected "str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc"  [arg-type]
bazel-out/.../my_test.pytest_main.py:84: error: Argument 1 to "Path" has incompatible type "str | None"; expected "str | PathLike[str]"  [arg-type]
bazel-out/.../my_test.pytest_main.py:109: error: Unsupported left operand type for + ("None")  [operator]
bazel-out/.../my_test.pytest_main.py:109: note: Left operand is of type "str | None"
bazel-out/.../my_test.pytest_main.py:114: error: Argument 1 to "open" has incompatible type "str | None"; expected "int | str | bytes | PathLike[str] | PathLike[bytes]"  [arg-type]
```

The current workaround to [exclude these tests via tags](https://github.com/theoremlp/rules_mypy/issues/32#issuecomment-2448191134) however these are not currently passed to generated `py_pytest_main`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Enables `py_test` tags passing to generated `py_pytest_main`

### Test plan

Build/Unit tests
```shell
bazel build //...
bazel test //...
```

- Manual testing; please provide instructions so we can reproduce:

**tools/aspects.bzl**:
```
load("@pip_types//:types.bzl", "types")
load("@rules_mypy//mypy:mypy.bzl", "mypy")

mypy_aspect = mypy(
	mypy_ini = "@@//:mypy.ini",
	types = types,
	suppression_tags = ["no-mypy", "no-checks"],
)
```


**...<path_to_my_test>/BUILD.bazel**:
```
py_test (
  name = "my_test",
  srcs = ["my_test.py"],
  pytest_main = True,
  deps = [
     ...
  ],
  tags = ["no-mypy"],
)
```

No mypy errors are raised.

