### PR TITLE
uv/host: Strip stdout of sw_vers on MacOS

### DIFF
--- a/uv/private/host/repository.bzl
+++ b/uv/private/host/repository.bzl
@@ -24,7 +24,7 @@ def _platform(rctx):
 
     if os == "osx":
         res = rctx.execute(["sw_vers", "-productVersion"])
-        ver = res.stdout.split(".")
+        ver = res.stdout.strip().split(".")
         return "libsystem", "{}.{}".format(ver[0], ver[1])
 
     elif os == "linux":


### PR DESCRIPTION
The output of `sw_vers` on various MacOS versions (in my case 26.1) can include a newline at the end, which causes:
```
ERROR: /private/var/tmp/_bazel_zsol/63b99ba49019d270ca10253bff172211/external/aspect_rules_py+/uv/private/constraints/platform/BUILD.bazel:81:9: in _platform_version_at_least rule @@aspect_rules_py+//uv/private/constraints/platform:_is_macos_at_least_10_13_flag:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_zsol/63b99ba49019d270ca10253bff172211/external/aspect_rules_py+/uv/private/constraints/platform/defs.bzl", line 62, column 12, in _platform_version_at_least_impl
		int(x)
Error in int: invalid base-10 literal: "1\n"
```

This PR avoids the error by calling `strip()` on the result of `sw_vers -productVersion`.

---

### Changes are visible to end-users: yes


- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed an issue with using the experimental uv rules on MacOS 26.1

### Test plan

- Covered by existing test cases
