### PR TITLE
Generate fewer targets for platform constraints

### DIFF
--- a/uv/private/constraints/platform/defs.bzl
+++ b/uv/private/constraints/platform/defs.bzl
@@ -38,14 +38,6 @@ def supported_platform(platform_tag):
 # Adapted from rules_python's config_settings.bzl
 MAJOR_MINOR_FLAG = Label("//uv/private/constraints/platform:platform_version")
 
-def is_platform_version_at_least(name, version, **kwargs):
-    _platform_version_at_least(
-        name = name,
-        at_least = version,
-        visibility = ["//visibility:private"],
-        **kwargs
-    )
-
 def _platform_version_at_least_impl(ctx):
     flag_value = ctx.attr._major_minor[BuildSettingInfo].value
 
@@ -58,7 +50,7 @@ def _platform_version_at_least_impl(ctx):
     value = "true" if current >= at_least else "false"
     return [config_common.FeatureFlagInfo(value = value)]
 
-_platform_version_at_least = rule(
+platform_version_at_least = rule(
     implementation = _platform_version_at_least_impl,
     attrs = {
         "at_least": attr.string(mandatory = True),

--- a/uv/private/constraints/platform/macro.bzl
+++ b/uv/private/constraints/platform/macro.bzl
@@ -2,7 +2,7 @@
 
 """
 
-load(":defs.bzl", "is_platform_version_at_least")
+load(":defs.bzl", "platform_version_at_least")
 
 ## These are defined but we're ignoring them for now.
 # android_21_arm64_v8a
@@ -74,17 +74,17 @@ def generate_macos(visibility):
     for major in range(10, 30):
         for minor in range(0, 20):
             major_minor = (major, minor)
-            flag_name = "_is_macos_at_least_%s_%s_flat" % major_minor
-            is_platform_version_at_least(
-                name = flag_name,
-                version = "%s.%s" % major_minor,
+            version_flag = "_is_macos_at_least_%s_%s_flat" % major_minor
+            platform_version_at_least(
+                name = version_flag,
+                at_least = "%s.%s" % major_minor,
             )
 
             for arch in arches:
                 native.config_setting(
                     name = "macosx_%s_%s_%s" % (major, minor, arch),
                     flag_values = {
-                        flag_name: "true",
+                        version_flag: "true",
                         ":platform_libc": "libsystem",
                     },
                     constraint_values = [
@@ -142,17 +142,17 @@ def generate_manylinux(visibility):
     # glibc 1.X ran for not that long and was in the 90s
     for major in [2]:
         for minor in range(0, 51):
-            flag_name = "is_glibc_at_least_{}_{}".format(major, minor)
-            is_platform_version_at_least(
-                name = flag_name,
-                version = "{}.{}".format(major, minor),
+            version_flag = "_is_glibc_at_least_{}_{}".format(major, minor)
+            platform_version_at_least(
+                name = version_flag,
+                at_least = "{}.{}".format(major, minor),
             )
 
             for arch in arches:
                 native.config_setting(
                     name = "manylinux_{}_{}_{}".format(major, minor, arch),
                     flag_values = {
-                        flag_name: "true",
+                        version_flag: "true",
                         ":platform_libc": "glibc",
                     },
                     constraint_values = [
@@ -206,17 +206,17 @@ def generate_musllinux(visibility):
         [2, 1],  # Hypothetical
         [2, 2],  # Hypothetical
     ]:
-        flag_name = "is_musl_at_least_{}_{}".format(major, minor)
-        is_platform_version_at_least(
-            name = flag_name,
-            version = "{}.{}".format(major, minor),
+        version_flag = "_is_musl_at_least_{}_{}".format(major, minor)
+        platform_version_at_least(
+            name = version_flag,
+            at_least = "{}.{}".format(major, minor),
         )
 
         for arch in arches:
             native.config_setting(
                 name = "musllinux_{}_{}_{}".format(major, minor, arch),
                 flag_values = {
-                    flag_name: "true",
+                    version_flag: "true",
                     ":platform_libc": "musl",
                 },
                 constraint_values = [


### PR DESCRIPTION
skylib's implementation of `config_setting_group` is a little wild, it generates chains of selects and alias targets. We don't really need to do that, we can just declare what we want directly.

`bazel query //uv/private/constraints/platform:all | wc -l` drops from 12K to 5.3K. All the removed targets were private so feels like this should be fine.

Also:

before:
<img width="1681" height="238" alt="image" src="https://github.com/user-attachments/assets/6f849dd8-bb39-4811-8bcf-e64ec7f94eac" />

after:
<img width="1675" height="280" alt="image" src="https://github.com/user-attachments/assets/ec71aa2e-3bed-4ee0-949a-8d050258e79a" />


---

### Changes are visible to end-users: no

### Test plan
- Covered by existing test cases