### PR TITLE
fix(uv): Propagate sdist build failures

### DIFF
--- a/uv/private/sdist_build/build_helper.py
+++ b/uv/private/sdist_build/build_helper.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 import shutil
 import sys
 from os import getenv, listdir, path
-from subprocess import call
+from subprocess import check_call
 
 # Under Bazel, the source dir of a sdist to build is immutable. `build` and
 # other tools however are constitutionally incapable of not writing to the
@@ -29,12 +29,17 @@ shutil.copytree(opts.srcdir, t, dirs_exist_ok=True)
 
 outdir = path.abspath(opts.outdir)
 
-call([
-    sys.executable,
-    "-m", "build",
-    "--wheel",
-    "--no-isolation",
-    "--outdir", outdir,
-], cwd=t)
+try:
+    check_call([
+        sys.executable,
+        "-m", "build",
+        "--wheel",
+        "--no-isolation",
+        "--outdir", outdir,
+    ], cwd=t)
+finally:
+    print(listdir(outdir), file=sys.stderr)
 
-print(listdir(outdir), file=sys.stderr)
+if not listdir(outdir):
+    print("Failed to build!", file=sys.stderr)
+    exit(1)


### PR DESCRIPTION
Need to use `check_call` so that sdist builds properly fail if the called build operation fails. Hopefully we can remove this whole wrapper shortly for `uv build`.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Failed sdist builds under the UV extension now correctly fail the build chain.

### Test plan

- Manual testing
