### PR TITLE
refactor: extract pth file creation and imports depset into reusable pth.bzl helpers

### DIFF
--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -31,9 +31,15 @@ bzl_library(
 )
 
 bzl_library(
+    name = "pth",
+    srcs = ["pth.bzl"],
+)
+
+bzl_library(
     name = "py_binary",
     srcs = ["py_binary.bzl"],
     deps = [
+        ":pth",
         ":py_library",
         "@bazel_lib//lib:expand_make_vars",
         "@bazel_lib//lib:paths",

--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -33,6 +33,10 @@ bzl_library(
 bzl_library(
     name = "pth",
     srcs = ["pth.bzl"],
+    deps = [
+        "@bazel_skylib//lib:paths",
+        "@rules_python//python:defs_bzl",
+    ],
 )
 
 bzl_library(
@@ -51,10 +55,10 @@ bzl_library(
     srcs = ["py_library.bzl"],
     deps = [
         ":providers",
+        ":pth",
         ":py_semantics",
         ":py_wheel",
         "@bazel_skylib//lib:new_sets",
-        "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:types",
         "@rules_python//python:defs_bzl",
     ],
@@ -87,6 +91,7 @@ bzl_library(
     name = "py_unpacked_wheel",
     srcs = ["py_unpacked_wheel.bzl"],
     deps = [
+        ":pth",
         ":py_library",
         ":py_semantics",
         "//py/private/toolchain:types",

--- a/py/private/pth.bzl
+++ b/py/private/pth.bzl
@@ -38,6 +38,16 @@ def _make_import_path(label, workspace, imp):
 def make_imports_depset(deps, imports, workspace_name, label = None, extra_imports_depsets = []):
     """Build an imports depset from PyInfo providers and explicit import paths.
 
+    This helper merges transitive imports from `deps` and resolves any relative
+    `imports` against the target's package. It also automatically appends the
+    workspace root so that repo-relative imports work:
+
+    - The current `workspace_name` is always appended.
+    - If `label` is provided and it originates from an external workspace,
+      `label.workspace_name` is appended as well.
+
+    This means callers do not need to manually add the workspace root.
+
     Args:
         deps: List of targets that provide PyInfo. Their transitive imports are merged.
         imports: List of explicit import path strings. Relative paths (e.g. "..")
@@ -57,10 +67,8 @@ def make_imports_depset(deps, imports, workspace_name, label = None, extra_impor
     else:
         import_paths = list(imports)
 
-    # Add the workspace name in the imports such that repo-relative imports work.
     import_paths.append(workspace_name)
 
-    # Handle the case where its a target from an external workspace that uses repo-relative imports
     if label and label.workspace_name:
         import_paths.append(label.workspace_name)
 
@@ -75,6 +83,21 @@ def make_imports_depset(deps, imports, workspace_name, label = None, extra_impor
 
 def write_pth_file(ctx, name, imports_depset, escape = None):
     """Create a .pth file from an imports depset.
+
+    A `.pth` file is dropped into the venv's `site-packages` directory so that
+    the interpreter adds those directories to `sys.path` at startup.
+
+    When `escape` is provided, it is prepended to every import path and also
+    written as the first line of the file. This is used by `py_binary` because
+    the `.pth` file lives deep inside the venv tree, e.g.:
+
+        {name}.runfiles/.{name}.venv/lib/python{version}/site-packages/{name}.pth
+
+    The `escape` value is the relative path from `site-packages` back to the
+    runfiles root (e.g. `../../../../..`). By writing it as the first line, the
+    runfiles root itself becomes importable, which is required by a few targets
+    (notably `@rules_python//python/runfiles`) that rely on the root being on
+    `sys.path` but have no `imports` attribute to hint that they need it.
 
     Args:
         ctx: The rule context.

--- a/py/private/pth.bzl
+++ b/py/private/pth.bzl
@@ -1,0 +1,32 @@
+"""Helper functions for creating Python .pth files."""
+
+def write_pth_file(ctx, name, imports_depset, escape = None):
+    """Create a .pth file from an imports depset.
+
+    Args:
+        ctx: The rule context.
+        name: Base name for the output file (`{name}.pth`).
+        imports_depset: A depset of strings containing import paths.
+        escape: Optional prefix to prepend to each import path. Also written as
+            the first line of the file. For py_binary-style rules, this should be
+            the relative path from site-packages to the runfiles root.
+
+    Returns:
+        The declared File for the .pth file.
+    """
+    pth_lines = ctx.actions.args()
+    pth_lines.use_param_file("%s", use_always = True)
+    pth_lines.set_param_file_format("multiline")
+
+    if escape:
+        pth_lines.add(escape)
+        pth_lines.add_all(imports_depset, format_each = "{}/%s".format(escape))
+    else:
+        pth_lines.add_all(imports_depset)
+
+    pth_file = ctx.actions.declare_file("{}.pth".format(name))
+    ctx.actions.write(
+        output = pth_file,
+        content = pth_lines,
+    )
+    return pth_file

--- a/py/private/pth.bzl
+++ b/py/private/pth.bzl
@@ -1,4 +1,77 @@
-"""Helper functions for creating Python .pth files."""
+"""Helper functions for creating Python .pth files and building imports depsets."""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_python//python:defs.bzl", "PyInfo")
+
+def _make_import_path(label, workspace, imp):
+    if imp.startswith("/"):
+        fail(
+            "Import path '{imp}' on target {target} is invalid. Absolute paths are not supported.".format(
+                imp = imp,
+                target = str(label),
+            ),
+        )
+
+    base_segments = label.package.split("/")
+    path_segments = imp.split("/")
+
+    relative_segments = 0
+    for segment in path_segments:
+        if segment == "..":
+            relative_segments += 1
+        else:
+            break
+
+    if relative_segments == (len(base_segments) + 1):
+        fail(
+            "Import path '{imp}' on target {target} is invalid. Import paths must not escape the workspace root".format(
+                imp = imp,
+                target = str(label),
+            ),
+        )
+
+    if imp.startswith(".."):
+        return paths.normalize(paths.join(workspace, *(base_segments[0:-relative_segments] + path_segments[relative_segments:])))
+    else:
+        return paths.normalize(paths.join(workspace, label.package, imp))
+
+def make_imports_depset(deps, imports, workspace_name, label = None, extra_imports_depsets = []):
+    """Build an imports depset from PyInfo providers and explicit import paths.
+
+    Args:
+        deps: List of targets that provide PyInfo. Their transitive imports are merged.
+        imports: List of explicit import path strings. Relative paths (e.g. "..")
+            are resolved against the label's package if label is provided.
+        workspace_name: The workspace name to include for repo-relative imports.
+        label: Optional label used to resolve relative import paths.
+        extra_imports_depsets: Additional depsets of imports to merge.
+
+    Returns:
+        A depset of import path strings.
+    """
+    if label:
+        import_paths = [
+            _make_import_path(label, label.workspace_name or workspace_name, im)
+            for im in imports
+        ]
+    else:
+        import_paths = list(imports)
+
+    # Add the workspace name in the imports such that repo-relative imports work.
+    import_paths.append(workspace_name)
+
+    # Handle the case where its a target from an external workspace that uses repo-relative imports
+    if label and label.workspace_name:
+        import_paths.append(label.workspace_name)
+
+    return depset(
+        direct = import_paths,
+        transitive = [
+            target[PyInfo].imports
+            for target in deps
+            if PyInfo in target
+        ] + extra_imports_depsets,
+    )
 
 def write_pth_file(ctx, name, imports_depset, escape = None):
     """Create a .pth file from an imports depset.

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -3,7 +3,7 @@
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@rules_python//python:defs.bzl", "PyInfo")
-load("//py/private:pth.bzl", "write_pth_file")
+load("//py/private:pth.bzl", "make_imports_depset", "write_pth_file")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "VENV_TOOLCHAIN")
@@ -24,7 +24,13 @@ def _py_binary_rule_impl(ctx):
 
     # Check for duplicate virtual dependency names. Those that map to the same resolution target would have been merged by the depset for us.
     virtual_resolution = _py_library.resolve_virtuals(ctx)
-    imports_depset = _py_library.make_imports_depset(ctx, extra_imports_depsets = virtual_resolution.imports)
+    imports_depset = make_imports_depset(
+        deps = ctx.attr.deps,
+        imports = getattr(ctx.attr, "imports", []),
+        workspace_name = ctx.workspace_name,
+        label = ctx.label,
+        extra_imports_depsets = virtual_resolution.imports,
+    )
 
     # The venv is created at the root in the runfiles tree, in 'VENV_NAME', the full path is "${RUNFILES_DIR}/${VENV_NAME}",
     # but depending on if we are running as the top level binary or a tool, then $RUNFILES_DIR may be absolute or relative.

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -32,6 +32,11 @@ def _py_binary_rule_impl(ctx):
         extra_imports_depsets = virtual_resolution.imports,
     )
 
+    # All "import" paths from `py_library` start with the workspace name, so we need to go back up the tree for
+    # each segment from site-packages in the venv to the root of the runfiles tree.
+    # Five .. will get us back to the root of the venv:
+    # {name}.runfiles/.{name}.venv/lib/python{version}/site-packages/first_party.pth
+    # If the target is defined with a slash, it adds to the level of nesting
     target_depth = len(ctx.label.name.split("/")) - 1
     escape = "/".join(([".."] * (4 + target_depth)))
 

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -32,22 +32,9 @@ def _py_binary_rule_impl(ctx):
         extra_imports_depsets = virtual_resolution.imports,
     )
 
-    # The venv is created at the root in the runfiles tree, in 'VENV_NAME', the full path is "${RUNFILES_DIR}/${VENV_NAME}",
-    # but depending on if we are running as the top level binary or a tool, then $RUNFILES_DIR may be absolute or relative.
-    # Paths in the .pth are relative to the site-packages folder where they reside.
-    # All "import" paths from `py_library` start with the workspace name, so we need to go back up the tree for
-    # each segment from site-packages in the venv to the root of the runfiles tree.
-    # Five .. will get us back to the root of the venv:
-    # {name}.runfiles/.{name}.venv/lib/python{version}/site-packages/first_party.pth
-    # If the target is defined with a slash, it adds to the level of nesting
     target_depth = len(ctx.label.name.split("/")) - 1
     escape = "/".join(([".."] * (4 + target_depth)))
 
-    # A few imports rely on being able to reference the root of the runfiles tree as a Python module,
-    # the common case here being the @rules_python//python/runfiles target that adds the runfiles helper,
-    # which ends up in bazel_tools/tools/python/runfiles/runfiles.py, but there are no imports attrs that hint we
-    # should be adding the root to the PYTHONPATH
-    # Maybe in the future we can opt out of this?
     site_packages_pth_file = write_pth_file(ctx, ctx.attr.name, imports_depset, escape)
 
     default_env = {

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -3,6 +3,7 @@
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py/private:pth.bzl", "write_pth_file")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "VENV_TOOLCHAIN")
@@ -25,10 +26,6 @@ def _py_binary_rule_impl(ctx):
     virtual_resolution = _py_library.resolve_virtuals(ctx)
     imports_depset = _py_library.make_imports_depset(ctx, extra_imports_depsets = virtual_resolution.imports)
 
-    pth_lines = ctx.actions.args()
-    pth_lines.use_param_file("%s", use_always = True)
-    pth_lines.set_param_file_format("multiline")
-
     # The venv is created at the root in the runfiles tree, in 'VENV_NAME', the full path is "${RUNFILES_DIR}/${VENV_NAME}",
     # but depending on if we are running as the top level binary or a tool, then $RUNFILES_DIR may be absolute or relative.
     # Paths in the .pth are relative to the site-packages folder where they reside.
@@ -45,15 +42,7 @@ def _py_binary_rule_impl(ctx):
     # which ends up in bazel_tools/tools/python/runfiles/runfiles.py, but there are no imports attrs that hint we
     # should be adding the root to the PYTHONPATH
     # Maybe in the future we can opt out of this?
-    pth_lines.add(escape)
-
-    pth_lines.add_all(imports_depset, format_each = "{}/%s".format(escape))
-
-    site_packages_pth_file = ctx.actions.declare_file("{}.pth".format(ctx.attr.name))
-    ctx.actions.write(
-        output = site_packages_pth_file,
-        content = pth_lines,
-    )
+    site_packages_pth_file = write_pth_file(ctx, ctx.attr.name, imports_depset, escape)
 
     default_env = {
         "BAZEL_TARGET": str(ctx.label).lstrip("@"),

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -5,10 +5,10 @@ without binding them to a particular version of that package.
 """
 
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:providers.bzl", "PyVirtualInfo")
+load("//py/private:pth.bzl", "make_imports_depset")
 
 def _make_instrumented_files_info(ctx, extra_source_attributes = [], extra_dependency_attributes = []):
     return coverage_common.instrumented_files_info(
@@ -98,61 +98,13 @@ def _resolve_virtuals(ctx, ignore_missing = False):
         missing = missing,
     )
 
-def _make_import_path(label, workspace, imp):
-    if imp.startswith("/"):
-        fail(
-            "Import path '{imp}' on target {target} is invalid. Absolute paths are not supported.".format(
-                imp = imp,
-                target = str(label),
-            ),
-        )
-
-    base_segments = label.package.split("/")
-    path_segments = imp.split("/")
-
-    relative_segments = 0
-    for segment in path_segments:
-        if segment == "..":
-            relative_segments += 1
-        else:
-            break
-
-    # Check if the relative segments that the import path starts with match the number of segments in the base path
-    # that would break use out of the workspace root.
-    # The +1 is base_segments would take the path to the root, then one more to escape.
-    if relative_segments == (len(base_segments) + 1):
-        fail(
-            "Import path '{imp}' on target {target} is invalid. Import paths must not escape the workspace root".format(
-                imp = imp,
-                target = str(label),
-            ),
-        )
-
-    if imp.startswith(".."):
-        return paths.normalize(paths.join(workspace, *(base_segments[0:-relative_segments] + path_segments[relative_segments:])))
-    else:
-        return paths.normalize(paths.join(workspace, label.package, imp))
-
 def _make_imports_depset(ctx, imports = [], extra_imports_depsets = []):
-    import_paths = [
-        _make_import_path(ctx.label, ctx.label.workspace_name or ctx.workspace_name, im)
-        for im in getattr(ctx.attr, "imports", imports)
-    ] + [
-        # Add the workspace name in the imports such that repo-relative imports work.
-        ctx.workspace_name,
-    ]
-
-    # Handle the case where its a target from an external workspace that uses repo-relative imports
-    if ctx.label.workspace_name:
-        import_paths.append(ctx.label.workspace_name)
-
-    return depset(
-        direct = import_paths,
-        transitive = [
-            target[PyInfo].imports
-            for target in getattr(ctx.attr, "deps", [])
-            if PyInfo in target
-        ] + extra_imports_depsets,
+    return make_imports_depset(
+        deps = getattr(ctx.attr, "deps", []),
+        imports = getattr(ctx.attr, "imports", imports),
+        workspace_name = ctx.workspace_name,
+        label = ctx.label,
+        extra_imports_depsets = extra_imports_depsets,
     )
 
 def _make_merged_runfiles(ctx, extra_depsets = [], extra_runfiles = [], extra_runfiles_depsets = []):

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py/private:pth.bzl", "make_imports_depset")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "UNPACK_TOOLCHAIN")
@@ -39,7 +40,12 @@ def _py_unpacked_wheel_impl(ctx):
         ),
         "site-packages",
     )
-    imports = _py_library.make_imports_depset(ctx, imports = [import_path])
+    imports = make_imports_depset(
+        deps = getattr(ctx.attr, "deps", []),
+        imports = [import_path],
+        workspace_name = ctx.workspace_name,
+        label = ctx.label,
+    )
 
     return [
         DefaultInfo(

--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -49,8 +49,8 @@ bzl_library(
     ],
     deps = [
         ":types.bzl",
-        "//py/private:pth",
         "//py/private:providers",
+        "//py/private:pth",
         "//py/private:py_library",
         "//py/private:py_semantics",
         "//py/private:transitions",

--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -49,6 +49,7 @@ bzl_library(
     ],
     deps = [
         ":types.bzl",
+        "//py/private:pth",
         "//py/private:providers",
         "//py/private:py_library",
         "//py/private:py_semantics",

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -64,7 +64,6 @@ def _py_venv_base_impl(ctx):
     # Check for duplicate virtual dependency names. Those that map to the same resolution target would have been merged by the depset for us.
     virtual_resolution = _py_library.resolve_virtuals(ctx)
 
-    # Note that this adds the workspace root for us (sigh), don't need to add to it
     imports_depset = make_imports_depset(
         deps = ctx.attr.deps,
         imports = getattr(ctx.attr, "imports", []),

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -3,6 +3,7 @@
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//py/private:pth.bzl", "write_pth_file")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_version_transition")
@@ -66,16 +67,7 @@ def _py_venv_base_impl(ctx):
     # Note that this adds the workspace root for us (sigh), don't need to add to it
     imports_depset = _py_library.make_imports_depset(ctx, extra_imports_depsets = virtual_resolution.imports)
 
-    pth_lines = ctx.actions.args()
-    pth_lines.use_param_file("%s", use_always = True)
-    pth_lines.set_param_file_format("multiline")
-    pth_lines.add_all(imports_depset)
-
-    site_packages_pth_file = ctx.actions.declare_file("{}.pth".format(ctx.attr.name))
-    ctx.actions.write(
-        output = site_packages_pth_file,
-        content = pth_lines,
-    )
+    site_packages_pth_file = write_pth_file(ctx, ctx.attr.name, imports_depset)
 
     env_file = ctx.actions.declare_file("{}.env".format(ctx.attr.name))
 

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -3,7 +3,7 @@
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("//py/private:pth.bzl", "write_pth_file")
+load("//py/private:pth.bzl", "make_imports_depset", "write_pth_file")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_version_transition")
@@ -65,7 +65,13 @@ def _py_venv_base_impl(ctx):
     virtual_resolution = _py_library.resolve_virtuals(ctx)
 
     # Note that this adds the workspace root for us (sigh), don't need to add to it
-    imports_depset = _py_library.make_imports_depset(ctx, extra_imports_depsets = virtual_resolution.imports)
+    imports_depset = make_imports_depset(
+        deps = ctx.attr.deps,
+        imports = getattr(ctx.attr, "imports", []),
+        workspace_name = ctx.workspace_name,
+        label = ctx.label,
+        extra_imports_depsets = virtual_resolution.imports,
+    )
 
     site_packages_pth_file = write_pth_file(ctx, ctx.attr.name, imports_depset)
 


### PR DESCRIPTION
Both `py_binary` and `py_venv` contained duplicated logic for:
1. Building an `imports_depset` from `PyInfo` providers, explicit imports, and workspace names.
2. Serializing that depset into a `.pth` file.

This complexity was internal to `py_library.bzl` and had to be replicated by any rule author wanting to generate `.pth` files and invoke the venv rust tool directly.

### Changes

- **Added `py/private/pth.bzl`** with two public helpers:
  - `make_imports_depset(deps, imports, workspace_name, label, extra_imports_depsets)` — Builds an `imports_depset` from `PyInfo` providers and explicit import paths. Handles relative import resolution (e.g. `".."`), workspace root validation, and repo-relative imports.
  - `write_pth_file(ctx, name, imports_depset, escape)` — Creates the `.pth` file (unchanged from first iteration).

- **Refactored `py/private/py_library.bzl`** — The existing `_make_imports_depset` now delegates to `make_imports_depset` from `pth.bzl`, preserving backward compatibility with existing tests that pass a fake `ctx`.

- **Refactored `py/private/py_binary.bzl`**, **`py/private/py_venv/py_venv.bzl`**, and **`py/private/py_unpacked_wheel.bzl`** — All now call `make_imports_depset` directly from `pth.bzl` instead of going through `py_library_utils`.

- **Updated BUILD files** — Added `bzl_library` `:pth` and wired dependencies for `:py_library`, `:py_binary`, `:py_unpacked_wheel`, and `:py_venv`.

### API for rule authors

```starlark
load("//py/private:pth.bzl", "make_imports_depset", "write_pth_file")

def _my_rule_impl(ctx):
    imports_depset = make_imports_depset(
        deps = ctx.attr.deps,
        imports = ctx.attr.imports,
        workspace_name = ctx.workspace_name,
        label = ctx.label,
    )
    pth_file = write_pth_file(ctx, ctx.attr.name, imports_depset)
    # Pass pth_file to the venv rust tool via --pth-file
```

### Verification

- **Root workspace**: `bazel test //... --nobuild` — 8826 targets analyzed without errors.
- **Root tests**: 12/12 relevant tests passed (import-pathing, py_venv, external-deps, py-test).
- **E2E tests**: 12/13 passed (1 platform-specific skip). Key pth and pytest tests all green.