### PR TITLE
chore: Upgrade to rules_rs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,15 +4,13 @@ common --enable_bzlmod
 
 # Ignore slow manual and release targets
 # Prevents materializing crossbuild
-build --build_tag_filters=-manual,-release
-test --test_tag_filters=-manual,-release
+common --build_tag_filters=-manual,-release
 
-test --test_output=errors
+common --test_output=errors
 
 # Define value used by tests
-build --define=SOME_VAR=SOME_VALUE
+common --define=SOME_VAR=SOME_VALUE
 
-#common --features=-libtool
 common --incompatible_enable_cc_toolchain_resolution
 
 # TODO(bzlmod): Don't break proto
@@ -20,8 +18,7 @@ common --per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_B
 common --host_per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
 
 # Don't try and auto detect the cc toolchain, as we use our own gcc toolchains.
-common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-common --incompatible_enable_cc_toolchain_resolution
+common --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 # Don't link against libunwind on macos as it causes linking failures (https://github.com/bazel-contrib/toolchains_llvm/pull/346)
 common:macos --@toolchains_llvm//toolchain/config:libunwind=False
@@ -35,7 +32,7 @@ common:release --@rules_rust//rust/settings:lto=fat
 common:release --@rules_rust//:extra_rustc_flags=-Cpanic=abort
 
 # Speed up local development by using the non-hermetic CPP toolchain.
-common:nollvm --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0
+common:nollvm --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0
 common:nollvm --noincompatible_enable_cc_toolchain_resolution
 
 # Load any settings specific to the current user.

--- a/.bcr/patches/remove_dev_deps.patch
+++ b/.bcr/patches/remove_dev_deps.patch
@@ -1,11 +1,9 @@
---- a/MODULE.bazel	2025-10-28 13:13:30
-+++ b/MODULE.bazel	2025-10-28 13:13:30
-@@ -22,557 +22,5 @@
-     "@aspect_rules_py//py/private/toolchain/venv/...",
-     "@aspect_rules_py//py/private/toolchain/unpack/...",
+--- a/MODULE.bazel	2025-10-30 12:25:53
++++ b/MODULE.bazel	2025-10-30 12:25:53
+@@ -24,554 +24,3 @@
      "@aspect_rules_py//py/private/toolchain/shim/...",
--)
--
+ )
+ 
 -################################################################################
 -# Dev deps
 -#
@@ -293,8 +291,8 @@
 -    ],
 -    target_triple = "x86_64-unknown-linux-musl",
 -    versions = [RUST_VERSION],  # "versions" only set in first instance of "rust_darwin_x86_64" repository_set (see comment above)
- )
- 
+-)
+-
 -# -> linux arm (musl)
 -rust.repository_set(
 -    name = "rust_darwin_x86_64",
@@ -383,18 +381,17 @@
 -bazel_dep(name = "xz", version = "5.4.5.bcr.5")
 -bazel_dep(name = "zstd", version = "1.5.7")
 -bazel_dep(name = "bzip2", version = "1.0.8.bcr.2")
+-bazel_dep(name = "rules_rs", version = "0.0.7")
 -
 -crate = use_extension(
--    "@rules_rust//crate_universe:extension.bzl",
+-    "@rules_rs//rs:extensions.bzl",
 -    "crate",
 -)
 -crate.from_cargo(
 -    name = "crates",
--    cargo_lockfile = "//:Cargo.lock",
--    manifests = [
--        "//:Cargo.toml",
--    ],
--    supported_platform_triples = [
+-    cargo_lock = "//:Cargo.lock",
+-    cargo_toml = "//:Cargo.toml",
+-    platform_triples = [
 -        "aarch64-apple-darwin",
 -        "aarch64-unknown-linux-gnu",
 -        "x86_64-apple-darwin",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 
 # TODO(arrdem): Consolidate on just needing the one bazel_lib
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
-bazel_dep(name = "bazel_lib", version = "3.0.0-rc.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_python", version = "1.0.0")
@@ -401,18 +401,17 @@ register_toolchains("@rust_toolchains//:all")
 bazel_dep(name = "xz", version = "5.4.5.bcr.5")
 bazel_dep(name = "zstd", version = "1.5.7")
 bazel_dep(name = "bzip2", version = "1.0.8.bcr.2")
+bazel_dep(name = "rules_rs", version = "0.0.7")
 
 crate = use_extension(
-    "@rules_rust//crate_universe:extension.bzl",
+    "@rules_rs//rs:extensions.bzl",
     "crate",
 )
 crate.from_cargo(
     name = "crates",
-    cargo_lockfile = "//:Cargo.lock",
-    manifests = [
-        "//:Cargo.toml",
-    ],
-    supported_platform_triples = [
+    cargo_lock = "//:Cargo.lock",
+    cargo_toml = "//:Cargo.toml",
+    platform_triples = [
         "aarch64-apple-darwin",
         "aarch64-unknown-linux-gnu",
         "x86_64-apple-darwin",

--- a/bazel/include/cargo.MODULE.bazel
+++ b/bazel/include/cargo.MODULE.bazel
@@ -4,18 +4,17 @@
 bazel_dep(name = "xz", version = "5.4.5.bcr.5")
 bazel_dep(name = "zstd", version = "1.5.7")
 bazel_dep(name = "bzip2", version = "1.0.8.bcr.2")
+bazel_dep(name = "rules_rs", version = "0.0.7")
 
 crate = use_extension(
-    "@rules_rust//crate_universe:extension.bzl",
+    "@rules_rs//rs:extensions.bzl",
     "crate",
 )
 crate.from_cargo(
     name = "crates",
-    cargo_lockfile = "//:Cargo.lock",
-    manifests = [
-        "//:Cargo.toml",
-    ],
-    supported_platform_triples = [
+    cargo_lock = "//:Cargo.lock",
+    cargo_toml = "//:Cargo.toml",
+    platform_triples = [
         "aarch64-apple-darwin",
         "aarch64-unknown-linux-gnu",
         "x86_64-apple-darwin",

--- a/bazel/rust/defs.bzl
+++ b/bazel/rust/defs.bzl
@@ -31,6 +31,7 @@ def rust_binary(name, rustc_env_files = [], version_key = "", crate_features = [
         rustc_env_files: Additional env files to pass to the rust compiler
         version_key: Stamp key to use for version replacement at compile time
         crate_features: Create features to enable for the binary target
+        platform: optional platform to transition to
         **kwargs: Additional args to pass to rust_binary
     """
 

--- a/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
+++ b/py/tests/py_venv_image_layer/my_app_arm64_layers_listing.yaml
@@ -2495,9 +2495,9 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/bin/
   - -rwxr-xr-x  0 0      0        2801 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/bin/activate
-  - -rwxr-xr-x  0 0      0      701600 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/bin/python
-  - -rwxr-xr-x  0 0      0      701600 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
-  - -rwxr-xr-x  0 0      0      701600 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
+  - -rwxr-xr-x  0 0      0      701472 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/bin/python
+  - -rwxr-xr-x  0 0      0      701472 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/bin/python3
+  - -rwxr-xr-x  0 0      0      701472 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/bin/python3.9
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/lib/python3.9/
   - -rwxr-xr-x  0 0      0         349 Jan  1  2023 ./py/tests/py_venv_image_layer/my_app_bin.runfiles/_main/py/tests/py_venv_image_layer/.my_app_bin/pyvenv.cfg


### PR DESCRIPTION
Swap `rules_rs` in as a replacement for `rules_rust`'s cargo which has significant overhead and frustrating reconfiguration behavior.

### Changes are visible to end-users: no

### Test plan

This is the test plan.
