### PR TITLE
fix: Update Gazelle integration link in migrating.md

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -8,7 +8,7 @@ Migration is a "drop-in replacement" for the majority of use cases.
 Instead of loading from `@rules_python//python:defs.bzl`, load from `@aspect_rules_py//py:defs.bzl`.
 The rest of the BUILD file can remain the same.
 
-If using Gazelle, see the note on [using with Gazelle](/README.md#using-with-gazelle)
+If using Gazelle, see the note on [using with Gazelle](/README.md#gazelle-integration)
 
 ## Remaining notes
 


### PR DESCRIPTION
Fix broken link in docs. Since you have a `.pre-commit-config.yaml`, you might want to add https://github.com/hofbi/bazel-ide/blob/0f3a63d0c3b0462726f753e3ba8cbe176acdd3ec/.pre-commit-config.yaml#L174C1-L178C62 which should prevent these links from ever getting outdated.

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
