### PR TITLE
Support providing py_test's main from a separate package

### DIFF
--- a/py/private/py_executable.bzl
+++ b/py/private/py_executable.bzl
@@ -26,7 +26,7 @@ def _determine_main(ctx):
     """
     if ctx.attr.main:
         # Deviation from rules_python: allow a leading colon, e.g. `main = ":my_target"`
-        proposed_main = ctx.attr.main.removeprefix(":")
+        _, _, proposed_main = ctx.attr.main.rpartition(":")
         if not proposed_main.endswith(".py"):
             fail("main {} must end in '.py'".format(proposed_main))
     else:


### PR DESCRIPTION
A call to `py_test` using a `main` from a separate package, such as

```
py_test(
    name = "repro",
    srcs = [
        "//common:test_main.py",  # Exported by //common:BUILD.bazel.
        "specific_test.py",       # A second srcs file is needed to force the failure.
    ],
    main = "//common:test_main.py",
)
```

works when using `py_test` from `rules_python` v1.4.1, but fails when using `aspect_rules_py` v1.6.0:

```
$ bazel test test:repro
INFO: Invocation ID: e1a579a3-5f06-48a4-93ac-493157878ad1
ERROR: /Users/peter/repro/test/BUILD.bazel:4:8: in determine_main rule //test:repro.find_main:
Traceback (most recent call last):
        File "/private/var/tmp/_bazel_peter/76f5e50945d4cebf81e863f9c06c01bc/external/aspect_rules_py+/py/private/py_executable.bzl", line 73, column 55, in _determine_main_impl
                return DefaultInfo(files = depset([_determine_main(ctx)]))
        File "/private/var/tmp/_bazel_peter/76f5e50945d4cebf81e863f9c06c01bc/external/aspect_rules_py+/py/private/py_executable.bzl", line 46, column 17, in _determine_main
                fail("could not find '{}' as specified by 'main' attribute".format(proposed_main))
Error in fail: could not find '//common:test_main.py' as specified by 'main' attribute
ERROR: /Users/peter/repro/test/BUILD.bazel:4:8: Analysis of target '//test:repro.find_main' failed
ERROR: Analysis of target '//test:repro' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.140s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
ERROR: No test targets were found, yet testing was requested
```

FWIW, I'm not sure this usage pattern is desirable; maybe I'll be able to do away with it in my codebase in the future. But it is an incompatibility that makes `aspect_rules_py` not a drop-in replacement for `rules_python`; I hit it while attempting to migrate.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
