### PR TITLE
fix(uv): Ensure normalization of build dep names

### DIFF
--- a/uv/private/extension.bzl
+++ b/uv/private/extension.bzl
@@ -310,6 +310,10 @@ def _parse_annotations(module_ctx, hub_specs, venv_specs):
                 if package["name"] in annotation_specs[ann.hub_name][ann.venv_name].per_package:
                     fail("Annotation conflict! Package %s is annotated in venv %s multiple times!" % (package["name"], ann.venv_name))
 
+                if "build-dependencies" in package:
+                    for it in package["build-dependencies"]:
+                        it["name"] = normalize_name(it["name"])
+
                 annotation_specs[ann.hub_name][ann.venv_name].per_package[package["name"]] = package
 
     return annotation_specs


### PR DESCRIPTION
For consistency with the main uv.lock loading code and to avoid failures to join annotations with their requirements we need to apply normalization here. Otherwise we can generate a build graph with inconsistent annotative deps.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Fixed the UV extension not normalizing annotative dependencies' names, potentially leading to false missing definition errors.

### Test plan

- Manual testing