### PR TITLE
fix: check `main` by resolved file basename, not label name

### DIFF
--- a/py/private/py_semantics.bzl
+++ b/py/private/py_semantics.bzl
@@ -104,8 +104,9 @@ def _determine_main(ctx):
         Artifact; the main file. If one can't be found, an error is raised.
     """
     if ctx.attr.main:
-        if not ctx.attr.main.label.name.endswith(".py"):
-            fail("main must end in '.py'")
+        # Check the resolved file, not the label name — the label may be a generator.
+        if not ctx.file.main.basename.endswith(".py"):
+            fail("main must end in '.py', got: " + ctx.file.main.basename)
 
         # Short circuit; if the user gave us a label, believe them.
         return ctx.file.main

--- a/py/tests/main-from-genrule/BUILD.bazel
+++ b/py/tests/main-from-genrule/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//py:defs.bzl", "py_binary", "py_test")
+
+# Regression: a `main = :label` whose label name doesn't end in `.py` must still
+# work when the label resolves to a `.py` file (e.g. a genrule output).
+genrule(
+    name = "gen_main",
+    outs = ["main_generated.py"],
+    cmd = "echo 'print(\"ok\")' > $@",
+)
+
+py_binary(
+    name = "main_from_genrule_bin",
+    srcs = [":gen_main"],
+    main = ":gen_main",
+)
+
+genrule(
+    name = "gen_test_main",
+    outs = ["test_main_generated.py"],
+    cmd = "echo 'def test_ok(): assert True' > $@",
+)
+
+py_test(
+    name = "main_from_genrule_test",
+    srcs = [":gen_test_main"],
+    main = ":gen_test_main",
+)


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- New test cases added
