### PR TITLE
fix(py_pex_binary): exclude hermetic python toolchain files to prevent AmbiguousDistributionError

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,6 +58,9 @@ interpreters.configure(
     ],
 )
 interpreters.toolchain(
+    python_version = "3.11",
+)
+interpreters.toolchain(
     python_version = "3.13",
 )
 use_repo(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -68,6 +68,14 @@ use_repo(
     "python_interpreters",
     # Individual platform repos — must be visible so the uv extension can
     # reference the host interpreter for sdist configure tooling.
+    "python_3_11_aarch64_apple_darwin",
+    "python_3_11_aarch64_unknown_linux_gnu",
+    "python_3_11_aarch64_unknown_linux_musl",
+    "python_3_11_i686_pc_windows_msvc",
+    "python_3_11_x86_64_apple_darwin",
+    "python_3_11_x86_64_pc_windows_msvc",
+    "python_3_11_x86_64_unknown_linux_gnu",
+    "python_3_11_x86_64_unknown_linux_musl",
     "python_3_13_aarch64_apple_darwin",
     "python_3_13_aarch64_unknown_linux_gnu",
     "python_3_13_aarch64_unknown_linux_musl",

--- a/py/private/py_pex_binary.bzl
+++ b/py/private/py_pex_binary.bzl
@@ -38,6 +38,8 @@ exclude_paths = [
     # these will match in bzlmod setup with --incompatible_use_plus_in_repo_names flag flipped.
     "rules_python++python+",
     "aspect_rules_py+/py/tools/",
+    # these will match the hermetic python interpreter from rules_py extension
+    "python_interpreters~",
     "python_interpreters+",
 ]
 

--- a/py/private/py_pex_binary.bzl
+++ b/py/private/py_pex_binary.bzl
@@ -38,6 +38,7 @@ exclude_paths = [
     # these will match in bzlmod setup with --incompatible_use_plus_in_repo_names flag flipped.
     "rules_python++python+",
     "aspect_rules_py+/py/tools/",
+    "python_interpreters+",
 ]
 
 # determines if the given file is a `distinfo`, `dep` or a `source`
@@ -53,6 +54,11 @@ def _map_srcs(f, workspace):
     for exclude in exclude_paths:
         if dest_path.find(exclude) != -1:
             return []
+
+    if "_distutils_hack" in f.path:
+        return []
+    if "distutils-precedence.pth" in f.path:
+        return []
 
     site_packages_i = f.path.find("site-packages")
 

--- a/py/tests/py-pex-binary/BUILD.bazel
+++ b/py/tests/py-pex-binary/BUILD.bazel
@@ -4,10 +4,12 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//py:defs.bzl", "py_binary", "py_pex_binary")
 
 # Test that both single-file modules (six) and multi-file modules (cowsay) work with py_pex_binary.
+# Also tests that py_pex_binary works with hermetic Python toolchains (python_version = 3.11).
 py_binary(
     name = "print_modules_bin",
     srcs = ["print_modules.py"],
     data = ["data.txt"],
+    python_version = "3.11",
     deps = [
         "@pypi//cowsay",
         "@pypi//six",


### PR DESCRIPTION
## Problem

When building a `py_pex_binary` from a `py_binary` that uses a hermetic Python toolchain (e.g., from rules_python), the build fails with:
```
pex.dist_metadata.AmbiguousDistributionError: Found more than one distribution inside external/python3_9_x86_64-unknown-linux-gnu/lib/python3.9/site-packages/:
pip-23.2.1.dist-info/METADATA
setuptools-68.2.2.dist-info/METADATA
```

This happens because the hermetic Python interpreter includes pip and setuptools in its `site-packages`, and `py_pex_binary` was incorrectly including these as dependencies. When `Distribution.load()` is called on the `site-packages` directory, it finds multiple `.dist-info` directories and raises an error.

## Solution

Exclude hermetic Python toolchain files from being processed as PEX dependencies:

1. **Added exclusion pattern** for the hermetic interpreter repository:
   - Pattern: `python_interpreters+` (matches repos like `aspect_rules_py++python_interpreters+python_3_11_aarch64_apple_darwin`)

2. **Added specific file exclusions** for internal toolchain files:
   - `_distutils_hack` - Part of the interpreter's distutils shim
   - `distutils-precedence.pth` - Interpreter configuration file

## Changes

- `py/private/py_pex_binary.bzl`: Added exclusion patterns and specific file filters
- `py/tests/py-pex-binary/BUILD.bazel`: Updated test to use hermetic Python 3.11 toolchain to validate the fix

## Testing

bazel test //py/tests/py-pex-binary:test__print_modules_pex
//py/tests/py-pex-binary:test__print_modules_pex  PASSED