### PR TITLE
fix(venv): skip symlinking runfiles __pycache__/__init__.pyc

### DIFF
--- a/py/tools/py/src/pth.rs
+++ b/py/tools/py/src/pth.rs
@@ -165,6 +165,14 @@ pub fn create_symlinks(
             )
             .into_diagnostic()
             .wrap_err("Unable to write to runfiles __init__.py file")?;
+        }
+        // Skip pre-compiled .pyc for the runfiles __init__.py — we write a custom shim
+        // above and stale bytecode from the original wheel would shadow it, especially
+        // under unchecked-hash invalidation mode (PEP 552 flags=0x01).
+        else if dir.ends_with("runfiles/__pycache__")
+            && entry.file_name().to_string_lossy().starts_with("__init__.")
+        {
+            // Intentionally not symlinked.
         } else if dir != root_dir || entry.file_name() != "__init__.py" {
             create_symlink(&entry, root_dir, dst_dir, collision_strategy)?;
         }


### PR DESCRIPTION
The venv tool writes a custom `__init__.py` shim for the `runfiles` package to fix `_FindPythonRunfilesRoot()` for rules_py's deeper venv layout (see #377). However, it was still symlinking the pre-compiled `__init__.cpython-*.pyc` from the installed wheel into `runfiles/__pycache__/`.

Under `unchecked-hash` pyc invalidation (PEP 552 `flags=0x01`), Python trusts the stale `.pyc` unconditionally, so the shim never executes and the runfiles library fails with incorrect root paths. Even under `checked-hash` mode, the stale bytecode is pointless since the source it was compiled from no longer matches.

This is a belt-and-suspenders companion to #873 (which changes the default invalidation mode to `checked-hash`). With this fix, users who opt into `unchecked-hash` for performance won't silently break `runfiles`.

### Changes are visible to end-users: no

### Test plan

- Manual testing: confirmed stale `.pyc` no longer appears in venv `runfiles/__pycache__/` after rebuild
- Covered by existing test cases (runfiles-dependent tests that were failing now pass)