### PR TITLE
chore: use hermetic awk for mtree manipulation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,7 @@ bazel_dep(name = "aspect_tools_telemetry", version = "0.2.6")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_python", version = "0.29.0")
 bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "gawk", version = "5.3.2.bcr.1")  # Required to manipulate mtree files
 
 bazel_lib = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
 bazel_lib.expand_template()

--- a/docs/py_image_layer.md
+++ b/docs/py_image_layer.md
@@ -38,12 +38,10 @@ oci_image(
 
 <pre>
 py_image_layer(<a href="#py_image_layer-name">name</a>, <a href="#py_image_layer-binary">binary</a>, <a href="#py_image_layer-root">root</a>, <a href="#py_image_layer-layer_groups">layer_groups</a>, <a href="#py_image_layer-compress">compress</a>, <a href="#py_image_layer-tar_args">tar_args</a>, <a href="#py_image_layer-compute_unused_inputs">compute_unused_inputs</a>,
-               <a href="#py_image_layer-platform">platform</a>, <a href="#py_image_layer-owner">owner</a>, <a href="#py_image_layer-group">group</a>, <a href="#py_image_layer-kwargs">kwargs</a>)
+               <a href="#py_image_layer-platform">platform</a>, <a href="#py_image_layer-owner">owner</a>, <a href="#py_image_layer-group">group</a>, <a href="#py_image_layer-awk">awk</a>, <a href="#py_image_layer-kwargs">kwargs</a>)
 </pre>
 
 Produce a separate tar output for each layer of a python app
-
-&gt; Requires `awk` to be installed on the host machine/rbe runner.
 
 For better performance, it is recommended to split the output of a py_binary into multiple layers.
 This can be done by grouping files into layers based on their path by using the `layer_groups` attribute.
@@ -77,6 +75,7 @@ The default layer groups are:
 | <a id="py_image_layer-platform"></a>platform |  The platform to use for the transition. Default is None. See: https://github.com/bazel-contrib/bazel-lib/blob/main/docs/transitions.md#platform_transition_binary-target_platform   |  <code>None</code> |
 | <a id="py_image_layer-owner"></a>owner |  An owner uid for the uncompressed files. See mtree_mutate: https://github.com/bazel-contrib/bazel-lib/blob/main/docs/tar.md#mutating-the-tar-contents   |  <code>None</code> |
 | <a id="py_image_layer-group"></a>group |  A group uid for the uncompressed files. See mtree_mutate: https://github.com/bazel-contrib/bazel-lib/blob/main/docs/tar.md#mutating-the-tar-contents   |  <code>None</code> |
+| <a id="py_image_layer-awk"></a>awk |  The awk command to use. Default is <code>@gawk</code>.   |  <code>"@gawk"</code> |
 | <a id="py_image_layer-kwargs"></a>kwargs |  attribute that apply to all targets expanded by the macro   |  none |
 
 **RETURNS**

--- a/py/repositories.bzl
+++ b/py/repositories.bzl
@@ -37,6 +37,28 @@ def rules_py_dependencies():
         url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.10.0/bazel-lib-v2.10.0.tar.gz",
     )
 
+    # from https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/gawk/5.3.2.bcr.1
+    http_archive(
+        name = "gawk",
+        remote_file_urls = {
+            "BUILD.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/BUILD.bazel"],
+            "MODULE.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/MODULE.bazel"],
+            "posix/config_darwin.h": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/posix/config_darwin.h"],
+            "posix/config_linux.h": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/posix/config_linux.h"],
+            "test/BUILD.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/test/BUILD.bazel"],
+        },
+        remote_file_integrity = {
+            "BUILD.bazel": "sha256-dt89+9IJ3UzQvoKzyXOiBoF6ok/4u4G0cb0Ja+plFy0=",
+            "MODULE.bazel": "sha256-zfjL5e51DbBLeIeMljPMdugNz0QWy+mCrDqSIvgHE8g=",
+            "posix/config_darwin.h": "sha256-gPVRlvtdXPw4Ikwd5S89wPPw5AaiB2HTHa1KOtj40mU=",
+            "posix/config_linux.h": "sha256-iEaeXYBUCvprsIEEi5ipwqt0JV8d73+rLgoBYTegC6Q=",
+            "test/BUILD.bazel": "sha256-NktOb/GQZ8AimXwLEfGFMJB3TtgAFhobM5f9aWsHwLQ=",
+        },
+        url = "https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
+        strip_prefix = "gawk-5.3.2",
+        integrity = "sha256-+MNIZQnecFGSE4sA7ywAu73Q6Eww1cB9I/xzqdxMycw=",
+    )
+
     http_archive(
         name = "rules_python",
         sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",

--- a/py/repositories.bzl
+++ b/py/repositories.bzl
@@ -42,7 +42,7 @@ def rules_py_dependencies():
         name = "gawk",
         remote_file_urls = {
             "BUILD.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/BUILD.bazel"],
-            "MODULE.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/MODULE.bazel"],
+            "MODULE.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/MODULE.bazel"],
             "posix/config_darwin.h": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/posix/config_darwin.h"],
             "posix/config_linux.h": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/posix/config_linux.h"],
             "test/BUILD.bazel": ["https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/gawk/5.3.2.bcr.1/overlay/test/BUILD.bazel"],


### PR DESCRIPTION
Testing locally isn't working on MacOS arm64:

```
ERROR: /private/var/tmp/_bazel_alexeagle/ac5c25dfb9cf2a4fcbea5ab9eb6f568e/external/gawk/BUILD.bazel:52:11: Linking external/gawk/libsupport.a [for tool] failed: (Exit 1): llvm-ar failed: error executing CppArchive command (from target @@gawk//:support) external/llvm_toolchain/bin/llvm-ar @bazel-out/darwin_arm64-opt-exec-ST-a828a81199fe/bin/external/gawk/libsupport.a-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/llvm_toolchain/bin/llvm-ar: error: only one operation may be specified
OVERVIEW: LLVM Archiver
```