### PR TITLE
fix(e2e): Add @platforms//os:linux to OCI distroless exec tests

### DIFF
--- a/e2e/cases/oci/distroless/BUILD.bazel
+++ b/e2e/cases/oci/distroless/BUILD.bazel
@@ -67,6 +67,7 @@ container_structure_test(
     image = ":amd64_image",
     platform = "linux/amd64",
     target_compatible_with = [
+        "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
 )
@@ -92,6 +93,7 @@ container_structure_test(
     image = ":arm64_image",
     platform = "linux/aarch64",
     target_compatible_with = [
+        "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
 )


### PR DESCRIPTION
The `container_structure_test` targets in `e2e/cases/oci/distroless` exec Linux container images and cannot run on macOS. The existing `target_compatible_with` only constrained on CPU architecture, so `amd64_exec_test` passed the constraint check on macOS Intel (`darwin_x86_64`) and failed at runtime on the BCR presubmit.

Adds `@platforms//os:linux` to both `amd64_exec_test` and `arm64_exec_test`.

### Changes are visible to end-users: no

### Test plan

- `arm64_exec_test` was already correctly skipped on macOS Intel (CPU mismatch), confirming the skip mechanism works
- Adding `@platforms//os:linux` will cause `amd64_exec_test` to also be skipped on macOS hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)