### PR TITLE
test(e2e): add namespace package regression test (#547)

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -281,6 +281,17 @@ uv.project(
 )
 # }}}
 
+# For cases/pth-namespace-547
+# Regression: namespace packages spanning multiple wheels (#547).
+# {{{
+uv.project(
+    default_build_dependencies = [],
+    hub_name = "pypi",
+    lock = "//cases/pth-namespace-547:uv.lock",
+    pyproject = "//cases/pth-namespace-547:pyproject.toml",
+)
+# }}}
+
 # For cases/pytest-main-867
 # Cross-repo pytest_main=True regression test.
 # {{{

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+
+# Test namespace package resolution with the symlink-forest venv.
+py_venv_test(
+    name = "test",
+    srcs = ["__test__.py"],
+    main = "__test__.py",
+    package_collisions = "warning",
+    python_version = "3.11",
+    venv = "pth-namespace-547",
+    deps = [
+        "@pypi//jaraco_classes",
+        "@pypi//jaraco_functools",
+    ],
+)
+
+# Test namespace packages with the legacy py_test (.pth strategy).
+py_test(
+    name = "test_legacy",
+    srcs = ["__test__.py"],
+    main = "__test__.py",
+    venv = "pth-namespace-547",
+    deps = [
+        "@pypi//jaraco_classes",
+        "@pypi//jaraco_functools",
+    ],
+)

--- a/e2e/cases/pth-namespace-547/__test__.py
+++ b/e2e/cases/pth-namespace-547/__test__.py
@@ -1,0 +1,43 @@
+"""Regression test for #547: namespace packages spanning multiple wheels.
+
+The jaraco.functools and jaraco.classes packages both contribute to the
+`jaraco` implicit namespace package. Importing from both must succeed,
+verifying that the venv correctly supports packages that share a
+top-level namespace.
+"""
+
+import os
+import sys
+
+
+def test_namespace_imports():
+    """Both jaraco sub-packages must be importable."""
+    import jaraco.functools
+    import jaraco.classes
+
+    # Verify both packages loaded real modules (not empty stubs)
+    assert jaraco.functools.__file__ is not None, (
+        "jaraco.functools should be a real module with __file__"
+    )
+    assert jaraco.classes.__file__ is not None, (
+        "jaraco.classes should be a real module with __file__"
+    )
+
+
+def test_jaraco_is_namespace_package():
+    """The jaraco package must be a namespace package, not a regular one."""
+    import jaraco
+
+    # Namespace packages have no __file__ attribute (or it's None).
+    # In a symlink-forest venv, both packages are merged into one
+    # site-packages directory, so __path__ may have only one entry —
+    # but jaraco must still be a namespace package (no __file__).
+    assert not hasattr(jaraco, "__file__") or jaraco.__file__ is None, (
+        f"jaraco should be a namespace package but has __file__={jaraco.__file__}"
+    )
+
+
+if __name__ == "__main__":
+    test_namespace_imports()
+    test_jaraco_is_namespace_package()
+    print("PASS: namespace package resolution works correctly")

--- a/e2e/cases/pth-namespace-547/pyproject.toml
+++ b/e2e/cases/pth-namespace-547/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "pth-namespace-547"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "build",
+    "setuptools",
+    "jaraco-functools",
+    "jaraco-classes",
+]

--- a/e2e/cases/pth-namespace-547/uv.lock
+++ b/e2e/cases/pth-namespace-547/uv.lock
@@ -1,0 +1,105 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "build"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", size = 50054, upload-time = "2026-01-08T16:41:47.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/0d/84a4380f930db0010168e0aa7b7a8fed9ba1835a8fbb1472bc6d0201d529/build-1.4.0-py3-none-any.whl", hash = "sha256:6a07c1b8eb6f2b311b96fcbdbce5dab5fe637ffda0fd83c9cac622e927501596", size = 24141, upload-time = "2026-01-08T16:41:46.453Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pth-namespace-547"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "build" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-functools" },
+    { name = "setuptools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "build" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-functools" },
+    { name = "setuptools" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]


### PR DESCRIPTION
The original issue reported broken imports with NVIDIA's omni namespace
packages — multiple wheels contributing to the same top-level namespace
couldn't resolve each other's submodules.

The symlink forest venv strategy has since resolved this class of
problem by merging files from multiple wheels into a single
site-packages directory tree. This test verifies the fix using
`jaraco.functools` + `jaraco.classes` (two wheels sharing the `jaraco`
implicit namespace), under both `py_venv_test` and `py_test`.

Closes #547

### Changes are visible to end-users: no

### Test plan

- New test cases added: `e2e/cases/pth-namespace-547` with both `test` (venv) and `test_legacy` (py_test) targets