### PR TITLE
fix(uv): prevent venv BUILD.bazel collisions from repo root imports

### DIFF
--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -133,18 +133,19 @@ def _make_import_path(label, workspace, imp):
     else:
         return paths.normalize(paths.join(workspace, label.package, imp))
 
-def _make_imports_depset(ctx, imports = [], extra_imports_depsets = []):
+def _make_imports_depset(ctx, imports = [], extra_imports_depsets = [], include_repo_import = True):
     import_paths = [
         _make_import_path(ctx.label, ctx.label.workspace_name or ctx.workspace_name, im)
         for im in getattr(ctx.attr, "imports", imports)
-    ] + [
-        # Add the workspace name in the imports such that repo-relative imports work.
-        ctx.workspace_name,
     ]
 
-    # Handle the case where its a target from an external workspace that uses repo-relative imports
-    if ctx.label.workspace_name:
-        import_paths.append(ctx.label.workspace_name)
+    if include_repo_import:
+        # Add the workspace name in the imports such that repo-relative imports work.
+        import_paths.append(ctx.workspace_name)
+
+        # Handle the case where its a target from an external workspace that uses repo-relative imports
+        if ctx.label.workspace_name:
+            import_paths.append(ctx.label.workspace_name)
 
     return depset(
         direct = import_paths,

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -39,7 +39,7 @@ def _py_unpacked_wheel_impl(ctx):
         ),
         "site-packages",
     )
-    imports = _py_library.make_imports_depset(ctx, imports = [import_path])
+    imports = _py_library.make_imports_depset(ctx, imports = [import_path], include_repo_import = False)
 
     return [
         DefaultInfo(

--- a/uv/private/defs.bzl
+++ b/uv/private/defs.bzl
@@ -1,11 +1,44 @@
 "Internal helpers."
 
+load("@rules_python//python:defs.bzl", "PyInfo")
 load("@with_cfg.bzl", "with_cfg")
-load("//py:defs.bzl", "py_library")
+load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 
 LIB_MODE = "//uv/private/constraints:lib_mode"
 
-py_whl_library, _ = with_cfg(py_library).set(Label(LIB_MODE), "whl").build()
+def _py_whl_library_impl(ctx):
+    """A stripped-down py_library that does not add repo roots as import paths.
+
+    Wheel libraries have explicit import paths (into site-packages) and should
+    never contribute their repository root as an import root. Doing so causes
+    the venv builder to walk the entire repo directory, symlinking non-Python
+    files (like BUILD.bazel) into site-packages and triggering collisions.
+    """
+    transitive_srcs = _py_library.make_srcs_depset(ctx)
+    imports = _py_library.make_imports_depset(ctx, include_repo_import = False)
+    runfiles = _py_library.make_merged_runfiles(ctx, extra_runfiles = ctx.files.srcs)
+
+    return [
+        DefaultInfo(
+            files = depset(direct = ctx.files.srcs, transitive = [transitive_srcs]),
+            default_runfiles = runfiles,
+        ),
+        PyInfo(
+            imports = imports,
+            transitive_sources = transitive_srcs,
+            has_py2_only_sources = False,
+            has_py3_only_sources = True,
+            uses_shared_libraries = False,
+        ),
+    ]
+
+_py_whl_library_rule = rule(
+    implementation = _py_whl_library_impl,
+    attrs = _py_library.attrs,
+    provides = [PyInfo],
+)
+
+py_whl_library, _ = with_cfg(_py_whl_library_rule).set(Label(LIB_MODE), "whl").build()
 
 def _lib_mode_transition_impl(settings, attr):
     return {LIB_MODE: "lib"}


### PR DESCRIPTION
Fixes #858.

`py_whl_library` and `py_unpacked_wheel` were unconditionally adding their repository root as a Python import path (backwards compat with repo-relative imports). This caused the venv builder to `WalkDir` entire repo root directories, symlinking `BUILD.bazel` files into `site-packages` and triggering collisions when multiple wheel repos contributed to the same venv — notably sdist `build_tool` targets whose deps span multiple external repos.

- Add `include_repo_import` parameter to `_make_imports_depset` (default `True`, preserving existing behavior)
- Set `False` for `py_unpacked_wheel` which already provides explicit `site-packages` import paths
- Replace `with_cfg(py_library)` for `py_whl_library` with a dedicated rule that also sets `False`

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- `//py/...` and `cd e2e && //...` pass
- TODO: add e2e test exercising sdist builds with multiple build deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)