### PR TITLE
fix(venv): Honor user warnings setting

### DIFF
--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -857,20 +857,18 @@ pub fn populate_venv(
             }
 
             had_collision = true;
-            eprintln!("Collision detected at destination: {}", dest.display());
-            for source in sources {
-                match source {
-                    Command::Copy { src, .. } | Command::CopyAndPatch { src, .. } => {
-                        if emit_error {
+            if emit_error {
+                eprintln!("Collision detected at destination: {}", dest.display());
+                for source in sources {
+                    match source {
+                        Command::Copy { src, .. } | Command::CopyAndPatch { src, .. } => {
                             eprintln!("  - Source: {} (Copy)", src.display())
                         }
-                    }
-                    Command::Symlink { src, .. } => {
-                        if emit_error {
+                        Command::Symlink { src, .. } => {
                             eprintln!("  - Source: {} (Symlink)", src.display())
                         }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }


### PR DESCRIPTION
Fixes #676

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed an issue which caused `py_venv_*` to emit suppressed warnings

### Test plan

- Manual testing
