### PR TITLE
fix(ci): Allow cancelling slow pre-commit job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
 
   pre-commit:
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && !cancelled()
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fixes slow pre-commit runs which block CI iteration on re-push.

### Changes are visible to end-users: no

### Test plan

This is the test plan (CI workflow YAML still valid).
