### PR TITLE
fix(venv_link): Restore original venv name mangling

### DIFF
--- a/py/private/py_venv/link.py
+++ b/py/private/py_venv/link.py
@@ -15,11 +15,7 @@ virtualenv_home = os.path.realpath(os.environ["VIRTUAL_ENV"])
 virtualenv_name = os.path.basename(virtualenv_home)
 runfiles_dir = os.path.realpath(os.environ["RUNFILES_DIR"])
 builddir = os.path.realpath(os.environ["BUILD_WORKING_DIRECTORY"])
-
-# Chop off the runfiles tree prefix
-virtualenv_path = virtualenv_home.lstrip(runfiles_dir).lstrip("/")
-# Chop off the repo name to get a repo-relative path
-virtualenv_path = virtualenv_path[virtualenv_path.find("/"):]
+target_package, target_name = os.environ["BAZEL_TARGET"].split("//", 1)[1].split(":")
 
 PARSER = argparse.ArgumentParser(
     prog="link",
@@ -36,7 +32,7 @@ PARSER.add_argument(
 PARSER.add_argument(
     "--dest",
     dest="dest",
-    default=os.path.join(builddir, os.path.dirname(virtualenv_path)),
+    default=os.path.join(builddir, target_package),
     help="Dir to link the virtualenv into",
 )
 


### PR DESCRIPTION
Reported by @jimmyt857 in testing of v1.6.0-rc0

Previously running the `examples/py_binary:py_binary.venv` target would create a link `$BUILD_WORKING_DIRECTORY/.examples+py_binary+py_binary.venv`. This behavior regressed in 1.5.0 and the link became simply `$BUILD_WORKING_DIRECTORY/.py_binary.venv`.

Restore the original behavior.

---

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- [x] Manual testing

```shellsession
❯ bazel run //examples/py_binary:py_binary.venv
INFO: Analyzed target //examples/py_binary:py_binary.venv (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/py_binary:py_binary.venv up-to-date:
  bazel-bin/examples/py_binary/py_binary.venv
INFO: Elapsed time: 0.815s, Critical Path: 0.05s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
INFO: Running command line: bazel-bin/examples/py_binary/py_binary.venv
usage: link [options]

Helper to create a symlink to a virtualenv in the source tree.

optional arguments:
  -h, --help   show this help message and exit
  --dest DEST  Dir to link the virtualenv into. Default is $BUILD_WORKING_DIRECTORY. (default: /Users/arrdem/Documents/work/aspect/rules_py)
  --name NAME  Name to link the virtualenv as. (default: .examples+py_binary+py_binary.venv)


Linking: /private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv -> /Users/arrdem/Documents/work/aspect/rules_py/.examples+py_binary+py_binary.venv

Link is up to date!

To configure the virtualenv in your IDE, configure an interpreter with the homedir
    /Users/arrdem/Documents/work/aspect/rules_py/.examples+py_binary+py_binary.venv

To activate the virtualenv in your shell run
    source /Users/arrdem/Documents/work/aspect/rules_py/.examples+py_binary+py_binary.venv/bin/activate
```
