### PR TITLE
Remove print statement from py_semantics.bzl

### DIFF
--- a/py/private/py_semantics.bzl
+++ b/py/private/py_semantics.bzl
@@ -120,7 +120,6 @@ def _determine_main(ctx):
             fail("name must not end in '.py'")
         proposed_main = ctx.label.name + ".py"
 
-        print(ctx.files.srcs)
         main_files = [src for src in ctx.files.srcs if _path_endswith(src.short_path, proposed_main)]
 
         if len(main_files) > 1:


### PR DESCRIPTION
Remove debug print statement for src files.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: execute and observe that on the legacy code paths bazel no longer emits debug logging.
