### PR TITLE
Fix bug in `py_venv` when using non runfiles python interpreter

### DIFF
--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -122,7 +122,7 @@ def _py_venv_base_impl(ctx):
             # user tries to consume a `py_venv_binary` across repo boundaries
             # which could cause repo mapping to become relevant.
             "--repo=" + (ctx.label.repo_name or ctx.workspace_name),
-            "--python=" + to_rlocation_path(ctx, py_toolchain.python) if py_toolchain.runfiles_interpreter else py_toolchain.python.path,
+            "--python=" + (to_rlocation_path(ctx, py_toolchain.python) if py_toolchain.runfiles_interpreter else py_toolchain.python.path),
             "--pth-file=" + site_packages_pth_file.path,
             "--env-file=" + env_file.path,
             "--bin-dir=" + ctx.bin_dir.path,


### PR DESCRIPTION
We were hitting the following error when using a system python instead of a runfiles python.


`'--venv-shim=external/aspect_rules_py~~py_tools~rules_py_tools.linux_amd64/shim' /usr/bin/python3 '--pth-file=bazel-out/k8-fastbuild/bin/foo/bar/venv.pth' '--env-file=bazel-out/k8-fastbuild/bin/foo/bar/venv.env' '--bin-dir=bazel-out/k8-fastbuild/bin' '--collision-strategy=error' '--venv-name=.venv' '--mode=static-copy' '--version=3.12')`

`error: unexpected argument '/usr/bin/python3' found`

After debugging, realized that the `--python` argument identifier is being omitted when a non-runfiles python is used. The problem is in the `if` / `else` clause. Validated this works using a patch file.

### Test plan

- Covered by existing test cases