### PR TITLE
refactor(wheels): propagate wheels via PyWheelInfo instead of DefaultInfo

### DIFF
--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -8,7 +8,7 @@ load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_python//python:defs.bzl", "PyInfo")
-load("//py/private:providers.bzl", "PyVirtualInfo")
+load("//py/private:providers.bzl", "PyVirtualInfo", "PyWheelInfo")
 
 def _make_instrumented_files_info(ctx, extra_source_attributes = [], extra_dependency_attributes = []):
     return coverage_common.instrumented_files_info(
@@ -17,6 +17,13 @@ def _make_instrumented_files_info(ctx, extra_source_attributes = [], extra_depen
         dependency_attributes = ["data", "deps"] + extra_dependency_attributes,
         extensions = ["py"],
     )
+
+def _make_wheel_depset(ctx):
+    return depset(transitive = [
+        target[PyWheelInfo].files
+        for target in ctx.attr.deps
+        if PyWheelInfo in target
+    ])
 
 def _make_srcs_depset(ctx):
     return depset(
@@ -178,6 +185,7 @@ def _py_library_impl(ctx):
     resolutions = _make_virtual_resolutions_depset(ctx)
     runfiles = _make_merged_runfiles(ctx, extra_runfiles = ctx.files.srcs)
     instrumented_files_info = _make_instrumented_files_info(ctx)
+    wheels = _make_wheel_depset(ctx)
 
     return [
         DefaultInfo(
@@ -195,6 +203,7 @@ def _py_library_impl(ctx):
             dependencies = virtuals,
             resolutions = resolutions,
         ),
+        PyWheelInfo(files = wheels, default_runfiles = ctx.runfiles()),
         instrumented_files_info,
     ]
 
@@ -230,6 +239,7 @@ _attrs = dict({
 _providers = [
     DefaultInfo,
     PyInfo,
+    PyWheelInfo,
 ]
 
 py_library_utils = struct(
@@ -240,6 +250,7 @@ py_library_utils = struct(
     make_instrumented_files_info = _make_instrumented_files_info,
     make_merged_runfiles = _make_merged_runfiles,
     make_srcs_depset = _make_srcs_depset,
+    make_wheel_depset = _make_wheel_depset,
     py_library_providers = _providers,
     resolve_virtuals = _resolve_virtuals,
 )

--- a/uv/private/defs.bzl
+++ b/uv/private/defs.bzl
@@ -1,36 +1,17 @@
 "Internal helpers."
 
-load("@with_cfg.bzl", "with_cfg")
-load("//py:defs.bzl", "py_library")
-
-LIB_MODE = "//uv/private/constraints:lib_mode"
-
-py_whl_library, _ = with_cfg(py_library).set(Label(LIB_MODE), "whl").build()
-
-def _lib_mode_transition_impl(settings, attr):
-    return {LIB_MODE: "lib"}
-
-lib_mode_transition = transition(
-    implementation = _lib_mode_transition_impl,
-    inputs = [],
-    outputs = [LIB_MODE],
-)
-
-def _whl_mode_transition_impl(settings, attr):
-    return {LIB_MODE: "whl"}
-
-whl_mode_transition = transition(
-    implementation = _whl_mode_transition_impl,
-    inputs = [],
-    outputs = [LIB_MODE],
-)
+load("//py/private:providers.bzl", "PyWheelInfo")
 
 def _whl_requirements_impl(ctx):
-    return [DefaultInfo(files = depset(transitive = [s.files for s in ctx.attr.srcs]))]
+    return [DefaultInfo(files = depset(transitive = [
+        s[PyWheelInfo].files
+        for s in ctx.attr.srcs
+        if PyWheelInfo in s
+    ]))]
 
 whl_requirements = rule(
     implementation = _whl_requirements_impl,
     attrs = {
-        "srcs": attr.label_list(cfg = whl_mode_transition),
+        "srcs": attr.label_list(),
     },
 )

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -7,7 +7,6 @@ build backend the sdist declares in its `[build-system]` table.
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_cc_toolchain = "find_cpp_toolchain")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
-load("//uv/private:defs.bzl", "lib_mode_transition")
 
 CC_TOOLCHAIN = "@bazel_tools//tools/cpp:toolchain_type"
 
@@ -130,7 +129,6 @@ specified Python dependencies under the configured Python toolchain.
             ],
         ),
     },
-    cfg = lib_mode_transition,
 )
 
 pep517_native_whl = rule(
@@ -181,5 +179,4 @@ constraints of the target platform.
         config_common.toolchain_type(CC_TOOLCHAIN, mandatory = False),
     ],
     fragments = ["cpp"],
-    cfg = lib_mode_transition,
 )

--- a/uv/private/uv_hub/repository.bzl
+++ b/uv/private/uv_hub/repository.bzl
@@ -58,7 +58,6 @@ config_setting(
     content = [
         """\
 load("@aspect_rules_py//py:defs.bzl", "py_library")
-load("@aspect_rules_py//uv/private:defs.bzl", "py_whl_library", "whl_requirements")
 """,
     ]
 
@@ -86,7 +85,6 @@ filegroup(
         content = [
             """\
 load("@aspect_rules_py//py:defs.bzl", "py_library")
-load("@aspect_rules_py//uv/private:defs.bzl", "py_whl_library")
 load("//:defs.bzl", "compatible_with")
 """,
         ]
@@ -109,9 +107,14 @@ alias(
     actual = "{name}",
     visibility = ["//visibility:public"],
 )
-py_whl_library(
+# TODO(v2): Remove. This target previously forced
+# whl_mode (returning the raw .whl file rather than the installed py_library).
+# That machinery has been removed; it now simply aliases :lib. Kept for API
+# compatibility — removing it would be a breaking change for callers that
+# reference @hub//<pkg>:whl directly.
+alias(
     name = "whl",
-    srcs = [":{name}"],
+    actual = ":{name}",
     visibility = ["//visibility:public"],
 )
 filegroup(

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -211,16 +211,6 @@ filegroup(
     srcs = {index_whl},
     visibility = ["//visibility:public"],
 )
-
-py_library(
-    name = "whl_lib",
-    srcs = [
-        ":whl"
-    ],
-    data = [
-    ],
-    visibility = ["//visibility:private"],
-)
 """.format(
             arms = _format_arms(select_arms),
             index_whl = indent(pprint([str(gazelle_index_whl)]), " " * 4).lstrip(),
@@ -275,12 +265,7 @@ whl_install(
 py_library(
     name = "install",
     srcs = [],
-    deps = [
-        select({{
-            "@aspect_rules_py//uv/private/constraints:libs_are_libs": ":actual_install",
-            "@aspect_rules_py//uv/private/constraints:libs_are_whls": ":whl_lib",
-        }}),
-    ] + {extra_deps},
+    deps = [":actual_install"] + {extra_deps},
     data = {extra_data},
     visibility = ["//visibility:public"],
 )
@@ -294,10 +279,7 @@ py_library(
             """
 alias(
     name = "install",
-    actual = select({
-        "@aspect_rules_py//uv/private/constraints:libs_are_libs": ":actual_install",
-        "@aspect_rules_py//uv/private/constraints:libs_are_whls": ":whl_lib",
-    }),
+    actual = ":actual_install",
     visibility = ["//visibility:public"],
 )
 """,

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -2,6 +2,7 @@
 """
 
 load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py/private:providers.bzl", "PyWheelInfo")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN", "UNPACK_TOOLCHAIN")
 
 def _whl_install(ctx):
@@ -95,6 +96,7 @@ def _whl_install(ctx):
             has_py3_only_sources = True,
             uses_shared_libraries = False,
         ),
+        PyWheelInfo(files = depset([archive]), default_runfiles = ctx.runfiles()),
     ]
 
 whl_install = rule(
@@ -142,5 +144,6 @@ lighter weight since the toolchain's files aren't inputs.
         DefaultInfo,
         OutputGroupInfo,
         PyInfo,
+        PyWheelInfo,
     ],
 )


### PR DESCRIPTION
This was a robots work to "stop propagating all the wheels via DefaultInfo" which @dzbarsky mentioned on slack.

--

Previously, wheel files leaked into DefaultInfo.files of every target that transitively depended on a pip package. This happened because whl_requirements used whl_mode_transition to flip lib_mode=whl across the dep graph, causing install aliases to resolve to whl_lib (a py_library with the raw .whl file as srcs). Since py_library propagates DefaultInfo.files transitively, every intermediate target accumulated all transitive .whl files as visible build outputs.

The fix introduces PyWheelInfo, a dedicated provider that carries wheel files without putting them in DefaultInfo:

- whl_install now returns PyWheelInfo(files=depset([archive])) alongside its existing DefaultInfo and PyInfo
- py_library propagates PyWheelInfo transitively from its deps, so the full set of transitive wheels is reachable from any node in the dep graph
- whl_requirements reads PyWheelInfo.files directly, with no cfg transition

Because whl_requirements no longer needs whl_mode_transition to surface wheels, the entire lib_mode machinery becomes unnecessary:

- whl_mode_transition was only used by whl_requirements (now gone) and py_whl_library (which only existed to force whl mode)
- lib_mode_transition on pep517_whl existed solely to counteract whl_mode_transition in source-build dep chains; without whl_mode_transition there is nothing to counteract
- whl_lib in each package repo and the libs_are_whls arm of the install select are removed; install always resolves to actual_install
- py_whl_library in the hub becomes a plain alias; PyWheelInfo is available on the same target without any mode transition

libs_are_libs and libs_are_whls config_settings are retained as no-op stubs for API compatibility.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
