### PR TITLE
tweak(ci): Automate pre-commit runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,33 @@ jobs:
 
   pre-commit:
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: pre-commit/action@v3.0.1
+        inputs:
+          extra_args: '--to-ref=HEAD --from-ref=${{ github.base_ref }}'
+      - name: Send automated commit
+        run: |
+          if ! git diff --quiet; then
+            git commit \
+              --author="aspect-marvin[bot] <marvin@aspect.build>" \
+              --all \
+              --message="Format"
+
+            for backoff in 5 10 15 20 25 30 runout; do
+              if ! git push; then
+                sleep $backoff
+              elif [ "$backoff" = "runout" ]; then
+                echo "ERROR: Failed to push commits!" >&2
+                exit 1
+              else
+                break
+              fi
+            done
+          fi
 
   verify-bcr-patches:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is an opinionated change, and to be very clear the opinion is mine. Linters which can also do formatting _should not_ be allowed to break CI. If there is a programmatically defined "right way" things should be done and tooling can do it, no purpose is served in making a human rerun a tool to apply that formatting.

Extend the `pre-commit` CI step so that it will commit (as @aspect-marvin) any formatting changes and push them back to the branch.

The motivation for doing this isn't just my own annoyance with pushing lint commits, but also so that PRs from @renovate-bot will trigger updates to the Gazelle manifest (or other code) so that those PRs can auto-merge.

---

### Changes are visible to end-users: no

### Test plan

N/A.