### PR TITLE
fix(venv): Use the interpreter to abspath

### DIFF
--- a/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
@@ -2510,7 +2510,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        8619 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        8620 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9

--- a/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
@@ -2510,7 +2510,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        8099 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        8619 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2491,7 +2491,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        8100 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        8620 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2491,7 +2491,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        8620 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        8621 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9

--- a/py/tools/py/src/activate.tmpl
+++ b/py/tools/py/src/activate.tmpl
@@ -86,7 +86,7 @@ _OLD_VIRTUAL_PATH="$PATH"
 {{RUNFILES_INTERPRETER}}
 
 _abspath() {
-   "${PYTHONEXECUTABLE}" -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$@"
+    "${PYTHONEXECUTABLE}" -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$@"
 }
 
 # Re-export abspath'd vars

--- a/py/tools/py/src/activate.tmpl
+++ b/py/tools/py/src/activate.tmpl
@@ -70,7 +70,7 @@ export PYTHONEXECUTABLE
 # unset PYTHONHOME if set
 # this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
 # could use `if (set -u; : $PYTHONHOME) ;` in bash.
-_OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-}"
+_OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-_activate_undef}"
 unset PYTHONHOME
 
 _OLD_VIRTUAL_PATH="$PATH"
@@ -85,6 +85,24 @@ _OLD_VIRTUAL_PATH="$PATH"
 # can provide some fallback handling around runfiles too.
 {{RUNFILES_INTERPRETER}}
 
+_abspath() {
+   "${PYTHONEXECUTABLE}" -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$@"
+}
+
+# Re-export abspath'd vars
+# This allows us to avoid relative path issues without incurring sandbox escapes
+VIRTUAL_ENV="$(_abspath "${VIRTUAL_ENV}")"
+export VIRTUAL_ENV
+
+PYTHONEXECUTABLE="$(_abspath "${PYTHONEXECUTABLE}")"
+export PYTHONEXECUTABLE
+
+if [ -n "${PYTHONHOME:-}" ]; then
+  PYTHONHOME="$(_abspath "${PYTHONHOME}")"
+  export PYTHONHOME
+fi
+
+# Now we can put the venv's absolute bin on the path
 PATH="$VIRTUAL_ENV/bin:$PATH"
 export PATH
 

--- a/py/tools/py/src/runfiles_interpreter.tmpl
+++ b/py/tools/py/src/runfiles_interpreter.tmpl
@@ -22,7 +22,7 @@ _activate_find_runfiles() {
        # find the manifest file and runfiles tree relative to the execroot.
 
        # HACK: We can't lazy-match to the first /bin/, so we have to manually count four groups
-       EXECROOT="$(echo "${1}" | sed 's/\(execroot\/[^\/]*\/[^\/]*\/[^\/]*\/[^\/]*\/\).*$/\1/' )"
+       EXECROOT="$(echo "${1}" | sed 's/\(execroot\/[^\/]*\/[^\/]*\/[^\/]*\/[^\/]*\).*$/\1/' )"
        export RUNFILES_DIR="${EXECROOT}/${RUNFILES_PATH}"
     elif [[ "${1}" == *.runfiles/* ]]; then
        # Examples:

--- a/py/tools/py/src/runfiles_interpreter.tmpl
+++ b/py/tools/py/src/runfiles_interpreter.tmpl
@@ -1,4 +1,4 @@
-# --- Runfiles-based interpreter setup --
+# --- Runfiles-based interpreter setup ---
 
 # If the runfiles dir is unset AND we will fail to find a runfiles manifest
 # based on inspecting $0, we need to try something different.

--- a/py/tools/venv_shim/src/main.rs
+++ b/py/tools/venv_shim/src/main.rs
@@ -170,7 +170,7 @@ fn main() -> miette::Result<()> {
     {
         eprintln!("[aspect] Found potential Python interpreters in PATH with matching version:");
         for exe in &python_executables {
-            println!("[aspect] - {:?}", exe);
+            eprintln!("[aspect] - {:?}", exe);
         }
     }
 


### PR DESCRIPTION
Identified in manual testing of v1.6.0-rc0.

Because of overly conservative removals of `realpath` in #579, an issue is exposed where `$VIRTUAL_ENV` would be an un-resolved relative path both under Bazel and more significantly once a user activates a linked venv. This isn't so bad for binaries which usually don't `chdir`, but it's a problem for shells.

Since MacOS doesn't ship a `realpath` which can be configured to ignore symlinks, we can't just `realpath` the runfiles dir or the virtualenv home. But once we've configured a Python interpreter what we can do is use `os.path.abspath`. Unlike `realpath`, `abspath` does not attempt to resolve symlink path segments. It just uses `normpath` to eliminate relative path segments. This allows us to compute an absolute path in a portable way, once we get an appropriate interpreter up and running.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

```
❯ bazel run //examples/py_binary:py_binary.venv
INFO: Analyzed target //examples/py_binary:py_binary.venv (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //examples/py_binary:py_binary.venv up-to-date:
  bazel-bin/examples/py_binary/py_binary.venv
INFO: Elapsed time: 0.785s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/examples/py_binary/py_binary.venv
Linking: /private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/.py_binary.venv -> /Users/arrdem/Documents/work/aspect/rules_py/examples/py_binary/.py_binary.venv

To activate the virtualenv run:
    source /Users/arrdem/Documents/work/aspect/rules_py/examples/py_binary/.py_binary.venv/bin/activate

Link is up to date!

❯ source /Users/arrdem/Documents/work/aspect/rules_py/examples/py_binary/.py_binary.venv/bin/activate

❯ env | grep -e PYTHON -e RUNFILES -e VIRTUAL -e VENV | sort
PYTHONEXECUTABLE=/Users/arrdem/Documents/work/aspect/rules_py/examples/py_binary/.py_binary.venv/bin/python
PYTHONHOME=/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/py_binary.venv.runfiles/python_toolchain_aarch64-apple-darwin
RUNFILES_DIR=/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/py_binary.venv.runfiles
RUNFILES_MANIFEST_FILE=/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/py_binary.venv.runfiles/MANIFEST
RUNFILES_REPO_MAPPING=/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/execroot/aspect_rules_py/bazel-out/darwin_arm64-fastbuild/bin/examples/py_binary/py_binary.venv.runfiles/_repo_mapping
VIRTUAL_ENV_DISABLE_PROMPT=1
VIRTUAL_ENV=/Users/arrdem/Documents/work/aspect/rules_py/examples/py_binary/.py_binary.venv
```