### PR TITLE
feat(py_venv): activate-less interpreter

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,6 +1,7 @@
 # See https://docs.aspect.build/workflows/configuration
 tasks:
   - test:
+      queue: aspect-large
   - finalization:
       queue: aspect-small
 notifications:

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "81528401c6d6fde79ca22def4e50d7ebc47f7f182a83a106d38e9e1279da39a5",
+  "checksum": "f1be4baa5924515e3e3bfe91c4afbfa084b2751aec2f7560df597efbcdc4dc3b",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",
@@ -14740,6 +14740,37 @@
       ],
       "license_file": "LICENSE"
     },
+    "runfiles 0.1.0": {
+      "name": "runfiles",
+      "version": "0.1.0",
+      "package_url": "https://github.com/aspect-build/rules_py",
+      "repository": null,
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "runfiles",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "runfiles",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.1.0"
+      },
+      "license": "Apache 2",
+      "license_ids": [],
+      "license_file": null
+    },
     "rust-netrc 0.1.1": {
       "name": "rust-netrc",
       "version": "0.1.1",
@@ -27114,6 +27145,7 @@
   "binary_crates": [],
   "workspace_members": {
     "py 0.1.0": "py/tools/py",
+    "runfiles 0.1.0": "py/tools/runfiles",
     "unpack_bin 0.1.0": "py/tools/unpack_bin",
     "venv_bin 0.1.0": "py/tools/venv_bin",
     "venv_shim 0.1.0": "py/tools/venv_shim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "runfiles"
+version = "0.1.0"
+
+[[package]]
 name = "rust-netrc"
 version = "0.1.1"
 source = "git+https://github.com/gribouille/netrc?rev=544f3890b621f0dc30fcefb4f804269c160ce2e9#544f3890b621f0dc30fcefb4f804269c160ce2e9"
@@ -3286,6 +3290,7 @@ name = "venv_shim"
 version = "0.1.0"
 dependencies = [
  "miette",
+ "runfiles",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "py/tools/py",
     "py/tools/venv_bin",
     "py/tools/unpack_bin",
-    "py/tools/venv_shim", "py/tools/runfiles",
+    "py/tools/venv_shim",
+    "py/tools/runfiles",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "py/tools/py",
     "py/tools/venv_bin",
     "py/tools/unpack_bin",
-    "py/tools/venv_shim",
+    "py/tools/venv_shim", "py/tools/runfiles",
 ]
 
 [workspace.package]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -87,6 +87,7 @@ crate.from_cargo(
         "//py/tools/unpack_bin:Cargo.toml",
         "//py/tools/venv_bin:Cargo.toml",
         "//py/tools/venv_shim:Cargo.toml",
+        "//py/tools/runfiles:Cargo.toml",
     ],
 )
 use_repo(crate, "crate_index")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -284,6 +284,7 @@ crates_repository(
         "//py/tools/unpack_bin:Cargo.toml",
         "//py/tools/venv_bin:Cargo.toml",
         "//py/tools/venv_shim:Cargo.toml",
+        "//py/tools/runfiles:Cargo.toml",
     ],
 )
 

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -39,6 +39,7 @@ crates_repository(
         "@aspect_rules_py//py/tools/unpack_bin:Cargo.toml",
         "@aspect_rules_py//py/tools/venv_bin:Cargo.toml",
         "@aspect_rules_py//py/tools/venv_shim:Cargo.toml",
+        "@aspect_rules_py//py/tools/runfiles:Cargo.toml",
     ],
 )
 

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -101,10 +101,10 @@ def _py_venv_base_impl(ctx):
     rfs = _py_library.make_merged_runfiles(
         ctx,
         extra_depsets = [
-            py_toolchain.files,
-            srcs_depset,
-        ] + virtual_resolution.srcs + virtual_resolution.runfiles +
-        ([py_toolchain.files] if py_toolchain.runfiles_interpreter else []),
+                            py_toolchain.files,
+                            srcs_depset,
+                        ] + virtual_resolution.srcs + virtual_resolution.runfiles +
+                        ([py_toolchain.files] if py_toolchain.runfiles_interpreter else []),
         extra_runfiles_depsets = [
             ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
         ],
@@ -135,11 +135,11 @@ def _py_venv_base_impl(ctx):
             ),
             "--include-system-site-packages=" + ({
                 True: "true",
-                False: "false"
+                False: "false",
             }[ctx.attr.include_system_site_packages]),
             "--include-user-site-packages=" + ({
                 True: "true",
-                False: "false"
+                False: "false",
             }[ctx.attr.include_system_site_packages]),
         ] + (["--debug"] if ctx.attr.debug else []),
         inputs = rfs.merge_all([
@@ -318,9 +318,9 @@ to be unusable. Many libraries assume these packages will always be available
 and may not reliably declare their dependencies such that Bazel will satisfy
 them, so choosing isolation could expose packaging errors.
 
-"""
+""",
     ),
-        "include_user_site_packages": attr.bool(
+    "include_user_site_packages": attr.bool(
         default = False,
         doc = """`pyvenv.cfg` feature flag for the `aspect-include-user-site-packages` extension key.
 
@@ -336,7 +336,7 @@ to be unusable. Many libraries assume these packages will always be available
 and may not reliably declare their dependencies such that Bazel will satisfy
 them, so choosing isolation could expose packaging errors.
 
-"""
+""",
     ),
 })
 

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -113,11 +113,17 @@ def _py_venv_base_impl(ctx):
     venv_name = ".{}".format(ctx.attr.name)
     venv_dir = ctx.actions.declare_directory(venv_name)
 
+    print(ctx.label.repo_name or ctx.workspace_name)
+
     ctx.actions.run(
         executable = venv_tool,
         arguments = [
             "--location=" + venv_dir.path,
             "--venv-shim=" + py_shim.bin.bin.path,
+            # Post-bzlmod we need to record the current repository in case the
+            # user tries to consume a `py_venv_binary` across repo boundaries
+            # which could cause repo mapping to become relevant.
+            "--repo=" + (ctx.label.repo_name or ctx.workspace_name),
             "--python=" + to_rlocation_path(ctx, py_toolchain.python) if py_toolchain.runfiles_interpreter else py_toolchain.python.path,
             "--pth-file=" + site_packages_pth_file.path,
             "--env-file=" + env_file.path,

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -113,8 +113,6 @@ def _py_venv_base_impl(ctx):
     venv_name = ".{}".format(ctx.attr.name)
     venv_dir = ctx.actions.declare_directory(venv_name)
 
-    print(ctx.label.repo_name or ctx.workspace_name)
-
     ctx.actions.run(
         executable = venv_tool,
         arguments = [

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -133,6 +133,10 @@ def _py_venv_base_impl(ctx):
                 py_toolchain.interpreter_version_info.major,
                 py_toolchain.interpreter_version_info.minor,
             ),
+            "--include-system-site-packages=" + ({
+                True: "true",
+                False: "false"
+            }[ctx.attr.include_system_site_packages]),
         ] + (["--debug"] if ctx.attr.debug else []),
         inputs = rfs.merge_all([
             ctx.runfiles(files = [
@@ -293,6 +297,24 @@ A collision can occur when multiple packages providing the same file are install
     ),
     "debug": attr.bool(
         default = False,
+    ),
+    "include_system_site_packages": attr.bool(
+        default = True,
+        doc = """`pyvenv.cfg` feature flag for the `include-system-site-packages` key.
+
+When `True`, the user's site directory AND the interpreter's site directory will
+be included into the runtime pythonpath.
+
+When `False`, only the virtualenv's site directory and the interpreter's core
+libraries will be included into the runtime pythonpath.
+
+`False` is obviously preferable as it increases hermeticity, but the choice of
+`False` cases for instance a `pip` or `setuptools` bundled into the interpreter
+to be unusable. Many libraries assume these packages will always be available
+and may not reliably declare their dependencies such that Bazel will satisfy
+them, so choosing isolation could expose packaging errors.
+
+"""
     ),
 })
 

--- a/py/tests/py-venv-disable-systemsite/BUILD.bazel
+++ b/py/tests/py-venv-disable-systemsite/BUILD.bazel
@@ -8,9 +8,9 @@ py_venv_test(
     imports = [
         ".",
     ],
+    include_system_site_packages = False,
     main = "test.py",
     deps = [
         "@pypi_cowsay//:pkg",
     ],
-    include_system_site_packages = False,
 )

--- a/py/tests/py-venv-disable-systemsite/BUILD.bazel
+++ b/py/tests/py-venv-disable-systemsite/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//py/private/py_venv:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "test",
+    srcs = [
+        "test.py",
+    ],
+    imports = [
+        ".",
+    ],
+    main = "test.py",
+    deps = [
+        "@pypi_cowsay//:pkg",
+    ],
+    include_system_site_packages = False,
+)

--- a/py/tests/py-venv-disable-systemsite/test.py
+++ b/py/tests/py-venv-disable-systemsite/test.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import site
+
+print("---")
+print("__file__:", __file__)
+print("sys.prefix:", sys.prefix)
+print("sys.executable:", sys.executable)
+print("site.PREFIXES:")
+for p in site.PREFIXES:
+    print(" -", p)
+
+# The virtualenv module should have already been loaded at interpreter startup
+assert "_virtualenv" in sys.modules
+print(site.PREFIXES)
+
+assert len(site.getsitepackages()) == 1

--- a/py/tests/py-venv-disable-usersite/BUILD.bazel
+++ b/py/tests/py-venv-disable-usersite/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//py/private/py_venv:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "test",
+    srcs = [
+        "test.py",
+    ],
+    imports = [
+        ".",
+    ],
+    main = "test.py",
+    deps = [
+        "@pypi_cowsay//:pkg",
+    ],
+    include_user_site_packages = False,
+)

--- a/py/tests/py-venv-disable-usersite/BUILD.bazel
+++ b/py/tests/py-venv-disable-usersite/BUILD.bazel
@@ -8,9 +8,9 @@ py_venv_test(
     imports = [
         ".",
     ],
+    include_user_site_packages = False,
     main = "test.py",
     deps = [
         "@pypi_cowsay//:pkg",
     ],
-    include_user_site_packages = False,
 )

--- a/py/tests/py-venv-disable-usersite/test.py
+++ b/py/tests/py-venv-disable-usersite/test.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import site
+
+print("---")
+print("__file__:", __file__)
+print("sys.prefix:", sys.prefix)
+print("sys.executable:", sys.executable)
+print("site.PREFIXES:")
+for p in site.PREFIXES:
+    print(" -", p)
+
+# The virtualenv module should have already been loaded at interpreter startup
+assert "_virtualenv" in sys.modules
+print(site.PREFIXES)
+
+assert len(site.getsitepackages()) == 1

--- a/py/tests/py-venv-enable-site/BUILD.bazel
+++ b/py/tests/py-venv-enable-site/BUILD.bazel
@@ -8,10 +8,10 @@ py_venv_test(
     imports = [
         ".",
     ],
+    include_system_site_packages = True,
+    include_user_site_packages = True,
     main = "test.py",
     deps = [
         "@pypi_cowsay//:pkg",
     ],
-    include_user_site_packages = True,
-    include_system_site_packages = True,
 )

--- a/py/tests/py-venv-enable-site/BUILD.bazel
+++ b/py/tests/py-venv-enable-site/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//py/private/py_venv:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "test",
+    srcs = [
+        "test.py",
+    ],
+    imports = [
+        ".",
+    ],
+    main = "test.py",
+    deps = [
+        "@pypi_cowsay//:pkg",
+    ],
+    include_user_site_packages = True,
+    include_system_site_packages = True,
+)

--- a/py/tests/py-venv-enable-site/test.py
+++ b/py/tests/py-venv-enable-site/test.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import site
+
+print("---")
+print("__file__:", __file__)
+print("sys.prefix:", sys.prefix)
+print("sys.executable:", sys.executable)
+print("site.PREFIXES:")
+for p in site.PREFIXES:
+    print(" -", p)
+
+# The virtualenv module should have already been loaded at interpreter startup
+assert "_virtualenv" in sys.modules
+
+# And we should have at least two site packages roots
+assert len(site.getsitepackages()) >= 2
+
+# And the user site flag should be set
+assert site.ENABLE_USER_SITE

--- a/py/tests/py-venv-standalone-interpreter/BUILD.bazel
+++ b/py/tests/py-venv-standalone-interpreter/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//py/private/py_venv:defs.bzl", "py_venv_binary")
+
+py_venv_binary(
+    name = "ex",
+    srcs = [
+        "ex.py",
+    ],
+    imports = [
+        ".",
+    ],
+    main = "ex.py",
+    deps = [
+        "@pypi_cowsay//:pkg",
+    ],
+)
+
+sh_test(
+    name = "test",
+    srcs = [
+        "test.sh",
+    ],
+    data = [
+        ":ex",
+    ],
+)

--- a/py/tests/py-venv-standalone-interpreter/BUILD.bazel copy
+++ b/py/tests/py-venv-standalone-interpreter/BUILD.bazel copy
@@ -1,0 +1,25 @@
+load("//py/private/py_venv:defs.bzl", "py_venv_binary")
+
+py_venv_binary(
+    name = "ex",
+    srcs = [
+        "ex.py",
+    ],
+    imports = [
+        ".",
+    ],
+    main = "ex.py",
+    deps = [
+        "@pypi_cowsay//:pkg",
+    ],
+)
+
+sh_test(
+    name = "test",
+    srcs = [
+        "test.sh",
+    ],
+    data = [
+        ":ex",
+    ],
+)

--- a/py/tests/py-venv-standalone-interpreter/ex.py
+++ b/py/tests/py-venv-standalone-interpreter/ex.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+def hello():
+    return "Hello, world!"

--- a/py/tests/py-venv-standalone-interpreter/test.sh
+++ b/py/tests/py-venv-standalone-interpreter/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -ex
+
+ROOT="$(dirname $0)"
+
+"$ROOT"/.ex/bin/python --help
+
+if [ "Hello, world!" != "$($ROOT/.ex/bin/python -c 'from ex import hello; print(hello())')" ]; then
+    exit 1
+fi

--- a/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
@@ -2511,12 +2511,12 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
   - -rwxr-xr-x  0 0      0        2853 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
-  - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
-  - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
-  - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
+  - -rwxr-xr-x  0 0      0      854280 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
+  - -rwxr-xr-x  0 0      0      854280 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
+  - -rwxr-xr-x  0 0      0      854280 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
-  - -rwxr-xr-x  0 0      0         344 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         343 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         299 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/

--- a/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
@@ -2510,13 +2510,13 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        8620 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
-  - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
-  - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
-  - -rwxr-xr-x  0 0      0      817416 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
+  - -rwxr-xr-x  0 0      0        2856 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
+  - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
+  - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
-  - -rwxr-xr-x  0 0      0         323 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         301 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         299 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/

--- a/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_amd64_layers_listing.yaml
@@ -2510,13 +2510,13 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        2856 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        2853 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      850184 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
-  - -rwxr-xr-x  0 0      0         301 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         344 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         299 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2497,7 +2497,7 @@ files:
   - -rwxr-xr-x  0 0      0      726736 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
-  - -rwxr-xr-x  0 0      0         345 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         344 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         299 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2491,13 +2491,13 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        8621 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
-  - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
-  - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
-  - -rwxr-xr-x  0 0      0      698064 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
+  - -rwxr-xr-x  0 0      0        2856 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0      726736 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
+  - -rwxr-xr-x  0 0      0      726736 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
+  - -rwxr-xr-x  0 0      0      726736 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
-  - -rwxr-xr-x  0 0      0         323 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         302 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         299 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2491,13 +2491,13 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/
-  - -rwxr-xr-x  0 0      0        2856 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
+  - -rwxr-xr-x  0 0      0        2853 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
   - -rwxr-xr-x  0 0      0      726736 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python
   - -rwxr-xr-x  0 0      0      726736 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
   - -rwxr-xr-x  0 0      0      726736 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
-  - -rwxr-xr-x  0 0      0         302 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         345 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         299 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py/py/tests/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/bazel_tools/

--- a/py/tools/py/BUILD.bazel
+++ b/py/tools/py/BUILD.bazel
@@ -19,6 +19,7 @@ rust_library(
         "//py/tools/venv_bin:__pkg__",
     ],
     deps = [
+        "//py/tools/runfiles",
         "@crate_index//:itertools",
         "@crate_index//:miette",
         "@crate_index//:pathdiff",
@@ -33,6 +34,5 @@ rust_library(
         "@crate_index//:uv-python",
         "@crate_index//:uv-virtualenv",
         "@crate_index//:walkdir",
-        "//py/tools/runfiles",
     ],
 )

--- a/py/tools/py/BUILD.bazel
+++ b/py/tools/py/BUILD.bazel
@@ -33,5 +33,6 @@ rust_library(
         "@crate_index//:uv-python",
         "@crate_index//:uv-virtualenv",
         "@crate_index//:walkdir",
+        "//py/tools/runfiles",
     ],
 )

--- a/py/tools/py/src/activate.tmpl
+++ b/py/tools/py/src/activate.tmpl
@@ -79,29 +79,6 @@ _OLD_VIRTUAL_PATH="$PATH"
 # We set these before runfiles initialization so that we can use it as part of a fallback path
 {{ENVVARS}}
 
-# Initialize the runfiles interpreter if we're using one. Note that this happens
-# AFTER unsetting the PYTHONHOME so that we can set PYTHONHOME if we're using a
-# full bundled interpreter, and after we set the Bazel-specific envvars so we
-# can provide some fallback handling around runfiles too.
-{{RUNFILES_INTERPRETER}}
-
-_abspath() {
-    "${PYTHONEXECUTABLE}" -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$@"
-}
-
-# Re-export abspath'd vars
-# This allows us to avoid relative path issues without incurring sandbox escapes
-VIRTUAL_ENV="$(_abspath "${VIRTUAL_ENV}")"
-export VIRTUAL_ENV
-
-PYTHONEXECUTABLE="$(_abspath "${PYTHONEXECUTABLE}")"
-export PYTHONEXECUTABLE
-
-if [ -n "${PYTHONHOME:-}" ]; then
-  PYTHONHOME="$(_abspath "${PYTHONHOME}")"
-  export PYTHONHOME
-fi
-
 # Now we can put the venv's absolute bin on the path
 PATH="$VIRTUAL_ENV/bin:$PATH"
 export PATH

--- a/py/tools/py/src/activate.tmpl
+++ b/py/tools/py/src/activate.tmpl
@@ -49,8 +49,6 @@ deactivate () {
     fi
 }
 
-{{DEBUG}}
-
 # unset irrelevant variables
 deactivate nondestructive
 

--- a/py/tools/py/src/pyvenv.cfg.tmpl
+++ b/py/tools/py/src/pyvenv.cfg.tmpl
@@ -2,5 +2,6 @@ home = ./bin/python3
 implementation = CPython
 version_info = {{MAJOR}}.{{MINOR}}.{{PATCH}}
 include-system-site-packages = {{INCLUDE_SYSTEM_SITE}}
+aspect-include-user-site-packages = {{INCLUDE_USER_SITE}}
 relocatable = true
 {{INTERPRETER}}

--- a/py/tools/py/src/pyvenv.cfg.tmpl
+++ b/py/tools/py/src/pyvenv.cfg.tmpl
@@ -1,6 +1,6 @@
 home = ./bin/python3
 implementation = CPython
 version_info = {{MAJOR}}.{{MINOR}}.{{PATCH}}
-include-system-site-packages = true
+include-system-site-packages = {{INCLUDE_SYSTEM_SITE}}
 relocatable = true
 {{INTERPRETER}}

--- a/py/tools/py/src/pyvenv.cfg.tmpl
+++ b/py/tools/py/src/pyvenv.cfg.tmpl
@@ -1,8 +1,6 @@
 home = ./bin/python3
 implementation = CPython
-version_info = {}.{}.{}
-# FIXME: Can we flip this to false?
-# In the case of a virtualenv with .runfiles-packaged Python this needs to be true
-# And in the case of a leaked/external interpreter this still needs to be true...
+version_info = {{MAJOR}}.{{MINOR}}.{{PATCH}}
 include-system-site-packages = true
 relocatable = true
+{{INTERPRETER}}

--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -376,9 +376,6 @@ aspect-runfiles-repo = {1}
         .wrap_err("Unable to create activate script")?;
     }
 
-    // FIXME: Add `activate` scripts here? Nobody should be activating these.
-    // Probably.
-
     // Create the site dir
     fs::create_dir_all(&venv.site_dir)
         .into_diagnostic()
@@ -514,7 +511,6 @@ pub fn populate_venv_with_copies(
             eprintln!("Entry is site-packages...");
 
             // If the entry is external then we have to adjust the path
-            // FIXME: This isn't quite right outside of bzlmod
             if workspace != main_module {
                 entry = PathBuf::from("external")
                     .join(PathBuf::from(workspace))
@@ -537,7 +533,6 @@ pub fn populate_venv_with_copies(
             for prefix in [&action_src_dir, &action_bin_dir] {
                 let src_dir = prefix.join(&bin_dir);
                 if src_dir.exists() {
-                    // FIXME: Need to correct shebangs
                     create_tree(&src_dir, &venv.bin_dir, &collision_strategy)?;
                 }
             }

--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -210,6 +210,7 @@ pub fn create_empty_venv<'a>(
     env_file: &Option<PathBuf>,
     venv_shim: &Option<PathBuf>,
     debug: bool,
+    include_system_site_packages: bool,
 ) -> miette::Result<Virtualenv> {
     let build_dir = current_dir().into_diagnostic()?;
     let home_dir = &build_dir.join(location.to_path_buf());
@@ -265,7 +266,11 @@ aspect_runfiles_repo = {1}
             .replace("{{MAJOR}}", &venv.version_info.major.to_string())
             .replace("{{MINOR}}", &venv.version_info.minor.to_string())
             .replace("{{PATCH}}", &venv.version_info.patch.to_string())
-            .replace("{{INTERPRETER}}", interpreter_cfg_snippet),
+            .replace("{{INTERPRETER}}", interpreter_cfg_snippet)
+            .replace(
+                "{{INCLUDE_SYSTEM_SITE}}",
+                &include_system_site_packages.to_string(),
+            ),
     )
     .into_diagnostic()?;
 

--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -203,7 +203,7 @@ const RELOCATABLE_SHEBANG: &str = "\
 /// - Do we _have_ to include activate scripts?
 /// - Do we _have_ to include a versioned symlink?
 pub fn create_empty_venv<'a>(
-    repo: &String,
+    repo: &str,
     python: &Path,
     version: PythonVersionInfo,
     location: &'a Path,
@@ -247,7 +247,7 @@ pub fn create_empty_venv<'a>(
 
     let interpreter_cfg_snippet = if using_runfiles_interpreter {
         format!(
-            "
+            "\
 # Non-standard extension keys used by the Aspect shim
 aspect-runfiles-interpreter = {0}
 aspect-runfiles-repo = {1}

--- a/py/tools/runfiles/BUILD.bazel
+++ b/py/tools/runfiles/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+rust_library(
+    name = "runfiles",
+    srcs = ["src/lib.rs"],
+    visibility = ["//visibility:public"],
+)

--- a/py/tools/runfiles/Cargo.toml
+++ b/py/tools/runfiles/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "runfiles"
+version.workspace = true
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+
+[dependencies]

--- a/py/tools/runfiles/README.md
+++ b/py/tools/runfiles/README.md
@@ -1,0 +1,5 @@
+# Runfiles
+
+Vendored from rules_rust since we're stuck on an old rules_rust which doesn't
+yet have that target, using the dep via rules_rust breaks Cargo/rust-analyzer
+anyway and the crates.io release is stale.

--- a/py/tools/runfiles/src/lib.rs
+++ b/py/tools/runfiles/src/lib.rs
@@ -1,0 +1,653 @@
+//! Runfiles lookup library for Bazel-built Rust binaries and tests.
+//!
+//! USAGE:
+//!
+//! 1. Depend on this runfiles library from your build rule:
+//! ```python
+//!   rust_binary(
+//!       name = "my_binary",
+//!       ...
+//!       data = ["//path/to/my/data.txt"],
+//!       deps = ["@rules_rust//rust/runfiles"],
+//!   )
+//! ```
+//!
+//! 2. Import the runfiles library.
+//! ```ignore
+//! use runfiles::Runfiles;
+//! ```
+//!
+//! 3. Create a Runfiles object and use `rlocation!`` to look up runfile paths:
+//! ```ignore
+//!
+//! use runfiles::{Runfiles, rlocation};
+//!
+//! let r = Runfiles::create().unwrap();
+//! let path = rlocation!(r, "my_workspace/path/to/my/data.txt").expect("Failed to locate runfile");
+//!
+//! let f = File::open(path).unwrap();
+//!
+//! // ...
+//! ```
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+const RUNFILES_DIR_ENV_VAR: &str = "RUNFILES_DIR";
+const MANIFEST_FILE_ENV_VAR: &str = "RUNFILES_MANIFEST_FILE";
+const TEST_SRCDIR_ENV_VAR: &str = "TEST_SRCDIR";
+
+#[macro_export]
+macro_rules! rlocation {
+    ($r:expr, $path:expr) => {
+        $r.rlocation_from($path, env!("REPOSITORY_NAME"))
+    };
+}
+
+/// The error type for [Runfiles] construction.
+#[derive(Debug)]
+pub enum RunfilesError {
+    /// Directory based runfiles could not be found.
+    RunfilesDirNotFound,
+
+    /// An [I/O Error](https://doc.rust-lang.org/std/io/struct.Error.html)
+    /// which occurred during the creation of directory-based runfiles.
+    RunfilesDirIoError(io::Error),
+
+    /// An [I/O Error](https://doc.rust-lang.org/std/io/struct.Error.html)
+    /// which occurred during the creation of manifest-file-based runfiles.
+    RunfilesManifestIoError(io::Error),
+
+    /// A manifest file could not be parsed.
+    RunfilesManifestInvalidFormat,
+
+    /// The bzlmod repo-mapping file could not be found.
+    RepoMappingNotFound,
+
+    /// The bzlmod repo-mapping file could not be parsed.
+    RepoMappingInvalidFormat,
+
+    /// An [I/O Error](https://doc.rust-lang.org/std/io/struct.Error.html)
+    /// which occurred during the parsing of a repo-mapping file.
+    RepoMappingIoError(io::Error),
+
+    /// An error indicating a specific Runfile was not found.
+    RunfileNotFound(PathBuf),
+
+    /// An [I/O Error](https://doc.rust-lang.org/std/io/struct.Error.html)
+    /// which occurred when operating with a particular runfile.
+    RunfileIoError(io::Error),
+}
+
+impl std::fmt::Display for RunfilesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RunfilesError::RunfilesDirNotFound => write!(f, "RunfilesDirNotFound"),
+            RunfilesError::RunfilesDirIoError(err) => write!(f, "RunfilesDirIoError: {:?}", err),
+            RunfilesError::RunfilesManifestIoError(err) => {
+                write!(f, "RunfilesManifestIoError: {:?}", err)
+            }
+            RunfilesError::RunfilesManifestInvalidFormat => write!(f, "RepoMappingInvalidFormat"),
+            RunfilesError::RepoMappingNotFound => write!(f, "RepoMappingInvalidFormat"),
+            RunfilesError::RepoMappingInvalidFormat => write!(f, "RepoMappingInvalidFormat"),
+            RunfilesError::RepoMappingIoError(err) => write!(f, "RepoMappingIoError: {:?}", err),
+            RunfilesError::RunfileNotFound(path) => {
+                write!(f, "RunfileNotFound: {}", path.display())
+            }
+            RunfilesError::RunfileIoError(err) => write!(f, "RunfileIoError: {:?}", err),
+        }
+    }
+}
+
+impl std::error::Error for RunfilesError {}
+
+impl PartialEq for RunfilesError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::RunfilesDirIoError(l0), Self::RunfilesDirIoError(r0)) => {
+                l0.to_string() == r0.to_string()
+            }
+            (Self::RunfilesManifestIoError(l0), Self::RunfilesManifestIoError(r0)) => {
+                l0.to_string() == r0.to_string()
+            }
+            (Self::RepoMappingIoError(l0), Self::RepoMappingIoError(r0)) => {
+                l0.to_string() == r0.to_string()
+            }
+            (Self::RunfileNotFound(l0), Self::RunfileNotFound(r0)) => l0 == r0,
+            (Self::RunfileIoError(l0), Self::RunfileIoError(r0)) => {
+                l0.to_string() == r0.to_string()
+            }
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
+/// A specialized [`std::result::Result`] type for
+pub type Result<T> = std::result::Result<T, RunfilesError>;
+
+#[derive(Debug)]
+enum Mode {
+    /// Runfiles located in a directory indicated by the `RUNFILES_DIR` environment
+    /// variable or a neighboring `*.runfiles` directory to the executable.
+    DirectoryBased(PathBuf),
+
+    /// Runfiles represented as a mapping of `rlocationpath` to real paths indicated
+    /// by the `RUNFILES_MANIFEST_FILE` environment variable.
+    ManifestBased(HashMap<PathBuf, PathBuf>),
+}
+
+type RepoMappingKey = (String, String);
+type RepoMapping = HashMap<RepoMappingKey, String>;
+
+/// An interface for accessing to [Bazel runfiles](https://bazel.build/extending/rules#runfiles).
+#[derive(Debug)]
+pub struct Runfiles {
+    mode: Mode,
+    repo_mapping: RepoMapping,
+}
+
+impl Runfiles {
+    /// Creates a manifest based Runfiles object when
+    /// RUNFILES_MANIFEST_FILE environment variable is present,
+    /// or a directory based Runfiles object otherwise.
+    pub fn create() -> Result<Self> {
+        let mode = if let Some(manifest_file) = std::env::var_os(MANIFEST_FILE_ENV_VAR) {
+            Self::create_manifest_based(Path::new(&manifest_file))?
+        } else {
+            let dir = find_runfiles_dir()?;
+            let manifest_path = dir.join("MANIFEST");
+            match manifest_path.exists() {
+                true => Self::create_manifest_based(&manifest_path)?,
+                false => Mode::DirectoryBased(dir),
+            }
+        };
+
+        let repo_mapping = raw_rlocation(&mode, "_repo_mapping")
+            // This is the only place directory based runfiles might do file IO for a runfile. In the
+            // event that a `_repo_mapping` file does not exist, a default map should be created. Otherwise
+            // if the file is known to exist, parse it and raise errors for users should parsing fail.
+            .filter(|f| f.exists())
+            .map(parse_repo_mapping)
+            .transpose()?
+            .unwrap_or_default();
+
+        Ok(Runfiles { mode, repo_mapping })
+    }
+
+    fn create_manifest_based(manifest_path: &Path) -> Result<Mode> {
+        let manifest_content = std::fs::read_to_string(manifest_path)
+            .map_err(RunfilesError::RunfilesManifestIoError)?;
+        let path_mapping = manifest_content
+            .lines()
+            .flat_map(|line| {
+                let pair = line
+                    .split_once(' ')
+                    .ok_or(RunfilesError::RunfilesManifestInvalidFormat)?;
+                Ok::<(PathBuf, PathBuf), RunfilesError>((pair.0.into(), pair.1.into()))
+            })
+            .collect::<HashMap<_, _>>();
+        Ok(Mode::ManifestBased(path_mapping))
+    }
+
+    /// Returns the runtime path of a runfile.
+    ///
+    /// Runfiles are data-dependencies of Bazel-built binaries and tests.
+    /// The returned path may not be valid. The caller should check the path's
+    /// validity and that the path exists.
+    /// @deprecated - this is not bzlmod-aware. Prefer the `rlocation!` macro or `rlocation_from`
+    pub fn rlocation(&self, path: impl AsRef<Path>) -> Option<PathBuf> {
+        let path = path.as_ref();
+        if path.is_absolute() {
+            return Some(path.to_path_buf());
+        }
+        raw_rlocation(&self.mode, path)
+    }
+
+    /// Returns the runtime path of a runfile.
+    ///
+    /// Runfiles are data-dependencies of Bazel-built binaries and tests.
+    /// The returned path may not be valid. The caller should check the path's
+    /// validity and that the path exists.
+    ///
+    /// Typically this should be used via the `rlocation!` macro to properly set source_repo.
+    pub fn rlocation_from(&self, path: impl AsRef<Path>, source_repo: &str) -> Option<PathBuf> {
+        let path = path.as_ref();
+        if path.is_absolute() {
+            return Some(path.to_path_buf());
+        }
+
+        let path_str = path.to_str().expect("Should be valid UTF8");
+        let (repo_alias, repo_path): (&str, Option<&str>) = match path_str.split_once('/') {
+            Some((name, alias)) => (name, Some(alias)),
+            None => (path_str, None),
+        };
+        let key: (String, String) = (source_repo.into(), repo_alias.into());
+        if let Some(target_repo_directory) = self.repo_mapping.get(&key) {
+            match repo_path {
+                Some(repo_path) => {
+                    raw_rlocation(&self.mode, format!("{target_repo_directory}/{repo_path}"))
+                }
+                None => raw_rlocation(&self.mode, target_repo_directory),
+            }
+        } else {
+            raw_rlocation(&self.mode, path)
+        }
+    }
+}
+
+fn raw_rlocation(mode: &Mode, path: impl AsRef<Path>) -> Option<PathBuf> {
+    let path = path.as_ref();
+    match mode {
+        Mode::DirectoryBased(runfiles_dir) => Some(runfiles_dir.join(path)),
+        Mode::ManifestBased(path_mapping) => path_mapping.get(path).cloned(),
+    }
+}
+
+fn parse_repo_mapping(path: PathBuf) -> Result<RepoMapping> {
+    let mut repo_mapping = RepoMapping::new();
+
+    for line in std::fs::read_to_string(path)
+        .map_err(RunfilesError::RepoMappingIoError)?
+        .lines()
+    {
+        let parts: Vec<&str> = line.splitn(3, ',').collect();
+        if parts.len() < 3 {
+            return Err(RunfilesError::RepoMappingInvalidFormat);
+        }
+        repo_mapping.insert((parts[0].into(), parts[1].into()), parts[2].into());
+    }
+
+    Ok(repo_mapping)
+}
+
+/// Returns the .runfiles directory for the currently executing binary.
+pub fn find_runfiles_dir() -> Result<PathBuf> {
+    assert!(
+        std::env::var_os(MANIFEST_FILE_ENV_VAR).is_none(),
+        "Unexpected call when {} exists",
+        MANIFEST_FILE_ENV_VAR
+    );
+
+    // If Bazel told us about the runfiles dir, use that without looking further.
+    if let Some(runfiles_dir) = std::env::var_os(RUNFILES_DIR_ENV_VAR).map(PathBuf::from) {
+        if runfiles_dir.is_dir() {
+            return Ok(runfiles_dir);
+        }
+    }
+    if let Some(test_srcdir) = std::env::var_os(TEST_SRCDIR_ENV_VAR).map(PathBuf::from) {
+        if test_srcdir.is_dir() {
+            return Ok(test_srcdir);
+        }
+    }
+
+    // Consume the first argument (argv[0])
+    let exec_path = std::env::args().next().expect("arg 0 was not set");
+
+    let current_dir =
+        env::current_dir().expect("The current working directory is always expected to be set.");
+
+    let mut binary_path = PathBuf::from(&exec_path);
+    loop {
+        // Check for our neighboring `${binary}.runfiles` directory.
+        let mut runfiles_name = binary_path.file_name().unwrap().to_owned();
+        runfiles_name.push(".runfiles");
+
+        let runfiles_path = binary_path.with_file_name(&runfiles_name);
+        if runfiles_path.is_dir() {
+            return Ok(runfiles_path);
+        }
+
+        // Check if we're already under a `*.runfiles` directory.
+        {
+            // TODO: 1.28 adds Path::ancestors() which is a little simpler.
+            let mut next = binary_path.parent();
+            while let Some(ancestor) = next {
+                if ancestor
+                    .file_name()
+                    .is_some_and(|f| f.to_string_lossy().ends_with(".runfiles"))
+                {
+                    return Ok(ancestor.to_path_buf());
+                }
+                next = ancestor.parent();
+            }
+        }
+
+        if !fs::symlink_metadata(&binary_path)
+            .map_err(RunfilesError::RunfilesDirIoError)?
+            .file_type()
+            .is_symlink()
+        {
+            break;
+        }
+        // Follow symlinks and keep looking.
+        let link_target = binary_path
+            .read_link()
+            .map_err(RunfilesError::RunfilesDirIoError)?;
+        binary_path = if link_target.is_absolute() {
+            link_target
+        } else {
+            let link_dir = binary_path.parent().unwrap();
+            current_dir.join(link_dir).join(link_target)
+        }
+    }
+
+    Err(RunfilesError::RunfilesDirNotFound)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::ffi::OsStr;
+    use std::ffi::OsString;
+    use std::fs::File;
+    use std::hash::Hash;
+    use std::io::prelude::*;
+    use std::sync::{Mutex, OnceLock};
+
+    /// A mutex used to guard
+    static GLOBAL_MUTEX: OnceLock<Mutex<i32>> = OnceLock::new();
+
+    /// Mock out environment variables for a given body fo work. Very similar to
+    /// [temp-env](https://crates.io/crates/temp-env).
+    fn with_mock_env<K, V, F, R>(kvs: impl AsRef<[(K, Option<V>)]>, closure: F) -> R
+    where
+        K: AsRef<OsStr> + Clone + Eq + Hash,
+        V: AsRef<OsStr> + Clone,
+        F: FnOnce() -> R,
+    {
+        let mtx = GLOBAL_MUTEX.get_or_init(|| Mutex::new(0));
+
+        // Ignore poisoning as it's expected to be another test failing an assertion.
+        let _guard = mtx.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        // track the original state of the environment.
+        let mut old_env = HashMap::new();
+
+        // Replace or remove requested environment variables.
+        for (env, val) in kvs.as_ref() {
+            // Track the original state of the variable.
+            match std::env::var_os(env) {
+                Some(v) => old_env.insert(env, Some(v)),
+                None => old_env.insert(env, None::<OsString>),
+            };
+
+            match val {
+                Some(v) => std::env::set_var(env, v),
+                None => std::env::remove_var(env),
+            }
+        }
+
+        // Run requested work.
+        let result = closure();
+
+        // Restore original environment
+        for (env, val) in old_env {
+            match val {
+                Some(v) => std::env::set_var(env, v),
+                None => std::env::remove_var(env),
+            }
+        }
+
+        result
+    }
+
+    #[test]
+    fn test_mock_env() {
+        let original_name = std::env::var("TEST_WORKSPACE").unwrap();
+        assert!(
+            !original_name.is_empty(),
+            "In Bazel tests, `TEST_WORKSPACE` is expected to be populated."
+        );
+
+        let mocked_name = with_mock_env([("TEST_WORKSPACE", Some("foobar"))], || {
+            std::env::var("TEST_WORKSPACE").unwrap()
+        });
+
+        assert_eq!(mocked_name, "foobar");
+        assert_eq!(original_name, std::env::var("TEST_WORKSPACE").unwrap());
+    }
+
+    /// Create a temp directory to act as a runfiles directory for testing
+    /// [super::Mode::DirectoryBased] style runfiles.
+    fn make_runfiles_like_dir(name: &str) -> String {
+        with_mock_env([("FAKE", None::<&str>)], || {
+            let r = Runfiles::create().unwrap();
+
+            let path = "rules_rust/rust/runfiles/data/sample.txt";
+            let f = rlocation!(r, path).unwrap();
+
+            let temp_dir = PathBuf::from(std::env::var("TEST_TMPDIR").unwrap());
+            let runfiles_dir = temp_dir.join(name);
+            let test_path = runfiles_dir.join(path);
+            if let Some(parent) = test_path.parent() {
+                std::fs::create_dir_all(parent).expect("Failed to create test path parents.");
+            }
+
+            std::fs::copy(f, test_path).expect("Failed to copy test file");
+
+            runfiles_dir.to_str().unwrap().to_string()
+        })
+    }
+
+    /// Test the general behavior of runfiles. The behavior of runfiles will change
+    /// depending on the system but each mode is explicitly covered in other tests.
+    #[test]
+    fn test_standard_lookup() {
+        let r = Runfiles::create().unwrap();
+
+        let f = rlocation!(r, "rules_rust/rust/runfiles/data/sample.txt").unwrap();
+
+        let mut f = File::open(&f)
+            .unwrap_or_else(|e| panic!("Failed to open file: {}\n{:?}", f.display(), e));
+
+        let mut buffer = String::new();
+        f.read_to_string(&mut buffer).unwrap();
+
+        assert_eq!("Example Text!", buffer);
+    }
+
+    /// Only `RUNFILES_DIR` is set.
+    #[test]
+    fn test_env_only_runfiles_dir() {
+        let runfiles_dir = make_runfiles_like_dir("test_env_only_runfiles_dir");
+
+        with_mock_env(
+            [
+                (MANIFEST_FILE_ENV_VAR, None::<&str>),
+                (RUNFILES_DIR_ENV_VAR, Some(runfiles_dir.as_str())),
+                (TEST_SRCDIR_ENV_VAR, None::<&str>),
+            ],
+            || {
+                let r = Runfiles::create().unwrap();
+
+                let d = rlocation!(r, "rules_rust").unwrap();
+                let f = rlocation!(r, "rules_rust/rust/runfiles/data/sample.txt").unwrap();
+                assert_eq!(d.join("rust/runfiles/data/sample.txt"), f);
+
+                let mut f = File::open(&f)
+                    .unwrap_or_else(|e| panic!("Failed to open file: {}\n{:?}", f.display(), e));
+
+                let mut buffer = String::new();
+                f.read_to_string(&mut buffer).unwrap();
+
+                assert_eq!("Example Text!", buffer);
+            },
+        );
+    }
+
+    /// Only `TEST_SRCDIR` is set.
+    #[test]
+    fn test_env_only_test_srcdir() {
+        let runfiles_dir = make_runfiles_like_dir("test_env_only_test_srcdir");
+
+        with_mock_env(
+            [
+                (MANIFEST_FILE_ENV_VAR, None::<&str>),
+                (RUNFILES_DIR_ENV_VAR, None::<&str>),
+                (TEST_SRCDIR_ENV_VAR, Some(runfiles_dir.as_str())),
+            ],
+            || {
+                let r = Runfiles::create().unwrap();
+
+                let runfile = rlocation!(r, "rules_rust/rust/runfiles/data/sample.txt").unwrap();
+
+                let mut f = File::open(&runfile)
+                    .unwrap_or_else(|e| panic!("Failed to open: {}\n{:?}", runfile.display(), e));
+
+                let mut buffer = String::new();
+                f.read_to_string(&mut buffer).unwrap();
+
+                assert_eq!("Example Text!", buffer);
+            },
+        );
+    }
+
+    /// `RUNFILES_DIR`, `TEST_SRCDIR`, and `MANIFEST_FILE_ENV_VAR` are not set. This
+    /// will test the `.runfiles` directory lookup.
+    ///
+    /// This test is skipped on windows as these directories are not guaranteed
+    /// to have been created.
+    #[cfg(not(target_family = "windows"))]
+    #[test]
+    fn test_env_nothing_set() {
+        with_mock_env(
+            [
+                (RUNFILES_DIR_ENV_VAR, None::<&str>),
+                (TEST_SRCDIR_ENV_VAR, None::<&str>),
+                (MANIFEST_FILE_ENV_VAR, None::<&str>),
+            ],
+            || {
+                let r = Runfiles::create().unwrap();
+
+                let mut f =
+                    File::open(rlocation!(r, "rules_rust/rust/runfiles/data/sample.txt").unwrap())
+                        .unwrap();
+
+                let mut buffer = String::new();
+                f.read_to_string(&mut buffer).unwrap();
+
+                assert_eq!("Example Text!", buffer);
+            },
+        );
+    }
+
+    #[test]
+    fn test_manifest_based_can_read_data_from_runfiles() {
+        let mut path_mapping = HashMap::new();
+        path_mapping.insert("a/b".into(), "c/d".into());
+        let r = Runfiles {
+            mode: Mode::ManifestBased(path_mapping),
+            repo_mapping: RepoMapping::new(),
+        };
+
+        assert_eq!(r.rlocation("a/b"), Some(PathBuf::from("c/d")));
+    }
+
+    #[test]
+    fn test_manifest_based_missing_file() {
+        let mut path_mapping = HashMap::new();
+        path_mapping.insert("a/b".into(), "c/d".into());
+        let r = Runfiles {
+            mode: Mode::ManifestBased(path_mapping),
+            repo_mapping: RepoMapping::new(),
+        };
+
+        assert_eq!(r.rlocation("does/not/exist"), None);
+    }
+
+    fn dedent(text: &str) -> String {
+        text.lines()
+            .map(|l| l.trim_start())
+            .collect::<Vec<&str>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn test_parse_repo_mapping() {
+        let temp_dir = PathBuf::from(std::env::var("TEST_TMPDIR").unwrap());
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let valid = temp_dir.join("test_parse_repo_mapping.txt");
+        std::fs::write(
+            &valid,
+            dedent(
+                r#",rules_rust,rules_rust
+            bazel_tools,__main__,rules_rust
+            local_config_cc,rules_rust,rules_rust
+            local_config_sh,rules_rust,rules_rust
+            local_config_xcode,rules_rust,rules_rust
+            platforms,rules_rust,rules_rust
+            rules_rust_tinyjson,rules_rust,rules_rust
+            rust_darwin_aarch64__aarch64-apple-darwin__stable_tools,rules_rust,rules_rust
+            "#,
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            parse_repo_mapping(valid),
+            Ok(RepoMapping::from([
+                (
+                    ("local_config_xcode".to_owned(), "rules_rust".to_owned()),
+                    "rules_rust".to_owned()
+                ),
+                (
+                    ("platforms".to_owned(), "rules_rust".to_owned()),
+                    "rules_rust".to_owned()
+                ),
+                (
+                    (
+                        "rust_darwin_aarch64__aarch64-apple-darwin__stable_tools".to_owned(),
+                        "rules_rust".to_owned()
+                    ),
+                    "rules_rust".to_owned()
+                ),
+                (
+                    ("rules_rust_tinyjson".to_owned(), "rules_rust".to_owned()),
+                    "rules_rust".to_owned()
+                ),
+                (
+                    ("local_config_sh".to_owned(), "rules_rust".to_owned()),
+                    "rules_rust".to_owned()
+                ),
+                (
+                    ("bazel_tools".to_owned(), "__main__".to_owned()),
+                    "rules_rust".to_owned()
+                ),
+                (
+                    ("local_config_cc".to_owned(), "rules_rust".to_owned()),
+                    "rules_rust".to_owned()
+                ),
+                (
+                    ("".to_owned(), "rules_rust".to_owned()),
+                    "rules_rust".to_owned()
+                )
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_parse_repo_mapping_invalid_file() {
+        let temp_dir = PathBuf::from(std::env::var("TEST_TMPDIR").unwrap());
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let invalid = temp_dir.join("test_parse_repo_mapping_invalid_file.txt");
+
+        assert!(matches!(
+            parse_repo_mapping(invalid.clone()).err().unwrap(),
+            RunfilesError::RepoMappingIoError(_)
+        ));
+
+        std::fs::write(&invalid, "invalid").unwrap();
+
+        assert_eq!(
+            parse_repo_mapping(invalid),
+            Err(RunfilesError::RepoMappingInvalidFormat),
+        );
+    }
+}

--- a/py/tools/runfiles/src/lib.rs
+++ b/py/tools/runfiles/src/lib.rs
@@ -183,7 +183,6 @@ impl Runfiles {
     }
 
     fn create_manifest_based(manifest_path: &Path) -> Result<Mode> {
-        eprintln!("{manifest_path:?}");
         let manifest_content = std::fs::read_to_string(manifest_path)
             .map_err(RunfilesError::RunfilesManifestIoError)?;
         let path_mapping = manifest_content

--- a/py/tools/runfiles/src/lib.rs
+++ b/py/tools/runfiles/src/lib.rs
@@ -352,7 +352,7 @@ mod test {
     /// A mutex used to guard
     static GLOBAL_MUTEX: OnceLock<Mutex<i32>> = OnceLock::new();
 
-    /// Mock out environment variables for a given body fo work. Very similar to
+    /// Mock out environment variables for a given body to work. Very similar to
     /// [temp-env](https://crates.io/crates/temp-env).
     fn with_mock_env<K, V, F, R>(kvs: impl AsRef<[(K, Option<V>)]>, closure: F) -> R
     where

--- a/py/tools/venv_bin/src/main.rs
+++ b/py/tools/venv_bin/src/main.rs
@@ -94,13 +94,23 @@ struct VenvArgs {
 
     #[clap(
         long,
-        default_missing_value("true"),
-        default_value("true"),
+        default_missing_value("false"),
+        default_value("false"),
         num_args(0..=1),
         require_equals(true),
         action = ArgAction::Set,
     )]
     include_system_site_packages: bool,
+
+    #[clap(
+        long,
+        default_missing_value("false"),
+        default_value("false"),
+        num_args(0..=1),
+        require_equals(true),
+        action = ArgAction::Set,
+    )]
+    include_user_site_packages: bool,
 }
 
 fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
@@ -131,6 +141,7 @@ fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
                 &args.venv_shim,
                 args.debug,
                 args.include_system_site_packages,
+                args.include_user_site_packages,
             )?;
 
             py::venv::populate_venv_with_copies(
@@ -160,6 +171,7 @@ fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
                 &args.venv_shim,
                 args.debug,
                 args.include_system_site_packages,
+                args.include_user_site_packages,
             )?;
 
             py::venv::populate_venv_with_pth(

--- a/py/tools/venv_bin/src/main.rs
+++ b/py/tools/venv_bin/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use clap::ArgAction;
 use clap::Parser;
 use miette::miette;
 use miette::Context;
@@ -90,6 +91,16 @@ struct VenvArgs {
 
     #[arg(long, default_value_t = false)]
     debug: bool,
+
+    #[clap(
+        long,
+        default_missing_value("true"),
+        default_value("true"),
+        num_args(0..=1),
+        require_equals(true),
+        action = ArgAction::Set,
+    )]
+    include_system_site_packages: bool,
 }
 
 fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
@@ -119,6 +130,7 @@ fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
                 &args.env_file,
                 &args.venv_shim,
                 args.debug,
+                args.include_system_site_packages,
             )?;
 
             py::venv::populate_venv_with_copies(
@@ -147,6 +159,7 @@ fn venv_cmd_handler(args: VenvArgs) -> miette::Result<()> {
                 &args.env_file,
                 &args.venv_shim,
                 args.debug,
+                args.include_system_site_packages,
             )?;
 
             py::venv::populate_venv_with_pth(

--- a/py/tools/venv_shim/BUILD.bazel
+++ b/py/tools/venv_shim/BUILD.bazel
@@ -6,8 +6,8 @@ rust_binary(
         "src/main.rs",
     ],
     deps = [
-        "@crate_index//:miette",
         "//py/tools/runfiles",
+        "@crate_index//:miette",
     ],
 )
 

--- a/py/tools/venv_shim/BUILD.bazel
+++ b/py/tools/venv_shim/BUILD.bazel
@@ -7,6 +7,7 @@ rust_binary(
     ],
     deps = [
         "@crate_index//:miette",
+        "//py/tools/runfiles",
     ],
 )
 

--- a/py/tools/venv_shim/Cargo.toml
+++ b/py/tools/venv_shim/Cargo.toml
@@ -20,3 +20,4 @@ path = "src/main.rs"
 
 [dependencies]
 miette = { workspace = true }
+runfiles = { path = "../runfiles" }

--- a/py/tools/venv_shim/src/main.rs
+++ b/py/tools/venv_shim/src/main.rs
@@ -95,7 +95,6 @@ fn parse_venv_cfg(venv_root: &Path, cfg_path: &Path) -> miette::Result<PyCfg> {
             },
             user_site: user_site.expect("User site flag not set!"),
         }),
-        // FIXME: Kinda useless copy in this case
         (Some(version), None, None) => Ok(PyCfg {
             root: venv_root.to_path_buf(),
             cfg: cfg_path.to_path_buf(),

--- a/py/tools/venv_shim/src/main.rs
+++ b/py/tools/venv_shim/src/main.rs
@@ -15,8 +15,9 @@ fn find_venv_root() -> miette::Result<(PathBuf, PathBuf)> {
         let cfg = root.join(PYVENV);
         if cfg.exists() {
             return Ok((root, cfg));
+        } else {
+            eprintln!("Warning: $VIRTUAL_ENV is set but seems to be invalid; ignoring")
         }
-        // FIXME: Else warn that the VIRTUAL_ENV is invalid before continuing
     }
 
     if let Some(this) = args().next() {

--- a/py/tools/venv_shim/src/main.rs
+++ b/py/tools/venv_shim/src/main.rs
@@ -218,7 +218,7 @@ fn main() -> miette::Result<()> {
     // location on Linux-based platforms.
     cmd.arg0(&venv_interpreter);
 
-    // Psuedo-`activate`
+    // Pseudo-`activate`
     cmd.env("VIRTUAL_ENV", &venv_root.to_str().unwrap());
     let venv_bin = (&venv_root).join("bin").to_str().unwrap().to_owned();
     if let Ok(current_path) = var("PATH") {


### PR DESCRIPTION
This patch reworks how the interpreter shim operates to eliminate the data dependency on the `activate` script having been evaluated and move the parameters which previously came via the shell environment.

Because the behavior of `activate` isn't actually specified, we previously assumed that it was safe to just extend `activate`. This isn't true at all it turns out. Under normal operation the interpreter initialization as implemented in `Modules/getpath.py` provides special behavior when the interpreter's observed filename (`argv[0]`) is a symlink as it is in a normal non-relocatable virtualenv. In this case the interpreter and will search for a `pyvenv.cfg` relative to the "interpreter" and implicitly activate the venv as needed.

Our `./bin/python` being an actual binary interrupts this which means we're on our own to make `getpath` and `site` do the needful.

This should be as simple as setting the `home=` key in the `pyvenv.cfg`, but there isn't a principled way other than going through the runfiles library to locate where the interpreter lands in the runfiles tree relative to the virtualenv. Ideally we'd set the `home=` key to a relative path and mostly move on. Instead due in part to bzlmod munging we have to do the repo mapping dance which can't be done statically. So we need to do `rlocation` somewhere.

The solution this patch comes to is moving that `rlocation` logic out of the `activate` script and into the launcher itself so that the launcher can search for the needed `$PYTHONHOME` and desired interpreter without the user having previously loaded the required parameters into the env via `activate`.

Fixes #594.
Fixes #631.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

The `py_venv_binary` and friends no longer depend on their virtualenvs being `activated` via the shell. Their interpreters can safely be invoked directly as under an IDE or in a Spark environment.

The `py_venv_binary` now no longer includes NEITHER the user's site-packages NOR the interpreter's site-packages directory unless the `enable_system_site_packages` or `enable_user_site_packages` attributes are explicitly set. This prevents accidental non-hermetic imports.

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:

```shellsession
❯ aspect build //py/tests/py-internal-venv:test && bazel-bin/py/tests/py-internal-venv/test.runfiles/aspect_rules_py/py/tests/py-internal-venv/.test/bin/python -c 'import sys; from pprint import pprint; pprint(sys.path)'
INFO: Analyzed target //py/tests/py-internal-venv:test (2 packages loaded, 922 targets configured).
INFO: From Compiling Rust bin shim_macos_aarch64_build (1 files):
warning: fields `cfg` and `version_info` are never read
  --> py/tools/venv_shim/src/main.rs:45:5
   |
43 | struct PyCfg {
   |        ----- fields in this struct
44 |     root: PathBuf,
45 |     cfg: PathBuf,
   |     ^^^
46 |     version_info: String,
   |     ^^^^^^^^^^^^
   |
   = note: `PyCfg` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default

warning: 1 warning emitted

INFO: Found 1 target...
Target //py/tests/py-internal-venv:test up-to-date:
  bazel-bin/py/tests/py-internal-venv/test
INFO: Elapsed time: 10.289s, Critical Path: 6.72s
INFO: 4 processes: 1 internal, 3 darwin-sandbox.
INFO: Build completed successfully, 4 total actions
"bazel-bin/py/tests/py-internal-venv/test.runfiles/MANIFEST"
['',
 '/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/external/python_toolchain_aarch64-apple-darwin/lib/python39.zip',
 '/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/external/python_toolchain_aarch64-apple-darwin/lib/python3.9',
 '/private/var/tmp/_bazel_arrdem/93bfea6cdc1153cc29a75400cd38823a/external/python_toolchain_aarch64-apple-darwin/lib/python3.9/lib-dynload',
 '/Users/arrdem/Documents/work/aspect/rules_py/bazel-bin/py/tests/py-internal-venv/test.runfiles/aspect_rules_py/py/tests/py-internal-venv/.test/lib/python3.9/site-packages',
 '/Users/arrdem/Documents/work/aspect/rules_py/bazel-bin/py/tests/py-internal-venv/test.runfiles/aspect_rules_py/py/tests/py-internal-venv',
 '/Users/arrdem/Documents/work/aspect/rules_py/bazel-bin/py/tests/py-internal-venv/test.runfiles/aspect_rules_py']
```

### TODO
- [x] Need to add automated tests covering entrypoint bypass
- [x] Need to add automated tests covering the usersite behavior
- [x] Need to add automated tests covering the system site behavior