### PR TITLE
fix(sdist_build): Set determinism env vars for reproducible wheel builds

### DIFF
--- a/uv/private/sdist_build/rule.bzl
+++ b/uv/private/sdist_build/rule.bzl
@@ -44,6 +44,10 @@ def _sdist_build(ctx):
         ],
         env = {
             "SETUPTOOLS_SCM_PRETEND_VERSION": ctx.attr.version,
+            # Determinism: fix hash seed so dict/set iteration order is stable
+            "PYTHONHASHSEED": "0",
+            # Determinism: reproducible timestamps in archives
+            "SOURCE_DATE_EPOCH": "0",
         } | ctx.configuration.default_shell_env,
         exec_group = "target",
     )


### PR DESCRIPTION
## Summary

- Sets `PYTHONHASHSEED=0` and `SOURCE_DATE_EPOCH=0` in the sdist build action environment
- `PYTHONHASHSEED=0` fixes dict/set iteration order so metadata and file listings are stable across runs
- `SOURCE_DATE_EPOCH=0` ensures timestamps embedded in wheel archives are reproducible

Reported by @dzbarsky.

## Test plan

- [x] `bazel test //...` — 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)