### PR TITLE
Remove one of the dependencies on uv-python

### DIFF
--- a/py/tools/py/src/unpack.rs
+++ b/py/tools/py/src/unpack.rs
@@ -4,13 +4,9 @@ use std::{
     str::FromStr,
 };
 
-use miette::{miette, IntoDiagnostic, Result};
+use miette::{IntoDiagnostic, Result};
 
-pub fn unpack_wheel(version: &str, location: &Path, wheel: &Path) -> Result<()> {
-    let python_version: uv_python::PythonVersion = version
-        .parse()
-        .map_err(|_| miette!("Failed to parse Python version"))?;
-
+pub fn unpack_wheel(version_major: u8, version_minor: u8, location: &Path, wheel: &Path) -> Result<()> {
     let wheel_file_reader = fs::File::open(wheel).into_diagnostic()?;
 
     let temp = tempfile::tempdir().into_diagnostic()?;
@@ -21,8 +17,8 @@ pub fn unpack_wheel(version: &str, location: &Path, wheel: &Path) -> Result<()> 
         .join("lib")
         .join(format!(
             "python{}.{}",
-            python_version.major(),
-            python_version.minor()
+            version_major,
+            version_minor,
         ))
         .join("site-packages");
 
@@ -37,7 +33,7 @@ pub fn unpack_wheel(version: &str, location: &Path, wheel: &Path) -> Result<()> 
 
     let layout = uv_install_wheel::Layout {
         sys_executable: PathBuf::new(),
-        python_version: (python_version.major(), python_version.minor()),
+        python_version: (version_major, version_minor),
         // Don't stamp in the path to the interpreter into the generated bins
         // as we don't want an absolute path here.
         // Perhaps this should be set to just "python" so it picks up the one in the venv path?

--- a/py/tools/unpack_bin/src/main.rs
+++ b/py/tools/unpack_bin/src/main.rs
@@ -15,14 +15,15 @@ struct UnpackArgs {
     #[arg(long)]
     wheel: PathBuf,
 
-    /// Python version, eg 3.8.12
-    /// Must be separated by dots.
+    /// Python version, eg 3.8.12 => major = 3, minor = 8
     #[arg(long)]
-    python_version: String,
+    python_version_major: u8,
+    #[arg(long)]
+    python_version_minor: u8,
 }
 
 fn unpack_cmd_handler(args: UnpackArgs) -> miette::Result<()> {
-    py::unpack_wheel(&args.python_version, &args.into, &args.wheel)
+    py::unpack_wheel(args.python_version_major, args.python_version_minor, &args.into, &args.wheel)
 }
 
 fn main() -> miette::Result<()> {


### PR DESCRIPTION
At first I thought this was the only dep and was excited to drop it, but then I realized we also use it to detect the interpreter. Still, it seems reasonable to avoid parsing an already-parsed version string and this leaves us 1 step closers to trimming the dep.

While I was here, I prepped the action for path mapping so we could avoid duplicating it across configs

### Changes are visible to end-users: no

### Test plan
existing tests?