### PR TITLE
test(e2e): add pytest-mock regression test

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -271,6 +271,16 @@ uv.project(
 )
 # }}}
 
+# For cases/pytest-mock-530
+# Regression: pytest-mock plugin discovery with py_test and py_venv_test.
+# {{{
+uv.project(
+    hub_name = "pypi",
+    lock = "//cases/pytest-mock-530:uv.lock",
+    pyproject = "//cases/pytest-mock-530:pyproject.toml",
+)
+# }}}
+
 # For cases/pytest-main-867
 # Cross-repo pytest_main=True regression test.
 # {{{

--- a/e2e/cases/pytest-mock-530/BUILD.bazel
+++ b/e2e/cases/pytest-mock-530/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+
+# Regression test for #530: pytest-mock plugin must be discoverable.
+py_test(
+    name = "test_mock_py_test",
+    srcs = ["test_mock.py"],
+    pytest_main = True,
+    venv = "pytest-mock-530",
+    deps = [
+        "@pypi//pytest",
+        "@pypi//pytest_mock",
+    ],
+)
+
+py_venv_test(
+    name = "test_mock_py_venv_test",
+    srcs = [
+        "__test__.py",
+        "test_mock.py",
+    ],
+    main = "__test__.py",
+    venv = "pytest-mock-530",
+    deps = [
+        "@pypi//pytest",
+        "@pypi//pytest_mock",
+    ],
+)

--- a/e2e/cases/pytest-mock-530/__test__.py
+++ b/e2e/cases/pytest-mock-530/__test__.py
@@ -1,0 +1,17 @@
+"""py_venv_test entry point — runs pytest on test_mock.py."""
+
+import subprocess
+import sys
+import os
+
+
+def main():
+    test_file = os.path.join(os.path.dirname(__file__), "test_mock.py")
+    rc = subprocess.run(
+        [sys.executable, "-m", "pytest", test_file, "-v"],
+    ).returncode
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/cases/pytest-mock-530/pyproject.toml
+++ b/e2e/cases/pytest-mock-530/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "pytest-mock-530"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "pytest",
+    "pytest-mock",
+]

--- a/e2e/cases/pytest-mock-530/test_mock.py
+++ b/e2e/cases/pytest-mock-530/test_mock.py
@@ -1,0 +1,31 @@
+"""Regression test for #530: pytest-mock must work with py_test and py_venv_test.
+
+Exercises the ``mocker`` fixture provided by the pytest-mock plugin, which
+requires pytest plugin discovery to function correctly.
+"""
+
+
+def _real_function():
+    return 42
+
+
+def test_mocker_patch(mocker):
+    """The mocker fixture should be available and functional."""
+    mocker.patch(f"{__name__}._real_function", return_value=99)
+    assert _real_function() == 99
+
+
+def test_mocker_spy(mocker):
+    """mocker.spy should wrap a real function and track calls."""
+    spy = mocker.spy(__import__("os.path", fromlist=["exists"]), "exists")
+    import os.path
+    os.path.exists("/")
+    spy.assert_called_once_with("/")
+
+
+def test_mocker_mock_object(mocker):
+    """mocker.MagicMock should create mock objects."""
+    mock = mocker.MagicMock()
+    mock.some_method.return_value = "hello"
+    assert mock.some_method() == "hello"
+    mock.some_method.assert_called_once()

--- a/e2e/cases/pytest-mock-530/uv.lock
+++ b/e2e/cases/pytest-mock-530/uv.lock
@@ -1,0 +1,91 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-mock-530"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+]


### PR DESCRIPTION
pytest-mock works correctly with both `py_test` (using `pytest_main=True`) and `py_venv_test` on current main. The original issue was likely a configuration problem — either using `@pypi//pytest-mock` (hyphen, doesn't exist) instead of `@pypi//pytest_mock` (underscore), or not including `pytest-mock` in the project's `pyproject.toml` dependencies.

This adds an e2e regression test to make sure it stays working.

Closes #530

### Changes are visible to end-users: no

### Test plan

- New test cases added
- Both `bazel test //cases/pytest-mock-530:test_mock_py_test` and `bazel test //cases/pytest-mock-530:test_mock_py_venv_test` pass, exercising the `mocker` fixture, `mocker.spy`, and `MagicMock`