### PR TITLE
fix(uv): resolve multi-match version constraints to greatest version

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -186,6 +186,16 @@ uv.project(
 )
 # }}}
 
+# For cases/uv-conflict-max-863
+# Regression: broad constraint matching multiple lockfile versions must pick the greatest.
+# {{{
+uv.project(
+    hub_name = "pypi",
+    lock = "//cases/uv-conflict-max-863:uv.lock",
+    pyproject = "//cases/uv-conflict-max-863:pyproject.toml",
+)
+# }}}
+
 # For cases/uv-conflict-tilde-856
 # {{{
 uv.project(

--- a/e2e/cases/uv-conflict-max-863/BUILD.bazel
+++ b/e2e/cases/uv-conflict-max-863/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "test_a",
+    srcs = ["test_a.py"],
+    main = "test_a.py",
+    venv = "max-a",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_venv_test(
+    name = "test_b",
+    srcs = ["test_b.py"],
+    main = "test_b.py",
+    venv = "max-b",
+    deps = [
+        "@pypi//packaging",
+    ],
+)

--- a/e2e/cases/uv-conflict-max-863/pyproject.toml
+++ b/e2e/cases/uv-conflict-max-863/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "max-conflict-863"
+version = "0.0.0"
+requires-python = "== 3.10.19"
+dependencies = []
+
+[dependency-groups]
+# Broad constraint: ">21.0" matches both 21.3 and 26.0 in the lockfile.
+# Per pip preference order, 26.0 (the greatest match) must be selected.
+max-a = [
+    "packaging>21.0",
+]
+
+# Narrow constraint: only matches 21.3
+max-b = [
+    "packaging>=21.0,<22.0",
+]
+
+[tool.uv]
+conflicts = [
+    [
+      { group = "max-a" },
+      { group = "max-b" },
+    ],
+]

--- a/e2e/cases/uv-conflict-max-863/test_a.py
+++ b/e2e/cases/uv-conflict-max-863/test_a.py
@@ -1,0 +1,2 @@
+import packaging
+assert packaging.__version__ == "26.0", f"Expected 26.0 (greatest match for >21.0), got {packaging.__version__}"

--- a/e2e/cases/uv-conflict-max-863/test_b.py
+++ b/e2e/cases/uv-conflict-max-863/test_b.py
@@ -1,0 +1,2 @@
+import packaging
+assert packaging.__version__ == "21.3", f"Expected 21.3 (only match for >=21.0,<22.0), got {packaging.__version__}"

--- a/e2e/cases/uv-conflict-max-863/uv.lock
+++ b/e2e/cases/uv-conflict-max-863/uv.lock
@@ -1,0 +1,56 @@
+version = 1
+revision = 3
+requires-python = "==3.10.19"
+conflicts = [[
+    { package = "max-conflict-863", group = "max-a" },
+    { package = "max-conflict-863", group = "max-b" },
+]]
+
+[[package]]
+name = "max-conflict-863"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+max-a = [
+    { name = "packaging", version = "26.0", source = { registry = "https://pypi.org/simple" } },
+]
+max-b = [
+    { name = "packaging", version = "21.3", source = { registry = "https://pypi.org/simple" } },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+max-a = [{ name = "packaging", specifier = ">21.0" }]
+max-b = [{ name = "packaging", specifier = ">=21.0,<22.0" }]
+
+[[package]]
+name = "packaging"
+version = "21.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb", size = 84848, upload-time = "2021-11-18T00:39:13.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522", size = 40750, upload-time = "2021-11-18T00:39:10.932Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]

--- a/uv/private/versions/versions.bzl
+++ b/uv/private/versions/versions.bzl
@@ -195,11 +195,14 @@ def version_satisfies(version_str, specifier):
     return True
 
 def find_matching_version(specifier, candidate_versions):
-    """Finds the version from candidates that satisfies a specifier.
+    """Finds the greatest version from candidates that satisfies a specifier.
 
     When a dependency group lists a requirement like "numpy>=2.0", and the
     lockfile contains multiple versions of numpy (due to conflicts), this
     function determines which lockfile version the specifier refers to.
+
+    Per pip's preference order, when multiple candidates satisfy the
+    specifier, the greatest matching version is returned.
 
     Args:
         specifier: The version specifier string (e.g., ">=2.0", "==24.0").
@@ -209,7 +212,12 @@ def find_matching_version(specifier, candidate_versions):
     Returns:
         The matching value, or None if no candidate matches.
     """
+    best_version = None
+    best_value = None
     for version_str, value in candidate_versions.items():
         if version_satisfies(version_str, specifier):
-            return value
-    return None
+            parsed = parse_version(version_str)
+            if best_version == None or version_cmp(parsed, best_version) > 0:
+                best_version = parsed
+                best_value = value
+    return best_value

--- a/uv/private/versions/versions_test.bzl
+++ b/uv/private/versions/versions_test.bzl
@@ -732,9 +732,8 @@ def _find_matching_version_gte_client_test_impl(ctx):
     # >=2.1 should match 2.1.2 (only candidate >= 2.1)
     asserts.equals(env, ("proj", "numpy", "2.1.2", "__base__"), find_matching_version(">=2.1", candidates))
 
-    # >=2.0 matches at least one
-    result = find_matching_version(">=2.0", candidates)
-    asserts.true(env, result != None, ">=2.0 finds at least one")
+    # >=2.0 matches both; should return the greatest (2.1.2)
+    asserts.equals(env, ("proj", "numpy", "2.1.2", "__base__"), find_matching_version(">=2.0", candidates))
 
     # <2.1 should only match 2.0.0
     asserts.equals(env, ("proj", "numpy", "2.0.0", "__base__"), find_matching_version("<2.1", candidates))
@@ -751,10 +750,8 @@ def _find_matching_version_compound_test_impl(ctx):
         "2.0": ("proj", "foo", "2.0", "__base__"),
     }
 
-    # >=1.0,<2.0 should NOT match 2.0
-    result = find_matching_version(">=1.0,<2.0", candidates)
-    asserts.true(env, result != None, "at least one in [1.0,2.0)")
-    asserts.true(env, result != ("proj", "foo", "2.0", "__base__"), "2.0 excluded")
+    # >=1.0,<2.0 matches 1.0 and 1.5; should return the greatest (1.5)
+    asserts.equals(env, ("proj", "foo", "1.5", "__base__"), find_matching_version(">=1.0,<2.0", candidates))
 
     # ==2.0 should match exactly 2.0
     asserts.equals(env, ("proj", "foo", "2.0", "__base__"), find_matching_version("==2.0", candidates))
@@ -785,6 +782,52 @@ def _find_matching_version_single_test_impl(ctx):
     return unittest.end(env)
 
 find_matching_version_single_test = unittest.make(_find_matching_version_single_test_impl)
+
+def _find_matching_version_max_863_test_impl(ctx):
+    """Broad constraint matching multiple versions returns the greatest (#863)."""
+    env = unittest.begin(ctx)
+
+    # Simulates a lockfile with setuptools 81.1.0 and 82.0.0 (from uv conflicts).
+    # A dependency group specifying ">81.0.0" matches both; the greatest should win.
+    candidates = {
+        "81.1.0": ("proj", "setuptools", "81.1.0", "__base__"),
+        "82.0.0": ("proj", "setuptools", "82.0.0", "__base__"),
+    }
+    asserts.equals(
+        env,
+        ("proj", "setuptools", "82.0.0", "__base__"),
+        find_matching_version(">81.0.0", candidates),
+        ">81.0.0 selects greatest match (82.0.0)",
+    )
+
+    # Even when the greater version appears first in the dict, the result
+    # should be the same — order-independence.
+    candidates_reversed = {
+        "82.0.0": ("proj", "setuptools", "82.0.0", "__base__"),
+        "81.1.0": ("proj", "setuptools", "81.1.0", "__base__"),
+    }
+    asserts.equals(
+        env,
+        ("proj", "setuptools", "82.0.0", "__base__"),
+        find_matching_version(">81.0.0", candidates_reversed),
+        ">81.0.0 selects greatest match regardless of dict order",
+    )
+
+    # Three candidates, broad constraint matches all three
+    candidates_three = {
+        "60.0.0": ("proj", "setuptools", "60.0.0", "__base__"),
+        "75.8.0": ("proj", "setuptools", "75.8.0", "__base__"),
+        "82.0.0": ("proj", "setuptools", "82.0.0", "__base__"),
+    }
+    asserts.equals(
+        env,
+        ("proj", "setuptools", "82.0.0", "__base__"),
+        find_matching_version(">=60.0.0", candidates_three),
+        ">=60.0.0 selects greatest of three matches",
+    )
+    return unittest.end(env)
+
+find_matching_version_max_863_test = unittest.make(_find_matching_version_max_863_test_impl)
 
 # =============================================================================
 # Test suite
@@ -866,4 +909,5 @@ def versions_test_suite():
         find_matching_version_compound_test,
         find_matching_version_empty_test,
         find_matching_version_single_test,
+        find_matching_version_max_863_test,
     )


### PR DESCRIPTION
Fixes #863.

When a dependency group constraint like `>81.0.0` matches multiple versions in a lockfile (due to uv conflicts), `find_matching_version` previously returned whichever version happened to be first in dict iteration order. Now it returns the greatest matching version, per pip's preference order.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (behavior change only)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`find_matching_version` now selects the greatest matching version when multiple lockfile versions satisfy a dependency group constraint, instead of returning a non-deterministic result.

### Test plan

- New unit tests in `versions_test.bzl` (`find_matching_version_max_863_test`) covering two-candidate, reversed-order, and three-candidate scenarios
- Existing unit tests tightened to assert the exact greatest version instead of "at least one match"
- New e2e test `uv-conflict-max-863` with `packaging>21.0` matching both 21.3 and 26.0; asserts 26.0 is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)