### PR TITLE
Fix python interpreter lookup when space in path exists

### DIFF
--- a/py/private/run.tmpl.sh
+++ b/py/private/run.tmpl.sh
@@ -28,7 +28,7 @@ function python_location {
   local RUNFILES_INTERPRETER="{{RUNFILES_INTERPRETER}}"
 
   if [[ "${RUNFILES_INTERPRETER}" == "true" ]]; then
-    echo -n "$(alocation $(rlocation ${PYTHON}))"
+    echo -n "$(alocation "$(rlocation ${PYTHON})")"
   else
     echo -n "${PYTHON}"
   fi


### PR DESCRIPTION
Currently there's an edge-case where if you deploy your python application to a path that contains a space, the python interpreter lookup only provides the path up until the space. 

This PR fixes that by surrounding what is returned with `$(rlocation <path>)` in quotes to pass the full location to `alocation`

---

### Changes are visible to end-users: no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
