### PR TITLE
[feat] Support bin-on-bin deps by transitioning binaries into libraries

### DIFF
--- a/e2e/cases/bin-to-bin-deps/BUILD.bazel
+++ b/e2e/cases/bin-to-bin-deps/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_test", "py_library")
+
+py_library(
+    name = "lib",
+    imports = ["."],
+    srcs = ["lib.py"]
+)
+
+py_binary(
+    name = "bin_a",
+    srcs = ["bin_a.py"],
+    deps = [
+        ":lib"
+    ]
+)
+
+py_binary(
+    name = "bin_b",
+    srcs = ["bin_b.py"],
+    deps = [
+        ":bin_a"
+    ]
+)
+
+py_test(
+    name = "test",
+    srcs = ["test.py"],
+    deps = [
+        ":bin_a",
+        ":bin_b",
+    ]
+)

--- a/e2e/cases/bin-to-bin-deps/bin_a.py
+++ b/e2e/cases/bin-to-bin-deps/bin_a.py
@@ -1,0 +1,1 @@
+print("bin_a: Hello!")

--- a/e2e/cases/bin-to-bin-deps/bin_b.py
+++ b/e2e/cases/bin-to-bin-deps/bin_b.py
@@ -1,0 +1,5 @@
+from lib import get_msg
+
+print("bin_b: Hello!")
+
+print(get_msg())

--- a/e2e/cases/bin-to-bin-deps/lib.py
+++ b/e2e/cases/bin-to-bin-deps/lib.py
@@ -1,0 +1,3 @@
+
+def get_msg():
+    return "Hello from lib!"

--- a/e2e/cases/bin-to-bin-deps/test.py
+++ b/e2e/cases/bin-to-bin-deps/test.py
@@ -1,0 +1,4 @@
+from lib import get_msg
+
+def test_lib():
+    assert "Hello from lib!" == get_msg()

--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -1,6 +1,21 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(default_visibility = ["//py:__subpackages__"])
+
+exports_files(
+    [
+        "run.tmpl.sh",
+        "pytest.py.tmpl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "bin_to_lib_flag",
+    build_setting_default = True,
+    visibility = ["//:__subpackages__"]
+)
 
 exports_files(
     [

--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -3,14 +3,6 @@ load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(default_visibility = ["//py:__subpackages__"])
 
-exports_files(
-    [
-        "run.tmpl.sh",
-        "pytest.py.tmpl",
-    ],
-    visibility = ["//visibility:public"],
-)
-
 bool_flag(
     name = "bin_to_lib_flag",
     build_setting_default = True,

--- a/py/private/bin_to_lib.bzl
+++ b/py/private/bin_to_lib.bzl
@@ -15,21 +15,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:providers.bzl", "PyVirtualInfo")
-
-def _bin_to_lib_transition_impl(settings, attr):
-    return {
-        "//py/private:bin_to_lib_flag": False,
-    }
-
-bin_to_lib_transition = transition(
-    implementation = _bin_to_lib_transition_impl,
-    inputs = [
-        "//py/private:bin_to_lib_flag",
-    ],
-    outputs = [
-        "//py/private:bin_to_lib_flag",
-    ],
-)
+load(":transitions.bzl", "bin_to_lib_transition")
 
 def _add_executable(ctx, lib_providers):
     new_providers = []

--- a/py/private/bin_to_lib.bzl
+++ b/py/private/bin_to_lib.bzl
@@ -65,6 +65,9 @@ def wrap_with_bin_to_lib(bin_rule, lib_rule):
             return bin_providers
 
         lib_providers = lib_rule(ctx)
+
+        # It appears that one cannot transition the executable status of a binary.
+        #   This means we need to resolve an executable for binaries transitioned to libraries.
         return _add_executable(
             ctx,
             lib_providers,

--- a/py/private/bin_to_lib.bzl
+++ b/py/private/bin_to_lib.bzl
@@ -1,0 +1,68 @@
+"""
+
+Sometimes it is desirable for a python binary or venv to depend on another binary target or venv.
+This package reifies bin-dep-bin semantics by transitioning a binary into a library if it is
+ dependend upon by another binary.
+
+This functionality has the following benefits: 
+1. py_venv_binary behaves more like the original py_binary rule.
+2. Easier composition of venvs
+3. Better merge semantics for existing 
+
+"""
+
+
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py/private:providers.bzl", "PyVirtualInfo")
+
+def _bin_to_lib_transition_impl(settings, attr):
+    return {
+        "//py/private:bin_to_lib_flag": False,
+    }
+
+bin_to_lib_transition = transition(
+    implementation = _bin_to_lib_transition_impl,
+    inputs = [
+        "//py/private:bin_to_lib_flag",
+    ],
+    outputs = [
+        "//py/private:bin_to_lib_flag",
+    ],
+)
+
+
+def wrap_with_bin_to_lib(bin_rule, lib_rule):
+    def helper(ctx):
+        if not ctx.attr._binary_mode:
+            fail("Wrapped rule missing required attributes.")
+            
+        if ctx.attr._binary_mode[BuildSettingInfo].value:
+            return bin_rule(ctx)
+
+        # Ugly hack: Is there a better way?
+        dummy_file = ctx.actions.declare_file(
+            ctx.label.name + "_dummy_bin"
+        )
+        ctx.actions.write(
+            output = dummy_file,
+            content = "\n\n",
+        )
+        return lib_rule(ctx, dummy_file)
+    return helper
+
+bin_to_lib = struct(
+    wrapper = wrap_with_bin_to_lib,
+    attribs = dict({
+        "_binary_mode": attr.label(
+            default="//py/private:bin_to_lib_flag"
+        ),
+        "deps": attr.label_list(
+            doc = "Targets that produce Python code, commonly `py_library` rules.",
+            providers = [[PyInfo], [PyVirtualInfo], [CcInfo]],
+            cfg = bin_to_lib_transition
+        ),
+    })
+)
+

--- a/py/private/bin_to_lib.bzl
+++ b/py/private/bin_to_lib.bzl
@@ -2,15 +2,14 @@
 
 Sometimes it is desirable for a python binary or venv to depend on another binary target or venv.
 This package reifies bin-dep-bin semantics by transitioning a binary into a library if it is
- dependend upon by another binary.
+ depended upon by another binary.
 
 This functionality has the following benefits: 
 1. py_venv_binary behaves more like the original py_binary rule.
 2. Easier composition of venvs
-3. Better merge semantics for existing 
+3. Better merge semantics for existing binary rules.
 
 """
-
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -32,37 +31,57 @@ bin_to_lib_transition = transition(
     ],
 )
 
+def _add_executable(ctx, providers):
+    new_providers = []
+
+    # Ugly hack: Is there a better way?
+    dummy_file = ctx.actions.declare_file(
+        ctx.label.name + "_dummy_bin",
+    )
+    ctx.actions.write(
+        output = dummy_file,
+        content = "\n\n",
+    )
+
+    for p in providers:
+        if type(p) == "DefaultInfo":
+            new_providers.append(
+                DefaultInfo(
+                    files = p.files,
+                    default_runfiles = p.default_runfiles,
+                    executable = dummy_file,
+                ),
+            )
+        else:
+            new_providers.append(p)
+
+    return new_providers
 
 def wrap_with_bin_to_lib(bin_rule, lib_rule):
     def helper(ctx):
         if not ctx.attr._binary_mode:
             fail("Wrapped rule missing required attributes.")
-            
+
         if ctx.attr._binary_mode[BuildSettingInfo].value:
             return bin_rule(ctx)
 
-        # Ugly hack: Is there a better way?
-        dummy_file = ctx.actions.declare_file(
-            ctx.label.name + "_dummy_bin"
+        return _add_executable(
+            ctx,
+            lib_rule(ctx),
         )
-        ctx.actions.write(
-            output = dummy_file,
-            content = "\n\n",
-        )
-        return lib_rule(ctx, dummy_file)
+
     return helper
 
 bin_to_lib = struct(
     wrapper = wrap_with_bin_to_lib,
     attribs = dict({
         "_binary_mode": attr.label(
-            default="//py/private:bin_to_lib_flag"
+            default = "//py/private:bin_to_lib_flag",
         ),
         "deps": attr.label_list(
             doc = "Targets that produce Python code, commonly `py_library` rules.",
             providers = [[PyInfo], [PyVirtualInfo], [CcInfo]],
-            cfg = bin_to_lib_transition
+            cfg = bin_to_lib_transition,
         ),
-    })
+    }),
 )
-

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -8,6 +8,8 @@ load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "VENV_TOOLCHAIN")
 load(":transitions.bzl", "python_version_transition")
 
+load(":bin_to_lib.bzl", "bin_to_lib")
+
 def _dict_to_exports(env):
     return [
         "export %s=\"%s\"" % (k, v)
@@ -228,8 +230,11 @@ py_base = struct(
 
 py_binary = rule(
     doc = "Run a Python program under Bazel. Most users should use the [py_binary macro](#py_binary) instead of loading this directly.",
-    implementation = py_base.implementation,
-    attrs = py_base.attrs,
+    implementation = bin_to_lib.wrapper(
+        py_base.implementation,
+        _py_library.implementation
+    ),
+    attrs = py_base.attrs | bin_to_lib.attribs,
     toolchains = py_base.toolchains,
     executable = True,
     cfg = py_base.cfg,

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -171,7 +171,7 @@ def _make_merged_runfiles(ctx, extra_depsets = [], extra_runfiles = [], extra_ru
 
     return runfiles
 
-def _py_library_impl(ctx):
+def _py_library_impl(ctx, executable=None):
     transitive_srcs = _make_srcs_depset(ctx)
     imports = _make_imports_depset(ctx)
     virtuals = _make_virtual_depset(ctx)
@@ -183,6 +183,8 @@ def _py_library_impl(ctx):
         DefaultInfo(
             files = depset(direct = ctx.files.srcs),
             default_runfiles = runfiles,
+            # Ugly hack: Inject dummy executable in case this library is actually a transitioned binary.
+            executable = executable
         ),
         PyInfo(
             imports = imports,

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -171,7 +171,7 @@ def _make_merged_runfiles(ctx, extra_depsets = [], extra_runfiles = [], extra_ru
 
     return runfiles
 
-def _py_library_impl(ctx, executable=None):
+def _py_library_impl(ctx):
     transitive_srcs = _make_srcs_depset(ctx)
     imports = _make_imports_depset(ctx)
     virtuals = _make_virtual_depset(ctx)
@@ -183,8 +183,6 @@ def _py_library_impl(ctx, executable=None):
         DefaultInfo(
             files = depset(direct = ctx.files.srcs),
             default_runfiles = runfiles,
-            # Ugly hack: Inject dummy executable in case this library is actually a transitioned binary.
-            executable = executable
         ),
         PyInfo(
             imports = imports,

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -2,6 +2,7 @@
 
 load("@aspect_bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
+load("//py/private:bin_to_lib.bzl", "bin_to_lib")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_version_transition")
@@ -392,8 +393,11 @@ py_venv_base = struct(
 
 _py_venv = rule(
     doc = """Build a Python virtual environment and execute its interpreter.""",
-    implementation = _py_venv_rule_impl,
-    attrs = py_venv_base.attrs,
+    implementation = bin_to_lib.wrapper(
+        _py_venv_rule_impl,
+        _py_library.implementation,
+    ),
+    attrs = py_venv_base.attrs | bin_to_lib.attribs,
     toolchains = py_venv_base.toolchains,
     executable = True,
     cfg = py_venv_base.cfg,
@@ -411,8 +415,12 @@ def _wrap_with_debug(rule):
 
 _py_venv_binary = rule(
     doc = """Run a Python program under Bazel using a virtualenv.""",
-    implementation = _py_venv_binary_impl,
-    attrs = py_venv_base.attrs | py_venv_base.binary_attrs,
+    implementation = bin_to_lib.wrapper(
+        _py_venv_binary_impl,
+        _py_library.implementation,
+    ),
+    #implementation = _py_venv_binary_impl,
+    attrs = py_venv_base.attrs | py_venv_base.binary_attrs | bin_to_lib.attribs,
     toolchains = py_venv_base.toolchains,
     executable = True,
     cfg = py_venv_base.cfg,

--- a/py/private/transitions.bzl
+++ b/py/private/transitions.bzl
@@ -30,5 +30,20 @@ python_transition = transition(
     ],
 )
 
+def _bin_to_lib_transition_impl(settings, attr):
+    return {
+        "//py/private:bin_to_lib_flag": False,
+    }
+
+bin_to_lib_transition = transition(
+    implementation = _bin_to_lib_transition_impl,
+    inputs = [
+        "//py/private:bin_to_lib_flag",
+    ],
+    outputs = [
+        "//py/private:bin_to_lib_flag",
+    ],
+)
+
 # The old name, FIXME: refactor this out
 python_version_transition = python_transition


### PR DESCRIPTION
Our use case of rules_py would benefit from an ability for binary targets to depend on other binary targets in a manner amenable to composition of virtual environments. This PR attempts to achieve said functionality by transitioning a binary into a library if it is depended upon by another binary.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
