### PR TITLE
fix(py_test): Support target names with a `test_` prefix

### DIFF
--- a/docs/py_test.md
+++ b/docs/py_test.md
@@ -72,7 +72,7 @@ Run a Python program under Bazel. Most users should use the [py_test macro](#py_
 ## py_pytest_main
 
 <pre>
-py_pytest_main(<a href="#py_pytest_main-name">name</a>, <a href="#py_pytest_main-py_library">py_library</a>, <a href="#py_pytest_main-deps">deps</a>, <a href="#py_pytest_main-data">data</a>, <a href="#py_pytest_main-testonly">testonly</a>, <a href="#py_pytest_main-kwargs">kwargs</a>)
+py_pytest_main(<a href="#py_pytest_main-name">name</a>, <a href="#py_pytest_main-test_main">test_main</a>, <a href="#py_pytest_main-py_library">py_library</a>, <a href="#py_pytest_main-deps">deps</a>, <a href="#py_pytest_main-data">data</a>, <a href="#py_pytest_main-testonly">testonly</a>, <a href="#py_pytest_main-kwargs">kwargs</a>)
 </pre>
 
 py_pytest_main wraps the template rendering target and the final py_library.
@@ -83,6 +83,7 @@ py_pytest_main wraps the template rendering target and the final py_library.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="py_pytest_main-name"></a>name |  The name of the runable target that updates the test entry file.   |  none |
+| <a id="py_pytest_main-test_main"></a>test_main |  The name of the test entry file to be generated.   |  <code>None</code> |
 | <a id="py_pytest_main-py_library"></a>py_library |  Use this attribute to override the default py_library rule.   |  <code>&lt;unknown object com.google.devtools.build.skydoc.fakebuildapi.FakeStarlarkRuleFunctionsApi$RuleDefinitionIdentifier&gt;</code> |
 | <a id="py_pytest_main-deps"></a>deps |  A list containing the pytest library target, e.g., @pypi_pytest//:pkg.   |  <code>[]</code> |
 | <a id="py_pytest_main-data"></a>data |  A list of data dependencies to pass to the py_library target.   |  <code>[]</code> |

--- a/examples/pytest/BUILD.bazel
+++ b/examples/pytest/BUILD.bazel
@@ -38,3 +38,13 @@ py_test(
     shard_count = 2,
     deps = ["@pypi_pytest//:pkg"],
 )
+
+py_test(
+    # NB: target name starts with a test_ prefix
+    name = "test_prefix",
+    srcs = ["prefix_test.py"],
+    pytest_main = True,
+    deps = [
+        "@pypi_pytest//:pkg",
+    ],
+)

--- a/examples/pytest/prefix_test.py
+++ b/examples/pytest/prefix_test.py
@@ -1,0 +1,2 @@
+def test_always_passing():
+    assert True

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -163,8 +163,11 @@ def py_test(name, srcs = [], main = None, pytest_main = False, **kwargs):
         if main:
             fail("When pytest_main is set, the main attribute should not be set.")
         pytest_main_target = name + ".pytest_main"
-        main = pytest_main_target + ".py"
-        py_pytest_main(name = pytest_main_target)
+
+        # NB: The main name starts with a dot, so pytest does not mistakenly collect
+        # the file during test collection even if the target name starts with `test_`.
+        main = "." + pytest_main_target + ".py"
+        py_pytest_main(name = pytest_main_target, test_main = main)
         srcs.append(main)
         deps.append(pytest_main_target)
 

--- a/py/private/py_pytest_main.bzl
+++ b/py/private/py_pytest_main.bzl
@@ -58,11 +58,12 @@ _py_pytest_main = rule(
     },
 )
 
-def py_pytest_main(name, py_library = default_py_library, deps = [], data = [], testonly = True, **kwargs):
+def py_pytest_main(name, test_main = None, py_library = default_py_library, deps = [], data = [], testonly = True, **kwargs):
     """py_pytest_main wraps the template rendering target and the final py_library.
 
     Args:
         name: The name of the runable target that updates the test entry file.
+        test_main: The name of the test entry file to be generated.
         py_library: Use this attribute to override the default py_library rule.
         deps: A list containing the pytest library target, e.g., @pypi_pytest//:pkg.
         data: A list of data dependencies to pass to the py_library target.
@@ -70,7 +71,7 @@ def py_pytest_main(name, py_library = default_py_library, deps = [], data = [], 
         **kwargs: The extra arguments passed to the template rendering target.
     """
 
-    test_main = name + ".py"
+    test_main = test_main or name + ".py"
     tags = kwargs.pop("tags", [])
     visibility = kwargs.pop("visibility", [])
 


### PR DESCRIPTION
<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

Adds a `test_main` argument to `py_pytest_main` and propagates it from `py_test`. Uses a leading "." in the filename to suppress pytest collection.

In the current implementation, when `pytest_main = True`, the generated test entry file is named after the target with a `.pytest_main.py` extension. If the target name starts with `test_`, pytest may mistakenly collect the file as a test module, leading to confusing import errors.

```
==================================== ERRORS ====================================
_________ ERROR collecting examples/pytest/test_prefix.pytest_main.py __________
ImportError while importing test module '/home/nahue/.cache/bazel/_bazel_nahue/eb153f5901d0d2e97fac7a89d3cffa65/sandbox/linux-sandbox/402/execroot/aspect_rules_py/bazel-out/k8-fastbuild/bin/examples/pytest/test_prefix.runfiles/aspect_rules_py/examples/pytest/test_prefix.pytest_main.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../../../../../../../../../external/python_toolchain_x86_64-unknown-linux-gnu/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
E   ModuleNotFoundError: No module named 'test_prefix'
```

Alternatively, if this naming convention is decided to not be supported, we could maybe warn the user in a more friendly way when `py_test` is used with a name that may trigger this issue.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

fix(py_test): Target names with a `test_` prefix do not generate an import error when specifying `pytest_main = True`.

### Test plan

- New test cases added