### PR TITLE
Eager error checking for 'RUNFILES_DIR' in the run template

### DIFF
--- a/py/private/run.tmpl.sh
+++ b/py/private/run.tmpl.sh
@@ -35,7 +35,7 @@ function python_location {
 }
 
 VENV_TOOL="$(rlocation {{VENV_TOOL}})"
-VIRTUAL_ENV="$(alocation "${RUNFILES_DIR}/{{ARG_VENV_NAME}}")"
+VIRTUAL_ENV="$(alocation "${RUNFILES_DIR:?'RUNFILES_DIR' must be set}/{{ARG_VENV_NAME}}")"
 export VIRTUAL_ENV
 
 "${VENV_TOOL}" \


### PR DESCRIPTION
I had a weird error occur during a `--sandbox_debug` session where instead of running the code it just crashed with

```
Error:   × Unable to run command:
  ├─▶ Unable to create base venv directory
  ╰─▶ Permission denied (os error 13)
```

```
4062937 stat("/.mutator.venv", 0x7fff2b5c0ed0) = -1 ENOENT (No such file or directory)
4062937 mkdir("/.mutator.venv", 0777)   = -1 EACCES (Permission denied)
4062937 stat("/.mutator.venv", 0x7fff2b5c0c20) = -1 ENOENT (No such file or directory)
4062937 write(2, "\33[31m  \342\224\234\342\224\200\342\226\266 \33[0mUnable to create base venv directory", 57) = 57
```

This came from not having the RUNFILES_DIR environment variable setup correctly. This was with a remote build (did not try to reproduce with a local build) with `--build_runfile_links=false` so the bash runfiles snippet could not find the directories and set the variables to empty values. This is not caught by `set -u` as they are indeed set.

Instead the script proceeds with an empty variable expansion and bug. With this change we get a more actionable error message and avoids running code that targets "\<empty\>/\<something\>" which is known to be a bad idea. Thankfully it just crashes but with hard to understand messages. Where the sandbox debug behavior does not reflect what actually happens in the action when run by Bazel.

### Changes are visible to end-users: yes/no

Improves error reporting in rare cases. Avoids the risk of follow on errors of empty shell variables.

### Test plan

- Manual testing; please provide instructions so we can reproduce.

I think the key here is build remotely without runfiles links, then follow Bazel's sandbox debug functionality.