### PR TITLE
[uv] Add support for srcs_exclude_glob and data_exclude_glob

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -183,6 +183,27 @@ uv.override_package(
 )
 # }}}
 
+# For cases/uv-exclusions-848
+# {{{
+uv.project(
+    hub_name = "pypi",
+    lock = "//cases/uv-exclusions-848:uv.lock",
+    pyproject = "//cases/uv-exclusions-848:pyproject.toml",
+)
+uv.override_package(
+    name = "cowsay",
+    data_exclude_glob = [
+        "site-packages/*.dist-info/LICENSE.txt",
+        "site-packages/cowsay/main.py",
+    ],
+    lock = "//cases/uv-exclusions-848:uv.lock",
+    srcs_exclude_glob = [
+        "site-packages/cowsay/tests/**",
+        "site-packages/*.dist-info/METADATA",
+    ],
+)
+# }}}
+
 # For cases/uv-no-sdist-754
 # {{{
 uv.project(

--- a/e2e/cases/uv-exclusions-848/BUILD.bazel
+++ b/e2e/cases/uv-exclusions-848/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "test",
+    srcs = ["__test__.py"],
+    main = "__test__.py",
+    python_version = "3.11",
+    venv = "exclusions",
+    deps = [
+        "@pypi//cowsay",
+    ],
+)

--- a/e2e/cases/uv-exclusions-848/__test__.py
+++ b/e2e/cases/uv-exclusions-848/__test__.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+"""Test that exclusion globs remove the expected installed files."""
+
+import importlib
+import importlib.metadata
+
+import cowsay
+
+output = cowsay.get_output_string("cow", "exclusions work!")
+assert "exclusions work!" in output
+print("cowsay functional: OK")
+
+try:
+    importlib.import_module("cowsay.tests.solutions")
+except ModuleNotFoundError:
+    pass
+else:
+    raise AssertionError("srcs_exclude_glob did not prevent importing cowsay.tests.solutions")
+print("srcs_exclude_glob srcs: OK")
+
+dist = importlib.metadata.distribution("cowsay")
+assert dist.read_text("LICENSE.txt") is None, "data_exclude_glob did not remove LICENSE.txt"
+print("data_exclude_glob data: OK")
+
+main = importlib.import_module("cowsay.main")
+assert main is not None, (
+    "data_exclude_glob should not prevent importing cowsay.main because it is treated as srcs"
+)
+print("data_exclude_glob src preservation: OK")
+
+metadata_text = dist.read_text("METADATA")
+assert metadata_text is not None and "Name: cowsay" in metadata_text, (
+    "srcs_exclude_glob should not remove dist-info/METADATA because it is treated as data"
+)
+print("srcs_exclude_glob data preservation: OK")
+
+print("All exclusion tests passed.")

--- a/e2e/cases/uv-exclusions-848/pyproject.toml
+++ b/e2e/cases/uv-exclusions-848/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "exclusions"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "cowsay==6.0",
+]

--- a/e2e/cases/uv-exclusions-848/uv.lock
+++ b/e2e/cases/uv-exclusions-848/uv.lock
@@ -1,0 +1,24 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "cowsay"
+version = "6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/b5/e8e802ddc7f5219417dc7d7953eec81ffe48ad129b793f3040361e4aff89/cowsay-6.0.tar.gz", hash = "sha256:47445cb273684618a1786db8e8d05ec9258455f7eb74893e5d0933daafeb44ba", size = 25228, upload-time = "2023-09-08T17:16:36.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/56/7922bfc226ccd44221befb6b866aaa4da4170bc9d8b036ef0675ce0f1b53/cowsay-6.0-py2.py3-none-any.whl", hash = "sha256:77b07c508af48aa300a90f3b3c5c013a12360a71fc5c87b1efb763fe2803a775", size = 25411, upload-time = "2023-09-08T17:16:34.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/01/40be54532d7bd37c99d849bbdd590f0135ce13183365df6f0e85c475ca71/cowsay-6.0-py3-none-any.whl", hash = "sha256:011c067841451ea49baf8ff49c355bd7f659d53fc538459e0a84c12ae2b4e027", size = 25409, upload-time = "2023-09-08T17:25:17.505Z" },
+]
+
+[[package]]
+name = "exclusions"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "cowsay" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "cowsay", specifier = "==6.0" }]

--- a/py/tools/py/BUILD.bazel
+++ b/py/tools/py/BUILD.bazel
@@ -3,6 +3,7 @@ load("//bazel/rust:defs.bzl", "rust_library")
 rust_library(
     name = "py",
     srcs = [
+        "src/bazel_glob.rs",
         "src/lib.rs",
         "src/pth.rs",
         "src/unpack.rs",

--- a/py/tools/py/src/bazel_glob.rs
+++ b/py/tools/py/src/bazel_glob.rs
@@ -1,0 +1,223 @@
+use std::{
+    ffi::OsStr,
+    fmt,
+    path::{Component, Path},
+};
+
+use miette::{miette, Result};
+
+#[derive(Debug)]
+enum BazelGlobSegment {
+    Recursive,
+    Segment(String),
+}
+
+#[derive(Debug)]
+pub(crate) struct BazelGlob {
+    raw: String,
+    segments: Vec<BazelGlobSegment>,
+}
+
+impl BazelGlob {
+    pub(crate) fn parse(pattern: &str) -> Result<Self> {
+        if pattern.is_empty() {
+            return Err(miette!(
+                "Error in glob: invalid glob pattern '{}': pattern cannot be empty",
+                pattern
+            ));
+        }
+
+        let segments = pattern
+            .split('/')
+            .map(|segment| {
+                if segment.is_empty() {
+                    Err(miette!(
+                        "Error in glob: invalid glob pattern '{}': empty segment not permitted",
+                        pattern
+                    ))
+                } else if segment == "**" {
+                    Ok(BazelGlobSegment::Recursive)
+                } else if segment.contains("**") {
+                    Err(miette!(
+                        "Error in glob: invalid glob pattern '{}': recursive wildcard must be its own segment",
+                        pattern
+                    ))
+                } else {
+                    Ok(BazelGlobSegment::Segment(segment.to_owned()))
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            raw: pattern.to_owned(),
+            segments,
+        })
+    }
+
+    pub(crate) fn matches(&self, path: &Path) -> bool {
+        let Some(path_segments) = path_segments(path) else {
+            return false;
+        };
+        let mut current = vec![false; self.segments.len() + 1];
+        current[0] = true;
+        self.propagate_recursive_zero_matches(&mut current);
+
+        for path_segment in path_segments {
+            let mut next = vec![false; self.segments.len() + 1];
+
+            for (index, is_reachable) in current.iter().enumerate().take(self.segments.len()) {
+                if !is_reachable {
+                    continue;
+                }
+
+                match &self.segments[index] {
+                    BazelGlobSegment::Recursive => {
+                        next[index] = true;
+                    }
+                    BazelGlobSegment::Segment(pattern_segment) => {
+                        if matches_bazel_segment(pattern_segment, path_segment) {
+                            next[index + 1] = true;
+                        }
+                    }
+                }
+            }
+
+            self.propagate_recursive_zero_matches(&mut next);
+            current = next;
+        }
+
+        current[self.segments.len()]
+    }
+
+    // This is the same zero-segment transition Bazel's recursive glob star needs.
+    // Applying it once per frontier keeps matching O(pattern_segments * path_segments).
+    fn propagate_recursive_zero_matches(&self, states: &mut [bool]) {
+        for (index, segment) in self.segments.iter().enumerate() {
+            if states[index] && matches!(segment, BazelGlobSegment::Recursive) {
+                states[index + 1] = true;
+            }
+        }
+    }
+}
+
+impl fmt::Display for BazelGlob {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+fn path_segments(path: &Path) -> Option<Vec<&OsStr>> {
+    let mut segments = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => segments.push(segment),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+
+    Some(segments)
+}
+
+fn matches_bazel_segment(pattern: &str, segment: &OsStr) -> bool {
+    // Bazel's hidden-file behavior is special: bare `*` matches a dotfile, but
+    // compound patterns like `*.py` only match dotfiles when they start with `.`.
+    let segment = segment.as_encoded_bytes();
+
+    if segment.first() == Some(&b'.') && pattern != "*" && !pattern.starts_with('.') {
+        return false;
+    }
+
+    let pattern = pattern.as_bytes();
+
+    let mut pattern_index = 0;
+    let mut segment_index = 0;
+    let mut star_index = None;
+    let mut match_index = 0;
+
+    while segment_index < segment.len() {
+        if pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+            star_index = Some(pattern_index);
+            pattern_index += 1;
+            match_index = segment_index;
+        } else if pattern_index < pattern.len() && pattern[pattern_index] == segment[segment_index]
+        {
+            pattern_index += 1;
+            segment_index += 1;
+        } else if let Some(star_index) = star_index {
+            pattern_index = star_index + 1;
+            match_index += 1;
+            segment_index = match_index;
+        } else {
+            return false;
+        }
+    }
+
+    while pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+        pattern_index += 1;
+    }
+
+    pattern_index == pattern.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::BazelGlob;
+    use miette::Result;
+
+    #[test]
+    fn recursive_glob_matches_nested_paths() -> Result<()> {
+        let glob = BazelGlob::parse("**/tests/**")?;
+        assert!(glob.matches(Path::new(
+            "lib/python3.11/site-packages/cowsay/tests/test_api.py"
+        )));
+        assert!(!glob.matches(Path::new(
+            "lib/python3.11/site-packages/cowsay/main.py"
+        )));
+        Ok(())
+    }
+
+    #[test]
+    fn recursive_glob_matches_zero_segments() -> Result<()> {
+        let glob = BazelGlob::parse("**/*.py")?;
+        assert!(glob.matches(Path::new("main.py")));
+        assert!(glob.matches(Path::new("pkg/main.py")));
+        Ok(())
+    }
+
+    #[test]
+    fn hidden_file_behavior_matches_bazel_rules() -> Result<()> {
+        let wildcard = BazelGlob::parse("*")?;
+        let compound = BazelGlob::parse("*.py")?;
+        let hidden_compound = BazelGlob::parse(".*.py")?;
+
+        assert!(wildcard.matches(Path::new(".env")));
+        assert!(!compound.matches(Path::new(".hidden.py")));
+        assert!(hidden_compound.matches(Path::new(".hidden.py")));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_double_star_segment_is_rejected() {
+        assert!(BazelGlob::parse("foo**/bar").is_err());
+    }
+
+    #[test]
+    fn invalid_glob_errors_match_bazel_shape() {
+        assert_eq!(
+            BazelGlob::parse("").unwrap_err().to_string(),
+            "Error in glob: invalid glob pattern '': pattern cannot be empty"
+        );
+        assert_eq!(
+            BazelGlob::parse("foo//bar").unwrap_err().to_string(),
+            "Error in glob: invalid glob pattern 'foo//bar': empty segment not permitted"
+        );
+        assert_eq!(
+            BazelGlob::parse("foo**/bar").unwrap_err().to_string(),
+            "Error in glob: invalid glob pattern 'foo**/bar': recursive wildcard must be its own segment"
+        );
+    }
+}

--- a/py/tools/py/src/lib.rs
+++ b/py/tools/py/src/lib.rs
@@ -1,3 +1,4 @@
+mod bazel_glob;
 pub mod pth;
 pub mod unpack;
 pub mod venv;

--- a/py/tools/py/src/unpack.rs
+++ b/py/tools/py/src/unpack.rs
@@ -2,22 +2,113 @@ use std::{
     fs,
     path::{Path, PathBuf},
     str::FromStr,
+    sync::LazyLock,
 };
 
+use crate::bazel_glob::BazelGlob;
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic, Result};
 use percent_encoding::percent_decode_str;
+use walkdir::WalkDir;
 
 const RELOCATABLE_SHEBANG: &'static str = r#"/bin/sh
 '''exec' "$(dirname -- "$(realpath -- "$0")")"/'python3' "$0" "$@"
 ' '''
 "#;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RulesPythonFileKind {
+    Src,
+    Data,
+    Neither,
+}
+
+static PYC_TEMP_FILE_GLOB: LazyLock<BazelGlob> =
+    LazyLock::new(|| BazelGlob::parse("**/*.pyc.*").unwrap());
+static DIST_INFO_RECORD_GLOB: LazyLock<BazelGlob> =
+    LazyLock::new(|| BazelGlob::parse("**/*.dist-info/RECORD").unwrap());
+
+fn excluded_file_kind(path: &Path) -> RulesPythonFileKind {
+    if path.to_str() == Some("BUILD") || path.to_str() == Some("WORKSPACE") {
+        return RulesPythonFileKind::Neither;
+    }
+
+    let extension = path.extension();
+    if extension == Some("py".as_ref()) {
+        return RulesPythonFileKind::Src;
+    }
+
+    if extension == Some("pyi".as_ref()) || extension == Some("pyc".as_ref()) {
+        return RulesPythonFileKind::Neither;
+    }
+
+    if PYC_TEMP_FILE_GLOB.matches(path) || DIST_INFO_RECORD_GLOB.matches(path) {
+        return RulesPythonFileKind::Neither;
+    }
+
+    RulesPythonFileKind::Data
+}
+
+fn remove_excluded_files(
+    site_packages_dir: &Path,
+    srcs_exclude_globs: &[String],
+    data_exclude_globs: &[String],
+) -> Result<()> {
+    if srcs_exclude_globs.is_empty() && data_exclude_globs.is_empty() {
+        return Ok(());
+    }
+
+    let srcs_exclude_globs = srcs_exclude_globs
+        .iter()
+        .map(|pattern| BazelGlob::parse(pattern))
+        .collect::<Result<Vec<_>>>()?;
+    let data_exclude_globs = data_exclude_globs
+        .iter()
+        .map(|pattern| BazelGlob::parse(pattern))
+        .collect::<Result<Vec<_>>>()?;
+
+    for entry in WalkDir::new(site_packages_dir) {
+        let entry = entry.into_diagnostic()?;
+        if entry.file_type().is_dir() {
+            continue;
+        }
+
+        let path = entry.path().strip_prefix(site_packages_dir).unwrap();
+        let match_path = Path::new("site-packages").join(path);
+
+        let matching_glob = match excluded_file_kind(path) {
+            RulesPythonFileKind::Src => srcs_exclude_globs
+                .iter()
+                .find(|glob| glob.matches(&match_path)),
+            RulesPythonFileKind::Data => data_exclude_globs
+                .iter()
+                .find(|glob| glob.matches(&match_path)),
+            RulesPythonFileKind::Neither => None,
+        };
+
+        if let Some(matching_glob) = matching_glob {
+            fs::remove_file(entry.path())
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!(
+                        "Failed to remove excluded installed file '{}' matched by '{}'",
+                        match_path.display(),
+                        matching_glob
+                    )
+                })?;
+        }
+    }
+
+    Ok(())
+}
+
 pub fn unpack_wheel(
     version_major: u8,
     version_minor: u8,
     location: &Path,
     wheel: &Path,
+    srcs_exclude_globs: &[String],
+    data_exclude_globs: &[String],
 ) -> Result<()> {
     let wheel = if wheel.is_file() {
         wheel.to_owned()
@@ -88,5 +179,122 @@ pub fn unpack_wheel(
     )
     .into_diagnostic()?;
 
+    remove_excluded_files(&site_packages_dir, srcs_exclude_globs, data_exclude_globs)?;
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use super::{excluded_file_kind, RulesPythonFileKind};
+
+    #[test]
+    fn kind_matches_source_classification() {
+        assert_eq!(excluded_file_kind(Path::new("pkg/module.py")), RulesPythonFileKind::Src);
+    }
+
+    #[test]
+    fn kind_matches_data_classification() {
+        assert_eq!(
+            excluded_file_kind(Path::new("pkg/templates/index.html")),
+            RulesPythonFileKind::Data
+        );
+    }
+
+    #[test]
+    fn kind_preserves_non_src_non_data_files() {
+        assert_eq!(
+            excluded_file_kind(Path::new("pkg/module.pyi")),
+            RulesPythonFileKind::Neither
+        );
+        assert_eq!(
+            excluded_file_kind(Path::new("pkg/module.pyc")),
+            RulesPythonFileKind::Neither
+        );
+        assert_eq!(
+            excluded_file_kind(Path::new("pkg-1.0.dist-info/RECORD")),
+            RulesPythonFileKind::Neither
+        );
+    }
+
+    #[test]
+    fn kind_matches_recursive_dist_info_record_glob() {
+        assert_eq!(
+            excluded_file_kind(Path::new("pkg/foo.dist-info/RECORD")),
+            RulesPythonFileKind::Neither
+        );
+    }
+
+    #[test]
+    fn kind_only_matches_pyc_temp_files_by_file_name() {
+        assert_eq!(
+            excluded_file_kind(Path::new("pkg/cache.pyc.dir/data.txt")),
+            RulesPythonFileKind::Data
+        );
+        assert_eq!(
+            excluded_file_kind(Path::new("pkg/__pycache__/module.pyc.123")),
+            RulesPythonFileKind::Neither
+        );
+    }
+
+    #[test]
+    fn kind_preserves_root_build_and_workspace_files() {
+        assert_eq!(excluded_file_kind(Path::new("BUILD")), RulesPythonFileKind::Neither);
+        assert_eq!(
+            excluded_file_kind(Path::new("WORKSPACE")),
+            RulesPythonFileKind::Neither
+        );
+    }
+
+    #[test]
+    fn remove_excluded_files_requires_site_packages_prefix_for_exact_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let site_packages_dir = temp.path().join("site-packages");
+        let pkg_dir = site_packages_dir.join("pkg");
+
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("tests.py"), "").unwrap();
+
+        super::remove_excluded_files(&site_packages_dir, &["pkg/tests.py".to_owned()], &[])
+            .unwrap();
+
+        assert!(pkg_dir.join("tests.py").exists());
+    }
+
+    #[test]
+    fn remove_excluded_files_deletes_matching_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let site_packages_dir = temp.path().join("site-packages");
+        let pkg_dir = site_packages_dir.join("pkg");
+
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("tests.py"), "").unwrap();
+
+        super::remove_excluded_files(
+            &site_packages_dir,
+            &["site-packages/pkg/tests.py".to_owned()],
+            &[],
+        )
+        .unwrap();
+
+        assert!(!pkg_dir.join("tests.py").exists());
+    }
+
+    #[test]
+    fn remove_excluded_files_rejects_invalid_globs() {
+        let temp = tempfile::tempdir().unwrap();
+        let site_packages_dir = temp.path().join("site-packages");
+
+        fs::create_dir_all(&site_packages_dir).unwrap();
+
+        let error = super::remove_excluded_files(&site_packages_dir, &["foo**/bar".to_owned()], &[])
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Error in glob: invalid glob pattern 'foo**/bar': recursive wildcard must be its own segment"
+        );
+    }
 }

--- a/py/tools/unpack_bin/src/main.rs
+++ b/py/tools/unpack_bin/src/main.rs
@@ -20,10 +20,25 @@ struct UnpackArgs {
     python_version_major: u8,
     #[arg(long)]
     python_version_minor: u8,
+
+    /// Glob patterns for installed source files to remove after unpacking.
+    #[arg(long = "srcs-exclude-glob")]
+    srcs_exclude_glob: Vec<String>,
+
+    /// Glob patterns for installed data files to remove after unpacking.
+    #[arg(long = "data-exclude-glob")]
+    data_exclude_glob: Vec<String>,
 }
 
 fn unpack_cmd_handler(args: UnpackArgs) -> miette::Result<()> {
-    py::unpack_wheel(args.python_version_major, args.python_version_minor, &args.into, &args.wheel)
+    py::unpack_wheel(
+        args.python_version_major,
+        args.python_version_minor,
+        &args.into,
+        &args.wheel,
+        &args.srcs_exclude_glob,
+        &args.data_exclude_glob,
+    )
 }
 
 fn main() -> miette::Result<()> {

--- a/uv/private/apply_patches/whl_apply_patches.bzl
+++ b/uv/private/apply_patches/whl_apply_patches.bzl
@@ -30,6 +30,8 @@ def _whl_apply_patches(ctx):
         "--python-version-minor",
         py_toolchain.interpreter_version_info.minor,
     ])
+    arguments.add_all(ctx.attr.srcs_exclude_glob, before_each = "--srcs-exclude-glob")
+    arguments.add_all(ctx.attr.data_exclude_glob, before_each = "--data-exclude-glob")
 
     unpack = ctx.attr._unpack[platform_common.ToolchainInfo].bin.bin
     ctx.actions.run(
@@ -100,6 +102,14 @@ that correctly provides PyInfo.""",
         "patch_strip": attr.int(
             default = 0,
             doc = "Strip count for patches (-p flag).",
+        ),
+        "srcs_exclude_glob": attr.string_list(
+            default = [],
+            doc = "Glob patterns for installed source files to remove before patching.",
+        ),
+        "data_exclude_glob": attr.string_list(
+            default = [],
+            doc = "Glob patterns for installed data files to remove before patching.",
         ),
         "_unpack": attr.label(
             default = "//py/private/toolchain:resolved_unpack_toolchain",

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -215,6 +215,8 @@ def _parse_projects(module_ctx, hub_specs):
                 has_modifications = (
                     override.pre_build_patches or
                     override.post_install_patches or
+                    override.srcs_exclude_glob or
+                    override.data_exclude_glob or
                     override.extra_deps or
                     override.extra_data
                 )
@@ -223,7 +225,7 @@ def _parse_projects(module_ctx, hub_specs):
                     fail("uv.override_package() for '{}': `target` is mutually exclusive with patch/exclude attributes. Use `target` for full replacement OR patch/exclude attributes for modifications, not both.".format(override.name))
 
                 if not has_target and not has_modifications:
-                    fail("uv.override_package() for '{}': must specify either `target` for full replacement or at least one modification attribute (pre_build_patches, post_install_patches, extra_deps, extra_data).".format(override.name))
+                    fail("uv.override_package() for '{}': must specify either `target` for full replacement or at least one modification attribute (pre_build_patches, post_install_patches, srcs_exclude_glob, data_exclude_glob, extra_deps, extra_data).".format(override.name))
 
                 package_overrides[override_key] = override
 
@@ -368,11 +370,15 @@ def _parse_projects(module_ctx, hub_specs):
                 pkg_override = package_overrides.get((normalize_name(package["name"]), package["version"]))
                 post_install_patches = []
                 post_install_patch_strip = 0
+                srcs_exclude_glob = []
+                data_exclude_glob = []
                 extra_deps = []
                 extra_data = []
                 if pkg_override and not pkg_override.target:
                     post_install_patches = [str(p) for p in pkg_override.post_install_patches]
                     post_install_patch_strip = pkg_override.post_install_patch_strip
+                    srcs_exclude_glob = pkg_override.srcs_exclude_glob
+                    data_exclude_glob = pkg_override.data_exclude_glob
                     extra_deps = [str(d) for d in pkg_override.extra_deps]
                     extra_data = [str(d) for d in pkg_override.extra_data]
 
@@ -384,6 +390,8 @@ def _parse_projects(module_ctx, hub_specs):
                     sbuild = "@{}//:whl".format(sbuild_id) if has_sbuild else None,
                     post_install_patches = post_install_patches,
                     post_install_patch_strip = post_install_patch_strip,
+                    srcs_exclude_glob = srcs_exclude_glob,
+                    data_exclude_glob = data_exclude_glob,
                     extra_deps = extra_deps,
                     extra_data = extra_data,
                 )
@@ -535,6 +543,10 @@ def _uv_impl(module_ctx):
         if install_cfg.post_install_patches:
             install_kwargs["post_install_patches"] = json.encode(install_cfg.post_install_patches)
             install_kwargs["post_install_patch_strip"] = install_cfg.post_install_patch_strip
+        if install_cfg.srcs_exclude_glob:
+            install_kwargs["srcs_exclude_glob"] = json.encode(install_cfg.srcs_exclude_glob)
+        if install_cfg.data_exclude_glob:
+            install_kwargs["data_exclude_glob"] = json.encode(install_cfg.data_exclude_glob)
         if install_cfg.extra_deps:
             install_kwargs["extra_deps"] = json.encode(install_cfg.extra_deps)
         if install_cfg.extra_data:
@@ -632,22 +644,14 @@ _override_package_tag = tag_class(
         ),
 
         # BUILD-level modifications to the generated py_library target.
-        #
-        # FIXME: srcs_exclude_glob and data_exclude_glob are not yet implemented.
-        # Implementing them requires either extending the Rust unpack tool to
-        # accept exclusion patterns at install time, or adding a post-install
-        # tree-filtering action that can selectively remove files from a tree
-        # artifact. The attrs are commented out to avoid exposing a non-functional
-        # API surface.
-        #
-        # "srcs_exclude_glob": attr.string_list(
-        #     default = [],
-        #     doc = "Glob patterns to exclude from the package's srcs (e.g. '**/tests/**').",
-        # ),
-        # "data_exclude_glob": attr.string_list(
-        #     default = [],
-        #     doc = "Glob patterns to exclude from the package's data.",
-        # ),
+        "srcs_exclude_glob": attr.string_list(
+            default = [],
+            doc = "Glob patterns to exclude from installed package srcs.",
+        ),
+        "data_exclude_glob": attr.string_list(
+            default = [],
+            doc = "Glob patterns to exclude from installed package data.",
+        ),
         "extra_deps": attr.label_list(
             default = [],
             doc = "Additional deps to add to the package's py_library target.",

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -229,6 +229,9 @@ py_library(
     post_install_patches = json.decode(repository_ctx.attr.post_install_patches) if repository_ctx.attr.post_install_patches else []
     post_install_patch_strip = repository_ctx.attr.post_install_patch_strip
 
+    srcs_exclude_glob = json.decode(repository_ctx.attr.srcs_exclude_glob) if repository_ctx.attr.srcs_exclude_glob else []
+    data_exclude_glob = json.decode(repository_ctx.attr.data_exclude_glob) if repository_ctx.attr.data_exclude_glob else []
+
     extra_deps = json.decode(repository_ctx.attr.extra_deps) if repository_ctx.attr.extra_deps else []
     extra_data = json.decode(repository_ctx.attr.extra_data) if repository_ctx.attr.extra_data else []
 
@@ -244,10 +247,14 @@ whl_apply_patches(
     src = ":whl",
     patches = {patches},
     patch_strip = {strip},
+    srcs_exclude_glob = {srcs_exclude_glob},
+    data_exclude_glob = {data_exclude_glob},
     visibility = ["//visibility:private"],
 )""".format(
                 patches = repr(post_install_patches),
                 strip = post_install_patch_strip,
+                srcs_exclude_glob = repr(srcs_exclude_glob),
+                data_exclude_glob = repr(data_exclude_glob),
             ),
         )
     else:
@@ -257,8 +264,13 @@ whl_apply_patches(
 whl_install(
     name = "actual_install",
     src = ":whl",
+    srcs_exclude_glob = {srcs_exclude_glob},
+    data_exclude_glob = {data_exclude_glob},
     visibility = ["//visibility:private"],
-)""",
+)""".format(
+                srcs_exclude_glob = repr(srcs_exclude_glob),
+                data_exclude_glob = repr(data_exclude_glob),
+            ),
         )
 
     if extra_deps or extra_data:
@@ -305,6 +317,8 @@ whl_install = repository_rule(
         "sbuild": attr.label(),
         "post_install_patches": attr.string(default = ""),
         "post_install_patch_strip": attr.int(default = 0),
+        "srcs_exclude_glob": attr.string(default = ""),
+        "data_exclude_glob": attr.string(default = ""),
         "extra_deps": attr.string(default = ""),
         "extra_data": attr.string(default = ""),
     },

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -23,6 +23,8 @@ def _whl_install(ctx):
         "--python-version-minor",
         py_toolchain.interpreter_version_info.minor,
     ])
+    arguments.add_all(ctx.attr.srcs_exclude_glob, before_each = "--srcs-exclude-glob")
+    arguments.add_all(ctx.attr.data_exclude_glob, before_each = "--data-exclude-glob")
 
     # Need to read the toolchain config from the unpack target so we can grab
     # its bin and run it. Note that we have to do this dance in order to get the
@@ -77,6 +79,14 @@ lighter weight since the toolchain's files aren't inputs.
 """,
     attrs = {
         "src": attr.label(doc = "The wheel to install, or a tree artifact containing exactly one wheel at its root."),
+        "srcs_exclude_glob": attr.string_list(
+            default = [],
+            doc = "Glob patterns for installed source files to remove after unpacking.",
+        ),
+        "data_exclude_glob": attr.string_list(
+            default = [],
+            doc = "Glob patterns for installed data files to remove after unpacking.",
+        ),
         "_unpack": attr.label(
             default = "//py/private/toolchain:resolved_unpack_toolchain",
             cfg = "exec",


### PR DESCRIPTION
Expediting this functionality. I've only done a basic test with it internally.  The BazelGlob stuff is mostly vibes though if you trust the tests and that Codex is good at Bazel, maybe it's not completely slop. The changes to unpack.rs were initially Codex, but updated by me by hand.

Likely to merge conflict, since I based this patch on 1.8.6.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:
```starlark
uv.override_package(
    name = "csv-diff",
    lock = ":uv.lock",
    srcs_exclude_glob = [
        "site-packages/tests/**",
    ],
)
```
