### PR TITLE
fix(uv): Correct repo metadata usage & support pre-Bazel 8

### DIFF
--- a/.bcr/patches/remove_dev_deps.patch
+++ b/.bcr/patches/remove_dev_deps.patch
@@ -1,10 +1,9 @@
---- a/MODULE.bazel	2025-11-22 20:51:10
-+++ b/MODULE.bazel	2025-11-22 20:51:10
-@@ -39,558 +39,4 @@
- 
+--- a/MODULE.bazel	2025-12-01 15:38:57
++++ b/MODULE.bazel	2025-12-01 15:38:57
+@@ -41,556 +41,3 @@
  # HACK: In prod the includer's patch inserts the use_repo for multitool. This
  # solves the problem of needing a use_repo here in prod and below in dev.
--
+ 
 -################################################################################
 -# Dev deps
 -#
@@ -284,7 +283,7 @@
 -    target_triple = "x86_64-unknown-linux-musl",
 -    versions = [RUST_VERSION],  # "versions" only set in first instance of "rust_darwin_x86_64" repository_set (see comment above)
 -)
- 
+-
 -# -> linux arm (musl)
 -rust.repository_set(
 -    name = "rust_darwin_x86_64",
@@ -421,7 +420,6 @@
 -# from bazel/include/test.MODULE.bazel
 -# TODO: Replace with bazel_features?
 -# cf. https://github.com/bazel-contrib/bazelrc-preset.bzl/blob/main/MODULE.bazel#L8C1-L10C70
--bazel_dep(name = "bazel_features", version = "1.0.0")
 -bazel_dep(name = "rules_shell", version = "0.6.1")
 -
 -version = use_extension("@bazel_features//private:extensions.bzl", "version_extension")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 
 # TODO(arrdem): Consolidate on just needing the one bazel_lib
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
+bazel_dep(name = "bazel_features", version = "1.38.0")
 bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "1.0.0")
@@ -456,7 +457,6 @@ use_repo(crate, "crates")
 # from bazel/include/test.MODULE.bazel
 # TODO: Replace with bazel_features?
 # cf. https://github.com/bazel-contrib/bazelrc-preset.bzl/blob/main/MODULE.bazel#L8C1-L10C70
-bazel_dep(name = "bazel_features", version = "1.0.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
 version = use_extension("@bazel_features//private:extensions.bzl", "version_extension")

--- a/bazel/include/e2e.MODULE.bazel
+++ b/bazel/include/e2e.MODULE.bazel
@@ -1,4 +1,5 @@
 # FIXME: These are really the prod deps. Should be includeable.
+bazel_dep(name = "bazel_features", version = "1.38.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "bazel_lib", version = "3.0.0")

--- a/bazel/include/test.MODULE.bazel
+++ b/bazel/include/test.MODULE.bazel
@@ -1,6 +1,5 @@
 # TODO: Replace with bazel_features?
 # cf. https://github.com/bazel-contrib/bazelrc-preset.bzl/blob/main/MODULE.bazel#L8C1-L10C70
-bazel_dep(name = "bazel_features", version = "1.0.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
 version = use_extension("@bazel_features//private:extensions.bzl", "version_extension")

--- a/doc/venv_linking.md
+++ b/doc/venv_linking.md
@@ -1,0 +1,1 @@
+# Bazel managed virtualenvs

--- a/uv/private/extension.bzl
+++ b/uv/private/extension.bzl
@@ -37,11 +37,9 @@ Relies on the lockfile to enumerate:
 
 # Note that platform constraints are specified by markers in the lockfile, they cannot be explicitly specified.
 
-# FIXME: Need to add package name sanitization/mangling
-# https://github.com/bazel-contrib/rules_python/blob/main/python/private/normalize_name.bzl
-
 # FIXME: Need to explicitly test a lockfile with platform-conditional deps (tensorflow cpu vs gpu mac/linux)
 
+load("@bazel_features//:features.bzl", features = "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("//uv/private/constraints:repository.bzl", "configurations_hub")
 load("//uv/private/constraints/platform:defs.bzl", "supported_platform")
@@ -867,10 +865,6 @@ def _uv_impl(module_ctx):
 
     """
 
-    # Set the reproducible bit for this repo. This at least reduces how much
-    # junk we dump into the lockfile.
-    module_ctx.extension_metadata(reproducible = True)
-
     hub_specs = _parse_hubs(module_ctx)
 
     venv_specs = _parse_venvs(module_ctx, hub_specs)
@@ -916,6 +910,9 @@ def _uv_impl(module_ctx):
         name = "aspect_rules_py_pip_configurations",
         configurations = configurations,
     )
+
+    if features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
 
 _hub_tag = tag_class(
     attrs = {


### PR DESCRIPTION
- fix: repo metadata needs to be returned; not for side-effects
- fix: repo metadata needs to be conditional on Bazel > 8.3

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

Manual.