### PR TITLE
Fix debug logging in release

### DIFF
--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(default_visibility = [
     "//docs:__pkg__",
@@ -10,10 +11,15 @@ exports_files([
     "link.py",
 ])
 
+bool_flag(
+    name = "debug_venv",
+    build_setting_default = False,
+)
+
 config_setting(
-    name = "debug_build",
-    values = {
-        "compilation_mode": "dbg",
+    name = "debug_venv_setting",
+    flag_values = {
+        ":debug_venv": "True",
     },
 )
 

--- a/py/private/py_venv/link.py
+++ b/py/private/py_venv/link.py
@@ -39,7 +39,6 @@ PARSER.add_argument(
 
 
 if __name__ == "__main__":
-    PARSER.print_help(sys.stdout)
     opts = PARSER.parse_args()
     dest = Path(os.path.join(opts.dest, opts.name))
     print("""
@@ -59,7 +58,7 @@ Linking: {venv_home} -> {venv_path}
             dest.unlink()
         except FileNotFoundError:
             pass
-    
+
         # From -> to
         dest.symlink_to(virtualenv_home, target_is_directory=True)
         print("Link created!")

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -351,7 +351,7 @@ _py_venv = rule(
 
 def _wrap_with_debug(rule):
     def helper(**kwargs):
-        kwargs["debug"] = select({Label(":debug_build"): True, "//conditions:default": False})
+        kwargs["debug"] = select({Label(":debug_venv_setting"): True, "//conditions:default": False})
         return rule(**kwargs)
 
     return helper
@@ -383,7 +383,7 @@ def py_venv_link(venv_name = None, **kwargs):
 
     # Note that the binary is already wrapped with debug
     link_script = str(Label("//py/private/py_venv:link.py"))
-    kwargs["debug"] = select({Label(":debug_build"): True, "//conditions:default": False})
+    kwargs["debug"] = select({Label(":debug_venv_setting"): True, "//conditions:default": False})
     py_venv_binary(
         args = [] + (["--venv-name=" + venv_name] if venv_name else []),
         main = link_script,


### PR DESCRIPTION
debug_build was enabled for users who were using
`--compilation_mode=dbg`, which lead to `set -x` being set in the
terminal used to create the venv, and tons of logging users don't need
to see. The help for the venv tool was also printed.

Now to test this you pass `--@aspect_rules_py//py/private/py_venv:debug_venv=True`
