### PR TITLE
fix(venv_link): Repair venv link munging

### DIFF
--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -37,7 +37,10 @@ bzl_library(
 
 py_venv_test(
     name = "test_link",
-    main = "test_link.py",
-    srcs = ["test_link.py", "link.py"],
+    srcs = [
+        "link.py",
+        "test_link.py",
+    ],
     imports = ["."],
+    main = "test_link.py",
 )

--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":defs.bzl", "py_venv_test")
 
 package(default_visibility = [
     "//docs:__pkg__",
@@ -32,4 +33,11 @@ bzl_library(
         "@aspect_bazel_lib//lib:expand_make_vars",
         "@aspect_bazel_lib//lib:paths",
     ],
+)
+
+py_venv_test(
+    name = "test_link",
+    main = "test_link.py",
+    srcs = ["test_link.py", "link.py"],
+    imports = ["."],
 )

--- a/py/private/py_venv/test_link.py
+++ b/py/private/py_venv/test_link.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from link import munge_venv_name
+
+assert munge_venv_name("", ".foo_venv") == ".foo_venv"
+assert munge_venv_name("bar", ".foo_venv") == ".bar+foo_venv"
+assert munge_venv_name("bar/baz", ".foo_venv") == ".bar+baz+foo_venv"


### PR DESCRIPTION
Fixes the #593 report.

Reworks the venv linking script so that we can add tests covering munging and prevent future regressions.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes

Fixed a regression in the naming of virtualenv links.

### Test plan

- New test cases added
