### PR TITLE
chore(deps): Bump tools_telemetry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ module(
 # py_image_layer needs compute_unused_inputs attribute
 # py_image_layer needs repo_mapping fix.
 bazel_dep(name = "aspect_bazel_lib", version = "2.16.0")
-bazel_dep(name = "aspect_tools_telemetry", version = "0.2.6")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.2.8")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_python", version = "0.29.0")
 bazel_dep(name = "platforms", version = "0.0.7")


### PR DESCRIPTION
Chore. `0.2.8` has been stable for a while, upgrade to that.

### Changes are visible to end-users: no

### Test plan

N/A.