### PR TITLE
fix(py_venv): Add error for older runtimes

### DIFF
--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -50,6 +50,9 @@ def _py_venv_base_impl(ctx):
 
     py_toolchain = _py_semantics.resolve_toolchain(ctx)
 
+    if (py_toolchain.interpreter_version_info.major, py_toolchain.interpreter_version_info.minor) < (3, 11):
+        fail("The prebuild py_venv strategy requires Py 3.11.0 or later")
+
     # Note that we HAVE to grab these files from toolchains so that we can swap
     # in prebuild versions in production.
     py_shim = ctx.toolchains[SHIM_TOOLCHAIN]


### PR DESCRIPTION
Hopefully we can relax this later but for now add this to avoid user surprise.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`py_venv_binary` explicitly requires an interpreter of 3.11 or later.

### Test plan

- Covered by existing test cases
