### PR TITLE
fix(py_binary): Resolve .venv.pth action conflict with .venv target

### DIFF
--- a/e2e/cases/venv-conflict-608/BUILD.bazel
+++ b/e2e/cases/venv-conflict-608/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+py_binary(
+    name = "app",
+    srcs = ["app.py"],
+    python_version = "3.11",
+)
+
+# Regression test for https://github.com/aspect-build/rules_py/issues/608
+# and https://github.com/aspect-build/rules_py/issues/686.
+# Building a py_binary and its auto-generated .venv target in the same
+# invocation must not produce an action conflict on <name>.venv.pth.
+build_test(
+    name = "test_no_venv_conflict",
+    targets = [
+        ":app",
+        ":app.venv",
+    ],
+)

--- a/e2e/cases/venv-conflict-608/app.py
+++ b/e2e/cases/venv-conflict-608/app.py
@@ -1,0 +1,1 @@
+print("hello")

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -49,7 +49,7 @@ def _py_binary_rule_impl(ctx):
 
     pth_lines.add_all(imports_depset, format_each = "{}/%s".format(escape))
 
-    site_packages_pth_file = ctx.actions.declare_file("{}.venv.pth".format(ctx.attr.name))
+    site_packages_pth_file = ctx.actions.declare_file("{}.pth".format(ctx.attr.name))
     ctx.actions.write(
         output = site_packages_pth_file,
         content = pth_lines,


### PR DESCRIPTION
The `py_binary` macro creates both the binary rule and a `_py_venv_link` target named `{name}.venv` for IDE support. Both declared an output file named `{name}.venv.pth`, causing a Bazel action conflict when both were built in the same invocation (e.g. `bazel build :app :app.venv` or via `bazel query` feeding a target list).

Rename the binary rule's pth file from `{name}.venv.pth` to `{name}.pth`, consistent with `_py_venv_link` which also uses `{name}.pth` (producing `{name}.venv.pth` since its name is `{name}.venv`).

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`py_binary`: Fixed action conflict when building a `py_binary` target alongside its auto-generated `.venv` target.

### Test plan

- New e2e test: `e2e/cases/venv-conflict-608` — uses `build_test` to build both `:app` and `:app.venv` in the same invocation
- Existing `py/tests/...` suite passes (19/19)

Closes #608
Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)