### PR TITLE
fix(whl_install): use exec-configured interpreter for pyc compilation

### DIFF
--- a/py/private/toolchain/BUILD.bazel
+++ b/py/private/toolchain/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
-load(":tools.bzl", "dummy_toolchain", "resolved_unpack_toolchain", "resolved_venv_toolchain")
+load(":tools.bzl", "dummy_toolchain", "resolved_py_toolchain", "resolved_unpack_toolchain", "resolved_venv_toolchain")
 
 exports_files(
     ["python.sh"],
@@ -23,6 +23,11 @@ toolchain_type(
 
 resolved_venv_toolchain(
     name = "resolved_venv_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+resolved_py_toolchain(
+    name = "resolved_py_toolchain",
     visibility = ["//visibility:public"],
 )
 

--- a/py/private/toolchain/tools.bzl
+++ b/py/private/toolchain/tools.bzl
@@ -1,7 +1,7 @@
 """Declaration of concrete toolchains for our Rust tools"""
 
 load("@bazel_skylib//lib:structs.bzl", "structs")
-load(":types.bzl", "PyToolInfo", "UNPACK_TOOLCHAIN", "VENV_TOOLCHAIN")
+load(":types.bzl", "PY_TOOLCHAIN", "PyToolInfo", "UNPACK_TOOLCHAIN", "VENV_TOOLCHAIN")
 
 def PrebuiltToolConfig(
         target,
@@ -146,6 +146,26 @@ def _resolved_unpack_impl(ctx):
 resolved_unpack_toolchain = rule(
     implementation = _resolved_unpack_impl,
     toolchains = [UNPACK_TOOLCHAIN],
+)
+
+def _resolved_py_impl(ctx):
+    py_toolchain = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
+    return [
+        DefaultInfo(
+            files = depset([py_toolchain.interpreter] + py_toolchain.files.to_list()),
+            runfiles = ctx.runfiles(files = [py_toolchain.interpreter] + py_toolchain.files.to_list()),
+        ),
+        platform_common.ToolchainInfo(
+            interpreter = py_toolchain.interpreter,
+            files = py_toolchain.files,
+            interpreter_version_info = py_toolchain.interpreter_version_info,
+        ),
+    ]
+
+resolved_py_toolchain = rule(
+    implementation = _resolved_py_impl,
+    doc = "Re-exports the Python toolchain so it can be referenced via cfg='exec'.",
+    toolchains = [PY_TOOLCHAIN],
 )
 
 def _dummy_toolchain_impl(ctx):

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -35,12 +35,16 @@ def _whl_install(ctx):
         inputs = inputs + patch_files
 
     # Optional .pyc pre-compilation (runs after patching).
+    # Use the exec-configured interpreter so cross-arch builds work (the target
+    # interpreter may not be runnable on the build host). This is safe because
+    # .pyc bytecode varies by Python version, not by architecture.
     if ctx.attr.compile_pyc:
+        exec_py = ctx.attr._exec_python[platform_common.ToolchainInfo]
         arguments.add("--compile-pyc")
         arguments.add("--pyc-invalidation-mode", ctx.attr.pyc_invalidation_mode)
         arguments.add("--python")
-        arguments.add(py_toolchain.interpreter.path)
-        inputs = inputs + [py_toolchain.interpreter] + py_toolchain.files.to_list()
+        arguments.add(exec_py.interpreter.path)
+        inputs = inputs + [exec_py.interpreter] + exec_py.files.to_list()
 
     # Need to read the toolchain config from the unpack target so we can grab
     # its bin and run it. Note that we have to do this dance in order to get the
@@ -113,6 +117,10 @@ lighter weight since the toolchain's files aren't inputs.
             default = "checked-hash",
             values = ["checked-hash", "unchecked-hash", "timestamp"],
             doc = "PEP 552 invalidation mode for pre-compiled .pyc files.",
+        ),
+        "_exec_python": attr.label(
+            default = "//py/private/toolchain:resolved_py_toolchain",
+            cfg = "exec",
         ),
         "_unpack": attr.label(
             default = "//py/private/toolchain:resolved_unpack_toolchain",


### PR DESCRIPTION
When `compile_pyc` is enabled, `whl_install` invokes `compileall` using `py_toolchain.interpreter` which is resolved in **target** configuration. In cross-arch builds (e.g. x86 host building for arm64), the target interpreter isn't runnable on the build host, causing the action to fail.

This adds a `resolved_py_toolchain` rule (following the existing `resolved_unpack_toolchain` pattern) and references it via `cfg="exec"` so compileall gets a host-runnable interpreter. This is safe because `.pyc` bytecode depends on Python version, not architecture.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Cross-arch scenario validated in #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)