### PR TITLE
:bug: fix(venv): insidious creation/cleanup race condition

### DIFF
--- a/py/private/run.tmpl.sh
+++ b/py/private/run.tmpl.sh
@@ -35,7 +35,8 @@ function python_location {
 }
 
 VENV_TOOL="$(rlocation {{VENV_TOOL}})"
-VIRTUAL_ENV="$(alocation "${RUNFILES_DIR}/{{ARG_VENV_NAME}}")"
+VIRTUAL_ENV="$(alocation "${RUNFILES_DIR}/{{ARG_VENV_NAME}}.$$")"
+trap 'rm -rf "${VIRTUAL_ENV}"' EXIT
 export VIRTUAL_ENV
 
 "${VENV_TOOL}" \


### PR DESCRIPTION
Suffixes the venv created with the running shell's PID, ensuring that each call generates a venv at a unique location.

Also, explicitly cleans the venv up at the end to avoid too many piling up.

Fixes #858, #899.

---

I am near certain the issue I've been wrestling with is the same as #858 and that the root cause that this PR fixes is the same as the root cause for #899. I don't know if there is any code path in which the venv can be created outside the bazel output base, which is why I added the `trap` cleanup. If there isn't I am happy to remove that line.

---

### Test plan

<!-- Delete any which do not apply -->

- Manual testing; On a large enough codebase that uses `py_binary` and specific `venv`s (say, via the unstable `uv` based rules and `dependency_groups` and a `uv.lock` lockfile, and more specifically, one that has build actions that use a `py_binary` as a code generator), attempt to build on a beefy 96 core machine with just the right actions cached such that the venvs collide.
  Sadly as this is a race condition your machine needs to be just beefy enough that the actions run in the right order to create the perfect storm of pain.
  Then, do it again with this branch, and see that the venvs no longer collide.
  If one is using remote execution, you will not (or at least it will be very difficult) to be able to reproduce the original bug, because it appears that under remote execution the venvs are (a) potentially sharded across different nodes, and (b) I imagine the remote execution implementation defines its own prefix path per action, such that I am sure that there exist implementations that have a more unique path based on the action information.