### PR TITLE
py_library: load CcInfo provider

### DIFF
--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -6,6 +6,7 @@ without binding them to a particular version of that package.
 
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:providers.bzl", "PyVirtualInfo")
 


### PR DESCRIPTION
In Bazel 9, rules_cc is no longer autloaded.
This means we lose CcInfo as a global symbol and need to load it explicitly.

Fixes #731.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases