### PR TITLE
fix: Respect package_collisions in py_binary

### DIFF
--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -79,6 +79,7 @@ def _py_binary_or_test(name, rule, srcs, main, data = [], deps = [], **kwargs):
         tags = ["manual"],
         testonly = kwargs.get("testonly", False),
         target_compatible_with = kwargs.get("target_compatible_with", []),
+        package_collisions = kwargs.get("package_collisions")
     )
 
 def py_binary(name, srcs = [], main = None, **kwargs):


### PR DESCRIPTION
This change adds propagation of `package_collisions` parameter in `py_binary`. Currently, it's missed in the `py_binary` macro, and not passed through to `py_venv_link`, making it such that 

```py
py_binary(
    ...
    package_collision = "ignore",
)
```

Doesn't work and produces `--collision-strategy=error`

---

### Changes are visible to end-users: no

### Test plan

Manual testing: create a `py_binary` with a collision, add `package_collisions = "ignore"`, execute `bazel run ...:name_bin.venv`
