### PR TITLE
fix(uv): Get the sdist build machinery working reliably

### DIFF
--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -173,6 +173,8 @@ def _py_venv_rule_impl(ctx):
 
     # TODO: Zip output group to allow for bypassing filtering et. all
 
+    print(ctx.label, rfs)
+
     return [
         DefaultInfo(
             files = depset([

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,9 @@
+# Build depends
 setuptools
 build
+wheel
+
+# App depends
 django~=4.2.7
 colorama~=0.4.0
 click

--- a/uv/private/extension.bzl
+++ b/uv/private/extension.bzl
@@ -219,7 +219,7 @@ def _parse_locks(module_ctx, venv_specs):
                             d["name"] = normalize_name(d["name"])
 
             problems = []
-            has_tools = "build" in req_whls and "setuptools" in req_whls
+            has_tools = "build" in req_whls and "setuptools" in req_whls and "wheel" in req_whls
             for req, whls in req_whls.items():
                 if not whls and not has_tools:
                     problems.append(req)
@@ -227,8 +227,8 @@ def _parse_locks(module_ctx, venv_specs):
             if problems:
                 fail("""Error in lockfile {lockfile}
 
-The requirements `build` and `setuptools` are missing from, but the following requirements only provide sdists.
-Please update your lockfile to provide build tools in order to enable sdist support.
+The requirements `build`, `setuptools` or `wheel` are missing, but the following requirements only provide sdists.
+Please update your lockfile to provide these build tools in order to enable sdist support.
 
 Problems:
 {problems}""".format(
@@ -249,6 +249,7 @@ _default_annotations = struct(
     default_build_deps = [
         {"name": "setuptools"},
         {"name": "build"},
+        {"name": "wheel"},
     ],
 )
 
@@ -309,6 +310,10 @@ def _parse_annotations(module_ctx, hub_specs, venv_specs):
 
                 if package["name"] in annotation_specs[ann.hub_name][ann.venv_name].per_package:
                     fail("Annotation conflict! Package %s is annotated in venv %s multiple times!" % (package["name"], ann.venv_name))
+
+                if "build-dependencies" in package:
+                    for it in package["build-dependencies"]:
+                        it["name"] = normalize_name(it["name"])
 
                 annotation_specs[ann.hub_name][ann.venv_name].per_package[package["name"]] = package
 

--- a/uv/private/sdist_build/build_helper.py
+++ b/uv/private/sdist_build/build_helper.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 import shutil
 import sys
 from os import getenv, listdir, path
-from subprocess import call
+from subprocess import check_call
 
 # Under Bazel, the source dir of a sdist to build is immutable. `build` and
 # other tools however are constitutionally incapable of not writing to the
@@ -29,12 +29,17 @@ shutil.copytree(opts.srcdir, t, dirs_exist_ok=True)
 
 outdir = path.abspath(opts.outdir)
 
-call([
-    sys.executable,
-    "-m", "build",
-    "--wheel",
-    "--no-isolation",
-    "--outdir", outdir,
-], cwd=t)
+try:
+    check_call([
+        sys.executable,
+        "-m", "build",
+        "--wheel",
+        "--no-isolation",
+        "--outdir", outdir,
+    ], cwd=t)
+finally:
+    print(listdir(outdir), file=sys.stderr)
 
-print(listdir(outdir), file=sys.stderr)
+if not listdir(outdir):
+    print("Failed to build!", file=sys.stderr)
+    exit(1)

--- a/uv/private/sdist_build/rule.bzl
+++ b/uv/private/sdist_build/rule.bzl
@@ -45,7 +45,9 @@ def _sdist_build(ctx):
     )
 
     venv = ctx.attr.venv
+
     # print(venv[VirtualenvInfo], venv[DefaultInfo])
+    print(venv[DefaultInfo].files_to_run)
 
     # Options here:
     # 1. `python3 -m build` which requires the build library and works generally
@@ -64,11 +66,13 @@ def _sdist_build(ctx):
         ],
         inputs = [
             unpacked_sdist,
-            venv[VirtualenvInfo].home,
             ctx.file._helper,
-        ] + py_toolchain.files.to_list() + ctx.attr.venv[DefaultInfo].files.to_list(),
+        ],
         outputs = [
             wheel_dir,
+        ],
+        tools = [
+            venv[DefaultInfo].files_to_run,
         ],
     )
 


### PR DESCRIPTION
The initial UV cut mostly relied on unpacking prebuilt wheels with sdist builds sorta working. This PR captures a bunch of work driven by PI to hash out sdist building

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

TBD

### Test plan

- Manual testing; PI monorepo