### PR TITLE
refactor(sdist_build): Use py_venv_binary for build tool

### DIFF
--- a/uv/private/sdist_build/BUILD.bazel
+++ b/uv/private/sdist_build/BUILD.bazel
@@ -11,7 +11,6 @@ bzl_library(
         "rule.bzl",
     ],
     deps = [
-        "//py/private/py_venv:types",
         "//py/private/toolchain:types",
     ],
 )
@@ -22,4 +21,7 @@ bzl_library(
     deps = [":rule"],
 )
 
-exports_files(["build_helper.py"])
+exports_files(
+    ["build_helper.py"],
+    visibility = ["//visibility:public"],
+)

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -31,12 +31,13 @@ def _sdist_build_impl(repository_ctx):
     file that defines the necessary targets to do so.
 
     It creates:
-    1.  A `py_venv` target named `build_venv`, which contains the build-time
-        dependencies (e.g., `build`, `setuptools`, `wheel`) specified in the
-        `deps` attribute.
+    1.  A `py_venv_binary` target named `build_tool`, which bundles the build
+        helper script with build-time dependencies (e.g., `build`, `setuptools`,
+        `wheel`) specified in the `deps` attribute. As a proper binary with
+        runfiles, Bazel can materialize its interpreter at action time.
     2.  A target (either `sdist_build` or `sdist_native_build` from `rule.bzl`)
         named `whl`. When this target is built, it executes the wheel build process
-        for the given `src` sdist within the `build_venv`.
+        for the given `src` sdist using `build_tool`.
 
     The `is_native` attribute determines whether the build is for a pure-Python
     wheel or one that may contain C-extensions, which controls which underlying
@@ -57,17 +58,19 @@ def _sdist_build_impl(repository_ctx):
 
     repository_ctx.file("BUILD.bazel", content = """
 load("@aspect_rules_py//uv/private/sdist_build:rule.bzl", "{rule}")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv")
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
 
-py_venv(
-    name = "build_venv",
+py_venv_binary(
+    name = "build_tool",
+    main = "@aspect_rules_py//uv/private/sdist_build:build_helper.py",
+    srcs = ["@aspect_rules_py//uv/private/sdist_build:build_helper.py"],
     deps = {deps},
 )
 
 {rule}(
     name = "whl",
     src = "{src}",
-    venv = ":build_venv",
+    tool = ":build_tool",
     version = "{version}",
     args = [],{patch_attrs}
     visibility = ["//visibility:public"],

--- a/uv/private/sdist_build/rule.bzl
+++ b/uv/private/sdist_build/rule.bzl
@@ -2,31 +2,15 @@
 Actually building sdists.
 """
 
-# buildifier: disable=bzl-visibility
-load("//py/private/py_venv:types.bzl", "VirtualenvInfo")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "TARGET_EXEC_TOOLCHAIN")
 load("//uv/private:defs.bzl", "lib_mode_transition")
 
 def _sdist_build(ctx):
-    py_toolchain = ctx.exec_groups["target"].toolchains[PY_TOOLCHAIN].py3_runtime
-    # uv = ctx.toolchains[UV_TOOLCHAIN]
-
     archive = ctx.attr.src[DefaultInfo].files.to_list()[0]
 
-    # Now we need to do a build from the archive dir to a source artifact.
     wheel_dir = ctx.actions.declare_directory(
         "whl",
     )
-
-    venv = ctx.attr.venv
-    # print(venv[VirtualenvInfo], venv[DefaultInfo])
-
-    # Options here:
-    # 1. `python3 -m build` which requires the build library and works generally
-    # 2. `python3 setup.py bdist_wheel` which only requires setuptools but doesn't work for pyproject
-    # 3. `uv build` which works generally but causes our venv shim to really struggle
-    #
-    # We're going with #1 for now.
 
     # Build patch arguments if pre_build_patches are specified
     patch_args = []
@@ -38,25 +22,23 @@ def _sdist_build(ctx):
                 patch_args.extend(["--patch", f.path])
                 patch_inputs.append(f)
 
-    # Note that we have to use exec_group = "target" to force this action to
-    # inherit RBE placement properties matching the target platform so that
-    # it'll run remotely.
+    # The build tool is a py_venv_binary wrapping build_helper.py. Using it as
+    # a tool (not just an input) causes Bazel to materialize its runfiles in
+    # the action sandbox, which means the venv shim can find the interpreter
+    # via the standard runfiles mechanism regardless of whether the interpreter
+    # comes from an external repo or the main workspace.
     ctx.actions.run(
         mnemonic = "PySdistBuild",
         progress_message = "Source compiling {} to a whl".format(archive.basename),
-        executable = venv[VirtualenvInfo].home.path + "/bin/python3",
-        arguments = [
-            ctx.file._helper.path,
-        ] + ctx.attr.args + patch_args + [
+        executable = ctx.executable.tool,
+        arguments = ctx.attr.args + patch_args + [
             archive.path,
             wheel_dir.path,
         ],
-        # FIXME: Shouldn't need to add the Python toolchain files explicitly here; should be transitives/defaultinfo of the venv.
         inputs = [
             archive,
-            venv[VirtualenvInfo].home,
-            ctx.file._helper,
-        ] + py_toolchain.files.to_list() + ctx.attr.venv[DefaultInfo].files.to_list() + patch_inputs,
+        ] + patch_inputs,
+        tools = [ctx.attr.tool[DefaultInfo].files_to_run],
         outputs = [
             wheel_dir,
         ],
@@ -86,6 +68,13 @@ _PATCH_ATTRS = {
     ),
 }
 
+_sdist_build_attrs = {
+    "src": attr.label(),
+    "tool": attr.label(executable = True, cfg = "exec"),
+    "version": attr.string(),
+    "args": attr.string_list(default = ["--validate-anyarch"]),
+} | _PATCH_ATTRS
+
 sdist_build = rule(
     implementation = _sdist_build,
     doc = """Sdist to _anyarch_ whl build rule.
@@ -94,15 +83,8 @@ Consumes a sdist artifact and performs a build of that artifact with the
 specified Python dependencies under the configured Python toochain.
 
 """,
-    attrs = {
-        "src": attr.label(),
-        "venv": attr.label(),
-        "version": attr.string(),
-        "args": attr.string_list(default = ["--validate-anyarch"]),
-        "_helper": attr.label(allow_single_file = True, default = Label(":build_helper.py")),
-    } | _PATCH_ATTRS,
+    attrs = _sdist_build_attrs,
     exec_groups = {
-        # Copy-paste from above, but without the target constraint toolchain
         "target": exec_group(
             toolchains = [
                 PY_TOOLCHAIN,
@@ -124,13 +106,9 @@ The build is guaranteed to occur on an execution platform matching the
 constraints of the target platform.
 
 """,
-    attrs = {
-        "src": attr.label(),
-        "venv": attr.label(),
-        "version": attr.string(),
+    attrs = _sdist_build_attrs | {
         "args": attr.string_list(),
-        "_helper": attr.label(allow_single_file = True, default = Label(":build_helper.py")),
-    } | _PATCH_ATTRS,
+    },
     exec_groups = {
         # Create an exec group which depends on a toolchain which can only be
         # resolved to exec_compatible_with constraints equal to the target. This


### PR DESCRIPTION
## Summary

- Replaces `py_venv` + `_helper` script with a single `py_venv_binary` `tool` attr in `sdist_build` / `sdist_native_build` rules
- Using `tool` as an executable (with `cfg = "exec"`) causes Bazel to materialize its runfiles in the action sandbox, so the venv shim can find the interpreter via the standard runfiles mechanism regardless of whether it comes from an external repo or the main workspace
- Consolidates shared attrs into `_sdist_build_attrs` dict, reducing duplication between the two rule definitions
- The repository rule (`repository.bzl`) now generates a `py_venv_binary` target (`build_tool`) instead of a `py_venv` target, and passes it as the `tool` attr

## Test plan

- [x] `bazel test //...` — 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)