### PR TITLE
fix(py_venv): Correct 'home' key

### DIFF
--- a/py/tools/py/src/pyvenv.cfg.tmpl
+++ b/py/tools/py/src/pyvenv.cfg.tmpl
@@ -1,4 +1,4 @@
-home = ./bin/python3
+home = ./bin/
 implementation = CPython
 version_info = {{MAJOR}}.{{MINOR}}.{{PATCH}}
 include-system-site-packages = {{INCLUDE_SYSTEM_SITE}}


### PR DESCRIPTION
Fixes #796

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed a bug which caused some applications to fail when using a rules_py-defined Python virtualenv.

### Test plan

N/A.