### PR TITLE
test(e2e): add venv isolated mode regression test (#703)

### DIFF
--- a/e2e/cases/venv-isolated-mode-703/BUILD.bazel
+++ b/e2e/cases/venv-isolated-mode-703/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "test",
+    srcs = ["__test__.py"],
+    main = "__test__.py",
+    python_version = "3.11",
+    venv = "venv-isolated-mode-703",
+)

--- a/e2e/cases/venv-isolated-mode-703/__test__.py
+++ b/e2e/cases/venv-isolated-mode-703/__test__.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+"""Test that the venv interpreter works when invoked with -I (isolated mode).
+
+Regression test for https://github.com/aspect-build/rules_py/issues/703.
+
+IDE extensions (e.g. the VS Code Python extension) invoke the interpreter with
+`python -I ...` which sets isolated mode. Isolated mode implies -E (ignore
+environment variables) and -s (no user site). Since the venv shim relies on
+setting PYTHONHOME in the environment, -I/-E causes the interpreter to fail
+with "No module named 'encodings'" because it can't find the stdlib.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def test_python_dash_I():
+    """Invoke the venv interpreter with -I and verify it can still start."""
+    python = sys.executable
+    assert python, "sys.executable is not set"
+
+    # This is what IDE extensions do: python -I <script>
+    result = subprocess.run(
+        [python, "-I", "-c", "import sys; print(sys.executable)"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"STDOUT: {result.stdout}", file=sys.stderr)
+        print(f"STDERR: {result.stderr}", file=sys.stderr)
+    assert result.returncode == 0, (
+        f"'python -I -c ...' failed with rc={result.returncode}.\n"
+        f"stderr: {result.stderr}"
+    )
+    print(f"python -I: executable = {result.stdout.strip()}")
+
+
+def test_python_dash_E():
+    """Invoke the venv interpreter with -E (ignore environment)."""
+    python = sys.executable
+    result = subprocess.run(
+        [python, "-E", "-c", "import sys; print(sys.prefix)"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"STDOUT: {result.stdout}", file=sys.stderr)
+        print(f"STDERR: {result.stderr}", file=sys.stderr)
+    assert result.returncode == 0, (
+        f"'python -E -c ...' failed with rc={result.returncode}.\n"
+        f"stderr: {result.stderr}"
+    )
+    print(f"python -E: prefix = {result.stdout.strip()}")
+
+
+def test_python_dash_I_can_import():
+    """Verify that -I doesn't break stdlib imports."""
+    python = sys.executable
+    result = subprocess.run(
+        [python, "-I", "-c", "import json; print(json.dumps({'ok': True}))"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"STDOUT: {result.stdout}", file=sys.stderr)
+        print(f"STDERR: {result.stderr}", file=sys.stderr)
+    assert result.returncode == 0, (
+        f"'python -I -c import json' failed with rc={result.returncode}.\n"
+        f"stderr: {result.stderr}"
+    )
+    assert result.stdout.strip() == '{"ok": true}', (
+        f"Unexpected output: {result.stdout.strip()!r}"
+    )
+    print("python -I: stdlib imports work")
+
+
+if __name__ == "__main__":
+    test_python_dash_I()
+    test_python_dash_E()
+    test_python_dash_I_can_import()
+    print("All isolated mode tests passed.")


### PR DESCRIPTION
Adds a regression test for #703 confirming that `python -I` and `python -E` work correctly with the venv shim.

The reporter's IDE extension invoked the venv interpreter with `-I` (isolated mode), which implies `-E` (ignore environment variables). Since the shim previously relied on `PYTHONHOME` to locate the stdlib, `-E` caused a fatal "No module named 'encodings'" error.

The current shim implementation resolves this through `arg0()` spoofing and `pyvenv.cfg` discovery — CPython's `site.py` finds the stdlib without needing `PYTHONHOME` from the environment. This test locks in that behavior.

Closes #703

### Changes are visible to end-users: no

### Test plan

- New test cases added: `venv-isolated-mode-703` with three assertions (python -I, python -E, stdlib imports under -I)
- Full e2e suite passes (42 pass, 8 OCI skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)