### PR TITLE
deterministically resolve unconstrained dependencies when lockfile contains multiple versions

### DIFF
--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -1,6 +1,7 @@
 # TOOLCHAIN_DEPS
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":test_graph_utils.bzl", "graph_utils_test_suite")
+load(":test_projectfile.bzl", "projectfile_test_suite")
 
 bzl_library(
     name = "defs",
@@ -11,3 +12,4 @@ bzl_library(
 )
 
 graph_utils_test_suite()
+projectfile_test_suite()

--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -12,4 +12,5 @@ bzl_library(
 )
 
 graph_utils_test_suite()
+
 projectfile_test_suite()

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -86,12 +86,13 @@ def extract_requirement_marker_pairs(projectfile, lock_id, req_string, version_m
         # specifier against all known versions of this package in the lockfile.
         specifier = remainder.strip()
         pkg_vers = package_versions.get(pkg_name, {})
-        if specifier and pkg_vers:
+        if pkg_vers:
+            match_spec = specifier if specifier else ">=0"
             candidates = {
                 ver: (lock_id, pkg_name, ver, "__base__")
                 for ver in pkg_vers.keys()
             }
-            v = find_matching_version(specifier, candidates)
+            v = find_matching_version(match_spec, candidates)
     if v == None:
         fail("Unable to resolve a default version for requirement {} in {}".format(repr(req_string), projectfile))
     else:

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -1,0 +1,88 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":projectfile.bzl", "extract_requirement_marker_pairs")
+
+def _extract_requirement_marker_pairs_multi_version_no_specifier_test_impl(ctx):
+    env = unittest.begin(ctx)
+    result = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "build",
+        {},
+        {"build": {"1.3.0": 1, "1.4.0": 1}},
+    )
+    asserts.equals(env, 1, len(result))
+    dep, marker = result[0]
+    asserts.equals(env, ("proj", "build", "1.4.0", "__base__"), dep)
+    asserts.equals(env, "", marker)
+    return unittest.end(env)
+
+extract_requirement_marker_pairs_multi_version_no_specifier_test = unittest.make(
+    _extract_requirement_marker_pairs_multi_version_no_specifier_test_impl,
+)
+
+def _extract_requirement_marker_pairs_multi_version_with_specifier_test_impl(ctx):
+    env = unittest.begin(ctx)
+    result = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "build>=1.3.0,<1.4.0",
+        {},
+        {"build": {"1.2.0": 1, "1.3.0": 1, "1.4.0": 1}},
+    )
+    asserts.equals(env, 1, len(result))
+    dep, marker = result[0]
+    asserts.equals(env, ("proj", "build", "1.3.0", "__base__"), dep)
+    asserts.equals(env, "", marker)
+    return unittest.end(env)
+
+extract_requirement_marker_pairs_multi_version_with_specifier_test = unittest.make(
+    _extract_requirement_marker_pairs_multi_version_with_specifier_test_impl,
+)
+
+def _extract_requirement_marker_pairs_single_version_via_map_test_impl(ctx):
+    env = unittest.begin(ctx)
+    version_map = {"build": ("proj", "build", "1.2.0", "__base__")}
+    result = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "build",
+        version_map,
+        {"build": {"1.2.0": 1, "1.3.0": 1}},
+    )
+    asserts.equals(env, 1, len(result))
+    dep, marker = result[0]
+    asserts.equals(env, ("proj", "build", "1.2.0", "__base__"), dep)
+    asserts.equals(env, "", marker)
+    return unittest.end(env)
+
+extract_requirement_marker_pairs_single_version_via_map_test = unittest.make(
+    _extract_requirement_marker_pairs_single_version_via_map_test_impl,
+)
+
+def _extract_requirement_marker_pairs_with_extras_test_impl(ctx):
+    env = unittest.begin(ctx)
+    result = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        'build[extra1,extra2] >= 1.0; python_version >= "3.9"',
+        {},
+        {"build": {"1.0.0": 1, "1.1.0": 1}},
+    )
+    asserts.equals(env, 3, len(result))
+    asserts.equals(env, (("proj", "build", "1.1.0", "__base__"), 'python_version >= "3.9"'), result[0])
+    asserts.equals(env, (("proj", "build", "1.1.0", "extra1"), 'python_version >= "3.9"'), result[1])
+    asserts.equals(env, (("proj", "build", "1.1.0", "extra2"), 'python_version >= "3.9"'), result[2])
+    return unittest.end(env)
+
+extract_requirement_marker_pairs_with_extras_test = unittest.make(
+    _extract_requirement_marker_pairs_with_extras_test_impl,
+)
+
+def projectfile_test_suite():
+    unittest.suite(
+        "extract_requirement_marker_pairs_tests",
+        extract_requirement_marker_pairs_multi_version_no_specifier_test,
+        extract_requirement_marker_pairs_multi_version_with_specifier_test,
+        extract_requirement_marker_pairs_single_version_via_map_test,
+        extract_requirement_marker_pairs_with_extras_test,
+    )


### PR DESCRIPTION
When a `pyproject.toml` declares a dependency without a version specifier (e.g. `build`) and the `uv.lock` contains multiple versions of that package—commonly caused by `tool.uv.conflicts` or multiple dependency groups—Starlark analysis fails with:

```
Unable to resolve a default version for requirement ...
```

This happens because `extract_requirement_marker_pairs` in `uv/private/extension/projectfile.bzl` only falls back to `find_matching_version` when an explicit version specifier is present. If the specifier is empty, the fallback is skipped and the build aborts.

### Fix
Modified the *Look up version* block in `extract_requirement_marker_pairs` so that, when no default version exists and the requirement has no version constraint, we pass `">=0"` to `find_matching_version`. This deterministically selects the highest available version from the lockfile candidates instead of failing.

### Changes
- **`uv/private/extension/projectfile.bzl`**  
  - Relaxed the fallback condition from `if specifier and pkg_vers:` to `if pkg_vers:`.  
  - Default empty specifiers to `match_spec = ">=0"` before calling `find_matching_version`.  
  - Preserved the final `fail()` for packages that truly do not exist in the lockfile.

- **`uv/private/extension/test_projectfile.bzl`** *(new)*  
  Added unit tests covering:
  - Multi-version package without a specifier (selects latest).
  - Multi-version package with a specifier (honors the constraint).
  - Single-version lookup via `version_map` (no regression).
  - Extras and PEP 508 markers propagation.

- **`uv/private/extension/BUILD.bazel`**  
  Registered the new `projectfile_test_suite()`.

### Validation
```
bazel test //uv/private/extension:all   # 12/12 passed
bazel test //uv/private/versions:all     # 45/45 passed
```