### PR TITLE
fix(release): Remove hardcoded -Clto flag from release builds

### DIFF
--- a/tools/release/defs.bzl
+++ b/tools/release/defs.bzl
@@ -51,7 +51,6 @@ def rust_binary(name, visibility = [], **kwargs):
                     str(Label(":debug_build")): [],
                     "//conditions:default": [
                         "-Copt-level=3",
-                        "-Clto",
                         "-Cstrip=symbols",
                     ],
                 }),


### PR DESCRIPTION
The -Clto flag can conflict with parent module's Rust toolchain
configuration, particularly when embed-bitcode=no is set. This change
removes the hardcoded LTO flag to allow proper inheritance of toolchain
settings.

Related: https://github.com/bazelbuild/rules_rust/pull/3104/