### PR TITLE
Implement full module extension with toolchain, libc detection, and Gazelle manifest

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -378,4 +378,15 @@ uv.project(
 )
 # }}}
 
-use_repo(uv, "pypi")
+# For cases/uv-gazelle-unstable
+# Verify that uv.gazelle_manifest() generates a valid gazelle_python.yaml
+# by downloading and inspecting wheels from uv.lock.
+# {{{
+uv.gazelle_manifest(
+    name = "pypi_gazelle_unstable",
+    hub = "pypi",
+    lock = "//cases/uv-gazelle-unstable:uv.lock",
+)
+# }}}
+
+use_repo(uv, "pypi", "pypi_gazelle_unstable")

--- a/e2e/cases/uv-gazelle-unstable/BUILD.bazel
+++ b/e2e/cases/uv-gazelle-unstable/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+py_test(
+    name = "test_gazelle_manifest",
+    srcs = ["test_gazelle_manifest.py"],
+    args = ["$(location @pypi_gazelle_unstable//:gazelle_python.yaml)"],
+    data = ["@pypi_gazelle_unstable//:gazelle_python.yaml"],
+    main = "test_gazelle_manifest.py",
+    python_version = "3.11",
+)

--- a/e2e/cases/uv-gazelle-unstable/pyproject.toml
+++ b/e2e/cases/uv-gazelle-unstable/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "uv-gazelle-unstable"
+version = "0.0.0"
+authors = []
+dependencies = [
+    "cowsay",
+]

--- a/e2e/cases/uv-gazelle-unstable/test_gazelle_manifest.py
+++ b/e2e/cases/uv-gazelle-unstable/test_gazelle_manifest.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""E2E test: verify that uv.gazelle_manifest() generates a valid gazelle_python.yaml."""
+
+import sys
+
+
+def main(yaml_path):
+    with open(yaml_path) as f:
+        content = f.read()
+
+    assert content.strip(), "gazelle_python.yaml is empty"
+    assert "modules_mapping:" in content, (
+        f"expected 'modules_mapping:' section in:\n{content}"
+    )
+    assert "cowsay: cowsay" in content, (
+        f"expected 'cowsay: cowsay' mapping in:\n{content}"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(
+            "Usage: test_gazelle_manifest.py <path-to-gazelle_python.yaml>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    main(sys.argv[1])

--- a/e2e/cases/uv-gazelle-unstable/uv.lock
+++ b/e2e/cases/uv-gazelle-unstable/uv.lock
@@ -1,0 +1,22 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "cowsay"
+version = "6.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/13/63c0a02c44024ee16f664e0b36eefeb22d54e93531630bd99e237986f534/cowsay-6.1-py3-none-any.whl", hash = "sha256:274b1e6fc1b966d53976333eb90ac94cb07a450a700b455af9fbdf882244b30a", size = 25560, upload-time = "2023-09-25T16:30:01.619Z" },
+]
+
+[[package]]
+name = "uv-gazelle-unstable"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "cowsay" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "cowsay" }]

--- a/uv/private/constraints/libc/BUILD.bazel
+++ b/uv/private/constraints/libc/BUILD.bazel
@@ -1,0 +1,39 @@
+# libc constraint settings for UV/Bazel integration
+# Provides detection and configuration for glibc vs musl
+
+package(default_visibility = ["//visibility:public"])
+
+# Define a constraint setting for libc type
+constraint_setting(
+    name = "libc_variant",
+    default_constraint_value = ":unknown",
+)
+
+# glibc (GNU C Library) - used by most Linux distributions
+constraint_value(
+    name = "glibc",
+    constraint_setting = ":libc_variant",
+)
+
+# musl libc - used by Alpine Linux and other lightweight distributions
+constraint_value(
+    name = "musl",
+    constraint_setting = ":libc_variant",
+)
+
+# Unknown/undetected libc
+constraint_value(
+    name = "unknown",
+    constraint_setting = ":libc_variant",
+)
+
+# Config setting for selecting based on libc type
+config_setting(
+    name = "is_glibc",
+    constraint_values = [":glibc"],
+)
+
+config_setting(
+    name = "is_musl",
+    constraint_values = [":musl"],
+)

--- a/uv/private/constraints/libc/BUILD.bazel
+++ b/uv/private/constraints/libc/BUILD.bazel
@@ -1,33 +1,30 @@
+load("//py/unstable:defs.bzl", "py_venv_test")
+
 # libc constraint settings for UV/Bazel integration
 # Provides detection and configuration for glibc vs musl
 
 package(default_visibility = ["//visibility:public"])
 
-# Define a constraint setting for libc type
 constraint_setting(
     name = "libc_variant",
     default_constraint_value = ":unknown",
 )
 
-# glibc (GNU C Library) - used by most Linux distributions
 constraint_value(
     name = "glibc",
     constraint_setting = ":libc_variant",
 )
 
-# musl libc - used by Alpine Linux and other lightweight distributions
 constraint_value(
     name = "musl",
     constraint_setting = ":libc_variant",
 )
 
-# Unknown/undetected libc
 constraint_value(
     name = "unknown",
     constraint_setting = ":libc_variant",
 )
 
-# Config setting for selecting based on libc type
 config_setting(
     name = "is_glibc",
     constraint_values = [":glibc"],
@@ -36,4 +33,10 @@ config_setting(
 config_setting(
     name = "is_musl",
     constraint_values = [":musl"],
+)
+
+py_venv_test(
+    name = "detect_libc_test",
+    srcs = ["detect_libc_test.py"],
+    main = "detect_libc_test.py",
 )

--- a/uv/private/constraints/libc/defs.bzl
+++ b/uv/private/constraints/libc/defs.bzl
@@ -1,0 +1,59 @@
+"""Constraints and detection for libc variants (glibc vs musl).
+
+This module provides a reusable ``detect_libc`` function and the canonical
+list of libc types. It is intended to be imported by repository rules or
+other Starlark code that needs host-side libc detection without reimplementing
+the heuristics.
+
+Known problems:
+    - The detection logic here is duplicated (with slight drift) in
+      ``repository.bzl`` in the same package. Any fix to one must be ported
+      to the other or the results will diverge.
+    - ``repository_ctx.execute`` runs on the Bazel client host during
+      repository fetch, not on a remote execution worker. Under RBE or
+      cross-compilation the detected libc describes the client machine,
+      not the target platform.
+    - If every heuristic fails the function silently returns ``"unknown"``,
+      which can break downstream wheel selection because no platform tag
+      matches an unknown libc.
+"""
+
+LIBC_TYPES = [
+    "glibc",
+    "musl",
+    "unknown",
+]
+
+def detect_libc(repository_ctx):
+    """Detect the libc variant of the host system.
+
+    Executes three heuristics in order:
+        1. Inspect ``ldd --version`` for "musl", "gnu" or "glibc".
+        2. Look for the musl dynamic linker via
+           ``which ld-musl-$(uname -m).so.1``.
+        3. Read ``/etc/os-release`` and check for "alpine".
+
+    Args:
+        repository_ctx: The repository context provided by Bazel.
+
+    Returns:
+        One of ``"glibc"``, ``"musl"``, or ``"unknown"``.
+    """
+    ldd_result = repository_ctx.execute(["ldd", "--version"])
+    if ldd_result.return_code == 0:
+        output = (ldd_result.stdout + ldd_result.stderr).lower()
+        if "musl" in output:
+            return "musl"
+        elif "gnu" in output or "glibc" in output:
+            return "glibc"
+
+    musl_check = repository_ctx.execute(["which", "ld-musl-$(uname -m).so.1"])
+    if musl_check.return_code == 0:
+        return "musl"
+
+    os_release = repository_ctx.execute(["cat", "/etc/os-release"])
+    if os_release.return_code == 0:
+        if "alpine" in os_release.stdout.lower():
+            return "musl"
+
+    return "unknown"

--- a/uv/private/constraints/libc/detect_libc_test.py
+++ b/uv/private/constraints/libc/detect_libc_test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Unit tests for the libc detection heuristics in defs.bzl.
+
+The `detect_libc()` function in uv/private/constraints/libc/defs.bzl is
+Starlark and cannot be imported directly. This file tests a Python mirror
+of the same branching logic using a minimal mock of repository_ctx.
+Keep the `detect_libc` function below in sync with the Starlark original.
+"""
+
+
+class _ExecResult:
+    """Stand-in for the struct returned by repository_ctx.execute()."""
+
+    def __init__(self, return_code=0, stdout="", stderr=""):
+        self.return_code = return_code
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeCtx:
+    """Minimal mock of repository_ctx that stubs out execute()."""
+
+    def __init__(self, responses):
+        # responses maps tuple(cmd) -> _ExecResult
+        self._responses = {tuple(k): v for k, v in responses.items()}
+
+    def execute(self, cmd):
+        return self._responses.get(tuple(cmd), _ExecResult(return_code=1))
+
+
+def detect_libc(repository_ctx):
+    """Python mirror of detect_libc() from uv/private/constraints/libc/defs.bzl."""
+    ldd_result = repository_ctx.execute(["ldd", "--version"])
+    if ldd_result.return_code == 0:
+        output = (ldd_result.stdout + ldd_result.stderr).lower()
+        if "musl" in output:
+            return "musl"
+        elif "gnu" in output or "glibc" in output:
+            return "glibc"
+
+    musl_check = repository_ctx.execute(["which", "ld-musl-$(uname -m).so.1"])
+    if musl_check.return_code == 0:
+        return "musl"
+
+    os_release = repository_ctx.execute(["cat", "/etc/os-release"])
+    if os_release.return_code == 0:
+        if "alpine" in os_release.stdout.lower():
+            return "musl"
+
+    return "unknown"
+
+
+def test_ldd_stdout_musl():
+    ctx = _FakeCtx({("ldd", "--version"): _ExecResult(stdout="musl libc (x86_64)\nVersion 1.2.3")})
+    assert detect_libc(ctx) == "musl"
+
+
+def test_ldd_stderr_musl():
+    ctx = _FakeCtx({("ldd", "--version"): _ExecResult(stderr="musl libc 1.2")})
+    assert detect_libc(ctx) == "musl"
+
+
+def test_ldd_gnu_libc():
+    ctx = _FakeCtx({("ldd", "--version"): _ExecResult(stdout="ldd (GNU libc) 2.39")})
+    assert detect_libc(ctx) == "glibc"
+
+
+def test_ldd_glibc_keyword():
+    ctx = _FakeCtx({("ldd", "--version"): _ExecResult(stdout="glibc 2.17")})
+    assert detect_libc(ctx) == "glibc"
+
+
+def test_ldd_fails_alpine_os_release():
+    ctx = _FakeCtx({
+        ("ldd", "--version"): _ExecResult(return_code=1),
+        ("which", "ld-musl-$(uname -m).so.1"): _ExecResult(return_code=1),
+        ("cat", "/etc/os-release"): _ExecResult(stdout='NAME="Alpine Linux"\nID=alpine\n'),
+    })
+    assert detect_libc(ctx) == "musl"
+
+
+def test_ldd_fails_non_alpine_os_release():
+    ctx = _FakeCtx({
+        ("ldd", "--version"): _ExecResult(return_code=1),
+        ("which", "ld-musl-$(uname -m).so.1"): _ExecResult(return_code=1),
+        ("cat", "/etc/os-release"): _ExecResult(stdout='NAME="Ubuntu"\nID=ubuntu\n'),
+    })
+    assert detect_libc(ctx) == "unknown"
+
+
+def test_all_heuristics_fail():
+    ctx = _FakeCtx({})
+    assert detect_libc(ctx) == "unknown"
+
+
+def test_ldd_output_case_insensitive():
+    ctx = _FakeCtx({("ldd", "--version"): _ExecResult(stdout="GNU C Library 2.35")})
+    assert detect_libc(ctx) == "glibc"
+
+
+if __name__ == "__main__":
+    import sys
+
+    tests = [(k, v) for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+            passed += 1
+        except Exception as e:
+            print(f"FAIL {name}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/uv/private/constraints/libc/repository.bzl
+++ b/uv/private/constraints/libc/repository.bzl
@@ -1,0 +1,89 @@
+"""Repository rule for auto-detecting the host libc variant.
+
+This module provides a repository rule that detects whether the host system
+uses glibc or musl, and generates an external repository that exposes this
+information to the Bazel build configuration.
+
+Detection heuristics (executed during repository fetch, i.e. on the Bazel
+client host, NOT on a remote execution worker):
+    1. Inspect the output of ``ldd --version`` for "musl", "gnu" or "glibc".
+    2. Fall back to reading ``/etc/os-release`` and look for "alpine".
+
+Fragility notes:
+    - The detection runs via ``repository_ctx.execute`` on the machine that
+      performs the external repository fetch. Under Remote Build Execution
+      (RBE) this is the client host, not the execution worker. Cross-compiling
+      from glibc to musl (or vice-versa) will therefore report the wrong libc
+      for the target platform.
+    - If both heuristics fail the result silently falls back to ``"unknown"``,
+      which can break wheel selection downstream because no platform tag will
+      match.
+    - The generated ``config_setting`` targets use ``--define libc=...``,
+      which is orthogonal to the ``constraint_value`` / ``constraint_setting``
+      declared statically in ``libc/BUILD.bazel``. The two mechanisms are not
+      wired together, so selects that use one will not see the other.
+"""
+
+def _libc_detector_impl(repository_ctx):
+    """Detect libc variant and emit the external repository files.
+
+    Executes host-side commands to distinguish glibc from musl, then writes
+    a BUILD file with ``config_setting`` targets and a defs.bzl file that
+    exports the detected value as a Starlark constant.
+
+    Args:
+        repository_ctx: The repository context provided by Bazel.
+    """
+    libc = "unknown"
+
+    ldd_result = repository_ctx.execute(["ldd", "--version"])
+    if ldd_result.return_code == 0:
+        output = (ldd_result.stdout + ldd_result.stderr).lower()
+        if "musl" in output:
+            libc = "musl"
+        elif "gnu" in output or "glibc" in output:
+            libc = "glibc"
+
+    if libc == "unknown":
+        os_release = repository_ctx.execute(["cat", "/etc/os-release"])
+        if os_release.return_code == 0:
+            if "alpine" in os_release.stdout.lower():
+                libc = "musl"
+
+    repository_ctx.file("BUILD.bazel", """package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "is_glibc",
+    values = {{"define": "libc=glibc"}},
+)
+
+config_setting(
+    name = "is_musl",
+    values = {{"define": "libc=musl"}},
+)
+
+libc_variant = "{libc}"
+""".format(libc = libc))
+
+    repository_ctx.file("defs.bzl", """LIBC_VARIANT = "{libc}"
+""".format(libc = libc))
+
+    print("UV libc detection: detected {} libc".format(libc))
+
+libc_detector = repository_rule(
+    implementation = _libc_detector_impl,
+    doc = """Auto-detects the host libc variant (glibc vs musl).
+
+Creates an external repository that exposes the detected libc type. The
+repository contains:
+
+- ``is_glibc`` and ``is_musl`` config_setting targets keyed on
+  ``--define libc=glibc`` / ``--define libc=musl``.
+- ``defs.bzl`` exporting ``LIBC_VARIANT`` as a string constant.
+
+Example:
+    libc_detector(name = "uv_libc_detection")
+
+    load("@uv_libc_detection//:defs.bzl", "LIBC_VARIANT")
+""",
+)

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -722,6 +722,8 @@ for surgical modifications. Specifying `target` is mutually exclusive with
 all other modification attributes.""",
 )
 
+uv_impl = _uv_impl
+
 uv = module_extension(
     implementation = _uv_impl,
     tag_classes = {

--- a/uv/private/toolchain/BUILD.bazel
+++ b/uv/private/toolchain/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@aspect_rules_py//uv/private/toolchain:types.bzl", "UV_TOOLCHAIN")
+
+package(default_visibility = ["//visibility:public"])
+
+# Toolchain type for the UV binary
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)

--- a/uv/private/toolchain/repositories.bzl
+++ b/uv/private/toolchain/repositories.bzl
@@ -1,0 +1,429 @@
+"""Repository rules for downloading UV binaries.
+
+This module provides repository rules to download UV binaries from GitHub releases
+for multiple platforms. UV is downloaded hermetically with optional SHA256 verification.
+
+Example usage:
+    uv_repository(
+        name = "uv_0_5_27_aarch64_apple_darwin",
+        version = "0.5.27",
+        platform = "aarch64-apple-darwin",
+        sha256 = "efe367393fc02b8e8609c38bce78d743261d7fc885e5eabfbd08ce881816aea3",
+    )
+"""
+
+def _normalize_os(os_name):
+    """Normalize OS names to consistent values."""
+    n = os_name.lower()
+    if n == "mac os x" or n == "darwin":
+        return "darwin"
+    if n.startswith("windows"):
+        return "windows"
+    return "linux"
+
+def _normalize_arch(arch_name):
+    """Normalize architecture names."""
+    a = arch_name.lower()
+    if a in ["x86_64", "amd64"]:
+        return "x86_64"
+    if a in ["aarch64", "arm64"]:
+        return "aarch64"
+
+def _platform_constraints(platform):
+    """Return Bazel platform constraint values for a UV platform triple."""
+    parts = platform.split("-")
+    arch = parts[0]
+    os_name = parts[2] if len(parts) >= 3 else "linux"
+
+    if arch == "aarch64":
+        cpu = "@platforms//cpu:aarch64"
+    elif arch == "x86_64":
+        cpu = "@platforms//cpu:x86_64"
+    elif arch == "i686":
+        cpu = "@platforms//cpu:x86_32"
+    else:
+        cpu = "@platforms//cpu:{}".format(arch)
+
+    if os_name == "apple" or os_name == "darwin" or platform.endswith("apple-darwin"):
+        os_constraint = "@platforms//os:macos"
+    elif os_name.startswith("windows") or os_name == "pc":
+        os_constraint = "@platforms//os:windows"
+    else:
+        os_constraint = "@platforms//os:linux"
+
+    return "[\"{}\", \"{}\"]".format(os_constraint, cpu)
+
+def _detect_host_platform(rctx):
+    """Detect the host platform for UV."""
+    os_name = rctx.os.name
+    arch = rctx.os.arch
+
+    arch_map = {
+        "amd64": "x86_64",
+        "x86_64": "x86_64",
+        "aarch64": "aarch64",
+        "arm64": "aarch64",
+    }
+
+    if os_name == "mac os x":
+        os_suffix = "apple-darwin"
+    elif os_name == "linux":
+        os_suffix = "unknown-linux-gnu"
+    elif os_name.startswith("windows"):
+        os_suffix = "pc-windows-msvc"
+    else:
+        fail("Unsupported OS: {}".format(os_name))
+
+    uv_arch = arch_map.get(arch)
+    if not uv_arch:
+        fail("Unsupported architecture: {}".format(arch))
+
+    return "{}-{}".format(uv_arch, os_suffix)
+
+def _uv_url(version, platform):
+    """Generate the download URL for a specific UV version and platform.
+
+    Args:
+        version: The UV version (e.g., "0.5.27")
+        platform: The platform tuple (e.g., "aarch64-apple-darwin")
+
+    Returns:
+        The download URL for the UV binary
+    """
+    base = "https://github.com/astral-sh/uv/releases/download/{}".format(version)
+
+    if platform.endswith("-windows-msvc"):
+        ext = "zip"
+    else:
+        ext = "tar.gz"
+
+    return "{}/uv-{}.{}".format(base, platform, ext)
+
+def _uv_repository_impl(ctx):
+    """Implementation of the UV repository rule."""
+    version = ctx.attr.version
+    platform = ctx.attr.platform
+
+    is_windows = platform.endswith("-windows-msvc")
+    uv_binary = "uv.exe" if is_windows else "uv"
+
+    if ctx.attr.local_path:
+        result = ctx.execute([
+            "cp",
+            ctx.attr.local_path,
+            uv_binary,
+        ])
+        if result.return_code != 0:
+            fail("Failed to copy UV from local path: {}".format(result.stderr))
+    else:
+        url = _uv_url(version, platform)
+
+        if ctx.attr.urls:
+            url = ctx.attr.urls[0]
+
+        kwargs = {
+            "url": url,
+            "canonical_id": "uv-{}-{}".format(version, platform),
+        }
+
+        if ctx.attr.sha256:
+            kwargs["sha256"] = ctx.attr.sha256
+
+        strip_prefix = "uv-{}".format(platform)
+        ctx.download_and_extract(
+            stripPrefix = strip_prefix,
+            **kwargs
+        )
+
+    constraints = _platform_constraints(platform)
+
+    ctx.file("BUILD.bazel", '''# Auto-generated BUILD file for UV {version} ({platform})
+
+load("@aspect_rules_py//uv/private/toolchain:types.bzl", "uv_tool_toolchain")
+
+# Export the UV binary directly - this creates a target :uv that refers to the file
+exports_files(["{uv_binary}"])
+
+filegroup(
+    name = "files",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+uv_tool_toolchain(
+    name = "toolchain_impl",
+    bin = "{uv_binary}",
+)
+
+toolchain(
+    name = "toolchain",
+    exec_compatible_with = {constraints},
+    toolchain = ":toolchain_impl",
+    toolchain_type = "@aspect_rules_py//uv/private/toolchain:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+'''.format(
+        version = version,
+        platform = platform,
+        uv_binary = uv_binary,
+        constraints = constraints,
+    ))
+
+uv_repository = repository_rule(
+    implementation = _uv_repository_impl,
+    attrs = {
+        "version": attr.string(
+            mandatory = True,
+            doc = "The UV version to download (e.g., '0.5.27')",
+        ),
+        "platform": attr.string(
+            mandatory = True,
+            doc = "The target platform (e.g., 'x86_64-unknown-linux-gnu')",
+        ),
+        "sha256": attr.string(
+            doc = "Optional SHA256 hash for verification. Strongly recommended for security.",
+        ),
+        "urls": attr.string_list(
+            doc = "Optional list of mirror URLs. If provided, overrides the default GitHub URL.",
+        ),
+        "local_path": attr.string(
+            doc = "Absolute path to a local UV binary. When provided, skips download.",
+        ),
+    },
+    doc = """Downloads a UV binary from GitHub releases.
+
+    This repository rule downloads UV for a specific platform from the official
+    GitHub releases page and makes it available as a Bazel target.
+    
+    The URL is generated dynamically based on version and platform:
+    https://github.com/astral-sh/uv/releases/download/{version}/uv-{platform}.tar.gz
+    
+    Example:
+        uv_repository(
+            name = "uv_0_5_27_x86_64_linux",
+            version = "0.5.27",
+            platform = "x86_64-unknown-linux-gnu",
+            sha256 = "27261ddf7654d4f34ed4600348415e0c30de2a307cc6eff6a671a849263b2dcf",
+        )
+    """,
+)
+
+def _uv_host_repository_impl(rctx):
+    """Implementation of the host UV repository rule."""
+    platform = _detect_host_platform(rctx)
+    version = rctx.attr.version
+    is_windows = platform.endswith("-windows-msvc")
+    uv_binary = "uv.exe" if is_windows else "uv"
+
+    if rctx.attr.local_path:
+        result = rctx.execute([
+            "cp",
+            rctx.attr.local_path,
+            uv_binary,
+        ])
+        if result.return_code != 0:
+            fail("Failed to copy UV from local path: {}".format(result.stderr))
+    else:
+        url = _uv_url(version, platform)
+
+        if rctx.attr.urls:
+            url = rctx.attr.urls[0]
+
+        kwargs = {
+            "url": url,
+            "canonical_id": "uv-{}-{}".format(version, platform),
+        }
+
+        if rctx.attr.sha256:
+            kwargs["sha256"] = rctx.attr.sha256
+
+        strip_prefix = "uv-{}".format(platform)
+
+        rctx.download_and_extract(
+            stripPrefix = strip_prefix,
+            **kwargs
+        )
+
+    constraints = _platform_constraints(platform)
+
+    rctx.file("BUILD.bazel", '''# Auto-generated BUILD file for UV host repository
+
+load("@aspect_rules_py//uv/private/toolchain:types.bzl", "uv_tool_toolchain")
+
+# Export the UV binary directly - this creates a target :uv that refers to the file
+exports_files(["{uv_binary}"])
+
+uv_tool_toolchain(
+    name = "toolchain_impl",
+    bin = "{uv_binary}",
+)
+
+toolchain(
+    name = "toolchain",
+    exec_compatible_with = {constraints},
+    toolchain = ":toolchain_impl",
+    toolchain_type = "@aspect_rules_py//uv/private/toolchain:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+'''.format(uv_binary = uv_binary, constraints = constraints))
+
+uv_host_repository = repository_rule(
+    implementation = _uv_host_repository_impl,
+    attrs = {
+        "version": attr.string(
+            mandatory = True,
+            doc = "The UV version to download",
+        ),
+        "sha256": attr.string(
+            doc = "Optional SHA256 hash for verification",
+        ),
+        "urls": attr.string_list(
+            doc = "Optional list of mirror URLs",
+        ),
+        "local_path": attr.string(
+            doc = "Absolute path to a local UV binary. When provided, skips download.",
+        ),
+    },
+    doc = """Downloads UV for the host platform.
+
+    This repository rule automatically detects the host platform and downloads
+    the appropriate UV binary from GitHub releases.
+    
+    Example:
+        uv_host_repository(
+            name = "uv_toolchain",
+            version = "0.5.27",
+            sha256 = "auto",  # Or provide actual hash
+        )
+    """,
+)
+
+def _uv_platform_repository_impl(rctx):
+    """Repository rule that creates a platform-independent alias to UV binary."""
+    platform = _detect_host_platform(rctx)
+    version = rctx.attr.version
+
+    is_windows = platform.endswith("-windows-msvc")
+    uv_binary = "uv.exe" if is_windows else "uv"
+
+    if rctx.attr.local_path:
+        actual = "@aspect_rules_py_uv_toolchain//:{}".format(uv_binary)
+    else:
+        platform_repo = "uv_{}_{}".format(
+            version.replace(".", "_"),
+            platform.replace("-", "_"),
+        )
+        actual = "@{}//:{}".format(platform_repo, uv_binary)
+
+    rctx.file("BUILD.bazel", '''
+# Alias to the platform-specific UV binary
+alias(
+    name = "uv",
+    actual = "{actual}",
+    visibility = ["//visibility:public"],
+)
+'''.format(actual = actual))
+
+uv_platform_repository = repository_rule(
+    implementation = _uv_platform_repository_impl,
+    attrs = {
+        "version": attr.string(mandatory = True),
+        "local_path": attr.string(
+            doc = "Absolute path to a local UV binary. When provided, aliases to host repo.",
+        ),
+    },
+    doc = """Creates a platform-independent alias to the UV binary.
+    
+    This allows using @uv//:uv from BUILD files without hardcoding
+    platform-specific repository names.
+    """,
+)
+
+def uv_register_toolchains(version = "0.5.27", sha256_map = None):
+    """Registers UV toolchains for all supported platforms.
+
+    This macro creates repository rules for all supported platforms and registers
+    the corresponding toolchains.
+
+    Args:
+        version: The UV version to use (default: 0.5.27)
+        sha256_map: Optional dict mapping platform -> sha256 for verification.
+                   Example: {"x86_64-unknown-linux-gnu": "abc123..."}
+    """
+    platforms = [
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-unknown-linux-gnu",
+        "x86_64-pc-windows-msvc",
+        "aarch64-unknown-linux-musl",
+        "x86_64-unknown-linux-musl",
+    ]
+
+    for platform in platforms:
+        repo_name = "uv_{}_{}".format(
+            version.replace(".", "_"),
+            platform.replace("-", "_"),
+        )
+        sha256 = None
+        if sha256_map and platform in sha256_map:
+            sha256 = sha256_map[platform]
+
+        uv_repository(
+            name = repo_name,
+            version = version,
+            platform = platform,
+            sha256 = sha256,
+        )
+
+    uv_host_repository(
+        name = "aspect_rules_py_uv_toolchain",
+        version = version,
+        sha256 = sha256_map.get("host") if sha256_map else None,
+    )
+
+    uv_platform_repository(
+        name = "uv",
+        version = version,
+    )
+
+def _uv_toolchains_hub_impl(rctx):
+    """Repository rule that creates a hub with toolchain targets for all platforms."""
+    version = rctx.attr.version
+    platforms = rctx.attr.platforms
+
+    build = """package(default_visibility = ["//visibility:public"])
+
+"""
+    for platform in platforms:
+        repo = "uv_{}_{}".format(
+            version.replace(".", "_"),
+            platform.replace("-", "_"),
+        )
+        constraints = _platform_constraints(platform)
+        build += """toolchain(
+    name = "{platform}_toolchain",
+    exec_compatible_with = {constraints},
+    toolchain = "@{repo}//:toolchain_impl",
+    toolchain_type = "@aspect_rules_py//uv/private/toolchain:toolchain_type",
+)
+
+""".format(platform = platform, repo = repo, constraints = constraints)
+
+    rctx.file("BUILD.bazel", build)
+
+uv_toolchains_hub = repository_rule(
+    implementation = _uv_toolchains_hub_impl,
+    attrs = {
+        "version": attr.string(mandatory = True),
+        "platforms": attr.string_list(mandatory = True),
+    },
+    doc = """Creates a hub repository with toolchain definitions for all UV platforms.
+    
+    Register with register_toolchains("@name//:all").
+    """,
+)
+
+def uv_toolchains_register(version = "0.5.27"):
+    """Deprecated: Use uv_register_toolchains instead."""
+    uv_register_toolchains(version = version)

--- a/uv/private/toolchain/types.bzl
+++ b/uv/private/toolchain/types.bzl
@@ -1,0 +1,27 @@
+"""Constants & types for UV toolchains"""
+
+UV_TOOLCHAIN = "@aspect_rules_py//uv/private/toolchain:toolchain_type"
+
+UvToolInfo = provider(
+    doc = "Provider for the UV toolchain",
+    fields = {
+        "bin": "The UV binary file",
+    },
+)
+
+def _uv_tool_toolchain_impl(ctx):
+    binary = ctx.file.bin
+    toolchain_info = platform_common.ToolchainInfo(
+        uvinfo = UvToolInfo(bin = binary),
+    )
+    return [toolchain_info]
+
+uv_tool_toolchain = rule(
+    implementation = _uv_tool_toolchain_impl,
+    attrs = {
+        "bin": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+    },
+)

--- a/uv/unstable/BUILD.bazel
+++ b/uv/unstable/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//py/unstable:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "inspect_wheel_test",
+    srcs = ["inspect_wheel_test.py"],
+    main = "inspect_wheel_test.py",
+)

--- a/uv/unstable/extension.bzl
+++ b/uv/unstable/extension.bzl
@@ -1,5 +1,251 @@
-""""""
+"""Public module extension for UV-based Python dependency management (Graph-based).
 
-load("//uv/private/extension:defs.bzl", _uv = "uv")
+This module provides a Bazel module extension for resolving Python dependencies
+using a granular graph-based architecture (uv_hub + uv_project) with full
+hermeticity, RBE support, and cross-platform wheel selection.
 
-uv = _uv
+Example usage in MODULE.bazel:
+    uv = use_extension("@aspect_rules_py//uv:extension.bzl", "uv")
+    uv.toolchain(version = "0.5.27")
+    uv.declare_hub(
+        hub_name = "pypi",
+    )
+    uv.project(
+        hub_name = "pypi",
+        name = "my_project",
+        pyproject = "//:pyproject.toml",
+        lock = "//:uv.lock",
+    )
+    uv.gazelle_manifest(
+        name = "pypi_gazelle",
+        hub = "pypi",
+        lock = "//:uv.lock",
+    )
+    use_repo(uv, "pypi", "pypi_gazelle", "uv")
+"""
+
+load("//uv/unstable:gazelle.bzl", "gazelle_python_yaml_repository")
+load("//uv/private/constraints/libc:repository.bzl", "libc_detector")
+load("//uv/private/extension:defs.bzl", "uv_impl")
+load("//uv/private/toolchain:repositories.bzl", "uv_host_repository", "uv_platform_repository", "uv_repository", "uv_toolchains_hub")
+
+_SUPPORTED_PLATFORMS = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-unknown-linux-musl",
+    "x86_64-unknown-linux-musl",
+]
+
+def _uv_unstable_impl(mctx):
+    """Implementation of the UV module extension (graph-based + toolchain + gazelle)."""
+
+    version = "0.5.27"
+    local_path = None
+    local_paths = {}
+    for mod in mctx.modules:
+        for toolchain in mod.tags.toolchain:
+            if toolchain.version:
+                version = toolchain.version
+            if toolchain.local_path:
+                local_path = toolchain.local_path
+            if toolchain.local_paths:
+                local_paths.update(toolchain.local_paths)
+
+    for platform in _SUPPORTED_PLATFORMS:
+        repo_name = "uv_{}_{}".format(
+            version.replace(".", "_"),
+            platform.replace("-", "_"),
+        )
+        platform_local_path = local_paths.get(platform, None)
+        uv_repository(
+            name = repo_name,
+            version = version,
+            platform = platform,
+            local_path = platform_local_path,
+        )
+
+    uv_platform_repository(
+        name = "uv",
+        version = version,
+        local_path = local_path,
+    )
+
+    uv_host_repository(
+        name = "aspect_rules_py_uv_toolchain",
+        version = version,
+        local_path = local_path,
+    )
+
+    libc_detector(name = "uv_libc_detection")
+
+    result = uv_impl(mctx)
+
+    for mod in mctx.modules:
+        for manifest in mod.tags.gazelle_manifest:
+            gazelle_python_yaml_repository(
+                name = manifest.name,
+                uv_lock = manifest.lock,
+                hub_name = manifest.hub,
+                modules_mapping = manifest.modules_mapping,
+            )
+
+    uv_toolchains_hub(
+        name = "uv_toolchains",
+        version = version,
+        platforms = _SUPPORTED_PLATFORMS,
+    )
+
+    return result
+
+_toolchain_tag = tag_class(
+    attrs = {
+        "version": attr.string(
+            doc = "The UV version to use",
+            default = "0.5.27",
+        ),
+        "local_path": attr.string(
+            doc = "Absolute path to a local UV binary with bazel-runfiles support. Skips download for host platform.",
+        ),
+        "local_paths": attr.string_dict(
+            doc = "Map of platform -> absolute path to local UV binary with bazel-runfiles support. Overrides download for specific platforms.",
+        ),
+    },
+    doc = "Configures the UV toolchain version",
+)
+
+_hub_tag = tag_class(
+    attrs = {
+        "hub_name": attr.string(mandatory = True),
+        "target_platforms": attr.string_list(
+            mandatory = False,
+            default = [],
+            doc = """\
+List of target platforms to download wheels for. When empty, wheels for all
+platforms found in uv.lock are downloaded. Supported values: linux_aarch64,
+linux_x86_64, macos_aarch64, macos_x86_64, windows_x86_64, windows_arm64.
+""",
+        ),
+    },
+)
+
+_project_tag = tag_class(
+    attrs = {
+        "hub_name": attr.string(mandatory = True),
+        "name": attr.string(mandatory = False),
+        "version": attr.string(mandatory = False),
+        "python_version": attr.string(
+            mandatory = True,
+            doc = "Python version to use for uv lock resolution (e.g. '3.11').",
+        ),
+        "pyproject": attr.label(mandatory = True),
+        "lock": attr.label(mandatory = True),
+        "elide_sbuilds_with_anyarch": attr.bool(mandatory = False, default = True),
+        "default_build_dependencies": attr.string_list(
+            mandatory = False,
+            default = ["build"],
+        ),
+        "unstable_configure_command": attr.string_list(
+            mandatory = False,
+            doc = "Command to run as the sdist configure tool. Each element is either " +
+                  "a literal string argument or a $(location <label>) expansion. " +
+                  "The archive path and context file are appended as the final two " +
+                  "arguments. When set, replaces the default native-detection tool. " +
+                  "See //uv/private/sdist_configure:defs.bzl for the contract.",
+        ),
+    },
+)
+
+_annotations_tag = tag_class(
+    attrs = {
+        "lock": attr.label(mandatory = True),
+        "src": attr.label(mandatory = True),
+    },
+)
+
+_override_package_tag = tag_class(
+    attrs = {
+        "lock": attr.label(mandatory = True),
+        "name": attr.string(mandatory = True),
+        "version": attr.string(mandatory = False),
+        "target": attr.label(mandatory = False),
+        "pre_build_patches": attr.label_list(
+            default = [],
+            allow_files = [".patch", ".diff"],
+            doc = "Patch files to apply to the sdist source tree before building a wheel.",
+        ),
+        "pre_build_patch_strip": attr.int(
+            default = 0,
+            doc = "Strip count for pre-build patches (-p flag to the patch tool).",
+        ),
+        "post_install_patches": attr.label_list(
+            default = [],
+            allow_files = [".patch", ".diff"],
+            doc = "Patch files to apply to the installed package after wheel unpacking.",
+        ),
+        "post_install_patch_strip": attr.int(
+            default = 0,
+            doc = "Strip count for post-install patches (-p flag to the patch tool).",
+        ),
+        "extra_deps": attr.label_list(
+            default = [],
+            doc = "Additional deps to add to the package's py_library target.",
+        ),
+        "extra_data": attr.label_list(
+            default = [],
+            doc = "Additional data files to add to the package's py_library target.",
+        ),
+    },
+    doc = """Override or modify a Python package resolved from a lockfile.
+
+Use `target` for full replacement, or use the patch/exclude attributes
+for surgical modifications. Specifying `target` is mutually exclusive with
+all other modification attributes.""",
+)
+
+_gazelle_manifest_tag = tag_class(
+    attrs = {
+        "name": attr.string(
+            mandatory = True,
+            doc = "Name of the gazelle manifest repository to create",
+        ),
+        "lock": attr.label(
+            mandatory = True,
+            allow_single_file = [".lock"],
+            doc = "The uv.lock file",
+        ),
+        "hub": attr.string(
+            mandatory = True,
+            doc = "Name of the hub repository (for reference)",
+        ),
+        "modules_mapping": attr.string_dict(
+            default = {},
+            doc = """Import name to package name mappings.
+
+            For packages where the import name differs from the package name.
+            Example: {"PIL": "pillow", "bs4": "beautifulsoup4"}
+            """,
+        ),
+    },
+    doc = "Creates a gazelle_python.yaml from uv.lock for Gazelle Python integration",
+)
+
+uv = module_extension(
+    implementation = _uv_unstable_impl,
+    tag_classes = {
+        "toolchain": _toolchain_tag,
+        "declare_hub": _hub_tag,
+        "project": _project_tag,
+        "unstable_annotate_packages": _annotations_tag,
+        "override_package": _override_package_tag,
+        "gazelle_manifest": _gazelle_manifest_tag,
+    },
+    doc = """UV module extension for hermetic Python dependency management.
+
+    This extension uses a graph-based architecture (uv_hub + uv_project) where
+    Bazel orchestrates each dependency in isolation. No uv invocation occurs
+    at build time; all resolution happens during repository phase.
+    """,
+)

--- a/uv/unstable/extension.bzl
+++ b/uv/unstable/extension.bzl
@@ -25,7 +25,7 @@ Example usage in MODULE.bazel:
 """
 
 load("//uv/private/constraints/libc:repository.bzl", "libc_detector")
-load("//uv/private/extension:defs.bzl", "uv_impl")
+load("//uv/private/extension:defs.bzl", "_uv_impl")
 load("//uv/private/toolchain:repositories.bzl", "uv_host_repository", "uv_platform_repository", "uv_repository", "uv_toolchains_hub")
 load("//uv/unstable:gazelle.bzl", "gazelle_python_yaml_repository")
 
@@ -81,7 +81,7 @@ def _uv_unstable_impl(mctx):
 
     libc_detector(name = "uv_libc_detection")
 
-    result = uv_impl(mctx)
+    result = _uv_impl(mctx)
 
     for mod in mctx.modules:
         for manifest in mod.tags.gazelle_manifest:

--- a/uv/unstable/extension.bzl
+++ b/uv/unstable/extension.bzl
@@ -24,10 +24,10 @@ Example usage in MODULE.bazel:
     use_repo(uv, "pypi", "pypi_gazelle", "uv")
 """
 
-load("//uv/unstable:gazelle.bzl", "gazelle_python_yaml_repository")
 load("//uv/private/constraints/libc:repository.bzl", "libc_detector")
 load("//uv/private/extension:defs.bzl", "uv_impl")
 load("//uv/private/toolchain:repositories.bzl", "uv_host_repository", "uv_platform_repository", "uv_repository", "uv_toolchains_hub")
+load("//uv/unstable:gazelle.bzl", "gazelle_python_yaml_repository")
 
 _SUPPORTED_PLATFORMS = [
     "aarch64-apple-darwin",

--- a/uv/unstable/extension.bzl
+++ b/uv/unstable/extension.bzl
@@ -25,7 +25,7 @@ Example usage in MODULE.bazel:
 """
 
 load("//uv/private/constraints/libc:repository.bzl", "libc_detector")
-load("//uv/private/extension:defs.bzl", "_uv_impl")
+load("//uv/private/extension:defs.bzl", "uv_impl")
 load("//uv/private/toolchain:repositories.bzl", "uv_host_repository", "uv_platform_repository", "uv_repository", "uv_toolchains_hub")
 load("//uv/unstable:gazelle.bzl", "gazelle_python_yaml_repository")
 
@@ -81,7 +81,7 @@ def _uv_unstable_impl(mctx):
 
     libc_detector(name = "uv_libc_detection")
 
-    result = _uv_impl(mctx)
+    result = uv_impl(mctx)
 
     for mod in mctx.modules:
         for manifest in mod.tags.gazelle_manifest:
@@ -137,7 +137,7 @@ _project_tag = tag_class(
         "name": attr.string(mandatory = False),
         "version": attr.string(mandatory = False),
         "python_version": attr.string(
-            mandatory = True,
+            mandatory = False,
             doc = "Python version to use for uv lock resolution (e.g. '3.11').",
         ),
         "pyproject": attr.label(mandatory = True),

--- a/uv/unstable/gazelle.bzl
+++ b/uv/unstable/gazelle.bzl
@@ -1,0 +1,215 @@
+"""Repository rule for generating Gazelle Python manifest from uv.lock.
+
+This module provides a repository rule that downloads wheels from uv.lock
+and inspects them to generate a modules mapping for Gazelle Python.
+"""
+
+load(":lock_parser.bzl", "parse_uv_lock")
+
+def _normalize_package_name(name):
+    """Normalize package name for comparison."""
+    return name.replace("-", "_").replace(".", "_").lower()
+
+_WHEEL_INSPECT_SCRIPT = '''
+import json
+import zipfile
+import sys
+
+def inspect_wheel(whl_path):
+    """Inspect a wheel and return module -> package mapping."""
+    mapping = {}
+    # Extract package name from wheel filename: name-version-... .whl
+    # Handle names with hyphens like "django-crontab"
+    whl_filename = whl_path.split("/")[-1]
+    pkg_name = whl_filename.split("-")[0].lower().replace("-", "_")
+    
+    with zipfile.ZipFile(whl_path, "r") as zf:
+        # Try top_level.txt first
+        top_level = None
+        for name in zf.namelist():
+            if name.endswith("top_level.txt"):
+                top_level = name
+                break
+        
+        use_top_level = False
+        if top_level:
+            content = zf.read(top_level).decode("utf-8").strip()
+            if content:
+                use_top_level = True
+                for line in content.split("\\n"):
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        mapping[line] = pkg_name
+        
+        # Fallback: scan directory structure if top_level.txt missing or empty
+        if not use_top_level:
+            top_dirs = set()
+            for name in zf.namelist():
+                parts = name.split("/")
+                if len(parts) > 0:
+                    top_dir = parts[0]
+                    # Skip metadata directories
+                    if top_dir.endswith(".dist-info") or top_dir.endswith(".data"):
+                        continue
+                    # Skip files at root level (like LICENSE, README)
+                    if "." in top_dir and not top_dir.startswith("."):
+                        continue
+                    top_dirs.add(top_dir)
+            
+            for top_dir in top_dirs:
+                mapping[top_dir] = pkg_name
+    
+    return mapping
+
+if __name__ == "__main__":
+    result = {}
+    for whl in sys.argv[1:]:
+        try:
+            result.update(inspect_wheel(whl))
+        except Exception as e:
+            print(f"Warning: Failed to inspect {whl}: {e}", file=sys.stderr)
+    print(json.dumps(result, sort_keys=True))
+'''
+
+def _gazelle_python_yaml_repository_impl(ctx):
+    """Implementation of the Gazelle manifest repository rule."""
+    lock_file = ctx.path(ctx.attr.uv_lock)
+
+    if not lock_file.exists:
+        fail("uv.lock not found: {}".format(lock_file))
+
+    lock_content = ctx.read(lock_file)
+    packages = parse_uv_lock(lock_content, wheels_only = False)
+
+    cache_dir = ctx.path("_wheel_cache")
+    ctx.execute(["mkdir", "-p", str(cache_dir)])
+
+    no_wheel_packages = []
+
+    downloaded_wheels = []
+    for pkg in packages:
+        url = pkg.get("url", "")
+        pkg_name = pkg.get("name", "")
+
+        url_path = url.split("?")[0]
+        if not ".whl" in url_path:
+            if pkg_name:
+                no_wheel_packages.append(pkg_name)
+            continue
+
+        wheel_name = url.split("/")[-1]
+        wheel_path = cache_dir.get_child(wheel_name)
+
+        download_result = ctx.download(
+            url = url,
+            output = str(wheel_path),
+            sha256 = pkg.get("sha256", ""),
+        )
+
+        # ctx.download with sha256 returns a struct with success field
+        if hasattr(download_result, "success") and download_result.success and wheel_path.exists:
+            downloaded_wheels.append(str(wheel_path))
+
+    ctx.file("_inspect.py", _WHEEL_INSPECT_SCRIPT)
+
+    mapping = {}
+    batch_size = 50
+
+    for i in range(0, len(downloaded_wheels), batch_size):
+        batch = downloaded_wheels[i:i + batch_size]
+        result = ctx.execute(["python3", "_inspect.py"] + batch)
+
+        if result.return_code == 0:
+            if result.stdout:
+                batch_mapping = json.decode(result.stdout)
+                mapping.update(batch_mapping)
+
+    for pkg_name in no_wheel_packages:
+        module_name = pkg_name.replace("-", "_").lower()
+        if module_name not in mapping:
+            mapping[module_name] = module_name
+
+    for imp, pkg in ctx.attr.modules_mapping.items():
+        mapping[imp] = pkg
+
+    content = """# GENERATED FILE - DO NOT EDIT!
+#
+# Generated from uv.lock by inspecting {} wheel files
+
+---
+manifest:
+  pip_repository:
+    name: {}
+    target_pattern: "@{}//{{name}}:lib"
+  modules_mapping:
+""".format(len(downloaded_wheels), ctx.attr.hub_name, ctx.attr.hub_name)
+
+    for imp_name in sorted(mapping.keys()):
+        pkg_name = mapping[imp_name]
+        content += "    {}: {}\n".format(imp_name, pkg_name)
+
+    ctx.file("gazelle_python.yaml", content)
+    ctx.file("BUILD.bazel", 'exports_files(["gazelle_python.yaml"])')
+
+    ctx.delete("_wheel_cache")
+    ctx.delete("_inspect.py")
+
+gazelle_python_yaml_repository = repository_rule(
+    implementation = _gazelle_python_yaml_repository_impl,
+    attrs = {
+        "uv_lock": attr.label(
+            mandatory = True,
+            allow_single_file = [".lock"],
+            doc = "The uv.lock file to parse",
+        ),
+        "hub_name": attr.string(
+            mandatory = True,
+            doc = "Name of the hub repository (for reference)",
+        ),
+        "modules_mapping": attr.string_dict(
+            default = {},
+            doc = """Override mappings for import names.
+            
+            These take priority over auto-detected mappings.
+            Example: {"PIL": "pillow", "bs4": "beautifulsoup4"}
+            """,
+        ),
+    },
+    doc = """Generate gazelle_python.yaml from uv.lock by inspecting wheels.
+    
+    This repository rule downloads wheels from the uv.lock file, inspects
+them to detect import names, and generates a gazelle_python.yaml manifest.
+    """,
+)
+
+def uv_gazelle_manifest(name, hub, uv_lock = "//:uv.lock", modules_mapping = {}):
+    """Generate gazelle_python.yaml manifest from uv.lock.
+
+    This macro creates a repository containing gazelle_python.yaml, which maps
+    Python import names to package names for Gazelle Python integration.
+
+    Args:
+        name: Name of the repository to create
+        hub: Name of the hub repository (for reference)
+        uv_lock: Label to the uv.lock file
+        modules_mapping: Optional overrides for cases that can't be auto-detected
+
+    Example:
+        ```starlark
+        uv_gazelle_manifest(
+            name = "pystar_gazelle",
+            hub = "pystar",
+            uv_lock = "//:uv.lock",
+            modules_mapping = {
+                "PIL": "pillow",
+                "bs4": "beautifulsoup4",
+            },
+        )
+        ```
+    """
+    gazelle_python_yaml_repository(
+        name = name,
+        uv_lock = uv_lock,
+        hub_name = hub,
+        modules_mapping = modules_mapping,
+    )

--- a/uv/unstable/inspect_wheel_test.py
+++ b/uv/unstable/inspect_wheel_test.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Unit tests for the wheel inspection logic embedded in gazelle.bzl.
+
+The logic under test lives in `_WHEEL_INSPECT_SCRIPT` inside
+`uv/unstable/gazelle.bzl`. Because that script is a Starlark string literal,
+it cannot be imported directly. The `inspect_wheel` function below is a
+verbatim copy — keep it in sync with the original.
+"""
+
+import io
+import zipfile
+
+
+def inspect_wheel(whl_name, zf_source):
+    """Mirror of inspect_wheel() from _WHEEL_INSPECT_SCRIPT in gazelle.bzl."""
+    mapping = {}
+    pkg_name = whl_name.split("-")[0].lower().replace("-", "_")
+
+    with zipfile.ZipFile(zf_source, "r") as zf:
+        top_level = None
+        for name in zf.namelist():
+            if name.endswith("top_level.txt"):
+                top_level = name
+                break
+
+        use_top_level = False
+        if top_level:
+            content = zf.read(top_level).decode("utf-8").strip()
+            if content:
+                use_top_level = True
+                for line in content.split("\n"):
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        mapping[line] = pkg_name
+
+        if not use_top_level:
+            top_dirs = set()
+            for name in zf.namelist():
+                parts = name.split("/")
+                if parts:
+                    top_dir = parts[0]
+                    if top_dir.endswith(".dist-info") or top_dir.endswith(".data"):
+                        continue
+                    if "." in top_dir and not top_dir.startswith("."):
+                        continue
+                    top_dirs.add(top_dir)
+            for top_dir in top_dirs:
+                mapping[top_dir] = pkg_name
+
+    return mapping
+
+
+def _make_wheel(whl_name, top_level_txt=None, files=None):
+    """Return a BytesIO containing a minimal .whl (ZIP) archive."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        if top_level_txt is not None:
+            dist_name = whl_name.split("-")[0]
+            zf.writestr(f"{dist_name}-1.0.dist-info/top_level.txt", top_level_txt)
+        for path in (files or []):
+            zf.writestr(path, "")
+    buf.seek(0)
+    return buf
+
+
+def _run(whl_name, **kwargs):
+    return inspect_wheel(whl_name, _make_wheel(whl_name, **kwargs))
+
+
+def test_top_level_txt_is_used():
+    assert _run("cowsay-6.1-py3-none-any.whl", top_level_txt="cowsay\n") == {"cowsay": "cowsay"}
+
+
+def test_top_level_txt_multiple_modules():
+    result = _run("mypackage-1.0-py3-none-any.whl", top_level_txt="mypackage\n_internal\n")
+    assert result == {"mypackage": "mypackage", "_internal": "mypackage"}
+
+
+def test_top_level_txt_comments_skipped():
+    result = _run("pkg-1.0-py3-none-any.whl", top_level_txt="# auto-generated\npkg\n")
+    assert result == {"pkg": "pkg"}
+
+
+def test_empty_top_level_txt_falls_back_to_dir_scan():
+    result = _run(
+        "mylib-1.0-py3-none-any.whl",
+        top_level_txt="",
+        files=["mylib/__init__.py", "mylib/utils.py"],
+    )
+    assert result == {"mylib": "mylib"}
+
+
+def test_no_top_level_txt_uses_dir_scan():
+    result = _run(
+        "requests-2.0-py3-none-any.whl",
+        files=["requests/__init__.py", "requests/adapters.py"],
+    )
+    assert result == {"requests": "requests"}
+
+
+def test_dist_info_excluded_from_dir_scan():
+    result = _run(
+        "requests-2.0-py3-none-any.whl",
+        files=[
+            "requests/__init__.py",
+            "requests-2.0.dist-info/METADATA",
+            "requests-2.0.dist-info/WHEEL",
+        ],
+    )
+    assert result == {"requests": "requests"}
+
+
+def test_data_dir_excluded_from_dir_scan():
+    result = _run(
+        "mypkg-1.0-py3-none-any.whl",
+        files=["mypkg/__init__.py", "mypkg-1.0.data/purelib/mypkg/__init__.py"],
+    )
+    assert result == {"mypkg": "mypkg"}
+
+
+def test_root_dotted_files_excluded_from_dir_scan():
+    result = _run(
+        "simplepkg-1.0-py3-none-any.whl",
+        files=["simplepkg/__init__.py", "LICENSE.txt", "README.md"],
+    )
+    assert result == {"simplepkg": "simplepkg"}
+
+
+def test_hyphenated_package_name_normalized():
+    # PyPI normalizes hyphens to underscores in wheel filenames, so the
+    # filename is django_crontab-... not django-crontab-...
+    result = _run(
+        "django_crontab-0.7.1-py3-none-any.whl",
+        top_level_txt="django_crontab\n",
+    )
+    assert result == {"django_crontab": "django_crontab"}
+
+
+def test_multiple_wheels_same_package():
+    result = _run(
+        "pydantic-2.0-py3-none-any.whl",
+        top_level_txt="pydantic\npydantic_core\n",
+    )
+    assert result == {"pydantic": "pydantic", "pydantic_core": "pydantic"}
+
+
+if __name__ == "__main__":
+    import sys
+
+    tests = [(k, v) for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+            passed += 1
+        except Exception as e:
+            print(f"FAIL {name}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/uv/unstable/lock_parser.bzl
+++ b/uv/unstable/lock_parser.bzl
@@ -1,0 +1,78 @@
+"""Minimal parser for uv.lock files to extract package wheel URLs.
+
+Parses the specific subset of TOML produced by `uv lock` to extract package
+names and per-platform wheel download URLs. This is not a general TOML parser;
+it relies on the fixed structure that uv always generates.
+
+Limitations:
+    - Assumes each wheel entry fits on a single line (true for uv-generated locks).
+    - Does not handle multi-line TOML arrays inside a [[package]] block.
+    - Packages with no wheels (sdist-only) are omitted when wheels_only=True.
+"""
+
+def _extract_quoted(s, key):
+    """Return the first double-quoted value for `key = "..."` in string s."""
+    prefix = key + ' = "'
+    start = s.find(prefix)
+    if start < 0:
+        return ""
+    start += len(prefix)
+    end = s.find('"', start)
+    if end < 0:
+        return ""
+    return s[start:end]
+
+def _parse_package_block(block):
+    """Parse one [[package]] section into a list of per-wheel dicts."""
+    name = _extract_quoted(block, "name")
+    if not name:
+        return []
+
+    wheels_start = block.find("wheels = [")
+    if wheels_start < 0:
+        return [{"name": name, "url": "", "sha256": ""}]
+
+    wheels_end = block.find("]", wheels_start + len("wheels = ["))
+    if wheels_end < 0:
+        return [{"name": name, "url": "", "sha256": ""}]
+
+    wheels_section = block[wheels_start:wheels_end]
+    result = []
+
+    for line in wheels_section.split("\n"):
+        if 'url = "' not in line:
+            continue
+        url = _extract_quoted(line, "url")
+        if not url:
+            continue
+        sha256 = ""
+        hash_val = _extract_quoted(line, "hash")
+        if hash_val.startswith("sha256:"):
+            sha256 = hash_val[len("sha256:"):]
+        result.append({"name": name, "url": url, "sha256": sha256})
+
+    if not result:
+        return [{"name": name, "url": "", "sha256": ""}]
+
+    return result
+
+def parse_uv_lock(content, wheels_only = True):
+    """Parse a uv.lock file and return a list of package dicts.
+
+    Args:
+        content: The raw string content of a uv.lock file.
+        wheels_only: When True (default), omit entries that have no wheel URL.
+
+    Returns:
+        A list of dicts, each with keys:
+            name   - package name as it appears in the lock file
+            url    - wheel download URL, or "" for sdist-only packages
+            sha256 - sha256 hash string (without "sha256:" prefix), or ""
+    """
+    packages = []
+    for part in content.split("[[package]]")[1:]:
+        for pkg in _parse_package_block(part):
+            if wheels_only and not pkg["url"]:
+                continue
+            packages.append(pkg)
+    return packages


### PR DESCRIPTION
Replaces the stub uv/unstable/extension.bzl (previously a one-liner alias to the    
  stable extension) with a complete, self-contained module extension that owns its own
   toolchain download, platform detection, and Gazelle integration.                   
                                                               
  New features

  Hermetic UV toolchain provisioning (uv/private/toolchain/)                          
  - uv_repository: downloads a UV binary for a specific platform from GitHub releases
  with optional SHA256 verification                                                   
  - uv_host_repository: auto-detects the host platform and provisions the correct
  binary                                                                              
  - uv_platform_repository: selects the right binary for the current Bazel execution  
  environment                                                                       
  - uv_toolchains_hub: wires all per-platform repos into a single toolchain_type hub  
  across 7 supported platforms (macOS arm/x86, Linux glibc/musl arm/x86, Windows x86)
  - New uv_tool_toolchain rule and UvToolInfo provider in                             
  uv/private/toolchain/types.bzl                               
                                                                                      
  Host libc detection (uv/private/constraints/libc/)           
  - detect_libc() function that inspects ldd --version, musl dynamic linker presence, 
  and /etc/os-release to distinguish glibc from musl at repository-fetch time         
  - libc_detector repository rule that writes the detected variant into a generated   
  defs.bzl (LIBC_VARIANT) and config_setting targets                                  
                                                                                      
  Gazelle manifest generation from uv.lock (uv/unstable/gazelle.bzl,
  uv/unstable/lock_parser.bzl)                                                        
  - gazelle_python_yaml_repository: repository rule that downloads wheels listed in
  uv.lock, inspects each wheel's top_level.txt (with directory-scan fallback) to map  
  import names → package names, and emits a gazelle_python.yaml                     
  - lock_parser.bzl: minimal uv.lock parser that extracts per-platform wheel URLs and 
  SHA256 hashes without requiring a full TOML library                                
  - Exposed as the new gazelle_manifest tag class on the unstable extension           
                                                                           
  Full uv module extension (uv/unstable/extension.bzl)                                
  - Upgraded from uv = _uv alias to a complete module_extension with six tag classes: 
  toolchain, declare_hub, project, unstable_annotate_packages, override_package,      
  gazelle_manifest                                                                    
  - Delegates dependency resolution to the stable uv_impl while adding toolchain      
  setup, libc detection, and Gazelle manifest generation on top
                                                                                      
  Tests
                                                                                      
  - //uv/unstable:inspect_wheel_test — 10 unit tests for the wheel inspection logic   
  (top_level.txt, directory scan fallback, metadata exclusion, name normalisation)
  - //uv/private/constraints/libc:detect_libc_test — 8 unit tests for the libc        
  detection heuristics via a Python mirror of the Starlark logic                      
  - //e2e/cases/uv-gazelle-unstable:test_gazelle_manifest — e2e test that exercises
  the new uv.gazelle_manifest() tag end-to-end and asserts the generated YAML contains
   the expected cowsay: cowsay mapping                         
                                                                                      
  Test plan                                                    

  - bazel test //uv/unstable:inspect_wheel_test                                       
  - bazel test //uv/private/constraints/libc:detect_libc_test
  - bazel test //... in the root workspace (all existing tests continue to pass)      
  - cd e2e && bazel test //cases/uv-gazelle-unstable:test_gazelle_manifest            
  - cd e2e && bazel test //... (full e2e suite)