### PR TITLE
feat(interpreter): add current_py_toolchain rule for Make variable support

### DIFF
--- a/e2e/cases/current-py-toolchain-896/BUILD.bazel
+++ b/e2e/cases/current-py-toolchain-896/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+# Verify that $(PYTHON3) Make variable is provided by
+# @python_interpreters//:current_py_toolchain.
+genrule(
+    name = "python_path",
+    outs = ["python_path.txt"],
+    cmd = "echo $(PYTHON3) > $@",
+    toolchains = ["@python_interpreters//:current_py_toolchain"],
+)
+
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+    data = [
+        ":python_path",
+        "@python_interpreters//:current_py_toolchain",
+    ],
+)

--- a/e2e/cases/current-py-toolchain-896/test.sh
+++ b/e2e/cases/current-py-toolchain-896/test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Verify that $(PYTHON3) resolves to a working Python interpreter.
+
+set -euo pipefail
+
+python_path_file="$(dirname "$0")/python_path.txt"
+if [[ ! -f "$python_path_file" ]]; then
+    # Try rlocation-style path (Bazel runfiles)
+    python_path_file="${RUNFILES_DIR:-$0.runfiles}/aspect_rules_py/e2e/cases/current-py-toolchain-896/python_path.txt"
+fi
+
+python_path="$(cat "$python_path_file" | tr -d '[:space:]')"
+
+if [[ -z "$python_path" ]]; then
+    echo "FAIL: PYTHON3 Make variable resolved to empty string"
+    exit 1
+fi
+
+echo "PYTHON3 resolved to: $python_path"
+
+# The path should contain "python" somewhere
+if [[ "$python_path" != *python* ]]; then
+    echo "FAIL: PYTHON3 path does not contain 'python': $python_path"
+    exit 1
+fi
+
+echo "PASS"

--- a/e2e/cases/current-py-toolchain-896/test.sh
+++ b/e2e/cases/current-py-toolchain-896/test.sh
@@ -3,11 +3,7 @@
 
 set -euo pipefail
 
-python_path_file="$(dirname "$0")/python_path.txt"
-if [[ ! -f "$python_path_file" ]]; then
-    # Try rlocation-style path (Bazel runfiles)
-    python_path_file="${RUNFILES_DIR:-$0.runfiles}/aspect_rules_py/e2e/cases/current-py-toolchain-896/python_path.txt"
-fi
+python_path_file="${TEST_SRCDIR}/_main/cases/current-py-toolchain-896/python_path.txt"
 
 python_path="$(cat "$python_path_file" | tr -d '[:space:]')"
 

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -8,6 +8,12 @@ alias(
 )
 
 bzl_library(
+    name = "current_py_toolchain",
+    srcs = ["current_py_toolchain.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -11,6 +11,7 @@ bzl_library(
     name = "current_py_toolchain",
     srcs = ["current_py_toolchain.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//py/private/interpreter:current_py_toolchain"],
 )
 
 bzl_library(
@@ -26,6 +27,7 @@ bzl_library(
         "//py/private:py_unpacked_wheel",
         "//py/private:py_wheel",
         "//py/private:virtual",
+        "//py/private/interpreter:current_py_toolchain",
         "//py/private/py_venv",
         "@bazel_lib//lib:utils",
     ],

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -19,6 +19,7 @@ bzl_library(
     name = "current_py_toolchain",
     srcs = ["current_py_toolchain.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//py/private/interpreter:current_py_toolchain"],
 )
 
 bzl_library(
@@ -33,6 +34,7 @@ bzl_library(
         "//py/private:py_unpacked_wheel",
         "//py/private:py_wheel",
         "//py/private:virtual",
+        "//py/private/interpreter:current_py_toolchain",
         "//py/private/py_venv",
         "//py/private/py_venv:py_venv_exec",
         "@bazel_lib//lib:utils",

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -16,6 +16,12 @@ label_flag(
 )
 
 bzl_library(
+    name = "current_py_toolchain",
+    srcs = ["current_py_toolchain.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],

--- a/py/current_py_toolchain.bzl
+++ b/py/current_py_toolchain.bzl
@@ -1,0 +1,5 @@
+"""Public entry point for current_py_toolchain rule."""
+
+load("//py/private/interpreter:current_py_toolchain.bzl", _current_py_toolchain = "current_py_toolchain")
+
+current_py_toolchain = _current_py_toolchain

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -42,8 +42,10 @@ load("//py/private:py_pex_binary.bzl", _py_pex_binary = "py_pex_binary")
 load("//py/private:py_pytest_main.bzl", _py_pytest_main = "py_pytest_main", _pytest_paths = "pytest_paths")
 load("//py/private:py_unpacked_wheel.bzl", _py_unpacked_wheel = "py_unpacked_wheel")
 load("//py/private:virtual.bzl", _resolutions = "resolutions")
+load("//py/private/interpreter:current_py_toolchain.bzl", _current_py_toolchain = "current_py_toolchain")
 load("//py/private/py_venv:defs.bzl", _py_venv_link = "py_venv_link")
 
+current_py_toolchain = _current_py_toolchain
 py_pex_binary = _py_pex_binary
 py_pytest_main = _py_pytest_main
 

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -24,6 +24,7 @@ load("//py/private:py_pex_binary.bzl", _py_pex_binary = "py_pex_binary")
 load("//py/private:py_pytest_main.bzl", _py_pytest_main = "py_pytest_main", _pytest_paths = "pytest_paths")
 load("//py/private:py_unpacked_wheel.bzl", _py_unpacked_wheel = "py_unpacked_wheel")
 load("//py/private:virtual.bzl", _resolutions = "resolutions")
+load("//py/private/interpreter:current_py_toolchain.bzl", _current_py_toolchain = "current_py_toolchain")
 load(
     "//py/private/py_venv:py_venv.bzl",
     _py_binary_with_venv = "py_binary_with_venv",
@@ -32,6 +33,7 @@ load(
 )
 load("//py/private/py_venv:py_venv_exec.bzl", _py_venv_exec = "py_venv_exec", _py_venv_exec_test = "py_venv_exec_test")
 
+current_py_toolchain = _current_py_toolchain
 py_pex_binary = _py_pex_binary
 py_pytest_main = _py_pytest_main
 

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load(":exclude_feature.bzl", "exclude_feature_flag")
 load(":version_util_test.bzl", "version_util_test_suite")
@@ -5,6 +6,11 @@ load(":version_util_test.bzl", "version_util_test_suite")
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["probe_interpreter.py"])
+
+bzl_library(
+    name = "current_py_toolchain",
+    srcs = ["current_py_toolchain.bzl"],
+)
 
 string_flag(
     name = "python_version",

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -8,6 +8,11 @@ package(default_visibility = ["//visibility:public"])
 exports_files(["probe_interpreter.py"])
 
 bzl_library(
+    name = "current_py_toolchain",
+    srcs = ["current_py_toolchain.bzl"],
+)
+
+bzl_library(
     name = "extension",
     srcs = ["extension.bzl"],
     deps = [

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -10,6 +10,7 @@ exports_files(["probe_interpreter.py"])
 bzl_library(
     name = "current_py_toolchain",
     srcs = ["current_py_toolchain.bzl"],
+    deps = ["//py/private/toolchain:types"],
 )
 
 bzl_library(

--- a/py/private/interpreter/current_py_toolchain.bzl
+++ b/py/private/interpreter/current_py_toolchain.bzl
@@ -1,0 +1,75 @@
+"""Rule to expose the resolved Python toolchain as Make variables.
+
+Provides `$(PYTHON3)` and `$(PYTHON3_ROOTPATH)` for use in `genrule`,
+`bazel_env`, and other rules that support Make variable expansion.
+"""
+
+_TOOLCHAIN_TYPE = "@bazel_tools//tools/python:toolchain_type"
+
+def _current_py_toolchain_impl(ctx):
+    direct = []
+    transitive = []
+    vars = {}
+
+    toolchain = ctx.toolchains[_TOOLCHAIN_TYPE]
+    if toolchain.py3_runtime:
+        if toolchain.py3_runtime.interpreter:
+            # Hermetic / in-tree interpreter (File object)
+            direct.append(toolchain.py3_runtime.interpreter)
+            transitive.append(toolchain.py3_runtime.files)
+            vars["PYTHON3"] = toolchain.py3_runtime.interpreter.path
+            vars["PYTHON3_ROOTPATH"] = toolchain.py3_runtime.interpreter.short_path
+        elif toolchain.py3_runtime.interpreter_path:
+            # Local / system interpreter (absolute path string)
+            vars["PYTHON3"] = toolchain.py3_runtime.interpreter_path
+            vars["PYTHON3_ROOTPATH"] = toolchain.py3_runtime.interpreter_path
+
+    files = depset(direct, transitive = transitive)
+    return [
+        platform_common.TemplateVariableInfo(vars),
+        DefaultInfo(
+            runfiles = ctx.runfiles(transitive_files = files),
+            files = files,
+        ),
+    ]
+
+current_py_toolchain = rule(
+    doc = """\
+Exposes the resolved Python 3 toolchain as Make variables.
+
+After toolchain resolution, this rule provides `$(PYTHON3)` and
+`$(PYTHON3_ROOTPATH)` for Make variable expansion in rules like
+`genrule` and `bazel_env`.
+
+An instance is automatically available at
+`@python_interpreters//:current_py_toolchain` when using the
+`python_interpreters` module extension.
+
+Example usage with `genrule`:
+
+```starlark
+genrule(
+    name = "run_python",
+    outs = ["output.txt"],
+    cmd = "$(PYTHON3) -c 'print(42)' > $@",
+    toolchains = ["@python_interpreters//:current_py_toolchain"],
+)
+```
+
+Example usage with `bazel_env`:
+
+```starlark
+bazel_env(
+    name = "bazel_env",
+    toolchains = {
+        "python": "@python_interpreters//:current_py_toolchain",
+    },
+    tools = {
+        "python": "$(PYTHON3)",
+    },
+)
+```
+""",
+    implementation = _current_py_toolchain_impl,
+    toolchains = [_TOOLCHAIN_TYPE],
+)

--- a/py/private/interpreter/current_py_toolchain.bzl
+++ b/py/private/interpreter/current_py_toolchain.bzl
@@ -4,14 +4,14 @@ Provides `$(PYTHON3)` and `$(PYTHON3_ROOTPATH)` for use in `genrule`,
 `bazel_env`, and other rules that support Make variable expansion.
 """
 
-_TOOLCHAIN_TYPE = "@bazel_tools//tools/python:toolchain_type"
+load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
 
 def _current_py_toolchain_impl(ctx):
     direct = []
     transitive = []
     vars = {}
 
-    toolchain = ctx.toolchains[_TOOLCHAIN_TYPE]
+    toolchain = ctx.toolchains[PY_TOOLCHAIN]
     if toolchain.py3_runtime:
         if toolchain.py3_runtime.interpreter:
             # Hermetic / in-tree interpreter (File object)
@@ -23,6 +23,8 @@ def _current_py_toolchain_impl(ctx):
             # Local / system interpreter (absolute path string)
             vars["PYTHON3"] = toolchain.py3_runtime.interpreter_path
             vars["PYTHON3_ROOTPATH"] = toolchain.py3_runtime.interpreter_path
+        else:
+            fail("py3_runtime has neither interpreter nor interpreter_path")
 
     files = depset(direct, transitive = transitive)
     return [
@@ -71,5 +73,5 @@ bazel_env(
 ```
 """,
     implementation = _current_py_toolchain_impl,
-    toolchains = [_TOOLCHAIN_TYPE],
+    toolchains = [PY_TOOLCHAIN],
 )

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -197,6 +197,7 @@ def _python_toolchains_impl(rctx):
     """Creates toolchain() registrations pointing to interpreter repos."""
     content = [
         'load("@bazel_skylib//lib:selects.bzl", "selects")',
+        'load("@aspect_rules_py//py/private/interpreter:current_py_toolchain.bzl", "current_py_toolchain")',
         'package(default_visibility = ["//visibility:public"])',
     ]
 
@@ -319,6 +320,12 @@ toolchain(
             target_compatible_with = target_compatible_with,
             target_settings = target_settings,
         ))
+
+    content.append("""
+current_py_toolchain(
+    name = "current_py_toolchain",
+)
+""")
 
     rctx.file("BUILD.bazel", content = "\n".join(content))
 

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -207,6 +207,7 @@ def _python_toolchains_impl(rctx):
     """Creates toolchain() registrations pointing to interpreter repos."""
     content = [
         'load("@bazel_skylib//lib:selects.bzl", "selects")',
+        'load("@aspect_rules_py//py/private/interpreter:current_py_toolchain.bzl", "current_py_toolchain")',
         'package(default_visibility = ["//visibility:public"])',
     ]
 
@@ -350,6 +351,10 @@ toolchain(
 exports_files(
     ["BUILD.bazel"],
     visibility = ["//visibility:public"],
+)
+
+current_py_toolchain(
+    name = "current_py_toolchain",
 )
 """)
 

--- a/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@aspect_rules_py//py/private/interpreter:current_py_toolchain.bzl", "current_py_toolchain")
 package(default_visibility = ["//visibility:public"])
 
 config_setting(
@@ -775,4 +776,8 @@ toolchain(
 exports_files(
     ["BUILD.bazel"],
     visibility = ["//visibility:public"],
+)
+
+current_py_toolchain(
+    name = "current_py_toolchain",
 )


### PR DESCRIPTION
## Summary

Closes #896.

Adds a `current_py_toolchain` rule that resolves the active Python toolchain and exposes `$(PYTHON3)` and `$(PYTHON3_ROOTPATH)` Make variables via `TemplateVariableInfo`. This enables `bazel_env` and `genrule` integration without depending on `rules_python`.

- Auto-instantiated in the `python_interpreters` hub repo at `@python_interpreters//:current_py_toolchain`
- Also exported from `@aspect_rules_py//py:defs.bzl` and `@aspect_rules_py//py:current_py_toolchain.bzl` for standalone use
- Handles both hermetic (PBS) and local system interpreters
- Includes e2e test verifying `$(PYTHON3)` expansion via `genrule`

### Usage

```starlark
# With bazel_env:
bazel_env(
    name = "bazel_env",
    toolchains = {
        "python": "@python_interpreters//:current_py_toolchain",
    },
    tools = {
        "python": "$(PYTHON3)",
    },
)

# With genrule:
genrule(
    name = "run_python",
    outs = ["output.txt"],
    cmd = "$(PYTHON3) -c 'print(42)' > $@",
    toolchains = ["@python_interpreters//:current_py_toolchain"],
)
```

## Test plan

- [x] e2e test `//e2e/cases/current-py-toolchain-896:test` passes
- [x] Existing e2e tests unaffected
- [x] `buildifier` and `buildifier-lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)