### PR TITLE
fix(pytest): Correct starlark deps

### DIFF
--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -63,8 +63,7 @@ bzl_library(
     name = "py_pytest_main",
     srcs = ["py_pytest_main.bzl"],
     deps = [
-        "@rules_python//docs:bazel_repo_tools",
-        "@rules_python//python:defs_bzl",
+        ":py_library",
     ],
 )
 


### PR DESCRIPTION
The dependencies set in the `deps` are not loaded in `py_pytest_main.bzl`.

This enables downstream targets to properly depend on `@aspect_rules_py//py:defs`

Otherwise we're running into an error:

```
ERROR: error loading package '@@rules_python+//docs': Unable to find package for @@[unknown repo 'dev_pip' requested from @@rules_python+]//:requirements.bzl: The repository '@@[unknown repo 'dev_pip' requested from @@rules_python+]' could not be resolved: No repository visible as '@dev_pip' from repository '@@rules_python+'.
ERROR: /private/var/tmp/_bazel_user/7870d530ca6897c426c1d0f00687a4c1/external/aspect_rules_py+/py/private/BUILD.bazel:62:12: error loading package '@@rules_python+//docs': Unable to find package for @@[unknown repo 'dev_pip' requested from @@rules_python+]//:requirements.bzl: The repository '@@[unknown repo 'dev_pip' requested from @@rules_python+]' could not be resolved: No repository visible as '@dev_pip' from repository '@@rules_python+'. and referenced by '@@aspect_rules_py+//py/private:py_pytest_main'
```

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:

```starlark
bzl_library(
    name = "foo",
    srcs = ["foo.bzl"],
    deps = [
       "@aspect_rules_py//py:defs",
   ],
)
```
