### PR TITLE
feat(uv): Support PEP 735 include-group syntax in dependency-groups

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -201,4 +201,13 @@ uv.project(
 )
 # }}}
 
+# For cases/uv-include-group (PEP 735 include-group syntax)
+# {{{
+uv.project(
+    hub_name = "pypi",
+    lock = "//cases/uv-include-group:uv.lock",
+    pyproject = "//cases/uv-include-group:pyproject.toml",
+)
+# }}}
+
 use_repo(uv, "pypi")

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "include_group",
+    srcs = [
+        "__test__.py",
+    ],
+    main = "__test__.py",
+    python_version = "3.11",
+    venv = "dev",
+    deps = [
+        "@pypi//pytest",
+        "@pypi//setuptools",
+    ],
+)

--- a/e2e/cases/uv-include-group/__test__.py
+++ b/e2e/cases/uv-include-group/__test__.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Test that PEP 735 include-group syntax works.
+
+The dev dependency group includes both build and test groups via:
+    dev = [
+        {include-group = "build"},
+        {include-group = "test"},
+    ]
+
+This test verifies that packages from both included groups are available.
+"""
+
+# From build group
+import setuptools
+print(f"setuptools: {setuptools.__file__}")
+
+# From test group
+import pytest
+print(f"pytest: {pytest.__file__}")

--- a/e2e/cases/uv-include-group/pyproject.toml
+++ b/e2e/cases/uv-include-group/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "include-group-test"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = []
+
+[dependency-groups]
+# Test PEP 735 include-group syntax
+build = [
+    "setuptools",
+]
+test = [
+    "pytest",
+]
+dev = [
+    {include-group = "build"},
+    {include-group = "test"},
+]

--- a/e2e/cases/uv-include-group/uv.lock
+++ b/e2e/cases/uv-include-group/uv.lock
@@ -1,0 +1,100 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "include-group-test"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+build = [
+    { name = "setuptools" },
+]
+dev = [
+    { name = "pytest" },
+    { name = "setuptools" },
+]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+build = [{ name = "setuptools" }]
+dev = [
+    { name = "pytest" },
+    { name = "setuptools" },
+]
+test = [{ name = "pytest" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]

--- a/uv/private/extension/dep_groups.bzl
+++ b/uv/private/extension/dep_groups.bzl
@@ -1,0 +1,82 @@
+"""Utilities for processing PEP 735 dependency groups."""
+
+def resolve_dependency_group_specs(dep_groups, group_name):
+    """Resolves include-group references in a dependency group.
+
+    PEP 735 allows dependency groups to include other groups via:
+        {include-group = "other-group"}
+
+    This function expands these references to their constituent requirement strings,
+    preserving the order of specs.
+
+    Args:
+        dep_groups: Dict mapping group names to lists of specs.
+        group_name: The name of the group to resolve.
+
+    Returns:
+        List of resolved requirement strings (no include-group dicts).
+    """
+    if group_name not in dep_groups:
+        fail("Dependency group '{}' not found. Available groups: {}".format(
+            group_name,
+            ", ".join(sorted(dep_groups.keys())),
+        ))
+
+    # Track which groups we've visited to detect cycles.
+    # We expand iteratively, one level at a time, until no include-groups remain.
+    visited = {group_name: True}
+
+    # Start with the specs from the requested group, tagged with their source for error messages.
+    # Each item is either a string (requirement) or a tuple (included_group_name, parent_path).
+    pending = []
+    for spec in dep_groups[group_name]:
+        if type(spec) == "dict":
+            if "include-group" not in spec:
+                fail("Unknown dict spec in dependency-group '{}': {}".format(group_name, spec))
+            pending.append((spec["include-group"], group_name))
+        else:
+            pending.append(spec)
+
+    # Repeatedly expand include-groups until none remain
+    for _ in range(100):  # Max nesting depth
+        has_includes = False
+        next_pending = []
+
+        for item in pending:
+            if type(item) == "tuple":
+                has_includes = True
+                included_group, parent = item
+
+                if included_group in visited:
+                    fail("Circular dependency-group reference detected: '{}' includes '{}' which was already visited".format(
+                        parent,
+                        included_group,
+                    ))
+
+                if included_group not in dep_groups:
+                    fail("Dependency group '{}' not found (included from '{}'). Available groups: {}".format(
+                        included_group,
+                        parent,
+                        ", ".join(sorted(dep_groups.keys())),
+                    ))
+
+                visited[included_group] = True
+
+                # Expand this include-group inline
+                for spec in dep_groups[included_group]:
+                    if type(spec) == "dict":
+                        if "include-group" not in spec:
+                            fail("Unknown dict spec in dependency-group '{}': {}".format(included_group, spec))
+                        next_pending.append((spec["include-group"], included_group))
+                    else:
+                        next_pending.append(spec)
+            else:
+                next_pending.append(item)
+
+        pending = next_pending
+
+        if not has_includes:
+            break
+
+    # At this point, pending should contain only strings
+    return pending

--- a/uv/private/extension/parser.bzl
+++ b/uv/private/extension/parser.bzl
@@ -7,6 +7,7 @@ load("//uv/private/constraints/python:defs.bzl", "supported_python")
 load("//uv/private/graph:sccs.bzl", "sccs")
 load("//uv/private/pprint:defs.bzl", "pprint")
 load("//uv/private/tomltool:toml.bzl", "toml")
+load(":dep_groups.bzl", "resolve_dependency_group_specs")
 load(":normalize_name.bzl", "normalize_name")
 
 def _normalize_deps(lock_id, lock_data):
@@ -300,9 +301,10 @@ def _collect_activated_extras(project_data, default_versions, graph):
     # Builds up {package: {configuration: {extra: {marker: 1}}}}
     activated_extras = {}
 
-    for group_name, specs in dep_groups.items():
+    for group_name in dep_groups.keys():
         normalized_dep_groups[group_name] = []
-        for spec in specs:
+        resolved_specs = resolve_dependency_group_specs(dep_groups, group_name)
+        for spec in resolved_specs:
             for dep, marker in _extract_requirement_marker_pairs(spec, default_versions):
                 normalized_dep_groups[group_name].append(dep)
 

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -4,6 +4,7 @@ Machinery specific to interacting with a pyproject.toml
 
 load("//uv/private:normalize_name.bzl", "normalize_name")
 load("//uv/private/versions:versions.bzl", "find_matching_version")
+load(":dep_groups.bzl", "resolve_dependency_group_specs")
 
 def extract_requirement_marker_pairs(projectfile, lock_id, req_string, version_map, package_versions = {}):
     """Parses a requirement string into a list of dependency-marker pairs.
@@ -147,9 +148,10 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
     # Builds up {package: {configuration: {extra: {marker: 1}}}}
     activated_extras = {}
 
-    for group_name, specs in dep_groups.items():
+    for group_name in dep_groups.keys():
         normalized_dep_groups[group_name] = []
-        for spec in specs:
+        resolved_specs = resolve_dependency_group_specs(dep_groups, group_name)
+        for spec in resolved_specs:
             for dep, marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions):
                 normalized_dep_groups[group_name].append(dep)
 


### PR DESCRIPTION
Follow-up to https://github.com/aspect-build/rules_py/issues/841#issuecomment-4027124653

PEP 735 allows dependency groups to reference other groups via the `{include-group = "other-group"}` syntax. This commit adds support for parsing and resolving these references in the uv.project extension.

The implementation:
- Adds a shared `resolve_dependency_group_specs()` helper in dep_groups.bzl
- Uses iterative expansion (Starlark doesn't support recursion)
- Detects circular references and provides clear error messages
- Preserves the order of specs when expanding include-groups

Example usage:
```toml
[dependency-groups]
build = ["setuptools"]
test = ["pytest"]
dev = [
    {include-group = "build"},
    {include-group = "test"},
]
```

Includes E2E test case in e2e/cases/uv-include-group/.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added
- Manual testing (using the internal codebase where I hit this + a `local_path_override` pointing rules_py at my fork with these changes)
