### PR TITLE
Sort keys for deterministic _aspect.pth ordering

### DIFF
--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -818,7 +818,11 @@ pub fn populate_venv(
     // Drain the plan, we'll refill it to contain only last-wins instructions.
     plan.clear();
 
-    for (dest, sources) in planned_destinations.iter() {
+    // Sort destination keys for a deterministic _aspect.pth ordering across builds.
+    let mut sorted_dests: Vec<&PathBuf> = planned_destinations.keys().collect();
+    sorted_dests.sort();
+    for dest in sorted_dests {
+        let sources = &planned_destinations[dest];
         // We ignore __init__.py files at import roots. They're entirely
         // erroneous and a result of --legacy_creat_init_files which has all
         // sorts of problems.


### PR DESCRIPTION
Sort `_aspect.pth` entries for deterministic ordering across builds.

`populate_venv` groups commands by destination using a `HashMap<PathBuf, Vec<Command>>`. Rust's `HashMap` uses a randomly seeded hash function (per-process), so iterating over it produces keys in a different order each run. This means `_aspect.pth` contains the same logical entries but in a different order on each `py_venv` rebuild.

The consequence is that any artifact depending on `_aspect.pth`'s content hash (e.g. a tar layer in an OCI image) sees a "change" even when no inputs changed, forcing a full cache miss and rebuild of large layers.

The fix is to sort `planned_destinations.keys()` before iterating, so that `_aspect.pth` is always written in lexicographic order.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (no user-visible API change, purely an internal determinism fix)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

> **Fix non-deterministic `_aspect.pth` ordering** - `_aspect.pth` entries are now written in sorted order, preventing spurious cache misses on downstream artifacts (e.g. OCI image layers) when only source files change.

### Test plan

- Covered by existing test cases