### PR TITLE
fix(uv): invalidate extension state when lock/annotation files change

### DIFF
--- a/uv/private/extension.bzl
+++ b/uv/private/extension.bzl
@@ -176,6 +176,9 @@ def _parse_locks(module_ctx, venv_specs):
             if lock.venv_name in lock_specs[lock.hub_name]:
                 fail("Multiple lockfiles detected for hub %s venv %s!" % (lock.hub_name, lock.venv_name))
 
+            # Keep module extension state keyed on lockfile content in normal
+            # lockfile modes so updated dependencies invalidate stale hub repos.
+            module_ctx.watch(lock.src)
             lockfile = toml.decode_file(module_ctx, lock.src)
             if lockfile.get("version") != 1:
                 fail("Lockfile %s is an unsupported format version!" % lock.src)
@@ -298,6 +301,8 @@ def _parse_annotations(module_ctx, hub_specs, venv_specs):
                 default_build_deps = [] + _default_annotations.default_build_deps,
             ))
 
+            # Track annotation file changes for module extension invalidation.
+            module_ctx.watch(ann.src)
             ann_content = toml.decode_file(module_ctx, ann.src)
             if ann_content.get("version") != "0.0.0":
                 fail("Annotations file %s doesn't specify a valid version= key" % ann.src)


### PR DESCRIPTION
## Summary
Fixes #797 by explicitly watching uv lock/annotation source files in the module extension so file content changes invalidate cached extension state in normal lockfile modes.

## Reproduction
Reproduced from a current head checkout using a minimal bzlmod workspace that depends on published `aspect_rules_py@1.8.4`:
1. Run `bazelisk mod deps --lockfile_mode=refresh` and query an existing dep (`@hub//cowsay:all`).
2. Update `uv.lock` to add a new dep (`click`) and rerun `bazelisk mod deps --lockfile_mode=refresh`.
3. Query `@hub//click:all`.

Actual on `1.8.4`: missing package error (`@@aspect_rules_py++uv+hub//click`).

## Change
- Add `module_ctx.watch(lock.src)` before lockfile decode.
- Add `module_ctx.watch(ann.src)` before annotations decode.
- Include comments describing why these watches are required.

## Verification
- Reproduced failure from current head checkout against published `1.8.4`.
- Verified this branch resolves `@hub//click:all` correctly under `--lockfile_mode=refresh`.
