### PR TITLE
fix(pyc): default to checked-hash invalidation, add invalidation_mode flag

### DIFF
--- a/py/tools/unpack_bin/src/main.rs
+++ b/py/tools/unpack_bin/src/main.rs
@@ -37,6 +37,11 @@ struct UnpackArgs {
     #[arg(long, default_value_t = false)]
     compile_pyc: bool,
 
+    /// PEP 552 invalidation mode for .pyc files.
+    /// One of: checked-hash, unchecked-hash, timestamp.
+    #[arg(long, default_value = "checked-hash")]
+    pyc_invalidation_mode: String,
+
     /// Path to the Python interpreter (required when --compile-pyc is set).
     #[arg(long)]
     python: Option<PathBuf>,
@@ -88,7 +93,7 @@ fn unpack_cmd_handler(args: UnpackArgs) -> miette::Result<()> {
                 "compileall",
                 "-q",
                 "--invalidation-mode",
-                "unchecked-hash",
+                &args.pyc_invalidation_mode,
             ])
             .arg(&site_packages)
             .status()

--- a/uv/private/pyc/BUILD.bazel
+++ b/uv/private/pyc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 bool_flag(
     name = "precompile",
@@ -9,5 +9,37 @@ bool_flag(
 config_setting(
     name = "is_precompile",
     flag_values = {":precompile": "True"},
+    visibility = ["//visibility:public"],
+)
+
+# Controls the PEP 552 invalidation mode for pre-compiled .pyc files.
+#
+# Supported values:
+#   "checked-hash"   (default) — Python validates the .pyc hash against the
+#                     source at import time. Safe when sources may be modified
+#                     after compilation (e.g. the runfiles __init__.py shim).
+#   "unchecked-hash" — Python trusts the .pyc unconditionally. Faster imports
+#                     but stale .pyc files will silently shadow source changes.
+#   "timestamp"      — Classic mtime-based invalidation.
+string_flag(
+    name = "invalidation_mode",
+    build_setting_default = "checked-hash",
+    values = [
+        "checked-hash",
+        "unchecked-hash",
+        "timestamp",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "is_unchecked_hash",
+    flag_values = {":invalidation_mode": "unchecked-hash"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "is_timestamp",
+    flag_values = {":invalidation_mode": "timestamp"},
     visibility = ["//visibility:public"],
 )

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -237,9 +237,19 @@ py_library(
         "//conditions:default": False,
     })"""
 
+    pyc_invalidation_mode_select = """select({
+        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
+        "//conditions:default": "checked-hash",
+    })"""
+
     install_attrs = """
     src = ":whl",
-    compile_pyc = {compile_pyc},""".format(compile_pyc = compile_pyc_select)
+    compile_pyc = {compile_pyc},
+    pyc_invalidation_mode = {pyc_invalidation_mode},""".format(
+        compile_pyc = compile_pyc_select,
+        pyc_invalidation_mode = pyc_invalidation_mode_select,
+    )
 
     if post_install_patches:
         install_attrs += """

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -37,6 +37,7 @@ def _whl_install(ctx):
     # Optional .pyc pre-compilation (runs after patching).
     if ctx.attr.compile_pyc:
         arguments.add("--compile-pyc")
+        arguments.add("--pyc-invalidation-mode", ctx.attr.pyc_invalidation_mode)
         arguments.add("--python")
         arguments.add(py_toolchain.interpreter.path)
         inputs = inputs + [py_toolchain.interpreter] + py_toolchain.files.to_list()
@@ -107,6 +108,11 @@ lighter weight since the toolchain's files aren't inputs.
         "compile_pyc": attr.bool(
             default = False,
             doc = "Pre-compile .pyc bytecode after unpacking and patching.",
+        ),
+        "pyc_invalidation_mode": attr.string(
+            default = "checked-hash",
+            values = ["checked-hash", "unchecked-hash", "timestamp"],
+            doc = "PEP 552 invalidation mode for pre-compiled .pyc files.",
         ),
         "_unpack": attr.label(
             default = "//py/private/toolchain:resolved_unpack_toolchain",


### PR DESCRIPTION
## Summary

The `unchecked-hash` pyc invalidation mode (introduced in #857) causes the venv tool's `runfiles/__init__.py` monkey-patch to be silently ignored, breaking `runfiles.Rlocation()` calls.

**Root cause:** The venv tool writes a custom `runfiles/__init__.py` shim that patches `_FindPythonRunfilesRoot()` to account for the venv directory depth. However, it also symlinks `__pycache__/__init__.cpython-*.pyc` from the installed wheel. With `unchecked-hash`, Python trusts this stale `.pyc` unconditionally — the shim `.py` is never read, the monkey-patch never runs, and `CurrentRepository()` raises:

```
ValueError: .../conftest.py does not lie under the runfiles root .../venv/lib
```

**Fix:** Default to `checked-hash`, where Python validates the `.pyc` hash against the source and falls back to the `.py` when they don't match. A new `invalidation_mode` flag lets users opt into faster modes when appropriate.

### Usage

```bash
# Default (safe): Python checks .pyc hash against source
bazel build //...

# Opt-in (fast): Python trusts .pyc unconditionally
bazel build --@aspect_rules_py//uv/private/pyc:invalidation_mode=unchecked-hash //...

# Classic mtime-based
bazel build --@aspect_rules_py//uv/private/pyc:invalidation_mode=timestamp //...
```

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (flag is self-documenting via BUILD comments)
- Breaking change (forces users to change their own code or config): no (default changes from broken to correct)
- Suggested release notes appear below: yes

`.pyc` pre-compilation now defaults to `checked-hash` invalidation mode (was `unchecked-hash`). This fixes a regression where the `runfiles` library's `Rlocation()` raised `ValueError` due to the venv shim being shadowed by a stale `.pyc`. Users who want the previous faster-but-unsafe behavior can set `--@aspect_rules_py//uv/private/pyc:invalidation_mode=unchecked-hash`.

### Test plan

- Verified fix against a client repo — 13/13 runfiles-dependent tests pass (were failing with `unchecked-hash`)
- `bazel build //py/tools/unpack_bin:unpack` — Rust binary compiles cleanly
- Existing test cases cover precompile=True path; invalidation mode is orthogonal

🤖 Generated with [Claude Code](https://claude.com/claude-code)