### PR TITLE
feat(telemetry): Integrate tools_telemetry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,12 +13,16 @@ module(
 # py_image_layer needs compute_unused_inputs attribute
 # py_image_layer needs repo_mapping fix.
 bazel_dep(name = "aspect_bazel_lib", version = "2.16.0")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.2.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_python", version = "0.29.0")
 bazel_dep(name = "platforms", version = "0.0.7")
 
 bazel_lib = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
 bazel_lib.expand_template()
+
+tel = use_extension("@aspect_tools_telemetry//:extension.bzl", "telemetry")
+use_repo(tel, "aspect_tools_telemetry_report")
 
 # Custom python version for testing only
 python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)

--- a/py/extensions.bzl
+++ b/py/extensions.bzl
@@ -1,5 +1,6 @@
 "Module Extensions used from MODULE.bazel"
 
+load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load("//tools:version.bzl", "IS_PRERELEASE")
 load(":toolchains.bzl", "DEFAULT_TOOLS_REPOSITORY", "rules_py_toolchains")
 


### PR DESCRIPTION
This patch integrates [tools_telemetry](https://github.com/aspect-build/tools_telemetry) into `rules_py`. Depending on `rules_py` will register a dependency into the telemetry system and produce a usage report when external repositories are invalidated.

### Changes are visible to end-users: yes

- Suggested release notes appear below: yes

`aspect_tools_telemetry` is now used for coarse grained usage tracking.

### Test plan

N/A.