### PR TITLE
test(e2e): Add Windows cross-build verification test

### DIFF
--- a/e2e/cases/windows-crossbuild-837/BUILD.bazel
+++ b/e2e/cases/windows-crossbuild-837/BUILD.bazel
@@ -1,0 +1,36 @@
+# Test that Windows cross-build interpreter toolchain provisioning works
+# correctly from a Linux host.
+#
+# Verifies Windows Python interpreter toolchains (x86_64, aarch64) are
+# registered from python-build-standalone. We verify at the analysis level
+# via genquery rather than building a full venv, because cross-compiling
+# the Rust venv tools to Windows requires a CC toolchain not yet configured.
+#
+# Windows-only wheel selection (pywin32) is covered by uv-no-sdist-754.
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+# Prove the Windows x86_64 interpreter toolchain exists by querying its deps.
+# If the toolchain repo was not provisioned, this query will fail at analysis time.
+genquery(
+    name = "windows_x64_toolchain_deps",
+    expression = "deps(@python_interpreters//:python_3_12_x86_64_pc_windows_msvc, 1)",
+    scope = ["@python_interpreters//:python_3_12_x86_64_pc_windows_msvc"],
+)
+
+# Prove the Windows aarch64 interpreter toolchain exists.
+genquery(
+    name = "windows_arm64_toolchain_deps",
+    expression = "deps(@python_interpreters//:python_3_12_aarch64_pc_windows_msvc, 1)",
+    scope = ["@python_interpreters//:python_3_12_aarch64_pc_windows_msvc"],
+)
+
+sh_test(
+    name = "test",
+    srcs = ["test_crossbuild.sh"],
+    data = [
+        ":windows_arm64_toolchain_deps",
+        ":windows_x64_toolchain_deps",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+)

--- a/e2e/cases/windows-crossbuild-837/test_crossbuild.sh
+++ b/e2e/cases/windows-crossbuild-837/test_crossbuild.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Windows cross-build test: verify that interpreter provisioning works
+# correctly for Windows targets from a Linux host.
+
+DIR="${TEST_SRCDIR}/_main/cases/windows-crossbuild-837"
+
+WIN_X64_DEPS="$(cat "$DIR/windows_x64_toolchain_deps")"
+WIN_ARM64_DEPS="$(cat "$DIR/windows_arm64_toolchain_deps")"
+
+errors=0
+
+# Check 1: Windows x86_64 toolchain resolved and has deps
+if [ -z "$WIN_X64_DEPS" ]; then
+    echo "FAIL: Windows x86_64 toolchain has no deps (not provisioned?)"
+    errors=$((errors + 1))
+else
+    echo "PASS: Windows x86_64 interpreter toolchain provisioned"
+fi
+
+# Check 2: Windows aarch64 toolchain resolved and has deps
+if [ -z "$WIN_ARM64_DEPS" ]; then
+    echo "FAIL: Windows aarch64 toolchain has no deps (not provisioned?)"
+    errors=$((errors + 1))
+else
+    echo "PASS: Windows aarch64 interpreter toolchain provisioned"
+fi
+
+# Check 3: Windows x86_64 toolchain references the interpreter repo
+if ! echo "$WIN_X64_DEPS" | grep -q 'x86_64_pc_windows_msvc'; then
+    echo "FAIL: Windows x86_64 toolchain doesn't reference expected interpreter repo"
+    errors=$((errors + 1))
+else
+    echo "PASS: Windows x86_64 toolchain references correct interpreter repo"
+fi
+
+if [ "$errors" -gt 0 ]; then
+    echo ""
+    echo "FAILED: $errors check(s) failed"
+    exit 1
+fi
+
+echo ""
+echo "PASS: Windows cross-build interpreter provisioning verified"
+echo "  - Windows interpreter toolchains provisioned from PBS (x86_64, aarch64)"


### PR DESCRIPTION
Verifies Windows interpreter toolchains (x86_64, aarch64) are provisioned from PBS via genquery at analysis level. Cross-compiling the Rust venv tools to Windows requires a CC toolchain not yet configured, so we don't build a full venv.

Windows-only wheel selection (pywin32) is already covered by `uv-no-sdist-754`; this test focuses on interpreter provisioning.

Rebased onto current main — all interpreter provisioning, ABI flags, and freethreaded support changes from the original branch have already landed via #836, #859, #871, and others.

### Changes are visible to end-users: no

### Test plan

- New test: `cd e2e && bazel test //cases/windows-crossbuild-837:test`
- Verified passing on Linux host

🤖 Generated with [Claude Code](https://claude.com/claude-code)