### PR TITLE
fix(py_*): Safer default application for exec_properties

### DIFF
--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -63,7 +63,7 @@ py_image_layer = _py_image_layer
 resolutions = _resolutions
 
 def _py_binary_or_test(name, rule, srcs, main, data = [], deps = [], resolutions = {}, **kwargs):
-    exec_properties = kwargs.pop("exec_properties", {})
+    exec_properties = kwargs.pop("exec_properties") or {}
     non_test_exec_properties = {k: v for k, v in exec_properties.items() if not k.startswith("test.")}
 
     # Compatibility with rules_python, see docs in py_executable.bzl


### PR DESCRIPTION
Tweak how we parse the `exec_properties` attribute so that the codepath is `None`-safe in case the user explicitly provided a `None` value somehow.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed #605.

### Test plan

- New test cases added