### PR TITLE
fix: Replace call with check_call on sdist build helper

### DIFF
--- a/uv/private/sdist_build/build_helper.py
+++ b/uv/private/sdist_build/build_helper.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 import shutil
 import sys
 from os import getenv, listdir, path
-from subprocess import call
+from subprocess import check_call
 
 # Under Bazel, the source dir of a sdist to build is immutable. `build` and
 # other tools however are constitutionally incapable of not writing to the
@@ -29,7 +29,7 @@ shutil.copytree(opts.srcdir, t, dirs_exist_ok=True)
 
 outdir = path.abspath(opts.outdir)
 
-call([
+check_call([
     sys.executable,
     "-m", "build",
     "--wheel",


### PR DESCRIPTION
If the build process fails for any reason, this `call` will happily swallow the error code.
Instead, we raise an exception to fail the wrapper if the sdist build fails.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): maybe (if they depended on broken builds)
- Suggested release notes appear below: yes

Suggested release notes: Fail Bazel build when sdist build fails.'

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
