### PR TITLE
fix(pypex): use a param file for PyPex when necessary

### DIFF
--- a/py/private/py_pex_binary.bzl
+++ b/py/private/py_pex_binary.bzl
@@ -76,6 +76,9 @@ def _py_python_pex_impl(ctx):
 
     args = ctx.actions.args()
 
+    args.use_param_file(param_file_arg = "@%s")
+    args.set_param_file_format("multiline")
+
     # Copy workspace name here to prevent ctx
     # being transferred to the execution phase.
     workspace_name = str(ctx.workspace_name)

--- a/py/tools/pex/main.py
+++ b/py/tools/pex/main.py
@@ -26,7 +26,7 @@ class InjectEnvAction(Action):
             )
         self.default.append(tuple(components))
 
-parser = ArgumentParser()
+parser = ArgumentParser(fromfile_prefix_chars='@')
 
 parser.add_argument(
     "-o",


### PR DESCRIPTION
Binaries with large numbers of source inputs (i.e. large transitive dependency trees) can lead to the argument vector's size exceeding the OS' limits. Spilling to a param file when the argument list grows long avoids this issue.

For smaller argument lists, skipping the param file generation is an option that results in slightly less build work (one less file to create).

This change is an alternate implementation of https://github.com/aspect-build/rules_py/pull/543/files. Unlike that change, this change uses the dedicated APIs for solving this problem — `ctx.actions.args.use_param_file` on the Bazel side, `fromfile_prefix_char` on the ArgumentParser side.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (no docs reference this case)
- Breaking change (forces users to change their own code or config): no
   * only builds that would have failed previously have their argv spilled to the param file
   * builds that worked because their argv were under-limit when passed in-line are unchanged in behaviour; they still pass their args inlinei 
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- Manual testing: my real application (cannot be shared sadly)

fixes https://github.com/aspect-build/rules_py/issues/542
