### PR TITLE
chore: Support --incompatible_disable_native_repo_rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -317,9 +317,3 @@ oci_pull(
 load("@container_structure_test//:repositories.bzl", "container_structure_test_register_toolchain")
 
 container_structure_test_register_toolchain(name = "cst")
-
-# For tests
-local_repository(
-    name = "rpy610_test",
-    path = "./py/tests/rpy610/subrepo",
-)

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -1,4 +1,6 @@
 # Override http_archive for local testing
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+
 local_repository(
     name = "aspect_rules_py",
     path = "../..",

--- a/e2e/use_release/WORKSPACE.bazel
+++ b/e2e/use_release/WORKSPACE.bazel
@@ -1,4 +1,6 @@
 # Override http_archive for local testing
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+
 local_repository(
     name = "aspect_rules_py",
     path = "../..",


### PR DESCRIPTION
So I don't keep having to bypass failures from this flag in BCR.

### Changes are visible to end-users: no

### Test plan

This is the test plan.