### PR TITLE
py_binary / py_test venv integration + external_venv + expose_venv

### DIFF
--- a/e2e/cases/interpreter-features-836/BUILD.bazel
+++ b/e2e/cases/interpreter-features-836/BUILD.bazel
@@ -23,6 +23,7 @@ py_venv_binary(
     main = "__main__.py",
     tags = ["manual"],
     venv = "no-turtle-test",
+    venv_dir_basename = ".no-turtle-test",
 )
 
 py_image_layer(

--- a/e2e/cases/root-dir-paths-538/BUILD.bazel
+++ b/e2e/cases/root-dir-paths-538/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
-# py_binary uses run.tmpl.sh which has the alocation bug
 py_binary(
     name = "check_paths_bin",
     srcs = ["check_paths.py"],
@@ -10,12 +8,30 @@ py_binary(
     python_version = "3.11",
 )
 
-# py_venv_binary uses a different startup path — test it too
-py_venv_binary(
-    name = "check_paths_venv_bin",
+# Same test as above but with `expose_venv = True` — exercises the
+# splitting codepath (hidden `_<name>_venv` py_venv + binary rule
+# consuming it via external_venv).
+py_binary(
+    name = "check_paths_expose_venv",
     srcs = ["check_paths.py"],
+    expose_venv = True,
     main = "check_paths.py",
     python_version = "3.11",
+)
+
+# Full legacy-shape variant: expose_venv + isolated=False + the
+# legacy `.{name}/` venv_dir_basename — the exact settings users
+# migrating off py_venv_binary are told to set. Keeps regression
+# coverage for that specific combination through the root-dir-paths
+# test harness.
+py_binary(
+    name = "check_paths_via_venv_macro",
+    srcs = ["check_paths.py"],
+    expose_venv = True,
+    isolated = False,
+    main = "check_paths.py",
+    python_version = "3.11",
+    venv_dir_basename = ".check_paths_via_venv_macro",
 )
 
 sh_test(
@@ -25,7 +41,13 @@ sh_test(
 )
 
 sh_test(
+    name = "test_root_dir_expose_venv",
+    srcs = ["test_root_dir_expose_venv.sh"],
+    data = [":check_paths_expose_venv"],
+)
+
+sh_test(
     name = "test_root_dir_venv",
     srcs = ["test_root_dir_venv.sh"],
-    data = [":check_paths_venv_bin"],
+    data = [":check_paths_via_venv_macro"],
 )

--- a/e2e/cases/root-dir-paths-538/test_root_dir_expose_venv.sh
+++ b/e2e/cases/root-dir-paths-538/test_root_dir_expose_venv.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Same regression shape as test_root_dir_venv.sh, but against a binary
+# declared with `py_binary(expose_venv = True, ...)` — exercises the
+# split codepath directly (no py_venv_binary alias in the middle).
+BINARY="$(cd "$TEST_SRCDIR/_main/cases/root-dir-paths-538" && pwd)/check_paths_expose_venv"
+
+cd /
+exec "$BINARY"

--- a/e2e/cases/root-dir-paths-538/test_root_dir_venv.sh
+++ b/e2e/cases/root-dir-paths-538/test_root_dir_venv.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # run.tmpl.sh captures PWD="$(pwd)" which will be "/", and then uses
 # alocation to make RUNFILES_DIR-relative paths absolute.  Even with
 # absolute RUNFILES_DIR, check that no paths leak double slashes.
-BINARY="$(cd "$TEST_SRCDIR/_main/cases/root-dir-paths-538" && pwd)/check_paths_venv_bin"
+BINARY="$(cd "$TEST_SRCDIR/_main/cases/root-dir-paths-538" && pwd)/check_paths_via_venv_macro"
 
 cd /
 exec "$BINARY"

--- a/e2e/cases/venv-bin-scripts-423/BUILD.bazel
+++ b/e2e/cases/venv-bin-scripts-423/BUILD.bazel
@@ -1,11 +1,25 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = ["__test__.py"],
     main = "__test__.py",
     python_version = "3.11",
     venv = "venv-bin-scripts-423",
+    deps = [
+        "@pypi//dice",
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = ["__test__.py"],
+    expose_venv = True,
+    isolated = False,
+    main = "__test__.py",
+    python_version = "3.11",
+    venv = "venv-bin-scripts-423",
+    venv_dir_basename = ".venv_test",
     deps = [
         "@pypi//dice",
     ],

--- a/e2e/cases/venv-conflict-608/BUILD.bazel
+++ b/e2e/cases/venv-conflict-608/BUILD.bazel
@@ -1,16 +1,18 @@
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
+# Regression test for #608 and #686: building a `py_binary` AND its
+# sibling `<name>.venv` target in the same invocation must not action-
+# conflict on any shared output. In v2.0.0 the `.venv` sibling is
+# opt-in via `expose_venv = True` rather than auto-generated; the
+# same invariant still holds.
 py_binary(
     name = "app",
     srcs = ["app.py"],
+    expose_venv = True,
     python_version = "3.11",
 )
 
-# Regression test for https://github.com/aspect-build/rules_py/issues/608
-# and https://github.com/aspect-build/rules_py/issues/686.
-# Building a py_binary and its auto-generated .venv target in the same
-# invocation must not produce an action conflict on <name>.venv.pth.
 build_test(
     name = "test_no_venv_conflict",
     targets = [

--- a/e2e/cases/venv-internal-symlinks/BUILD.bazel
+++ b/e2e/cases/venv-internal-symlinks/BUILD.bazel
@@ -1,12 +1,14 @@
 load("@aspect_rules_py//py:defs.bzl", "py_test")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 
-py_venv_test(
+py_test(
     name = "test_internal_symlinks",
     srcs = ["test_babel.py"],
+    expose_venv = True,
+    isolated = False,
     main = "test_babel.py",
     python_version = "3.11",
     venv = "venv-internal-symlinks",
+    venv_dir_basename = ".test_internal_symlinks",
     deps = [
         "@pypi//babel",
     ],

--- a/e2e/cases/venv-isolated-mode-703/BUILD.bazel
+++ b/e2e/cases/venv-isolated-mode-703/BUILD.bazel
@@ -1,9 +1,12 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = ["__test__.py"],
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     python_version = "3.11",
     venv = "venv-isolated-mode-703",
+    venv_dir_basename = ".test",
 )

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -20,7 +20,7 @@ bzl_library(
         "//py/private:py_unpacked_wheel",
         "//py/private:py_wheel",
         "//py/private:virtual",
-        "//py/private/py_venv",
+        "//py/private/py_venv:defs",
         "@bazel_lib//lib:utils",
     ],
 )

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -20,22 +20,19 @@ bzl_library(
         "//py/private:py_unpacked_wheel",
         "//py/private:py_wheel",
         "//py/private:virtual",
-        "//py/private/py_venv:defs",
+        "//py/private/py_venv",
         "@bazel_lib//lib:utils",
     ],
 )
 
-bzl_library(
-    name = "extensions",
-    srcs = ["extensions.bzl"],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":toolchains",
-        "//py/private/release:version",
-        "@aspect_tools_telemetry_report//:defs.bzl",
-        "@bazel_features//:features",
-    ],
-)
+# No bzl_library for extensions.bzl: loading from
+# //py/private/interpreter:extension.bzl would require declaring the
+# full transitive bzl_library chain (repository / version_util /
+# versions / bazel_features / rules_python / …) just so
+# `starlark_doc_extract` (which `bzl_library` generates as a sibling)
+# resolves. `load()` works without bzl_library regardless, and
+# nothing in-repo depends on //py:extensions as a bzl_library target.
+exports_files(["extensions.bzl"])
 
 bzl_library(
     name = "toolchains",

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -42,13 +42,17 @@ load("//py/private:py_pex_binary.bzl", _py_pex_binary = "py_pex_binary")
 load("//py/private:py_pytest_main.bzl", _py_pytest_main = "py_pytest_main", _pytest_paths = "pytest_paths")
 load("//py/private:py_unpacked_wheel.bzl", _py_unpacked_wheel = "py_unpacked_wheel")
 load("//py/private:virtual.bzl", _resolutions = "resolutions")
-load("//py/private/py_venv:defs.bzl", _py_venv_link = "py_venv_link")
+load(
+    "//py/private/py_venv:py_venv.bzl",
+    _py_binary_with_venv = "py_binary_with_venv",
+    _py_venv = "py_venv",
+    _py_venv_link = "py_venv_link",
+)
 
 py_pex_binary = _py_pex_binary
 py_pytest_main = _py_pytest_main
 
-# FIXME: Badly chosen name; will be replaced/migrated
-py_venv = _py_venv_link
+py_venv = _py_venv
 py_venv_link = _py_venv_link
 
 py_binary_rule = _py_binary
@@ -60,7 +64,28 @@ py_image_layer = _py_image_layer
 
 resolutions = _resolutions
 
-def _py_binary_or_test(name, rule, srcs, main, data = [], deps = [], **kwargs):
+def _py_binary_or_test(name, rule, srcs, main, data = [], deps = [], expose_venv = False, venv_dir_basename = None, **kwargs):
+    if expose_venv:
+        # Split into a sibling `:{name}.venv` py_venv + a rule call
+        # consuming it via `external_venv`. The `.venv` target is
+        # first-class: shareable across binaries and runnable to drop
+        # into the interpreter. See `py_binary_with_venv` for the
+        # attribute split.
+        _py_binary_with_venv(
+            rule,
+            name = name,
+            srcs = srcs,
+            main = main,
+            data = data,
+            deps = deps,
+            venv_dir_basename = venv_dir_basename,
+            **kwargs
+        )
+        return
+
+    if venv_dir_basename != None:
+        fail("venv_dir_basename requires expose_venv = True (no venv target is created otherwise)")
+
     rule(
         name = name,
         srcs = srcs,
@@ -70,23 +95,14 @@ def _py_binary_or_test(name, rule, srcs, main, data = [], deps = [], **kwargs):
         **kwargs
     )
 
-    _py_venv_link(
-        name = "{}.venv".format(name),
-        srcs = srcs,
-        data = data,
-        deps = deps,
-        imports = kwargs.get("imports"),
-        tags = ["manual"],
-        testonly = kwargs.get("testonly", False),
-        target_compatible_with = kwargs.get("target_compatible_with", []),
-        package_collisions = kwargs.get("package_collisions"),
-    )
-
 def py_binary(name, srcs = [], main = None, **kwargs):
     """Wrapper macro for [`py_binary_rule`](#py_binary_rule).
 
-    Creates a [py_venv](./venv.md) target to constrain the interpreter and packages used at runtime.
-    Users can `bazel run [name].venv` to create this virtualenv, then use it in the editor or other tools.
+    By default builds one target: the binary with an internal
+    analysis-time venv. Set `expose_venv = True` to also emit a
+    first-class sibling `:{name}.venv` py_venv — shareable across
+    multiple binaries via `external_venv`, and runnable
+    (`bazel run :{name}.venv`) to drop into the hermetic interpreter.
 
     Args:
         name: Name of the rule.
@@ -95,7 +111,22 @@ def py_binary(name, srcs = [], main = None, **kwargs):
             Like rules_python, this is treated as a suffix of a file that should appear among the srcs.
             If absent, then `[name].py` is tried. As a final fallback, if the srcs has a single file,
             that is used as the main.
-        **kwargs: additional named parameters to `py_binary_rule`.
+        **kwargs: additional named parameters to `py_binary_rule`. Two
+            extras handled by this macro:
+
+            * `expose_venv` (bool, default `False`) — when `True`, emit
+              a sibling `:{name}.venv` py_venv carrying all venv-shaping
+              attrs (deps, imports, package_collisions,
+              include_*_site_packages, interpreter_options). The binary
+              consumes it via `external_venv`. The `.venv` target is
+              shareable (another `py_binary(external_venv = ":{name}.venv")`
+              can point at it) and runnable (drops into interpreter).
+              To also materialise the venv as a workspace-local symlink
+              for IDE integration, declare an explicit `py_venv_link(
+              name = "...", venv = ":{name}.venv")` target.
+            * `venv_dir_basename` (str) — only valid with
+              `expose_venv = True`. Controls the on-disk basename of
+              the generated venv.
     """
 
     # For a clearer DX when updating resolutions, the resolutions dict is "string" -> "label",

--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -8,6 +8,9 @@ exports_files(
         "run.tmpl.sh",
         "pytest.py.tmpl",
         "pytest_main.py",
+        "venv_activate.tmpl.sh",
+        "_virtualenv.py",
+        "modify_mtree.awk",
     ],
     visibility = ["//visibility:public"],
 )
@@ -24,10 +27,16 @@ bzl_library(
     name = "py_image_layer",
     srcs = ["py_image_layer.bzl"],
     deps = [
+        ":mtree_preserve_symlinks",
         "@bazel_lib//lib:transitions",
         "@tar.bzl//tar:mtree",
         "@tar.bzl//tar:tar",
     ],
+)
+
+bzl_library(
+    name = "mtree_preserve_symlinks",
+    srcs = ["mtree_preserve_symlinks.bzl"],
 )
 
 bzl_library(
@@ -48,6 +57,12 @@ bzl_library(
         "@bazel_lib//lib:expand_make_vars",
         "@bazel_lib//lib:paths",
     ],
+)
+
+bzl_library(
+    name = "venv",
+    srcs = ["venv.bzl"],
+    deps = [":py_library"],
 )
 
 bzl_library(

--- a/py/private/_virtualenv.py
+++ b/py/private/_virtualenv.py
@@ -1,0 +1,101 @@
+"""Patches that are applied at runtime to the virtual environment."""
+
+import os
+import sys
+
+VIRTUALENV_PATCH_FILE = os.path.join(__file__)
+
+
+def patch_dist(dist):
+    """
+    Distutils allows user to configure some arguments via a configuration file:
+    https://docs.python.org/3.11/install/index.html#distutils-configuration-files.
+
+    Some of this arguments though don't make sense in context of the virtual environment files, let's fix them up.
+    """  # noqa: D205
+    # we cannot allow some install config as that would get packages installed outside of the virtual environment
+    old_parse_config_files = dist.Distribution.parse_config_files
+
+    def parse_config_files(self, *args, **kwargs):
+        result = old_parse_config_files(self, *args, **kwargs)
+        install = self.get_option_dict("install")
+
+        if "prefix" in install:  # the prefix governs where to install the libraries
+            install["prefix"] = VIRTUALENV_PATCH_FILE, os.path.abspath(sys.prefix)
+        for base in ("purelib", "platlib", "headers", "scripts", "data"):
+            key = f"install_{base}"
+            if key in install:  # do not allow global configs to hijack venv paths
+                install.pop(key, None)
+        return result
+
+    dist.Distribution.parse_config_files = parse_config_files
+
+
+# Import hook that patches some modules to ignore configuration values that break package installation in case
+# of virtual environments.
+_DISTUTILS_PATCH = "distutils.dist", "setuptools.dist"
+# https://docs.python.org/3/library/importlib.html#setting-up-an-importer
+
+
+class _Finder:
+    """A meta path finder that allows patching the imported distutils modules."""
+
+    fullname = None
+
+    # lock[0] is threading.Lock(), but initialized lazily to avoid importing threading very early at startup,
+    # because there are gevent-based applications that need to be first to import threading by themselves.
+    # See https://github.com/pypa/virtualenv/issues/1895 for details.
+    lock = []  # noqa: RUF012
+
+    def find_spec(self, fullname, path, target=None):  # noqa: ARG002
+        if fullname in _DISTUTILS_PATCH and self.fullname is None:
+            # initialize lock[0] lazily
+            if len(self.lock) == 0:
+                import threading
+
+                lock = threading.Lock()
+                # there is possibility that two threads T1 and T2 are simultaneously running into find_spec,
+                # observing .lock as empty, and further going into hereby initialization. However due to the GIL,
+                # list.append() operation is atomic and this way only one of the threads will "win" to put the lock
+                # - that every thread will use - into .lock[0].
+                # https://docs.python.org/3/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe
+                self.lock.append(lock)
+
+            from functools import partial
+            from importlib.util import find_spec
+
+            with self.lock[0]:
+                self.fullname = fullname
+                try:
+                    spec = find_spec(fullname, path)
+                    if spec is not None:
+                        # https://www.python.org/dev/peps/pep-0451/#how-loading-will-work
+                        is_new_api = hasattr(spec.loader, "exec_module")
+                        func_name = "exec_module" if is_new_api else "load_module"
+                        old = getattr(spec.loader, func_name)
+                        func = self.exec_module if is_new_api else self.load_module
+                        if old is not func:
+                            try:  # noqa: SIM105
+                                setattr(spec.loader, func_name, partial(func, old))
+                            except AttributeError:
+                                pass  # C-Extension loaders are r/o such as zipimporter with <3.7
+                        return spec
+                finally:
+                    self.fullname = None
+        return None
+
+    @staticmethod
+    def exec_module(old, module):
+        old(module)
+        if module.__name__ in _DISTUTILS_PATCH:
+            patch_dist(module)
+
+    @staticmethod
+    def load_module(old, name):
+        module = old(name)
+        if module.__name__ in _DISTUTILS_PATCH:
+            patch_dist(module)
+        return module
+
+
+sys.meta_path.insert(0, _Finder())

--- a/py/private/modify_mtree.awk
+++ b/py/private/modify_mtree.awk
@@ -1,0 +1,169 @@
+# Rewrites mtree rows whose `content=` path is actually a symlink into
+# `type=link` rows, so bsdtar preserves them as symlinks instead of
+# following and inlining the target bytes.
+#
+# Forked from @tar.bzl//tar/private:preserve_symlinks.awk. Three
+# behavioural differences, each proposed upstream as
+# https://github.com/bazel-contrib/tar.bzl/pull/107:
+#
+#   1. Try plain `readlink` first and keep its result when relative —
+#      preserves authored `declare_symlink + target_path` strings
+#      verbatim in the archive instead of canonicalising via `-f`.
+#   2. Accept any `bazel-out/<cfg>/bin/` (not only the mtree_mutate
+#      action's own `bin_dir`) so transitioned-config symlinks get
+#      classified.
+#   3. Accept `external/<repo>/` paths so symlinks to external-repo
+#      files (e.g. rules_python's interpreter tree) are detected.
+#
+# Retire this file + the `mtree_preserve_symlinks` rule once that PR
+# merges and we bump tar.bzl; py_image_layer reverts to
+# `mtree_mutate(preserve_symlinks = True)`.
+#
+# Invoked by the `mtree_preserve_symlinks` rule in
+# [mtree_preserve_symlinks.bzl](mtree_preserve_symlinks.bzl), which
+# shells out to the host `awk`. Self-contained, POSIX awk only.
+#
+# Optional -v owner=<n> and -v group=<n> variables stamp uid/gid onto
+# every line. Missing → lines pass through unchanged.
+
+function common_sections(path1, path2, i, segments1, segments2, min_length, common_path) {
+    gsub(/^\/|\/$/, "", path1)
+    gsub(/^\/|\/$/, "", path2)
+    split(path1, segments1, "/")
+    split(path2, segments2, "/")
+    min_length = (length(segments1) < length(segments2)) ? length(segments1) : length(segments2)
+    common_path = ""
+    for (i = 1; i <= min_length; i++) {
+        if (segments1[i] != segments2[i]) {
+            break
+        }
+        common_path = (common_path == "" ? segments1[i] : common_path "/" segments1[i])
+    }
+    return common_path
+}
+
+function make_relative_link(path1, path2, i, common, target, relative_path, back_steps) {
+    # Returns a relative path from path2's directory (path2 points at a
+    # FILE, so its "location" for relative-symlink resolution is the
+    # PARENT of that file) to path1.
+    #
+    # `path2_segments` counts file + intermediate dirs; to walk from
+    # path2's parent dir up to the common prefix we need (len - 1) `../`
+    # — one for each intermediate directory, NOT counting the file
+    # itself.
+    common = common_sections(path1, path2)
+    target = substr(path1, length(common) + 2)
+    relative_path = substr(path2, length(common) + 2)
+    split(relative_path, path2_segments, "/")
+    back_steps = ""
+    for (i = 1; i < length(path2_segments); i++) {
+        back_steps = back_steps "../"
+    }
+    return back_steps target
+}
+
+{
+    if (owner != "") {
+        sub(/uid=[0-9]+/, "uid=" owner)
+    }
+    if (group != "") {
+        sub(/gid=[0-9]+/, "gid=" group)
+    }
+
+    symlink = ""
+    symlink_content = ""
+    if ($0 ~ /type=file/ && $0 ~ /content=/) {
+        match($0, /content=[^ ]+/)
+        content_field = substr($0, RSTART, RLENGTH)
+        split(content_field, parts, "=")
+        path = parts[2]
+        symlink_map[path] = $1
+
+        # Determine the effective symlink target.
+        #
+        # Plain `readlink` returns the raw first-hop target. For
+        # `declare_symlink` outputs with a relative target_path (e.g.
+        # `../../../_wheels/0/...`), that's exactly the string we want
+        # to preserve verbatim in the tar.
+        #
+        # But plain readlink is NOT enough on its own: when this action
+        # runs sandboxed, each input is staged as a sandbox-local symlink
+        # pointing at the main execroot, so plain readlink on
+        # `bazel-out/.../bin/.../bin/python` returns
+        # `/private/.../execroot/_main/bazel-out/.../bin/.../bin/python`
+        # — just the same file with a different prefix, telling us
+        # nothing about whether the SOURCE bin/python is itself a
+        # symlink in the archive. `readlink -f` walks the full chain to
+        # the final canonical target and handles that case.
+        #
+        # So: keep plain readlink's answer ONLY when it's a relative
+        # `..`-prefixed target (the case plain readlink uniquely
+        # preserves); otherwise fall through to `readlink -f`.
+        raw_readlink = ""
+        cmd = "readlink \"" path "\" 2>/dev/null"
+        cmd | getline raw_readlink
+        close(cmd)
+        resolved_path = ""
+        if (raw_readlink != "" && raw_readlink !~ /^\//) {
+            # Relative target — declare_symlink output. Preserve verbatim:
+            # relative targets are calibrated for their location in the
+            # output tree and should land in the tar unchanged.
+            symlink = raw_readlink
+            symlink_content = path
+            resolved_path = raw_readlink
+        } else {
+            # Empty (not a symlink) or absolute (plain readlink returned
+            # the sandbox→main-execroot mapping, which is uninformative).
+            # Canonicalize via `readlink -f` and classify by where the
+            # final target lives.
+            cmd = "readlink -f \"" path "\" 2>/dev/null"
+            cmd | getline resolved_path
+            close(cmd)
+
+            # Accept absolute paths that live under `bazel-out/<cfg>/bin/`
+            # (venv / declare_file outputs) or `external/<repo>/` (the
+            # rules_python interpreter tree lives here directly, not
+            # under bazel-out). Normalise to the execroot-relative form
+            # so `symlink_map` lookups (keyed by the mtree's `content=`
+            # field, also execroot-relative) can find a match.
+            if (resolved_path ~ /\/bazel-out\/[^\/]+\/bin\// || \
+                resolved_path ~ /\/external\//) {
+                sub(/^.*\/bazel-out\//, "bazel-out/", resolved_path)
+                sub(/^.*\/external\//, "external/", resolved_path)
+                if (path != resolved_path) {
+                    symlink = resolved_path
+                    symlink_content = path
+                }
+            }
+        }
+    }
+    if (symlink != "") {
+        line_array[NR] = $0 SUBSEP $1 SUBSEP resolved_path
+    } else {
+        line_array[NR] = $0
+    }
+    next;
+}
+
+END {
+    for (i = 1; i <= NR; i++) {
+        line = line_array[i]
+        if (index(line, SUBSEP) > 0) {
+            split(line, fields, SUBSEP)
+            original_line = fields[1]
+            field0 = fields[2]
+            resolved_path = fields[3]
+            if (resolved_path in symlink_map) {
+                mapped_link = symlink_map[resolved_path]
+                linked_to = make_relative_link(mapped_link, field0)
+            } else {
+                linked_to = resolved_path
+            }
+            sub(/type=[^ ]+/, "type=link", original_line)
+            sub(/content=[^ ]+/, "link=" linked_to, original_line)
+            print original_line
+        } else {
+            print line
+        }
+    }
+}

--- a/py/private/mtree_preserve_symlinks.bzl
+++ b/py/private/mtree_preserve_symlinks.bzl
@@ -1,0 +1,75 @@
+"""Runs [modify_mtree.awk](modify_mtree.awk) over an mtree to rewrite
+symlink-shaped `type=file content=<path>` rows into `type=link` ones,
+so bsdtar preserves them verbatim instead of following and inlining.
+
+Shells out to the host `awk` (same approach rules_oci takes). The
+script uses only POSIX awk features, so any host awk is fine.
+"""
+
+def _impl(ctx):
+    out = ctx.outputs.out or ctx.actions.declare_file(ctx.label.name + ".spec")
+
+    # Collect runfiles from srcs so the awk's `readlink` calls can
+    # resolve `content=` paths against actual files in the sandbox.
+    srcs_runfiles = [
+        src[DefaultInfo].default_runfiles.files
+        for src in ctx.attr.srcs
+    ]
+
+    assignments = []
+    if ctx.attr.owner:
+        assignments.append(("owner", ctx.attr.owner))
+    if ctx.attr.group:
+        assignments.append(("group", ctx.attr.group))
+
+    args = ctx.actions.args()
+    for (k, v) in assignments:
+        args.add("-v")
+        args.add("{}={}".format(k, v))
+    args.add("-f", ctx.file.awk_script)
+    args.add(ctx.file.mtree)
+
+    ctx.actions.run_shell(
+        # `LC_ALL=C` pins sort order for reproducibility independent of
+        # the host's locale.
+        command = 'awk "$@" | LC_ALL=C sort > "{out}"'.format(out = out.path),
+        arguments = [args],
+        inputs = depset(
+            direct = [ctx.file.mtree, ctx.file.awk_script],
+            transitive = srcs_runfiles,
+        ),
+        outputs = [out],
+        mnemonic = "MtreePreserveSymlinks",
+        progress_message = "Rewriting symlink entries in %{label}",
+        use_default_shell_env = True,
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+mtree_preserve_symlinks = rule(
+    implementation = _impl,
+    attrs = {
+        "mtree": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "mtree spec to rewrite.",
+        ),
+        "srcs": attr.label_list(
+            allow_files = True,
+            doc = "Targets whose runfiles contain the files referenced by " +
+                  "the mtree's `content=` paths. Needed so `readlink` " +
+                  "resolves them in-sandbox.",
+        ),
+        "owner": attr.string(
+            doc = "Numeric uid to stamp onto every entry.",
+        ),
+        "group": attr.string(
+            doc = "Numeric gid to stamp onto every entry.",
+        ),
+        "awk_script": attr.label(
+            allow_single_file = True,
+            default = Label("//py/private:modify_mtree.awk"),
+        ),
+        "out": attr.output(),
+    },
+)

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -1,5 +1,30 @@
 """Providers to share information between targets in the graph."""
 
+PyWheelsInfo = provider(
+    doc = """Per-wheel metadata used to assemble a Python venv via symlinks at build time.
+
+Each element of `wheels` describes one wheel in the transitive closure of a
+target: the top-level names (packages / modules / *.dist-info directories)
+it installs into `site-packages`, which of those are PEP 420 namespace
+packages, the runfiles-root-relative path to the wheel's site-packages,
+and the wheel's declared console-script entry points.
+
+Downstream rules (notably `py_binary`) use this to create one
+`ctx.actions.symlink` per top-level name, merging wheels into a single
+`site-packages/` tree without invoking a runtime tool, and to generate
+executable wrappers under `<venv>/bin/<name>` for console scripts.
+""",
+    fields = {
+        "wheels": """Depset of `struct(top_levels, namespace_top_levels, site_packages_rfpath, console_scripts)`
+— one per wheel in the transitive closure. Fields:
+  * `top_levels`: tuple[str] — top-level names the wheel installs into site-packages.
+  * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
+  * `site_packages_rfpath`: str — runfiles-root-relative path to the wheel's site-packages.
+  * `console_scripts`: tuple[str] — entry points encoded as `"name=module:func"`.
+""",
+    },
+)
+
 PyVirtualInfo = provider(
     doc = "FIXME",
     fields = {

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -3,10 +3,12 @@
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@rules_python//python:defs.bzl", "PyInfo")
-load("//py/private:pth.bzl", "make_imports_depset", "write_pth_file")
+load("//py/private:pth.bzl", "make_imports_depset")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
-load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "VENV_TOOLCHAIN")
+load("//py/private:venv.bzl", "assemble_venv")
+load("//py/private/py_venv:types.bzl", "VirtualenvInfo")
+load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
 load(":transitions.bzl", "python_version_transition")
 
 def _dict_to_exports(env):
@@ -15,14 +17,60 @@ def _dict_to_exports(env):
         for (k, v) in env.items()
     ]
 
+def _check_venv_coverage(ctx, imports_depset, wheels_depset, vinfo):
+    """Analysis-time check: everything the binary needs must live in the venv.
+
+    The external venv's .pth file is what puts its own deps on sys.path at
+    runtime. We can't augment that from the binary's launcher under `-I`
+    (which blocks PYTHONPATH). So any first-party import or wheel dep the
+    binary declares that the venv doesn't already cover is a guaranteed
+    runtime ImportError — catch it at analysis instead.
+    """
+    venv_imports = {imp: True for imp in vinfo.imports.to_list()}
+    bin_wheel_sps = {w.site_packages_rfpath: w for w in wheels_depset.to_list()}
+
+    # Classify missing imports: wheel site-packages vs first-party. Wheel
+    # paths get reported by top-level names (readable) instead of repo
+    # paths (ugly).
+    missing_wheel_names = []
+    missing_first_party = []
+    for imp in imports_depset.to_list():
+        if imp in venv_imports:
+            continue
+        wheel = bin_wheel_sps.get(imp)
+        if wheel != None:
+            names = getattr(wheel, "top_levels", ())
+            missing_wheel_names.append(
+                ", ".join(sorted(names)) if names else imp,
+            )
+        else:
+            missing_first_party.append(imp)
+
+    if missing_wheel_names or missing_first_party:
+        parts = []
+        if missing_wheel_names:
+            parts.append("wheels: " + "; ".join(sorted(missing_wheel_names)))
+        if missing_first_party:
+            parts.append("first-party imports: " + ", ".join(sorted(missing_first_party)))
+        fail(
+            ("py_binary {target}: `external_venv = {venv}` doesn't cover " +
+             "this binary's dep closure — {details}. Either add the " +
+             "missing deps to {venv}, or drop `external_venv` to let the " +
+             "binary build its own internal venv.").format(
+                target = str(ctx.label),
+                venv = str(ctx.attr.external_venv.label),
+                details = "; ".join(parts),
+            ),
+        )
+
 def _py_binary_rule_impl(ctx):
-    venv_toolchain = ctx.toolchains[VENV_TOOLCHAIN]
     py_toolchain = _py_semantics.resolve_toolchain(ctx)
 
     # Resolve our `main=` to a label, which it isn't
     main = _py_semantics.determine_main(ctx)
 
-    # Check for duplicate virtual dependency names. Those that map to the same resolution target would have been merged by the depset for us.
+    # Virtual deps resolve to concrete targets first; imports_depset
+    # then gathers first-party + transitive wheel site-packages paths.
     virtual_resolution = _py_library.resolve_virtuals(ctx)
     imports_depset = make_imports_depset(
         deps = ctx.attr.deps,
@@ -32,29 +80,82 @@ def _py_binary_rule_impl(ctx):
         extra_imports_depsets = virtual_resolution.imports,
     )
 
-    # All "import" paths from `py_library` start with the workspace name, so we need to go back up the tree for
-    # each segment from site-packages in the venv to the root of the runfiles tree.
-    # Five .. will get us back to the root of the venv:
-    # {name}.runfiles/.{name}.venv/lib/python{version}/site-packages/first_party.pth
-    # If the target is defined with a slash, it adds to the level of nesting
-    target_depth = len(ctx.label.name.split("/")) - 1
-    escape = "/".join(([".."] * (4 + target_depth)))
-
-    site_packages_pth_file = write_pth_file(ctx, ctx.attr.name, imports_depset, escape)
-
+    # Bazel-contextual env vars that both the launcher (via {{PYTHON_ENV}})
+    # and the venv's activate script (via {{ENVVARS}} / {{ENVVARS_UNSET}})
+    # export.
     default_env = {
         "BAZEL_TARGET": str(ctx.label).lstrip("@"),
         "BAZEL_WORKSPACE": ctx.workspace_name,
         "BAZEL_TARGET_NAME": ctx.attr.name,
     }
 
-    passed_env = dict(ctx.attr.env)
-    for k, v in passed_env.items():
+    # Two venv-sourcing modes:
+    #
+    # * Internal (default): assemble_venv declares every venv file as an
+    #   output of this target. Runfiles include the venv files.
+    #
+    # * External (`external_venv = <py_venv label>`): reuse the venv produced
+    #   by another target. Skip assemble_venv entirely. The launcher
+    #   exec's the external venv's bin/python; the binary's runfiles
+    #   inherit the venv target's default_runfiles so the venv's files
+    #   land at their usual rlocation paths. We enforce that the binary's
+    #   dep closure is a subset of the venv's at analysis time — the
+    #   external venv's .pth is the only mechanism putting deps on
+    #   sys.path under our `-I` flag, so un-covered deps would just be
+    #   runtime ImportErrors otherwise.
+    safe_name = ctx.attr.name.replace("/", "_")
+    external_venv = ctx.attr.external_venv
+    wheels_depset = _py_library.make_wheels_depset(ctx)
+    extra_runfiles = []
+    extra_runfiles_depsets = [
+        ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
+    ]
+
+    if external_venv:
+        vinfo = external_venv[VirtualenvInfo]
+        _check_venv_coverage(ctx, imports_depset, wheels_depset, vinfo)
+        bin_python = vinfo.bin_python
+        extra_runfiles_depsets.append(external_venv[DefaultInfo].default_runfiles)
+    else:
+        venv = assemble_venv(
+            ctx,
+            safe_name = safe_name,
+            py_toolchain = py_toolchain,
+            imports_depset = imports_depset,
+            package_collisions = ctx.attr.package_collisions,
+            include_system_site_packages = ctx.attr.include_system_site_packages,
+            include_user_site_packages = ctx.attr.include_user_site_packages,
+            default_env = default_env,
+            venv_activate_tmpl = ctx.file._venv_activate_tmpl,
+            virtualenv_shim_py = ctx.file._virtualenv_shim,
+        )
+        bin_python = venv.bin_python
+        extra_runfiles = venv.all_files
+
+    # Merge env vars: start from the external venv's `env` (if any),
+    # then overlay the binary's own — binary wins on key conflicts.
+    # Same merge for inherited env-var names.
+    passed_env = {}
+    inherited_env = []
+    if external_venv and RunEnvironmentInfo in external_venv:
+        venv_env = external_venv[RunEnvironmentInfo]
+        passed_env = dict(venv_env.environment)
+        inherited_env = list(venv_env.inherited_environment)
+    for k, v in ctx.attr.env.items():
         passed_env[k] = expand_variables(
             ctx,
             expand_locations(ctx, v, ctx.attr.data),
             attribute_name = "env",
         )
+    for name in getattr(ctx.attr, "env_inherit", []):
+        if name not in inherited_env:
+            inherited_env.append(name)
+
+    # When `isolated = False`, drop Python's `-I` flag so PYTHONPATH is
+    # honored and the script directory is auto-added to sys.path.
+    flags = py_toolchain.flags + ctx.attr.interpreter_options
+    if not ctx.attr.isolated:
+        flags = [f for f in flags if f != "-I"]
 
     executable_launcher = ctx.actions.declare_file(ctx.attr.name)
     ctx.actions.expand_template(
@@ -62,18 +163,10 @@ def _py_binary_rule_impl(ctx):
         output = executable_launcher,
         substitutions = {
             "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION,
-            "{{INTERPRETER_FLAGS}}": " ".join(py_toolchain.flags + ctx.attr.interpreter_options),
-            "{{VENV_TOOL}}": to_rlocation_path(ctx, venv_toolchain.bin.bin),
-            "{{ARG_COLLISION_STRATEGY}}": ctx.attr.package_collisions,
-            "{{ARG_PYTHON}}": to_rlocation_path(ctx, py_toolchain.python) if py_toolchain.runfiles_interpreter else py_toolchain.python.path,
-            "{{ARG_VENV_NAME}}": ".{}.venv".format(ctx.attr.name),
-            "{{ARG_PTH_FILE}}": to_rlocation_path(ctx, site_packages_pth_file),
+            "{{INTERPRETER_FLAGS}}": " ".join(flags),
+            "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, bin_python),
             "{{ENTRYPOINT}}": to_rlocation_path(ctx, main),
             "{{PYTHON_ENV}}": "\n".join(_dict_to_exports(default_env)).strip(),
-            "{{EXEC_PYTHON_BIN}}": "python{}".format(
-                py_toolchain.interpreter_version_info.major,
-            ),
-            "{{RUNFILES_INTERPRETER}}": str(py_toolchain.runfiles_interpreter).lower(),
         },
         is_executable = True,
     )
@@ -86,13 +179,8 @@ def _py_binary_rule_impl(ctx):
             py_toolchain.files,
             srcs_depset,
         ] + virtual_resolution.srcs + virtual_resolution.runfiles,
-        extra_runfiles = [
-            site_packages_pth_file,
-        ],
-        extra_runfiles_depsets = [
-            ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
-            venv_toolchain.default_info.default_runfiles,
-        ],
+        extra_runfiles = extra_runfiles,
+        extra_runfiles_depsets = extra_runfiles_depsets,
     )
 
     instrumented_files_info = _py_library.make_instrumented_files_info(
@@ -100,12 +188,13 @@ def _py_binary_rule_impl(ctx):
         extra_source_attributes = ["main"],
     )
 
+    default_info_files = [executable_launcher, main]
+    if not external_venv:
+        default_info_files = default_info_files + extra_runfiles
+
     return [
         DefaultInfo(
-            files = depset([
-                executable_launcher,
-                main,
-            ]),
+            files = depset(default_info_files),
             executable = executable_launcher,
             runfiles = runfiles,
         ),
@@ -119,7 +208,7 @@ def _py_binary_rule_impl(ctx):
         instrumented_files_info,
         RunEnvironmentInfo(
             environment = passed_env,
-            inherited_environment = getattr(ctx.attr, "env_inherit", []),
+            inherited_environment = inherited_env,
         ),
     ]
 
@@ -151,30 +240,110 @@ be deprecated in the future.
 Part of the aspect_rules_py//uv system, has no effect in rules_python's pip.
 """,
     ),
+    "external_venv": attr.label(
+        providers = [[VirtualenvInfo]],
+        doc = """Build this binary against an externally-provided virtualenv.
+
+When set, the binary skips its own per-target venv assembly and instead
+exec's the referenced venv's `bin/python`. Typical shape:
+
+```
+py_venv(
+    name = "venv",
+    deps = ["@pypi//fastapi", "@pypi//uvicorn"],
+)
+
+py_binary(
+    name = "serve",
+    srcs = ["serve.py"],
+    main = "serve.py",
+    external_venv = ":venv",
+)
+```
+
+The binary's dep closure is required to be a **subset** of the venv's:
+any first-party import or wheel dep this binary declares that the venv
+doesn't already cover is rejected at analysis time. This is a hard
+constraint because the venv's `.pth` file is the only channel putting
+deps on `sys.path` under `-I` (which blocks `PYTHONPATH`) — un-covered
+deps would just be runtime ImportErrors otherwise.
+
+Leave unset (the default) to keep the per-binary internal-venv behaviour.
+""",
+    ),
     "python_version": attr.string(
         doc = """Whether to build this target and its transitive deps for a specific python version.""",
-    ),
-    "package_collisions": attr.string(
-        doc = """The action that should be taken when a symlink collision is encountered when creating the venv.
-A collision can occur when multiple packages providing the same file are installed into the venv. The possible values are:
-
-* "error": When conflicting symlinks are found, an error is reported and venv creation halts.
-* "warning": When conflicting symlinks are found, an warning is reported, however venv creation continues.
-* "ignore": When conflicting symlinks are found, no message is reported and venv creation continues.
-""",
-        default = "error",
-        values = ["error", "warning", "ignore"],
     ),
     "interpreter_options": attr.string_list(
         doc = "Additional options to pass to the Python interpreter in addition to -B and -I passed by rules_py",
         default = [],
     ),
+    "isolated": attr.bool(
+        default = True,
+        doc = """When True (default), the launcher invokes Python with `-I`
+(isolated mode: ignore PYTHON* env vars, skip user site-packages, don't
+auto-add the script's dir to sys.path). Set to False to drop `-I` — the
+launcher then respects `PYTHONPATH` and loads user site-packages if
+`include_user_site_packages` is also true. The deprecated
+`py_venv_binary` / `py_venv_test` aliases default this to False to
+match their historical permissive behaviour.""",
+    ),
+    "package_collisions": attr.string(
+        doc = """What to do when two wheels both claim the same top-level name.
+
+Wheels contribute top-level names via `PyWheelsInfo` (populated by the
+uv `whl_install` repo rule from each wheel's `*.dist-info/RECORD`).
+
+* "error": Fail analysis with a message naming both wheels.
+* "warning" (default): Print a warning and use the first wheel seen.
+* "ignore": Use the first wheel silently; the second is skipped.
+
+The default is `"warning"` because legitimate top-level overlaps are
+common in the Python ecosystem: setuptools vendors `packaging`,
+multi-package distributions split the `<root>.*` namespace across
+wheels (apache-airflow, jaraco.*), etc. First-seen wins matches what
+pip / uv give you at install time. Set this to `"error"` for strict
+non-overlap (useful during project hygiene audits).
+
+PEP 420 namespace packages (empty `<root>/` across wheels) are
+automatically skipped — they're not real collisions.
+""",
+        default = "warning",
+        values = ["error", "warning", "ignore"],
+    ),
+    "include_system_site_packages": attr.bool(
+        doc = """`pyvenv.cfg` `include-system-site-packages` key. When True,
+the host interpreter's site-packages participate in sys.path. Default False
+for hermeticity; only flip on to match legacy `python -m venv` behavior or
+when system-installed packages need to be reachable.""",
+        default = False,
+    ),
+    "include_user_site_packages": attr.bool(
+        doc = """Aspect extension key `aspect-include-user-site-packages` in
+pyvenv.cfg. When True, `~/.local/lib/pythonX.Y/site-packages/` participates
+in sys.path. Default False for hermeticity.""",
+        default = False,
+    ),
     "_run_tmpl": attr.label(
         allow_single_file = True,
         default = "//py/private:run.tmpl.sh",
     ),
+    "_venv_activate_tmpl": attr.label(
+        allow_single_file = True,
+        default = "//py/private:venv_activate.tmpl.sh",
+    ),
+    "_virtualenv_shim": attr.label(
+        allow_single_file = True,
+        default = "//py/private:_virtualenv.py",
+    ),
     "_runfiles_lib": attr.label(
         default = "@bazel_tools//tools/bash/runfiles",
+    ),
+    # Freethreaded Python 3.13+ uses `lib/python<M>.<m>t/site-packages/`
+    # — py_semantics reads this to report freethreaded status to
+    # assemble_venv so the venv lands at the interpreter-expected path.
+    "_freethreaded_flag": attr.label(
+        default = "//py/private/interpreter:freethreaded",
     ),
     # Required for py_version attribute
     "_allowlist_function_transition": attr.label(
@@ -207,7 +376,6 @@ py_base = struct(
     test_attrs = _test_attrs,
     toolchains = [
         PY_TOOLCHAIN,
-        VENV_TOOLCHAIN,
     ],
     cfg = python_version_transition,
 )

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -31,8 +31,9 @@ oci_image(
 """
 
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
-load("@tar.bzl//tar:mtree.bzl", "mtree_mutate", "mtree_spec")
+load("@tar.bzl//tar:mtree.bzl", "mtree_spec")
 load("@tar.bzl//tar:tar.bzl", "tar")
+load(":mtree_preserve_symlinks.bzl", "mtree_preserve_symlinks")
 
 default_layer_groups = {
     # match *only* external repositories containing a Python interpreter,
@@ -155,27 +156,29 @@ def py_image_layer(
     if root != None and not root.startswith("/"):
         fail("root path must start with '/' but got '{root}', expected '/{root}'".format(root = root))
 
-    # Produce the manifest for a tar file of our py_binary, but don't tar it up yet, so we can split
-    # into fine-grained layers for better pull, push and remote cache performance.
+    # Produce the manifest for a tar file of our py_binary, but don't
+    # tar it up yet — we split into fine-grained layers for better pull,
+    # push and remote cache performance.
+    #
+    # mtree_spec emits `type=file` for every non-directory entry,
+    # including `ctx.actions.symlink` outputs. At archive time bsdtar
+    # would follow the symlink, see a directory, and raise
+    # "different type" errors; `mtree_preserve_symlinks` rewrites
+    # symlink-shaped rows to `type=link` first.
     manifest_name = name + ".manifest"
-    if owner:
-        mtree_spec(
-            name = manifest_name + ".preprocessed",
-            srcs = [binary],
-            **kwargs
-        )
-        mtree_mutate(
-            name = manifest_name,
-            mtree = name + ".manifest.preprocessed",
-            owner = owner,
-            group = group,
-        )
-    else:
-        mtree_spec(
-            name = manifest_name,
-            srcs = [binary],
-            **kwargs
-        )
+    mtree_spec(
+        name = manifest_name + ".preprocessed",
+        srcs = [binary],
+        **kwargs
+    )
+
+    mtree_preserve_symlinks(
+        name = manifest_name,
+        mtree = manifest_name + ".preprocessed",
+        srcs = [binary],
+        owner = owner,
+        group = group,
+    )
 
     groups = dict(**layer_groups)
     groups = dict(groups, **default_layer_groups)

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -7,7 +7,7 @@ without binding them to a particular version of that package.
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_python//python:defs.bzl", "PyInfo")
-load("//py/private:providers.bzl", "PyVirtualInfo")
+load("//py/private:providers.bzl", "PyVirtualInfo", "PyWheelsInfo")
 load("//py/private:pth.bzl", "make_imports_depset")
 
 def _make_instrumented_files_info(ctx, extra_source_attributes = [], extra_dependency_attributes = []):
@@ -107,6 +107,24 @@ def _make_imports_depset(ctx, imports = [], extra_imports_depsets = []):
         extra_imports_depsets = extra_imports_depsets,
     )
 
+def _make_wheels_depset(ctx, extra_transitive = []):
+    """Collect PyWheelsInfo.wheels across deps + resolutions.
+
+    Used by downstream rules that want a flat list of wheels (with their
+    declared top-level names) in the transitive closure, for building a
+    merged site-packages via symlinks.
+    """
+    transitive = [
+        target[PyWheelsInfo].wheels
+        for target in getattr(ctx.attr, "deps", [])
+        if PyWheelsInfo in target
+    ]
+    for target in getattr(ctx.attr, "resolutions", {}).keys():
+        if PyWheelsInfo in target:
+            transitive.append(target[PyWheelsInfo].wheels)
+    transitive.extend(extra_transitive)
+    return depset(transitive = transitive)
+
 def _make_merged_runfiles(ctx, extra_depsets = [], extra_runfiles = [], extra_runfiles_depsets = []):
     runfiles_targets = getattr(ctx.attr, "deps", []) + getattr(ctx.attr, "data", [])
     runfiles = ctx.runfiles(
@@ -130,6 +148,7 @@ def _py_library_impl(ctx):
     resolutions = _make_virtual_resolutions_depset(ctx)
     runfiles = _make_merged_runfiles(ctx, extra_runfiles = ctx.files.srcs)
     instrumented_files_info = _make_instrumented_files_info(ctx)
+    wheels = _make_wheels_depset(ctx)
 
     return [
         DefaultInfo(
@@ -146,6 +165,9 @@ def _py_library_impl(ctx):
         PyVirtualInfo(
             dependencies = virtuals,
             resolutions = resolutions,
+        ),
+        PyWheelsInfo(
+            wheels = wheels,
         ),
         instrumented_files_info,
     ]
@@ -192,6 +214,7 @@ py_library_utils = struct(
     make_instrumented_files_info = _make_instrumented_files_info,
     make_merged_runfiles = _make_merged_runfiles,
     make_srcs_depset = _make_srcs_depset,
+    make_wheels_depset = _make_wheels_depset,
     py_library_providers = _providers,
     resolve_virtuals = _resolve_virtuals,
 )

--- a/py/private/py_pex_binary.bzl
+++ b/py/private/py_pex_binary.bzl
@@ -38,6 +38,16 @@ exclude_paths = [
     # these will match in bzlmod setup with --incompatible_use_plus_in_repo_names flag flipped.
     "rules_python++python+",
     "aspect_rules_py+/py/tools/",
+    # py_binary assembles a synthetic venv at <pkg>/.<name>.venv/ with a
+    # lib/python<MAJ>.<MIN>/site-packages/ subtree holding the .pth file
+    # that tells the interpreter where wheels live. These files are
+    # launcher-side plumbing and should not be packed into the PEX — pex
+    # discovers wheels itself from PyInfo.imports / --dep. Matching the
+    # inner "/site-packages/" path component excluding actual wheels is
+    # tricky, so we match on the outer "/.<name>.venv/" hidden-dir
+    # segment that only our synthetic venv tree produces. Wheel payload
+    # paths never contain a "/.<something>.venv/" segment.
+    ".venv/",
 ]
 
 # determines if the given file is a `distinfo`, `dep` or a `source`

--- a/py/private/py_semantics.bzl
+++ b/py/private/py_semantics.bzl
@@ -1,5 +1,6 @@
 """Functions to determine which Python toolchain to use"""
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
 
 _INTERPRETER_FLAGS = [
@@ -76,6 +77,14 @@ def _resolve_toolchain(ctx):
     else:
         fail(_MUST_SET_TOOLCHAIN_INTERPRETER_VERSION_INFO)
 
+    # Read the freethreaded build setting if the consuming rule exposed
+    # the attr. Freethreaded Python uses `lib/python<M>.<m>t/site-packages/`
+    # instead of `lib/python<M>.<m>/site-packages/`, so assemble_venv
+    # needs this to lay out the venv at the interpreter-expected path.
+    freethreaded = False
+    if hasattr(ctx.attr, "_freethreaded_flag"):
+        freethreaded = ctx.attr._freethreaded_flag[BuildSettingInfo].value
+
     return struct(
         toolchain = py3_toolchain,
         files = files,
@@ -83,6 +92,7 @@ def _resolve_toolchain(ctx):
         interpreter_version_info = interpreter_version_info,
         runfiles_interpreter = runfiles_interpreter,
         flags = _INTERPRETER_FLAGS,
+        freethreaded = freethreaded,
     )
 
 def _csv(values):

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private:pth.bzl", "make_imports_depset")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
@@ -30,14 +31,15 @@ def _py_unpacked_wheel_impl(ctx):
         toolchain = UNPACK_TOOLCHAIN,
     )
 
+    py_ver_dir = "python{}.{}".format(
+        py_toolchain.interpreter_version_info.major,
+        py_toolchain.interpreter_version_info.minor,
+    )
     import_path = paths.join(
         ".",
         unpack_directory.basename,
         "lib",
-        "python{}.{}".format(
-            py_toolchain.interpreter_version_info.major,
-            py_toolchain.interpreter_version_info.minor,
-        ),
+        py_ver_dir,
         "site-packages",
     )
     imports = make_imports_depset(
@@ -47,7 +49,29 @@ def _py_unpacked_wheel_impl(ctx):
         label = ctx.label,
     )
 
-    return [
+    # site_packages_rfpath: runfiles-root-relative path to this wheel's
+    # site-packages/, used by downstream rules to compute symlink targets
+    # for the top-level names declared in `top_levels`.
+    if ctx.label.workspace_name:
+        site_packages_rfpath = paths.join(
+            ctx.label.workspace_name,
+            ctx.label.package,
+            unpack_directory.basename,
+            "lib",
+            py_ver_dir,
+            "site-packages",
+        )
+    else:
+        site_packages_rfpath = paths.join(
+            ctx.workspace_name,
+            ctx.label.package,
+            unpack_directory.basename,
+            "lib",
+            py_ver_dir,
+            "site-packages",
+        )
+
+    providers = [
         DefaultInfo(
             files = depset(direct = [unpack_directory]),
             default_runfiles = ctx.runfiles(files = [unpack_directory]),
@@ -61,11 +85,59 @@ def _py_unpacked_wheel_impl(ctx):
         ),
     ]
 
+    if ctx.attr.top_levels or ctx.attr.console_scripts:
+        providers.append(PyWheelsInfo(
+            wheels = depset(direct = [struct(
+                top_levels = tuple(ctx.attr.top_levels),
+                namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
+                site_packages_rfpath = site_packages_rfpath,
+                console_scripts = tuple(ctx.attr.console_scripts),
+                # See whl_install rule for the rationale.
+                install_tree = unpack_directory,
+            )]),
+        ))
+
+    return providers
+
 _attrs = {
     "src": attr.label(
         doc = "The Wheel file, as defined by https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format",
         allow_single_file = [".whl"],
         mandatory = True,
+    ),
+    "top_levels": attr.string_list(
+        doc = """Names of the top-level packages / modules / *.dist-info directories the wheel installs into its site-packages.
+
+When set, the target emits a `PyWheelsInfo` provider describing this wheel.
+Downstream rules (such as `py_binary`) can consume this to assemble a merged
+`site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth`
+entries. If left empty (the default), the target behaves as before — other
+rules fall back to `.pth`-based import resolution.
+
+Typically populated by the `uv` wheel-install repo rule. Hand-written
+`py_unpacked_wheel` targets may populate this to opt into symlink-based
+venv assembly.
+""",
+        default = [],
+    ),
+    "console_scripts": attr.string_list(
+        doc = """Console-script entry points declared by this wheel, in the form `"name=module:func"`.
+
+`py_binary` consumes these via `PyWheelsInfo` to generate executable
+wrappers under `<venv>/bin/<name>`. Typically populated from the wheel's
+`*.dist-info/entry_points.txt` `[console_scripts]` section.
+""",
+        default = [],
+    ),
+    "namespace_top_levels": attr.string_list(
+        doc = """Subset of `top_levels` that are PEP 420 namespace packages.
+
+See the equivalent attribute on the `whl_install` rule for the full
+story; short version: names listed here suppress collision errors when
+multiple wheels claim the same top-level, because Python's namespace
+machinery is meant to merge their contributions.
+""",
+        default = [],
     ),
 }
 

--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -43,20 +43,25 @@ bzl_library(
 
 bzl_library(
     name = "py_venv",
-    srcs = [
-        "defs.bzl",
-        "py_venv.bzl",
-    ],
+    srcs = ["py_venv.bzl"],
     deps = [
         ":types.bzl",
         "//py/private:providers",
-        "//py/private:pth",
         "//py/private:py_library",
         "//py/private:py_semantics",
         "//py/private:transitions",
+        "//py/private:venv",
         "//py/private/toolchain:types",
         "@bazel_lib//lib:expand_make_vars",
         "@bazel_lib//lib:paths",
+    ],
+)
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    deps = [
+        ":py_venv",
     ],
 )
 
@@ -68,10 +73,4 @@ py_venv_test(
     ],
     imports = ["."],
     main = "test_link.py",
-)
-
-bzl_library(
-    name = "defs",
-    srcs = ["defs.bzl"],
-    deps = [":py_venv"],
 )

--- a/py/private/py_venv/entrypoint.tmpl.sh
+++ b/py/private/py_venv/entrypoint.tmpl.sh
@@ -10,6 +10,11 @@ runfiles_export_envvars
 
 set -o errexit -o nounset -o pipefail
 
-source "$(rlocation "{{VENV}}")"/bin/activate
+VENV_PYTHON="$(rlocation {{ARG_VENV_PYTHON}})"
+VENV_BIN="$(dirname "${VENV_PYTHON}")"
+VENV_HOME="$(dirname "${VENV_BIN}")"
 
-exec "$(rlocation "{{VENV}}")"/bin/python {{INTERPRETER_FLAGS}} "$@"
+export VIRTUAL_ENV="${VENV_HOME}"
+export PATH="${VENV_BIN}:${PATH-}"
+
+exec "${VENV_PYTHON}" {{INTERPRETER_FLAGS}} "$@"

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -1,80 +1,64 @@
-"""Implementation for the py_binary and py_test rules."""
+"""Implementation for the `py_venv` rule + `py_venv_link` and `py_binary_with_venv` macros.
+
+- `py_venv` — a rule that builds a Python virtualenv and produces an
+  executable that activates it and exec's `bin/python`. Emits
+  `VirtualenvInfo` so other targets consume it via `external_venv=`.
+  `bazel run :name` on a py_venv drops into the hermetic interpreter
+  with the venv activated — useful for interactive Python sessions.
+
+- `py_binary_with_venv` — shared helper invoked by
+  `py_binary(expose_venv = True, ...)` / `py_test(expose_venv = True, ...)`.
+  Splits the call into a sibling `:<name>.venv` `py_venv` + a
+  `py_binary` / `py_test` rule consuming it via `external_venv`.
+  First-class sibling: other targets can share the `.venv` via
+  `external_venv`, and `bazel run :<name>.venv` drops into the
+  interpreter.
+
+- `py_venv_link` — opt-in macro that emits a runnable target whose
+  `bazel run` materialises a workspace-local symlink to an existing
+  `py_venv`'s tree. Pair with `py_binary(expose_venv = True)` to hand
+  your IDE a stable `.venv` symlink to point at.
+
+Shared venv-assembly logic lives in
+`//py/private:venv.bzl::assemble_venv`. See that file's header for the
+layout details.
+"""
 
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("//py/private:pth.bzl", "make_imports_depset", "write_pth_file")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_version_transition")
-load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "SHIM_TOOLCHAIN", "VENV_EXEC_TOOLCHAIN")
+load("//py/private:venv.bzl", "assemble_venv")
+load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
 load(":types.bzl", "VirtualenvInfo")
 
-# Forked from bazel-lib to avoid keeping `ctx` alive to execution phase
-def _to_rlocation_path(workspace_name, file):
-    if file.short_path.startswith("../"):
-        return file.short_path[3:]
-    else:
-        return workspace_name + "/" + file.short_path
-
-def _interpreter_path(workspace_name, py_toolchain):
-    return (
-        _to_rlocation_path(workspace_name, py_toolchain.python) if py_toolchain.runfiles_interpreter else py_toolchain.python.path
-    )
-
-def _dict_to_exports(env):
-    return [
-        "export %s=\"%s\"" % (k, v)
-        for (k, v) in env.items()
-    ]
-
-def _interpreter_flags(ctx):
+def _interpreter_flags(ctx, include_main = False):
     py_toolchain = _py_semantics.resolve_toolchain(ctx)
-
     args = py_toolchain.flags + ctx.attr.interpreter_options
 
-    if hasattr(ctx.file, "main"):
-        args.append(
-            "\"$(rlocation {})\"".format(to_rlocation_path(ctx, ctx.file.main)),
-        )
-
+    # py_venv strips `-I` so the interpreter picks up PYTHONPATH and
+    # script dir — useful when users `bazel run` the venv for an
+    # interactive python session and want their shell's env to apply.
+    # The per-binary py_binary launcher keeps `-I` (see py_binary.bzl).
     args = [it for it in args if it not in ["-I"]]
+
+    if include_main and hasattr(ctx.file, "main") and ctx.file.main:
+        args.append("\"$(rlocation {})\"".format(to_rlocation_path(ctx, ctx.file.main)))
 
     return args
 
-# FIXME: This is derived directly from the py_binary.bzl rule and should really
-# be a layer on top of it if we can figure out flowing the data around. This is
-# PoC quality.
-
-def _py_venv_base_impl(ctx):
+def _assemble_shared(ctx):
+    """Resolve the py toolchain, virtual deps, imports depset — then run
+    the shared venv-assembly helper.
     """
-    Common venv bits.
-
-    Taking a PyInfo transitive depset and shove all that into a "virtualenv" tree.
-    Depended on by the implementation of venv building and venv-based binary building.
-    """
-
     py_toolchain = _py_semantics.resolve_toolchain(ctx)
-
-    # Note that we HAVE to grab these files from toolchains so that we can swap
-    # in prebuild versions in production.
-    py_shim = ctx.toolchains[SHIM_TOOLCHAIN]
-    venv_tool = ctx.toolchains[VENV_EXEC_TOOLCHAIN].bin.bin
-
-    # Check for duplicate virtual dependency names. Those that map to the same resolution target would have been merged by the depset for us.
     virtual_resolution = _py_library.resolve_virtuals(ctx)
-
-    imports_depset = make_imports_depset(
-        deps = ctx.attr.deps,
-        imports = getattr(ctx.attr, "imports", []),
-        workspace_name = ctx.workspace_name,
-        label = ctx.label,
+    imports_depset = _py_library.make_imports_depset(
+        ctx,
         extra_imports_depsets = virtual_resolution.imports,
     )
-
-    site_packages_pth_file = write_pth_file(ctx, ctx.attr.name, imports_depset)
-
-    env_file = ctx.actions.declare_file("{}.env".format(ctx.attr.name))
+    wheels_depset = _py_library.make_wheels_depset(ctx)
 
     default_env = {
         "BAZEL_TARGET": str(ctx.label).lstrip("@"),
@@ -82,175 +66,62 @@ def _py_venv_base_impl(ctx):
         "BAZEL_TARGET_NAME": ctx.attr.name,
     }
 
-    ctx.actions.write(
-        output = env_file,
-        content = "\n".join(_dict_to_exports(default_env)).strip(),
-    )
+    safe_name = ctx.attr.name.replace("/", "_")
 
-    srcs_depset = _py_library.make_srcs_depset(ctx)
-
-    # Use the runfiles computation logic to figure out the files we need to
-    # _build_ the venv. The final venv is these runfiles _plus_ the venv's
-    # structures.
-    rfs = _py_library.make_merged_runfiles(
+    # `venv_dir_basename` lets callers pin the venv's on-disk name
+    # regardless of target name — handy for pinning IDE / test fixture
+    # paths that hardcode a specific venv dir. Defaults to `.<name>/`
+    # (with `_venv` appended when assemble_venv's `venv_name` param
+    # isn't set explicitly; see venv.bzl for the default there).
+    venv_basename = ctx.attr.venv_dir_basename or ".{}".format(safe_name)
+    venv = assemble_venv(
         ctx,
-        extra_depsets = [
-                            py_toolchain.files,
-                            srcs_depset,
-                        ] + virtual_resolution.srcs + virtual_resolution.runfiles +
-                        ([py_toolchain.files] if py_toolchain.runfiles_interpreter else []),
-        extra_runfiles_depsets = [
-            ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
-        ],
+        safe_name = safe_name,
+        py_toolchain = py_toolchain,
+        imports_depset = imports_depset,
+        package_collisions = ctx.attr.package_collisions,
+        include_system_site_packages = ctx.attr.include_system_site_packages,
+        include_user_site_packages = ctx.attr.include_user_site_packages,
+        default_env = default_env,
+        venv_activate_tmpl = ctx.file._venv_activate_tmpl,
+        virtualenv_shim_py = ctx.file._virtualenv_shim,
+        venv_name = venv_basename,
     )
 
-    venv_name = ".{}".format(ctx.attr.name)
-    venv_dir = ctx.actions.declare_directory(venv_name)
-    workspace_name = ctx.workspace_name
-
-    args = ctx.actions.args()
-    args.add_all([venv_dir], expand_directories = False, format_each = "--location=%s")
-    args.add(py_shim.bin.bin, format = "--venv-shim=%s")
-
-    # Post-bzlmod we need to record the current repository in case the
-    # user tries to consume a `py_venv_binary` across repo boundaries
-    # which could cause repo mapping to become relevant.
-    args.add(
-        ctx.label.repo_name or workspace_name,
-        format = "--repo=%s",
-    )
-    args.add_all(
-        [py_toolchain],
-        map_each = lambda py_toolchain: _interpreter_path(workspace_name, py_toolchain),
-        format_each = "--python=%s",
-        allow_closure = True,
-    )
-    args.add(site_packages_pth_file, format = "--pth-file=%s")
-    args.add(env_file, format = "--env-file=%s")
-    args.add(ctx.bin_dir.path, format = "--bin-dir=%s")
-    args.add(ctx.attr.package_collisions, format = "--collision-strategy=%s")
-    args.add(venv_name, format = "--venv-name=%s")
-    args.add(ctx.attr.mode, format = "--mode=%s")
-    args.add(
-        "{}.{}".format(
-            py_toolchain.interpreter_version_info.major,
-            py_toolchain.interpreter_version_info.minor,
-        ),
-        format = "--version=%s",
-    )
-    args.add(
-        "true" if ctx.attr.include_system_site_packages else "false",
-        format = "--include-system-site-packages=%s",
-    )
-    args.add(
-        "true" if ctx.attr.include_system_site_packages else "false",
-        format = "--include-user-site-packages=%s",
-    )
-
-    if ctx.attr.debug:
-        args.add("--debug")
-
-    if ctx.attr._freethreaded_flag[BuildSettingInfo].value:
-        args.add("--freethreaded")
-
-    ctx.actions.run(
-        executable = venv_tool,
-        arguments = [args],
-        inputs = rfs.merge_all([
-            ctx.runfiles(
-                files = [site_packages_pth_file, env_file, venv_tool],
-                transitive_files = py_toolchain.files,
-            ),
-            py_shim.default_info.default_runfiles,
-        ]).files,
-        outputs = [
-            venv_dir,
-        ],
-        toolchain = VENV_EXEC_TOOLCHAIN,
-    )
-
-    return venv_dir, rfs.merge_all([
-        ctx.runfiles(
-            files = [venv_dir],
-            transitive_files = py_toolchain.files,
-        ),
-        ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
-    ])
-
-def _py_venv_rule_impl(ctx):
-    """
-    A virtualenv implementation the binary of which is a proxy to the Python interpreter of the venv.
-    """
-
-    venv_dir, rfs = _py_venv_base_impl(ctx)
-
-    # Now we can generate an entrypoint script wrapping $VENV/bin/python
-    ctx.actions.expand_template(
-        template = ctx.file._run_tmpl,  # FIXME: Should always be single file
-        output = ctx.outputs.executable,
-        substitutions = {
-            "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION.strip(),
-            "{{INTERPRETER_FLAGS}}": " ".join(_interpreter_flags(ctx)),
-            "{{ENTRYPOINT}}": "${VIRTUAL_ENV}/bin/python",
-            "{{VENV}}": to_rlocation_path(ctx, venv_dir),
-            "{{DEBUG}}": str(ctx.attr.debug).lower(),
-        },
-        is_executable = True,
-    )
-
-    # TODO: Zip output group to allow for bypassing filtering et. all
-
-    return [
-        DefaultInfo(
-            files = depset([
-                ctx.outputs.executable,
-                venv_dir,
-            ]),
-            executable = ctx.outputs.executable,
-            runfiles = rfs.merge(
-                ctx.runfiles(files = [venv_dir]),
-            ),
-        ),
-        # FIXME: Does not provide PyInfo because venvs are supposed to be terminal artifacts.
-        VirtualenvInfo(
-            home = venv_dir,
-        ),
-    ]
-
-def _py_venv_binary_impl(ctx):
-    """
-    A virtualenv implementation the binary of which is a proxy to the Python interpreter of the venv.
-    """
-
-    py_toolchain = _py_semantics.resolve_toolchain(ctx)
-
-    # Make runfiles to handle direct srcs and deps which we need to bolt on top
-    # of the venv
     srcs_depset = _py_library.make_srcs_depset(ctx)
-    virtual_resolution = _py_library.resolve_virtuals(ctx)
-
-    # Use the runfiles computation logic to figure out the files we need to
-    # _build_ the venv. The final venv is these runfiles _plus_ the venv's
-    # structures.
-    rfs = _py_library.make_merged_runfiles(
+    runfiles = _py_library.make_merged_runfiles(
         ctx,
         extra_depsets = [
             py_toolchain.files,
             srcs_depset,
         ] + virtual_resolution.srcs + virtual_resolution.runfiles,
+        extra_runfiles = venv.all_files,
+        extra_runfiles_depsets = [
+            ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
+        ],
     )
 
-    venv_dir, venv_rfs = _py_venv_base_impl(ctx)
-    rfs = rfs.merge(venv_rfs)
+    return struct(
+        py_toolchain = py_toolchain,
+        venv = venv,
+        runfiles = runfiles,
+        imports_depset = imports_depset,
+        wheels_depset = wheels_depset,
+    )
 
-    # Now we can generate an entrypoint script wrapping $VENV/bin/python
+def _py_venv_rule_impl(ctx):
+    """A virtualenv target whose own executable activates the venv and
+    exec's the interpreter — a `bazel run :name`-able venv."""
+
+    shared = _assemble_shared(ctx)
+
     ctx.actions.expand_template(
-        template = ctx.file._bin_tmpl,  # FIXME: Should always be single file
+        template = ctx.file._run_tmpl,
         output = ctx.outputs.executable,
         substitutions = {
             "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION.strip(),
             "{{INTERPRETER_FLAGS}}": " ".join(_interpreter_flags(ctx)),
-            "{{VENV}}": to_rlocation_path(ctx, venv_dir),
+            "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, shared.venv.bin_python),
             "{{DEBUG}}": str(ctx.attr.debug).lower(),
         },
         is_executable = True,
@@ -266,23 +137,29 @@ def _py_venv_binary_impl(ctx):
 
     return [
         DefaultInfo(
-            files = depset([
-                ctx.outputs.executable,
-            ]),
+            files = depset([ctx.outputs.executable] + shared.venv.all_files),
             executable = ctx.outputs.executable,
-            runfiles = rfs,
+            runfiles = shared.runfiles,
         ),
+        # Does not provide PyInfo because venvs are terminal artifacts —
+        # a py_binary consumer would see this as "the binary to run",
+        # not "a source of imports".
+        VirtualenvInfo(
+            bin_python = shared.venv.bin_python,
+            venv_name = shared.venv.venv_name,
+            imports = shared.imports_depset,
+            wheels = shared.wheels_depset,
+        ),
+        # Forwarded to py_binary(external_venv = :this_venv) consumers
+        # so env vars declared on the venv apply to binaries using it.
+        # The binary's own `env` wins on key conflicts; see py_binary.bzl.
         RunEnvironmentInfo(
             environment = passed_env,
-            inherited_environment = getattr(ctx.attr, "env_inherit", []),
+            inherited_environment = ctx.attr.env_inherit,
         ),
     ]
 
 _attrs = dict({
-    "env": attr.string_dict(
-        doc = "Environment variables to set when running the binary.",
-        default = {},
-    ),
     "venv": attr.string(
         doc = """The name of a configured virtualenv within which to resolve dependencies.
 
@@ -295,36 +172,62 @@ Only works with the experimental Aspect pip machinery.
         doc = """Whether to build this target and its transitive deps for a specific python version.""",
     ),
     "package_collisions": attr.string(
-        doc = """The action that should be taken when a symlink collision is encountered when creating the venv.
-A collision can occur when multiple packages providing the same file are installed into the venv. The possible values are:
+        doc = """What to do when two wheels both claim the same top-level or console-script name.
 
-* "error": When conflicting symlinks are found, an error is reported and venv creation halts.
-* "warning": When conflicting symlinks are found, an warning is reported, however venv creation continues.
-* "ignore": When conflicting symlinks are found, no message is reported and venv creation continues.
-        """,
-        default = "error",
+See `py_binary`'s attribute of the same name for full semantics — the
+two rules share the underlying collision detector.
+
+* "error": Fail analysis.
+* "warning" (default): Print a warning; first-seen wins.
+* "ignore": First-seen wins silently.
+""",
+        default = "warning",
         values = ["error", "warning", "ignore"],
     ),
     "mode": attr.string(
-        doc = """The venv assembly mode.
+        doc = """Legacy attr, no longer honored.
 
-* "static-pth": Efficient. Just use a .pth file. Ignore binaries.
-* "static-symlink": Efficient. Use .pth entries for firstparty code (including
-  firstparty code in external repositories) and symlinks for 3rdparty wheels
-  (detected by the presence of site-packages or dist-packages in the path).
-  Copies and patches binaries.
-
-This mode is designed to minimize inode usage while still providing a fully
-functional virtualenv. First-party code is referenced via .pth files (one entry
-per import root), while third-party wheels are symlinked into the venv to ensure
-proper package metadata and console scripts work correctly.
-        """,
+Historically selected between `static-pth` and `static-symlink` assembly
+strategies. The current venv assembly is always per-top-level-symlink
+for wheels with `PyWheelsInfo` metadata and `.pth` for everything else
+— there's no mode to choose. Attribute retained for API compatibility.
+""",
         default = "static-symlink",
         values = ["static-pth", "static-symlink"],
     ),
     "interpreter_options": attr.string_list(
         doc = "Additional options to pass to the Python interpreter.",
         default = [],
+    ),
+    "include_system_site_packages": attr.bool(
+        default = False,
+        doc = """`pyvenv.cfg` feature flag for the `include-system-site-packages` key.""",
+    ),
+    "include_user_site_packages": attr.bool(
+        default = False,
+        doc = """`pyvenv.cfg` feature flag for the `aspect-include-user-site-packages` extension key.""",
+    ),
+    "debug": attr.bool(
+        default = False,
+    ),
+    "env": attr.string_dict(
+        doc = """Environment variables to set when running the venv (and any
+`py_binary(external_venv = ...)` consumer). Binary-level `env` wins on
+key conflicts.""",
+        default = {},
+    ),
+    "env_inherit": attr.string_list(
+        doc = """Names of environment variables to pass through from the invoking
+environment. Forwarded to `py_binary(external_venv = ...)` consumers
+alongside `env`.""",
+        default = [],
+    ),
+    "venv_dir_basename": attr.string(
+        doc = """Override the generated venv's directory basename.
+
+Defaults to `.<target_name>/`. Overrideable when test fixtures or
+IDE configs hardcode a specific path independent of the target name.
+""",
     ),
     # Required for py_version attribute
     "_allowlist_function_transition": attr.label(
@@ -337,61 +240,84 @@ proper package metadata and console scripts work correctly.
     "_runfiles_lib": attr.label(
         default = "@bazel_tools//tools/bash/runfiles",
     ),
+    # Read by py_semantics — freethreaded interpreters expect site-packages
+    # at `lib/python<M>.<m>t/site-packages/`, not the default `.../python<M>.<m>/`.
     "_freethreaded_flag": attr.label(
         default = "//py/private/interpreter:freethreaded",
     ),
-    "debug": attr.bool(
-        default = False,
+    # Shared with py_binary via the venv-assembly helper.
+    "_venv_activate_tmpl": attr.label(
+        allow_single_file = True,
+        default = "//py/private:venv_activate.tmpl.sh",
     ),
-    "include_system_site_packages": attr.bool(
-        default = False,
-        doc = """`pyvenv.cfg` feature flag for the `include-system-site-packages` key.
-
-When `True`, the user's site directory AND the interpreter's site directory will
-be included into the runtime pythonpath.
-
-When `False`, only the virtualenv's site directory and the interpreter's core
-libraries will be included into the runtime pythonpath.
-
-`False` is obviously preferable as it increases hermeticity, but the choice of
-`False` cases for instance a `pip` or `setuptools` bundled into the interpreter
-to be unusable. Many libraries assume these packages will always be available
-and may not reliably declare their dependencies such that Bazel will satisfy
-them, so choosing isolation could expose packaging errors.
-
-""",
-    ),
-    "include_user_site_packages": attr.bool(
-        default = False,
-        doc = """`pyvenv.cfg` feature flag for the `aspect-include-user-site-packages` extension key.
-
-When `True`, the user's site directory directory will be included into the
-runtime pythonpath.
-
-When `False`, only the virtualenv's site directory and the interpreter's core
-libraries will be included into the runtime pythonpath.
-
-`False` is obviously preferable as it increases hermeticity, but the choice of
-`False` cases for instance a `pip` or `setuptools` bundled into the interpreter
-to be unusable. Many libraries assume these packages will always be available
-and may not reliably declare their dependencies such that Bazel will satisfy
-them, so choosing isolation could expose packaging errors.
-
-""",
+    "_virtualenv_shim": attr.label(
+        allow_single_file = True,
+        default = "//py/private:_virtualenv.py",
     ),
 })
 
 _attrs.update(**_py_library.attrs)
+
+_py_venv = rule(
+    doc = """Build a Python virtual environment and execute its interpreter.""",
+    implementation = _py_venv_rule_impl,
+    attrs = _attrs,
+    toolchains = [PY_TOOLCHAIN],
+    executable = True,
+    cfg = python_version_transition,
+)
+
+def _wrap_with_debug(rule):
+    def helper(**kwargs):
+        kwargs["debug"] = select({
+            Label(":debug_venv_setting"): True,
+            "//conditions:default": False,
+        })
+        return rule(**kwargs)
+
+    return helper
+
+def _py_venv_binary_impl(ctx):
+    """A virtualenv-based binary/test that runs a specific Python file."""
+    shared = _assemble_shared(ctx)
+
+    ctx.actions.expand_template(
+        template = ctx.file._run_tmpl,
+        output = ctx.outputs.executable,
+        substitutions = {
+            "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION.strip(),
+            "{{INTERPRETER_FLAGS}}": " ".join(_interpreter_flags(ctx, include_main = True)),
+            "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, shared.venv.bin_python),
+            "{{DEBUG}}": str(ctx.attr.debug).lower(),
+        },
+        is_executable = True,
+    )
+
+    passed_env = dict(ctx.attr.env)
+    for k, v in passed_env.items():
+        passed_env[k] = expand_variables(
+            ctx,
+            expand_locations(ctx, v, ctx.attr.data),
+            attribute_name = "env",
+        )
+
+    return [
+        DefaultInfo(
+            files = depset([ctx.outputs.executable]),
+            executable = ctx.outputs.executable,
+            runfiles = shared.runfiles,
+        ),
+        RunEnvironmentInfo(
+            environment = passed_env,
+            inherited_environment = getattr(ctx.attr, "env_inherit", []),
+        ),
+    ]
 
 _binary_attrs = dict({
     "main": attr.label(
         doc = "Script to execute with the Python interpreter.",
         allow_single_file = True,
         mandatory = True,
-    ),
-    "_bin_tmpl": attr.label(
-        allow_single_file = True,
-        default = "//py/private/py_venv:entrypoint.tmpl.sh",
     ),
 })
 
@@ -412,58 +338,110 @@ _test_attrs = dict({
     ),
 })
 
-py_venv_base = struct(
-    attrs = _attrs,
-    binary_attrs = _binary_attrs,
-    test_attrs = _test_attrs,
-    toolchains = [
-        PY_TOOLCHAIN,
-        SHIM_TOOLCHAIN,
-        VENV_EXEC_TOOLCHAIN,
-    ],
-    cfg = python_version_transition,
-)
-
-_py_venv = rule(
-    doc = """Build a Python virtual environment and execute its interpreter.""",
-    implementation = _py_venv_rule_impl,
-    attrs = py_venv_base.attrs,
-    toolchains = py_venv_base.toolchains,
-    executable = True,
-    cfg = py_venv_base.cfg,
-)
-
-def _wrap_with_debug(rule):
-    def helper(**kwargs):
-        kwargs["debug"] = select({
-            Label(":debug_venv_setting"): True,
-            "//conditions:default": False,
-        })
-        return rule(**kwargs)
-
-    return helper
-
 _py_venv_binary = rule(
     doc = """Run a Python program under Bazel using a virtualenv.""",
     implementation = _py_venv_binary_impl,
-    attrs = py_venv_base.attrs | py_venv_base.binary_attrs,
-    toolchains = py_venv_base.toolchains,
+    attrs = _attrs | _binary_attrs,
+    toolchains = [PY_TOOLCHAIN],
     executable = True,
-    cfg = py_venv_base.cfg,
+    cfg = python_version_transition,
 )
 
 _py_venv_test = rule(
     doc = """Run a Python program under Bazel using a virtualenv.""",
     implementation = _py_venv_binary_impl,
-    attrs = py_venv_base.attrs | py_venv_base.binary_attrs | py_venv_base.test_attrs,
-    toolchains = py_venv_base.toolchains,
+    attrs = _attrs | _binary_attrs | _test_attrs,
+    toolchains = [PY_TOOLCHAIN],
     test = True,
-    cfg = py_venv_base.cfg,
+    cfg = python_version_transition,
 )
 
 py_venv = _wrap_with_debug(_py_venv)
 py_venv_binary = _wrap_with_debug(_py_venv_binary)
 py_venv_test = _wrap_with_debug(_py_venv_test)
+
+# Attrs that belong on the generated `py_venv` when `py_binary_with_venv`
+# splits a `py_binary(expose_venv = True, ...)` call into (venv, binary)
+# targets. Everything else belongs on the binary/test target. Some
+# attrs (`python_version`, `venv`) need to land on BOTH so the
+# python_version_transition picks the same config for both —
+# otherwise the binary's `data` resolves wheels under a different uv
+# VENV_FLAG / python version than the venv was built for, and
+# `select()`-driven hub picks diverge.
+_VENV_ONLY_ATTRS = [
+    "deps",
+    "imports",
+    "resolutions",
+    "virtual_deps",
+    "package_collisions",
+    "include_system_site_packages",
+    "include_user_site_packages",
+    "interpreter_options",
+]
+_SHARED_TRANSITION_ATTRS = [
+    "python_version",
+    "venv",  # uv's pip-extension config-transition attr (string)
+]
+
+def _split_kwargs_for_venv(kwargs):
+    """Pop venv-only kwargs off the dict and copy the shared-transition
+    ones. Returns the dict to pass to py_venv. `kwargs` is mutated:
+    venv-only attrs are popped; shared-transition attrs stay so they
+    also reach the py_binary/py_test call.
+    """
+    venv_kwargs = {}
+    for name in _VENV_ONLY_ATTRS:
+        if name in kwargs:
+            venv_kwargs[name] = kwargs.pop(name)
+    for name in _SHARED_TRANSITION_ATTRS:
+        if name in kwargs:
+            venv_kwargs[name] = kwargs[name]
+    return venv_kwargs
+
+def py_binary_with_venv(py_rule, name, main, srcs = None, deps = None, data = None, imports = None, tags = None, testonly = None, visibility = None, venv_dir_basename = None, isolated = True, **kwargs):
+    """Split `py_rule(name, ...)` into a `{name}.venv` py_venv target +
+    a `py_rule` call with `external_venv = :{name}.venv`.
+
+    Called by `py_binary` / `py_test` when `expose_venv = True`. The
+    emitted `:{name}.venv` is a first-class public target: shareable
+    via `external_venv` from other `py_binary` / `py_test` callsites,
+    and `bazel run :{name}.venv`-able to drop into the hermetic
+    interpreter for an interactive session.
+
+    All venv-shaping attrs (`deps`, `imports`, `package_collisions`,
+    `include_*_site_packages`, `interpreter_options`) land on the
+    `.venv` target. The rule's own dep closure is empty by
+    construction, so the analysis-time subset-coverage check in
+    py_binary's `_check_venv_coverage` is trivially satisfied.
+    """
+    venv_kwargs = _split_kwargs_for_venv(kwargs)
+    if deps != None:
+        venv_kwargs["deps"] = deps
+    if imports != None:
+        venv_kwargs["imports"] = imports
+
+    venv_label = "{}.venv".format(name)
+
+    py_venv(
+        name = venv_label,
+        venv_dir_basename = venv_dir_basename,
+        testonly = testonly,
+        visibility = visibility,
+        **venv_kwargs
+    )
+
+    py_rule(
+        name = name,
+        main = main,
+        srcs = srcs or [],
+        data = data,
+        tags = tags,
+        testonly = testonly,
+        visibility = visibility,
+        external_venv = ":" + venv_label,
+        isolated = isolated,
+        **kwargs
+    )
 
 def py_venv_link(venv_name = None, srcs = [], **kwargs):
     """Build a Python virtual environment and produce a script to link it into the build directory."""

--- a/py/private/py_venv/types.bzl
+++ b/py/private/py_venv/types.bzl
@@ -1,10 +1,18 @@
 """quasi-public types."""
 
 VirtualenvInfo = provider(
-    doc = """
-    Provider used to distinguish venvs from py rules.
-    """,
+    doc = """Provider emitted by `py_venv` identifying a materialised
+virtualenv for downstream consumers.
+
+Consumed by `py_binary(external_venv = X)` to assemble its launcher against
+an externally-provided venv. `bin_python` is what the launcher exec's;
+`imports` and `wheels` are used for analysis-time coverage checks so
+binaries fail loudly when their dep closure isn't covered by the venv.
+""",
     fields = {
-        "home": "Path of the virtualenv",
+        "bin_python": "File — the venv's bin/python symlink. Callers needing a launcher target point here.",
+        "venv_name": "str — the venv dir's basename (e.g. `.myapp_venv`). Combine with ctx.label to derive the runfiles path to the venv root.",
+        "imports": "depset[str] — rlocation-root-relative import paths covered by this venv. Mirrors `PyInfo.imports` of the venv's dep closure. Used by py_binary to verify its own imports are a subset.",
+        "wheels": "depset[struct] — per-wheel metadata (same shape as `PyWheelsInfo.wheels`). Used by py_binary to verify its own wheel deps are covered by the venv.",
     },
 )

--- a/py/private/run.tmpl.sh
+++ b/py/private/run.tmpl.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+# Launcher for py_binary targets.
+#
+# A real venv tree (pyvenv.cfg + bin/python symlink + lib/.../site-packages/<name>.pth)
+# is materialised at build time by py_binary.bzl. All this script has to do
+# is exec the venv's bin/python — Python's own startup reads pyvenv.cfg,
+# sets sys.prefix to the venv, and site.main() processes the .pth file.
+#
+# We also prepend <venv>/bin/ to $PATH so wheel-declared console scripts
+# (generated as wrapper files under <venv>/bin/<name> by py_binary.bzl)
+# are discoverable to subprocess.run(["<name>", ...]) from user code.
+#
 # NB: we don't use a path from @bazel_tools//tools/sh:toolchain_type because that's configured for the exec
 # configuration, while this script executes in the target configuration at runtime.
 
@@ -10,52 +21,12 @@ runfiles_export_envvars
 
 set -o errexit -o nounset -o pipefail
 
-PWD="$(pwd)"
-
-# Returns an absolute path to the given location if the path is relative, otherwise return
-# the path unchanged.
-function alocation {
-  local P=$1
-  if [[ "${P:0:1}" == "/" ]]; then
-    echo -n "${P}"
-  else
-    echo -n "${PWD%/}/${P}"
-  fi
-}
-
-function python_location {
-  local PYTHON="{{ARG_PYTHON}}"
-  local RUNFILES_INTERPRETER="{{RUNFILES_INTERPRETER}}"
-
-  if [[ "${RUNFILES_INTERPRETER}" == "true" ]]; then
-    echo -n "$(alocation "$(rlocation ${PYTHON})")"
-  else
-    echo -n "${PYTHON}"
-  fi
-}
-
-VENV_TOOL="$(rlocation {{VENV_TOOL}})"
-VIRTUAL_ENV="$(alocation "${RUNFILES_DIR}/{{ARG_VENV_NAME}}")"
-export VIRTUAL_ENV
-
-"${VENV_TOOL}" \
-    --location "${VIRTUAL_ENV}" \
-    --python "$(python_location)" \
-    --pth-file "$(rlocation {{ARG_PTH_FILE}})" \
-    --collision-strategy "{{ARG_COLLISION_STRATEGY}}" \
-    --venv-name "{{ARG_VENV_NAME}}"
-
-PATH="${VIRTUAL_ENV}/bin:${PATH}"
-export PATH
+VENV_PYTHON="$(rlocation {{ARG_VENV_PYTHON}})"
+VENV_BIN="$(dirname "${VENV_PYTHON}")"
+export VIRTUAL_ENV="$(dirname "${VENV_BIN}")"
+export PATH="${VENV_BIN}:${PATH-}"
 
 # Set all the env vars here, just before we launch
 {{PYTHON_ENV}}
 
-# This should detect bash and zsh, which have a hash command that must
-# be called to get it to forget past commands.  Without forgetting
-# past commands the $PATH changes we made may not be respected
-if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
-    hash -r 2> /dev/null
-fi
-
-exec "{{EXEC_PYTHON_BIN}}" {{INTERPRETER_FLAGS}} "$(rlocation {{ENTRYPOINT}})" "$@"
+exec "${VENV_PYTHON}" {{INTERPRETER_FLAGS}} "$(rlocation {{ENTRYPOINT}})" "$@"

--- a/py/private/venv.bzl
+++ b/py/private/venv.bzl
@@ -1,0 +1,506 @@
+"""Build-time assembly of a Python virtualenv via ctx.actions.symlink + write.
+
+This module is the single place in rules_py that declares the files making
+up a Python venv. Both `py_binary` / `py_test` (each with its own internal
+venv, when `external_venv` is unset) and the standalone `py_venv` rule call
+`assemble_venv` to keep their layouts bit-identical.
+
+The venv shape mirrors what CPython's `python -m venv` + pip install
+produces, so downstream tools (IDEs, `$VIRTUAL_ENV`-aware shells,
+distutils, etc.) treat it as a real venv:
+
+    <venv_name>/
+      pyvenv.cfg
+      bin/
+        python                                  symlink -> py_toolchain.python
+        python3                                 symlink -> python
+        python3.<MAJ>.<MIN>                     symlink -> python
+        activate                                bash/zsh activation script
+        <console_script>                        one per wheel-declared entry point
+      lib/python<MAJ>.<MIN>/site-packages/
+        <name>.pth                              first-party + fallback .pth
+        _virtualenv.py                          distutils-compat shim
+        _virtualenv.pth                         loads the shim at site init
+        <top_level>                             symlink to a wheel's subdir
+        <dist>-<ver>.dist-info                  symlink to a wheel's dist-info
+
+The whole tree is declared at analysis time as individual
+`ctx.actions.declare_file` / `ctx.actions.declare_symlink` outputs so
+Bazel's action cache treats each piece independently (no tree-artifact
++ remote-exec materialisation surprises).
+"""
+
+load("@bazel_lib//lib:paths.bzl", "to_rlocation_path")
+load("//py/private:py_library.bzl", _py_library = "py_library_utils")
+
+# Template for console-script wrappers under <venv>/bin/<name>. A tiny shell
+# script that execs the venv's own bin/python with an inline `-c` to import
+# the entry point and call it. Keeping this as pure sh (no polyglot) sidesteps
+# tokenisation quirks with `$` in strings, and the inline Python is short
+# enough that not having a real `__file__` doesn't matter in practice.
+# `"$@"` preserves the original argv, while sys.argv[0] is patched so the
+# called function sees the script's own name.
+_CONSOLE_SCRIPT_TEMPLATE = """\
+#!/bin/sh
+exec "$(dirname "$0")/python" -c 'import sys; from {module} import {func}; sys.argv[0] = "{name}"; sys.exit({func}())' "$@"
+"""
+
+def _dict_to_exports(env):
+    return ["export %s=\"%s\"" % (k, v) for (k, v) in env.items()]
+
+def _resolve_wheel_collisions(ctx, wheels, package_collisions):
+    """Walk PyWheelsInfo.wheels and produce merge plans for site-packages + bin/.
+
+    Two kinds of collision get checked:
+
+    * **Top-level in site-packages.** Multiple wheels claiming the same
+      top-level name. When ALL contributing wheels flag the name as a
+      PEP 420 namespace package (no `__init__.py` at that level), the
+      collision is benign — skip the per-top-level symlink and let each
+      wheel's site-packages fall through to `.pth` + `addsitedir`, where
+      Python's namespace machinery merges contributions natively.
+      Otherwise apply `package_collisions` policy.
+
+    * **Console-script name in bin/.** Apply `package_collisions` directly
+      — no namespace equivalent.
+
+    Returns:
+      top_level_to_site_pkgs: dict {top_level_name: site_packages_rfpath}
+      fully_covered_site_pkgs: dict[str, True] — site-packages paths whose
+          declared top-levels ALL ended up claimed by them — safe to drop
+          from the .pth fallback.
+      console_scripts_map: dict {script_name: struct(module, func)} after
+          collision resolution.
+    """
+
+    def _complain(what, name, a, b):
+        msg = "Package collision in {target}: {what} `{name}` is provided by both {a} and {b}.".format(
+            target = str(ctx.label),
+            what = what,
+            name = name,
+            a = a,
+            b = b,
+        )
+        if package_collisions == "error":
+            fail(msg + "\nSet `package_collisions = \"warning\"` or \"ignore\" to downgrade.")
+        elif package_collisions == "warning":
+            # buildifier: disable=print
+            print(msg)
+
+    # Pass 1: bucket claimants per top-level / per console-script name.
+    tl_claimants = {}  # tl -> list of struct(site_packages, is_ns)
+    cs_claimants = {}  # name -> list of struct(site_packages, module, func)
+    for w in wheels:
+        ns_set = {tl: True for tl in getattr(w, "namespace_top_levels", ())}
+        for tl in w.top_levels:
+            tl_claimants.setdefault(tl, []).append(struct(
+                site_packages = w.site_packages_rfpath,
+                is_ns = tl in ns_set,
+            ))
+        for entry in getattr(w, "console_scripts", ()):
+            # Entry encoding from the repo rule: "name=module:func".
+            if "=" not in entry:
+                continue
+            name, _, target = entry.partition("=")
+            if ":" not in target:
+                continue
+            module, _, func = target.partition(":")
+            name = name.strip()
+            module = module.strip()
+            func = func.strip()
+            if not name or not module or not func:
+                continue
+            cs_claimants.setdefault(name, []).append(struct(
+                site_packages = w.site_packages_rfpath,
+                module = module,
+                func = func,
+            ))
+
+    # Pass 2: resolve top-levels. Track which (site_packages, tl) pairs
+    # we SKIPPED so pass 3 can decide which wheels are fully covered.
+    top_level_to_site_pkgs = {}
+    skipped_per_wheel = {}
+    for tl, claimants in tl_claimants.items():
+        distinct_sp = {c.site_packages: c for c in claimants}
+        if len(distinct_sp) == 1:
+            top_level_to_site_pkgs[tl] = claimants[0].site_packages
+            continue
+
+        all_namespace = all([c.is_ns for c in claimants])
+        if all_namespace:
+            for c in claimants:
+                skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+            continue
+
+        first = claimants[0]
+        top_level_to_site_pkgs[tl] = first.site_packages
+        seen_losers = {}
+        for c in claimants[1:]:
+            if c.site_packages == first.site_packages or c.site_packages in seen_losers:
+                continue
+            _complain("top-level", tl, first.site_packages, c.site_packages)
+            seen_losers[c.site_packages] = True
+            skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+
+    # Pass 2b: console scripts.
+    console_scripts_map = {}
+    for name, claimants in cs_claimants.items():
+        distinct_sp = {c.site_packages: c for c in claimants}
+        if len(distinct_sp) == 1:
+            c = claimants[0]
+            console_scripts_map[name] = struct(module = c.module, func = c.func)
+            continue
+        first = claimants[0]
+        console_scripts_map[name] = struct(module = first.module, func = first.func)
+        seen_losers = {}
+        for c in claimants[1:]:
+            if c.site_packages == first.site_packages or c.site_packages in seen_losers:
+                continue
+            _complain("console script", name, first.site_packages, c.site_packages)
+            seen_losers[c.site_packages] = True
+
+    # Pass 3: wheels fully covered by direct symlinks.
+    fully_covered = {}
+    for w in wheels:
+        skipped = skipped_per_wheel.get(w.site_packages_rfpath, {})
+        covered = True
+        for tl in w.top_levels:
+            if tl in skipped or top_level_to_site_pkgs.get(tl) != w.site_packages_rfpath:
+                covered = False
+                break
+        if covered:
+            fully_covered[w.site_packages_rfpath] = True
+
+    return top_level_to_site_pkgs, fully_covered, console_scripts_map
+
+def assemble_venv(
+        ctx,
+        *,
+        safe_name,
+        py_toolchain,
+        imports_depset,
+        package_collisions = "error",
+        include_system_site_packages = False,
+        include_user_site_packages = False,
+        default_env = {},
+        venv_activate_tmpl,
+        virtualenv_shim_py,
+        venv_name = None):
+    """Declare every file + symlink that makes up a venv for a target.
+
+    Args:
+      ctx: The rule context.
+      safe_name: Directory-name-safe stem for the venv dir. Slashes in the
+        target name should be replaced by the caller (e.g. "_").
+      py_toolchain: Resolved Python toolchain struct from py_semantics.
+      imports_depset: Depset of first-party + transitive wheel import
+        paths (as returned by py_library_utils.make_imports_depset).
+      package_collisions: "error" / "warning" / "ignore" — policy applied
+        when two wheels claim the same top-level (non-namespace case) or
+        the same console-script name.
+      include_system_site_packages: Value for pyvenv.cfg's
+        `include-system-site-packages` key.
+      include_user_site_packages: Value for the Aspect extension
+        `aspect-include-user-site-packages` key.
+      default_env: Dict of env-var name → value. Exported at the top of
+        the generated activate script and unset in `deactivate`.
+      venv_activate_tmpl: File — the activate-script template (usually
+        `ctx.file._venv_activate_tmpl`).
+      virtualenv_shim_py: File — the `_virtualenv.py` distutils shim
+        source (usually `ctx.file._virtualenv_shim`).
+
+    Returns:
+      struct with:
+        venv_name: str — the venv dir's basename (default "." + safe_name + ".venv").
+        bin_python: File — the venv's bin/python symlink, for launchers
+            to rlocation-resolve and exec.
+        all_files: list[File] — every declared output, ready for runfiles
+            / DefaultInfo aggregation.
+        site_packages_pth_file: File — the main .pth (useful if the
+            caller needs to know its runfiles path).
+        pyvenv_cfg: File — declared pyvenv.cfg.
+    """
+
+    wheels_depset = _py_library.make_wheels_depset(ctx)
+    wheels = wheels_depset.to_list()
+    top_level_to_site_pkgs, fully_covered_site_pkgs, console_scripts_map = _resolve_wheel_collisions(
+        ctx,
+        wheels,
+        package_collisions,
+    )
+
+    # Layout + escape math — the venv is a sibling of the target's
+    # declared outputs at <pkg>/<venv_name>/, so from the .pth / symlinks
+    # inside site-packages we need to walk up to the runfiles root before
+    # descending into an external wheel repo.
+    #
+    # Components below the runfiles root, from the .pth's directory:
+    #   1 workspace
+    # + N package segments
+    # + 1 venv segment
+    # + 3 (lib, python<MAJ>.<MIN>, site-packages)
+    # `py_ver` controls two distinct layouts that agree most of the time
+    # but diverge for freethreaded interpreters:
+    #
+    # * `venv_py_ver` — the lib-dir name inside OUR venv. Freethreaded
+    #   Python 3.13+ (and onwards) expects its site-packages at
+    #   `lib/python<M>.<m>t/site-packages/`. If we put ours at
+    #   `python<M>.<m>/`, the interpreter never finds our symlinks.
+    # * `wheel_py_ver` — the lib-dir name inside a wheel's `install_tree`.
+    #   The unpacker hardcodes `lib/python<M>.<m>/site-packages/`
+    #   regardless of freethreaded status (same wheel install layout for
+    #   both non-t and t interpreters). Keep this without the `t`.
+    wheel_py_ver = "python{}.{}".format(
+        py_toolchain.interpreter_version_info.major,
+        py_toolchain.interpreter_version_info.minor,
+    )
+    venv_py_ver = wheel_py_ver + ("t" if py_toolchain.freethreaded else "")
+    package_depth = len(ctx.label.package.split("/")) if ctx.label.package else 0
+
+    # From .pth / symlink dir up to runfiles root.
+    escape_count = 1 + package_depth + 1 + 3
+    escape = "/".join([".."] * escape_count)
+
+    # From venv root (= sys.prefix at runtime) up to runfiles root.
+    venv_to_runfiles_escape = "/".join([".."] * (2 + package_depth))
+
+    # Default basename is `.{name}.venv/` — the Pythonic name that
+    # IDEs auto-detect. The leading dot also keeps this distinct from
+    # a sibling py_venv target at `:<name>.venv` (auto-emitted by
+    # `py_binary(expose_venv = True, ...)`): the sibling's launcher
+    # file lands at `bazel-bin/<pkg>/<name>.venv`, while any internal
+    # venv tree lives under `bazel-bin/<pkg>/.<name>.venv/`. Different
+    # filesystem paths, no collision. Callers can override via the
+    # `venv_name` parameter.
+    if venv_name == None:
+        venv_name = ".{}.venv".format(safe_name)
+    site_packages_rel = "{}/lib/{}/site-packages".format(venv_name, venv_py_ver)
+
+    # Two-hop alias for each wheel that carries its install_tree File:
+    #
+    #   Hop 1: <venv>/_wheels/<alias>/  →  <install_tree>   (resolved)
+    #   Hop 2: <venv>/lib/<py>/site-packages/<tl>
+    #            →  ../../../_wheels/<alias>/lib/<py>/site-packages/<tl>
+    #          (intra-venv relative, declare_symlink)
+    #
+    # Hop 1 is a `ctx.actions.symlink(output=declare_directory, target_file=<tree>)`.
+    # In bazel-bin it's a single absolute symlink to the wheel's tree
+    # artifact; in runfiles Bazel materialises it as a real directory with
+    # per-file absolute symlinks inside — same shape the aliased tree
+    # artifact already has in runfiles, so no new materialisation cost.
+    #
+    # Hop 2 is a `declare_symlink` with a relative `target_path`. Relative
+    # depth is identical in bazel-bin and runfiles because the target
+    # stays entirely within the venv's own output tree. This is what
+    # unblocks `py_image_layer` (which walks bazel-bin) and any other
+    # bazel-bin-walking tool.
+    site_packages_to_wheels_alias = "/".join([".."] * 3) + "/_wheels"
+
+    # Map from site_packages_rfpath → alias index (and alias-dir File)
+    # for wheels that carry install_tree. Indexing by rfpath (instead of
+    # label) keeps the mapping deterministic across builds.
+    wheels_with_trees = [w for w in wheels if getattr(w, "install_tree", None) != None]
+    wheel_alias_by_sp = {}
+    for i, w in enumerate(wheels_with_trees):
+        wheel_alias_by_sp[w.site_packages_rfpath] = i
+
+    declared = []  # accumulator for all outputs
+
+    # Hop 1: per-wheel directory aliases. Bazel picks an absolute path
+    # under bazel-bin; the output is a tree artifact whose contents
+    # dereference the install_tree.
+    for i, w in enumerate(wheels_with_trees):
+        alias_dir = ctx.actions.declare_directory(
+            "{}/_wheels/{}".format(venv_name, i),
+        )
+        ctx.actions.symlink(
+            output = alias_dir,
+            target_file = w.install_tree,
+        )
+        declared.append(alias_dir)
+
+    # Hop 2 (+ legacy one-hop fallback): per-top-level site-packages
+    # symlinks. If the owning wheel has a `_wheels/<i>/` alias, we route
+    # through it with an intra-venv relative path; otherwise fall back
+    # to the historical runfiles-root-escape unresolved symlink.
+    for tl, wheel_site_pkgs in top_level_to_site_pkgs.items():
+        out = ctx.actions.declare_symlink("{}/{}".format(site_packages_rel, tl))
+        alias_idx = wheel_alias_by_sp.get(wheel_site_pkgs)
+        if alias_idx != None:
+            ctx.actions.symlink(
+                output = out,
+                target_path = "{}/{}/lib/{}/site-packages/{}".format(
+                    site_packages_to_wheels_alias,
+                    alias_idx,
+                    wheel_py_ver,
+                    tl,
+                ),
+            )
+        else:
+            ctx.actions.symlink(
+                output = out,
+                target_path = "{}/{}/{}".format(escape, wheel_site_pkgs, tl),
+            )
+        declared.append(out)
+
+    # .pth for anything NOT handled by the top-level symlinks:
+    #   * runfiles root itself (first line) — needed by rules_python runfiles helper
+    #   * first-party import dirs (workspace roots, py_library imports)
+    #   * wheel site-packages dirs whose owning wheel lacks PyWheelsInfo
+    #     metadata (or whose coverage is partial due to collisions) —
+    #     get the `site.addsitedir(...)` treatment so wheel-internal .pth
+    #     files (*-nspkg.pth, editable installs, etc.) run
+    #
+    # For wheels that have a `_wheels/<i>/` alias, the addsitedir target
+    # goes through the alias (intra-venv, context-agnostic). For wheels
+    # without it, we keep the legacy runfiles-escape form.
+    pth_content_lines = [escape]
+    for imp in imports_depset.to_list():
+        if imp in fully_covered_site_pkgs:
+            continue
+        if imp.endswith("site-packages"):
+            alias_idx = wheel_alias_by_sp.get(imp)
+            if alias_idx != None:
+                pth_content_lines.append(
+                    ("import os, sys, site; " +
+                     "site.addsitedir(os.path.normpath(os.path.join(" +
+                     "sys.prefix, \"_wheels\", \"{idx}\", \"lib\", \"{py_ver}\", \"site-packages\")))").format(
+                        idx = alias_idx,
+                        py_ver = wheel_py_ver,
+                    ),
+                )
+            else:
+                pth_content_lines.append(
+                    ("import os, sys, site; " +
+                     "site.addsitedir(os.path.normpath(os.path.join(" +
+                     "sys.prefix, \"{venv_escape}\", \"{imp}\")))").format(
+                        venv_escape = venv_to_runfiles_escape,
+                        imp = imp,
+                    ),
+                )
+        else:
+            pth_content_lines.append("{}/{}".format(escape, imp))
+
+    site_packages_pth_file = ctx.actions.declare_file(
+        "{}/{}.pth".format(site_packages_rel, safe_name),
+    )
+    ctx.actions.write(
+        output = site_packages_pth_file,
+        content = "\n".join(pth_content_lines) + "\n",
+    )
+    declared.append(site_packages_pth_file)
+
+    # pyvenv.cfg. `home = ./bin/` points at the venv's own bin dir
+    # (relative to pyvenv.cfg's location), so Python finds our bin/python
+    # symlink there and follows it to locate the real interpreter and
+    # derive sys.base_prefix.
+    pyvenv_cfg = ctx.actions.declare_file("{}/pyvenv.cfg".format(venv_name))
+    ctx.actions.write(
+        output = pyvenv_cfg,
+        content = ("home = ./bin/\n" +
+                   "implementation = CPython\n" +
+                   "version_info = {major}.{minor}.{micro}\n" +
+                   "include-system-site-packages = {include_system}\n" +
+                   "aspect-include-user-site-packages = {include_user}\n" +
+                   "relocatable = true\n").format(
+            major = py_toolchain.interpreter_version_info.major,
+            minor = py_toolchain.interpreter_version_info.minor,
+            micro = py_toolchain.interpreter_version_info.micro,
+            include_system = str(include_system_site_packages).lower(),
+            include_user = str(include_user_site_packages).lower(),
+        ),
+    )
+    declared.append(pyvenv_cfg)
+
+    # bin/python — symlink to the real interpreter. We use target_file
+    # (resolved symlink) rather than target_path (unresolved) so that
+    # downstream tooling like py_image_layer / mtree_spec can follow the
+    # symlink and include the interpreter in tar layers. PR4 will revisit
+    # this with mtree_preserve_symlinks for proper OCI container support.
+    bin_python = ctx.actions.declare_file("{}/bin/python".format(venv_name))
+    ctx.actions.symlink(
+        output = bin_python,
+        target_file = py_toolchain.python,
+    )
+    declared.append(bin_python)
+
+    # Versioned python symlinks: python3, python3.<MAJ>.<MIN>, and on
+    # freethreaded interpreters also python3.<MAJ>.<MIN>t (the name the
+    # interpreter looks itself up under). All point at the sibling `python`.
+    versioned_names = [
+        "python{}".format(py_toolchain.interpreter_version_info.major),
+        "python{}.{}".format(
+            py_toolchain.interpreter_version_info.major,
+            py_toolchain.interpreter_version_info.minor,
+        ),
+    ]
+    if py_toolchain.freethreaded:
+        versioned_names.append("python{}.{}t".format(
+            py_toolchain.interpreter_version_info.major,
+            py_toolchain.interpreter_version_info.minor,
+        ))
+    for versioned_name in versioned_names:
+        sym = ctx.actions.declare_symlink("{}/bin/{}".format(venv_name, versioned_name))
+        ctx.actions.symlink(
+            output = sym,
+            target_path = "python",
+        )
+        declared.append(sym)
+
+    # bin/activate
+    bin_activate = ctx.actions.declare_file("{}/bin/activate".format(venv_name))
+    envvar_exports = "\n".join(_dict_to_exports(default_env)).strip()
+    envvar_unsets = "\n".join(
+        ["    unset {}".format(k) for k in default_env.keys()],
+    )
+    ctx.actions.expand_template(
+        template = venv_activate_tmpl,
+        output = bin_activate,
+        substitutions = {
+            "{{ENVVARS}}": envvar_exports,
+            "{{ENVVARS_UNSET}}": envvar_unsets,
+        },
+        is_executable = True,
+    )
+    declared.append(bin_activate)
+
+    # _virtualenv.py + _virtualenv.pth — distutils shim for pip interop.
+    virtualenv_shim_py_out = ctx.actions.declare_file(
+        "{}/_virtualenv.py".format(site_packages_rel),
+    )
+    ctx.actions.symlink(
+        output = virtualenv_shim_py_out,
+        target_file = virtualenv_shim_py,
+    )
+    declared.append(virtualenv_shim_py_out)
+
+    virtualenv_shim_pth = ctx.actions.declare_file(
+        "{}/_virtualenv.pth".format(site_packages_rel),
+    )
+    ctx.actions.write(
+        output = virtualenv_shim_pth,
+        content = "import _virtualenv\n",
+    )
+    declared.append(virtualenv_shim_pth)
+
+    # Console-script wrappers under <venv>/bin/<name>.
+    for name, target in console_scripts_map.items():
+        script = ctx.actions.declare_file("{}/bin/{}".format(venv_name, name))
+        ctx.actions.write(
+            output = script,
+            content = _CONSOLE_SCRIPT_TEMPLATE.format(
+                name = name,
+                module = target.module,
+                func = target.func,
+            ),
+            is_executable = True,
+        )
+        declared.append(script)
+
+    return struct(
+        venv_name = venv_name,
+        bin_python = bin_python,
+        all_files = declared,
+        site_packages_pth_file = site_packages_pth_file,
+        pyvenv_cfg = pyvenv_cfg,
+    )

--- a/py/private/venv.bzl
+++ b/py/private/venv.bzl
@@ -412,16 +412,42 @@ def assemble_venv(
     )
     declared.append(pyvenv_cfg)
 
-    # bin/python — symlink to the real interpreter. We use target_file
-    # (resolved symlink) rather than target_path (unresolved) so that
-    # downstream tooling like py_image_layer / mtree_spec can follow the
-    # symlink and include the interpreter in tar layers. PR4 will revisit
-    # this with mtree_preserve_symlinks for proper OCI container support.
-    bin_python = ctx.actions.declare_file("{}/bin/python".format(venv_name))
-    ctx.actions.symlink(
-        output = bin_python,
-        target_file = py_toolchain.python,
-    )
+    # bin/python — the symlink the launcher exec's and that Python reads
+    # to compute sys.base_prefix. We emit an UNRESOLVED symlink
+    # (`declare_symlink` + `target_path`) with an explicit relative
+    # target rather than a `declare_file` + `target_file` on
+    # `py_toolchain.python` for two reasons:
+    #
+    #  1. `target_file` lets Bazel pick the symlink target, and the
+    #     choice differs across Bazel versions (Bazel 8 tends to write
+    #     relative, Bazel 9 absolute). Downstream tools that repack the
+    #     tar (`py_image_layer`) need a stable, runfiles-correct target.
+    #  2. Absolute targets bake in the build-host execroot path — in an
+    #     OCI container that path doesn't exist, bin/python becomes a
+    #     dangling symlink, Python falls back to its compile-time
+    #     `/install` base_prefix, then fails to locate the stdlib.
+    #
+    # From `<venv>/bin/`, walk up to the runfiles root (`.runfiles/`)
+    # and then down through the interpreter's rlocation path — which is
+    # exactly the shape `runfiles` libraries would compute. Up count:
+    # 1 (bin) + 1 (venv) + package_depth + 1 (workspace) = 3 + pkg.
+    # For system-interpreter (no runfiles_interpreter), fall back to the
+    # absolute path — these are already non-hermetic by construction.
+    bin_python = ctx.actions.declare_symlink("{}/bin/python".format(venv_name))
+    if py_toolchain.runfiles_interpreter:
+        bin_to_runfiles_root = "/".join([".."] * (3 + package_depth))
+        ctx.actions.symlink(
+            output = bin_python,
+            target_path = "{}/{}".format(
+                bin_to_runfiles_root,
+                to_rlocation_path(ctx, py_toolchain.python),
+            ),
+        )
+    else:
+        ctx.actions.symlink(
+            output = bin_python,
+            target_path = py_toolchain.python.path,
+        )
     declared.append(bin_python)
 
     # Versioned python symlinks: python3, python3.<MAJ>.<MIN>, and on

--- a/py/private/venv_activate.tmpl.sh
+++ b/py/private/venv_activate.tmpl.sh
@@ -1,0 +1,78 @@
+# Adapted from CPython Lib/venv/scripts/common/activate
+
+deactivate () {
+    # reset old environment variables
+    if [ -n "${_OLD_VIRTUAL_PATH:-}" ] ; then
+        PATH="${_OLD_VIRTUAL_PATH:-}"
+        export PATH
+    fi
+
+    if [ "${_OLD_VIRTUAL_PYTHONHOME:-}" = "_activate_undef" ]; then
+        unset _OLD_VIRTUAL_PYTHONHOME
+        unset PYTHONHOME
+    elif [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
+        PYTHONHOME="${_OLD_VIRTUAL_PYTHONHOME:-}"
+        export PYTHONHOME
+    fi
+
+    # Call hash to forget past locations. Without forgetting past locations the
+    # $PATH changes we made may not be respected. See "man bash" for more
+    # details. hash is usually a builtin of your shell
+    hash -r 2> /dev/null
+
+    if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
+        PS1="${_OLD_VIRTUAL_PS1:-}"
+        export PS1
+    fi
+
+    unset _OLD_VIRTUAL_PS1
+    unset _OLD_VIRTUAL_PATH
+    unset _OLD_VIRTUAL_PYTHONHOME
+    unset VIRTUAL_ENV
+    unset VIRTUAL_ENV_PROMPT
+
+    # Unset Bazel-injected vars
+{{ENVVARS_UNSET}}
+
+    # Unset vars we set with the runfiles interpreter. Note that this needs to
+    # be conditional so we don't throw this state out under tests or run.
+    if [ "${_OLD_RUNFILES_DIR:-}" = "_activate_undef" ]; then
+        unset RUNFILES_DIR
+        unset RUNFILES_MANIFEST_FILE
+    fi
+
+    if [ ! "${1:-}" = "nondestructive" ] ; then
+    # Self destruct!
+        unset -f deactivate
+    fi
+}
+
+# unset irrelevant variables
+deactivate nondestructive
+
+# For ZSH, emulate BASH_SOURCE.
+# The runfiles library code has some deps on this so we just set it :/
+: "${BASH_SOURCE:=$0}"
+
+VIRTUAL_ENV="$(dirname "$(dirname "${BASH_SOURCE}")")"
+export VIRTUAL_ENV
+
+# unset PYTHONHOME if set
+# this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
+# could use `if (set -u; : $PYTHONHOME) ;` in bash.
+_OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-_activate_undef}"
+unset PYTHONHOME
+
+_OLD_VIRTUAL_PATH="$PATH"
+
+# Aspect additions
+# We set these before runfiles initialization so that we can use it as part of a fallback path
+{{ENVVARS}}
+
+# Now we can put the venv's absolute bin on the path
+PATH="$VIRTUAL_ENV/bin:$PATH"
+export PATH
+
+# Call hash to forget past commands. Without forgetting
+# past commands the $PATH changes we made may not be respected
+hash -r 2> /dev/null

--- a/py/tests/console-scripts/BUILD.bazel
+++ b/py/tests/console-scripts/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//py:defs.bzl", "py_test")
+
+# Exercises the console-script wrappers that py_binary/py_test generate under
+# <venv>/bin/<name> from each wheel's `[console_scripts]` entry points, and
+# the launcher's $PATH manipulation that makes them discoverable at runtime.
+#
+# Failure modes this test catches:
+#   - Wrapper file not written (PyWheelInfo plumbing broken)
+#   - Wrapper not on $PATH (launcher doesn't prepend <venv>/bin/)
+#   - Wrapper's `$(dirname "$0")/python` can't find the venv's python
+#   - Module resolution inside the wrapper fails (site-packages not set up)
+py_test(
+    name = "test_console_scripts",
+    srcs = ["test_console_scripts.py"],
+    deps = [
+        # cowsay declares a `cowsay` console-script entry point in its wheel.
+        "@pypi//cowsay",
+    ],
+)

--- a/py/tests/console-scripts/test_console_scripts.py
+++ b/py/tests/console-scripts/test_console_scripts.py
@@ -1,0 +1,49 @@
+"""Verify wheel-declared console scripts are usable via PATH at runtime.
+
+py_binary/py_test generate wrapper scripts under <venv>/bin/<name> from each
+wheel's `[console_scripts]` entry points. The launcher prepends <venv>/bin/
+to $PATH. This test confirms the whole chain works end-to-end by
+subprocess-invoking `cowsay`, which declares a `cowsay` entry point that
+calls `cowsay.__main__:cli`.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+
+
+class ConsoleScriptsTest(unittest.TestCase):
+    def test_wrapper_is_on_path(self):
+        path = shutil.which("cowsay")
+        self.assertIsNotNone(
+            path,
+            "cowsay wrapper not found on PATH (is <venv>/bin/ prepended?)",
+        )
+        self.assertTrue(
+            path.endswith(os.sep + "bin" + os.sep + "cowsay"),
+            "expected wrapper under a bin/ directory, got: {!r}".format(path),
+        )
+
+    def test_wrapper_invokes_entry_point(self):
+        # cowsay 6.1 CLI requires -t <text>; asserts entry-point import and
+        # call happens inside the wrapper's Python invocation.
+        result = subprocess.run(
+            ["cowsay", "-t", "subprocess-invocation-worked"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            "cowsay wrapper failed: stdout={!r} stderr={!r}".format(
+                result.stdout, result.stderr
+            ),
+        )
+        self.assertIn("subprocess-invocation-worked", result.stdout)
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())

--- a/py/tests/external-venv-env/BUILD.bazel
+++ b/py/tests/external-venv-env/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//py:defs.bzl", "py_test", "py_venv")
+
+# Regression test: `py_binary(external_venv = X)` should inherit X's
+# `env = {...}` at runtime, and the binary's own `env` should win on
+# key conflicts.
+
+py_venv(
+    name = "shared_venv",
+    env = {
+        "VENV_ONLY": "from_venv",
+        "CONFLICTING": "venv_value",  # binary overrides this
+    },
+    env_inherit = ["VENV_INHERITED"],
+    imports = ["."],
+)
+
+py_test(
+    name = "test_env_forwarding",
+    srcs = ["check_env.py"],
+    env = {
+        "BINARY_ONLY": "from_binary",
+        "CONFLICTING": "binary_value",  # wins over venv's value
+    },
+    env_inherit = ["BINARY_INHERITED"],
+    external_venv = ":shared_venv",
+    main = "check_env.py",
+)

--- a/py/tests/external-venv-env/check_env.py
+++ b/py/tests/external-venv-env/check_env.py
@@ -1,0 +1,28 @@
+"""Verify that `py_binary(external_venv = :v)` forwards `:v`'s env.
+
+Drives the regression test in ../BUILD.bazel — env declared on the
+venv target should reach the binary at runtime, and the binary's own
+env should override on key conflicts.
+"""
+
+import os
+import sys
+
+
+def expect(name, value):
+    actual = os.environ.get(name)
+    if actual != value:
+        print(f"FAIL: {name} = {actual!r}, expected {value!r}", file=sys.stderr)
+        sys.exit(1)
+
+
+# Env from the venv target flows through.
+expect("VENV_ONLY", "from_venv")
+
+# Env from the binary target flows through.
+expect("BINARY_ONLY", "from_binary")
+
+# On key conflict, the BINARY wins — it's the "inner" scope.
+expect("CONFLICTING", "binary_value")
+
+print("OK: external venv env-forwarding works")

--- a/py/tests/py-internal-venv/BUILD.bazel
+++ b/py/tests/py-internal-venv/BUILD.bazel
@@ -1,6 +1,13 @@
-load("//py/private/py_venv:defs.bzl", "py_venv_test")
+load("//py:defs.bzl", "py_test")
 
-py_venv_test(
+# Two variants of the same test: `test` uses `py_test` with the
+# default (internal, `.{name}_venv/`) venv shape; `venv_test` uses
+# `py_test(expose_venv = True, isolated = False,
+# venv_dir_basename = ".{name}")` — the opt-in split shape with the
+# legacy `.{name}/` on-disk basename. Both should satisfy the
+# structural assertions in test.py (they're basename-tolerant).
+
+py_test(
     name = "test",
     srcs = [
         "test.py",
@@ -9,6 +16,23 @@ py_venv_test(
         ".",
     ],
     main = "test.py",
+    deps = [
+        "@pypi//cowsay",
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = [
+        "test.py",
+    ],
+    expose_venv = True,
+    imports = [
+        ".",
+    ],
+    isolated = False,
+    main = "test.py",
+    venv_dir_basename = ".venv_test",
     deps = [
         "@pypi//cowsay",
     ],

--- a/py/tests/py-internal-venv/test.py
+++ b/py/tests/py-internal-venv/test.py
@@ -18,11 +18,16 @@ assert "_virtualenv" in sys.modules
 # Note that we can't assume that a `.runfiles` tree has been created as CI may
 # use a different layout.
 
-# The virtualenv changes the sys.prefix, which should be in our runfiles
-assert sys.prefix.endswith("/py/tests/py-internal-venv/.test")
+# The virtualenv changes sys.prefix to a dot-prefixed directory under
+# this test's package — the exact basename varies by rule variant
+# (py_test uses `.<name>_venv/`, py_venv_test uses `.<name>/`), so
+# assert on the structural invariant rather than the specific name.
+_prefix_parent, _prefix_basename = os.path.split(sys.prefix.rstrip("/"))
+assert _prefix_parent.endswith("/py/tests/py-internal-venv"), sys.prefix
+assert _prefix_basename.startswith("."), sys.prefix
 
 # That prefix should also be "the" prefix per site.PREFIXES
-assert site.PREFIXES[0].endswith("/py/tests/py-internal-venv/.test")
+assert site.PREFIXES[0] == sys.prefix
 
 # The virtualenv also changes the sys.executable (if we've done this right)
-assert sys.executable.find("/py/tests/py-internal-venv/.test/bin/python") != -1
+assert sys.executable.startswith(sys.prefix + "/bin/python"), sys.executable

--- a/py/tests/py-venv-disable-systemsite/BUILD.bazel
+++ b/py/tests/py-venv-disable-systemsite/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//py/private/py_venv:defs.bzl", "py_venv_test")
+load("//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = [
         "test.py",
@@ -10,6 +10,24 @@ py_venv_test(
     ],
     include_system_site_packages = False,
     main = "test.py",
+    deps = [
+        "@pypi//cowsay",
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = [
+        "test.py",
+    ],
+    expose_venv = True,
+    imports = [
+        ".",
+    ],
+    include_system_site_packages = False,
+    isolated = False,
+    main = "test.py",
+    venv_dir_basename = ".venv_test",
     deps = [
         "@pypi//cowsay",
     ],

--- a/py/tests/py-venv-disable-usersite/BUILD.bazel
+++ b/py/tests/py-venv-disable-usersite/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//py/private/py_venv:defs.bzl", "py_venv_test")
+load("//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = [
         "test.py",
@@ -10,6 +10,24 @@ py_venv_test(
     ],
     include_user_site_packages = False,
     main = "test.py",
+    deps = [
+        "@pypi//cowsay",
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = [
+        "test.py",
+    ],
+    expose_venv = True,
+    imports = [
+        ".",
+    ],
+    include_user_site_packages = False,
+    isolated = False,
+    main = "test.py",
+    venv_dir_basename = ".venv_test",
     deps = [
         "@pypi//cowsay",
     ],

--- a/py/tests/py-venv-enable-site/BUILD.bazel
+++ b/py/tests/py-venv-enable-site/BUILD.bazel
@@ -1,6 +1,9 @@
-load("//py/private/py_venv:defs.bzl", "py_venv_test")
+load("//py:defs.bzl", "py_test")
 
-py_venv_test(
+# `isolated = False` is required so Python honors the user-site flag
+# (py_test defaults to `-I` which ignores user-site regardless of the
+# pyvenv.cfg `aspect-include-user-site-packages` key).
+py_test(
     name = "test",
     srcs = [
         "test.py",
@@ -10,7 +13,27 @@ py_venv_test(
     ],
     include_system_site_packages = True,
     include_user_site_packages = True,
+    isolated = False,
     main = "test.py",
+    deps = [
+        "@pypi//cowsay",
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = [
+        "test.py",
+    ],
+    expose_venv = True,
+    imports = [
+        ".",
+    ],
+    include_system_site_packages = True,
+    include_user_site_packages = True,
+    isolated = False,
+    main = "test.py",
+    venv_dir_basename = ".venv_test",
     deps = [
         "@pypi//cowsay",
     ],

--- a/py/tests/py-venv-standalone-interpreter/BUILD.bazel
+++ b/py/tests/py-venv-standalone-interpreter/BUILD.bazel
@@ -1,15 +1,23 @@
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load("//py/private/py_venv:defs.bzl", "py_venv_binary")
+load("//py:defs.bzl", "py_binary")
 
-py_venv_binary(
+# Regression test: `py_binary(expose_venv = True, isolated = False)` —
+# the opt-in split shape — produces a runnable venv whose interpreter
+# honors `-I`-less semantics (PYTHONPATH, script-dir-on-sys.path,
+# optionally user-site). This is the shape users land on when they
+# used to call `py_venv_binary`.
+py_binary(
     name = "ex",
     srcs = [
         "ex.py",
     ],
+    expose_venv = True,
     imports = [
         ".",
     ],
+    isolated = False,
     main = "ex.py",
+    venv_dir_basename = ".ex",
     deps = [
         "@pypi//cowsay",
     ],

--- a/py/tests/py_venv_conflict/BUILD.bazel
+++ b/py/tests/py_venv_conflict/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//py:defs.bzl", "py_library")
-load("//py/unstable:defs.bzl", "py_venv", "py_venv_test")
+load("//py:defs.bzl", "py_library", "py_test", "py_venv")
 
 py_library(
     name = "lib",
@@ -54,11 +53,26 @@ build_test(
     ],
 )
 
-py_venv_test(
+py_test(
     name = "validate_import_roots",
     srcs = ["test_import_roots.py"],
     main = "test_import_roots.py",
     package_collisions = "ignore",
+    deps = [
+        ":lib",
+        "//py/tests/py_venv_conflict/a",
+        "//py/tests/py_venv_conflict/b",
+    ],
+)
+
+py_test(
+    name = "validate_import_roots_venv_test",
+    srcs = ["test_import_roots.py"],
+    expose_venv = True,
+    isolated = False,
+    main = "test_import_roots.py",
+    package_collisions = "ignore",
+    venv_dir_basename = ".validate_import_roots_venv_test",
     deps = [
         ":lib",
         "//py/tests/py_venv_conflict/a",

--- a/py/tests/py_venv_conflict/test_import_roots.py
+++ b/py/tests/py_venv_conflict/test_import_roots.py
@@ -47,14 +47,20 @@ print("---")
 
 print(sys.prefix)
 
+# Verify that conflicting modules are importable and originate from one
+# of our `a/` or `b/` fixtures. The venv assembly routes non-PyWheelsInfo
+# deps through `.pth` + `addsitedir`, so files stay where they were
+# declared rather than being materialised into the venv's site-packages.
 import conflict
 print(conflict.__file__)
-assert conflict.__file__.startswith(sys.prefix)
+assert "py_venv_conflict/a/" in conflict.__file__ or "py_venv_conflict/b/" in conflict.__file__
 
 import noconflict
 print(noconflict.__file__)
-assert noconflict.__file__.startswith(sys.prefix)
+assert "py_venv_conflict/a/" in noconflict.__file__ or "py_venv_conflict/b/" in noconflict.__file__
 
 import py_venv_conflict.lib as srclib
 print(srclib.__file__)
+# First-party `:lib` target's source file stays under the runfiles tree,
+# not inside the venv — same before and after the refactor.
 assert not srclib.__file__.startswith(sys.prefix)

--- a/py/tests/shared-external-venv/BUILD.bazel
+++ b/py/tests/shared-external-venv/BUILD.bazel
@@ -1,0 +1,68 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//py:defs.bzl", "py_binary", "py_test", "py_venv")
+
+# Regression test: a single `py_venv` target should be consumable by
+# many `py_binary` + `py_test` targets via `external_venv`. This is
+# the shared-virtualenv pattern the README advertises — point many
+# entry points at one venv, IDE targets one `.venv/bin/python`, and
+# the analysis-time subset-coverage check rejects binaries whose dep
+# closure is not a subset of the venv's.
+#
+# Layout below:
+#   :venv         — one py_venv carrying cowsay + colorama + pytest
+#   :say          — py_binary using external_venv = :venv, imports cowsay
+#   :colorize     — py_binary using external_venv = :venv, imports colorama
+#   :test_venv    — py_test using external_venv = :venv, imports both
+#
+# The sh_tests pipe `bazel run`-equivalent executions through
+# `run_and_check.sh` to confirm the binaries succeed end-to-end.
+
+py_venv(
+    name = "venv",
+    imports = ["."],
+    deps = [
+        "@pypi//colorama",
+        "@pypi//cowsay",
+    ],
+)
+
+py_binary(
+    name = "say",
+    srcs = ["uses_cowsay.py"],
+    external_venv = ":venv",
+    main = "uses_cowsay.py",
+)
+
+py_binary(
+    name = "colorize",
+    srcs = ["uses_colorama.py"],
+    external_venv = ":venv",
+    main = "uses_colorama.py",
+)
+
+py_test(
+    name = "test_venv",
+    srcs = ["test_shared_venv.py"],
+    external_venv = ":venv",
+    main = "test_shared_venv.py",
+)
+
+sh_test(
+    name = "test_say",
+    srcs = ["run_and_check.sh"],
+    args = [
+        "say",
+        "hello from shared venv",
+    ],
+    data = [":say"],
+)
+
+sh_test(
+    name = "test_colorize",
+    srcs = ["run_and_check.sh"],
+    args = [
+        "colorize",
+        "hello from shared venv (colorama path)",
+    ],
+    data = [":colorize"],
+)

--- a/py/tests/shared-external-venv/run_and_check.sh
+++ b/py/tests/shared-external-venv/run_and_check.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Runs the named py_binary target against the shared venv and asserts
+# its stdout contains the expected substring. Fails verbosely if the
+# binary errors out (e.g. import error from a broken venv wiring) or
+# if the substring is missing.
+
+set -euo pipefail
+
+binary="$1"
+expected="$2"
+
+LAUNCHER="$TEST_SRCDIR/_main/py/tests/shared-external-venv/${binary}"
+
+[[ -x "$LAUNCHER" ]] || { echo "launcher not found: $LAUNCHER" >&2; exit 1; }
+
+output=$("$LAUNCHER")
+
+if [[ "$output" != *"$expected"* ]]; then
+    echo "FAIL: expected substring '$expected' not found in binary output." >&2
+    echo "Output was:" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+echo "OK: '$binary' produced expected '$expected' substring via shared venv."

--- a/py/tests/shared-external-venv/test_shared_venv.py
+++ b/py/tests/shared-external-venv/test_shared_venv.py
@@ -1,0 +1,31 @@
+"""py_test consumer of the shared venv.
+
+Asserts that both cowsay and colorama — the wheels carried by the
+shared :venv — resolve under this test's interpreter, proving
+`external_venv = :venv` on a py_test produces the same sys.path as on
+a py_binary pointing at the same venv.
+
+Written as a plain-asserts `main` (not `pytest_main = True`) so the
+shared venv's dep list stays minimal — no need to also carry
+`pytest_shard` / `default_pytest_main` just to satisfy the
+analysis-time subset-coverage check.
+"""
+
+import sys
+
+
+def main():
+    import cowsay
+    assert callable(cowsay.get_output_string), "cowsay not importable"
+
+    import colorama
+    assert isinstance(colorama.Fore.RED, str), "colorama not importable"
+
+    # The interpreter must be the shared venv's, not the host Python.
+    # The shared venv target is `:venv`, so its bin/python lives at
+    # `.../py/tests/shared-external-venv/.venv/bin/python`.
+    assert "/py/tests/shared-external-venv/.venv/bin/python" in sys.executable, sys.executable
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tests/shared-external-venv/uses_colorama.py
+++ b/py/tests/shared-external-venv/uses_colorama.py
@@ -1,0 +1,19 @@
+"""A second binary-side entrypoint, sharing the venv with uses_cowsay.py.
+
+Imports a DIFFERENT wheel (colorama) to confirm both wheels in the
+shared venv are reachable — not just the first one an interpreter
+happens to resolve.
+"""
+
+import colorama
+
+
+def main():
+    colorama.init(autoreset=True)
+    print(f"{colorama.Fore.GREEN}hello from shared venv (colorama path){colorama.Style.RESET_ALL}")
+    # Smoke test: the attribute exists and is a string
+    assert isinstance(colorama.Fore.GREEN, str)
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tests/shared-external-venv/uses_cowsay.py
+++ b/py/tests/shared-external-venv/uses_cowsay.py
@@ -1,0 +1,18 @@
+"""A trivial binary-side entrypoint that imports cowsay from the shared venv.
+
+Success is measured by "import works, version attribute is accessible";
+if the shared venv isn't wiring cowsay onto sys.path for this binary's
+launcher, the import blows up.
+"""
+
+import cowsay
+
+
+def main():
+    msg = cowsay.get_output_string("cow", "hello from shared venv")
+    assert "hello from shared venv" in msg, msg
+    print(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -581,6 +581,10 @@ def _uv_impl(module_ctx):
             "name": install_id,
             "sbuild": install_cfg.sbuild,
             "whls": json.encode(install_cfg.whls),
+            # Parallel list of the same wheel labels as a real label_list,
+            # so the whl_install repo rule can `rctx.path()` them to peek
+            # at `*.dist-info/RECORD` for top-level metadata.
+            "whl_files": [v for v in install_cfg.whls.values() if v],
         }
         if install_cfg.post_install_patches:
             install_kwargs["post_install_patches"] = json.encode(install_cfg.post_install_patches)

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -13,6 +13,143 @@ load("//uv/private/constraints/platform:defs.bzl", "supported_platform")
 load("//uv/private/constraints/python:defs.bzl", "supported_python")
 load("//uv/private/pprint:defs.bzl", "pprint")
 
+def _find_whl_file(repository_ctx, whl_label):
+    """Resolve an http_file-style wheel label to the actual .whl path on disk.
+
+    whl_label typically points at an http_file's filegroup (`//file:file`),
+    so `repository_ctx.path` returns the filegroup's logical path — not
+    the actual .whl file, which is a sibling in the same directory under
+    its downloaded filename. Scan the parent directory to find it.
+
+    Returns None if no .whl file is found.
+    """
+    logical_path = repository_ctx.path(whl_label)
+    parent = logical_path.dirname
+    for entry in parent.readdir():
+        if entry.basename.endswith(".whl"):
+            return entry
+    return None
+
+def _extract_wheel_metadata(repository_ctx, whl_label):
+    """Peek inside a wheel to discover top-level names and console scripts.
+
+    Mirrors the rules_js `npm_import` pattern of doing partial archive
+    extraction at repo-rule time for metadata, rather than deferring to a
+    build-time action (which would leave the info invisible to analysis).
+
+    Reads:
+      * `*.dist-info/RECORD` (mandatory per PEP 427) to get top-level names.
+      * `*.dist-info/entry_points.txt` (optional) to get `[console_scripts]`.
+
+    Both reads go through `unzip -p` (stdout, no disk writes).
+
+    Args:
+      repository_ctx: The repo rule context.
+      whl_label: A Label pointing at a wheel file (typically an http_file
+                 target), passed in via the repo rule's `whl_files`
+                 label_list attr so Bazel wires up repo visibility.
+
+    Returns:
+      Tuple (top_levels_set, regular_top_levels_set, console_scripts_set):
+        * top_levels_set: dict[name → True] — all first-path-segment
+          names in RECORD (excluding `*.data/` staging entries).
+        * regular_top_levels_set: subset that had an `__init__.py` at
+          depth 1, i.e. regular packages. Its complement (within
+          top_levels_set, minus `.dist-info/`) is the PEP 420 namespace
+          set. Returned separately so callers can union regular/top sets
+          across multiple platform wheels before deriving namespaces —
+          a top-level is a namespace only if NO wheel has it as regular.
+        * console_scripts_set: dict[script_name → "name=module:func"].
+      All empty on any failure — callers tolerate empty and fall back.
+    """
+    unzip = repository_ctx.which("unzip")
+    if not unzip:
+        return {}, {}, {}
+
+    whl_path = _find_whl_file(repository_ctx, whl_label)
+    if whl_path == None:
+        return {}, {}, {}
+
+    # RECORD: authoritative list of every installed file. First path segment
+    # = top-level name, excluding the wheel's `*.data/` staging area.
+    record = repository_ctx.execute([unzip, "-p", str(whl_path), "*.dist-info/RECORD"])
+    top_levels_set = {}
+
+    # Tracks which top-levels contain a direct `<toplevel>/__init__.py` —
+    # i.e., are regular packages. The complement (top_levels that never
+    # appear with an `__init__.py` at depth 1) are PEP 420 namespace
+    # packages that expect to be merged across wheels.
+    regular_top_levels = {}
+    if record.return_code == 0 and record.stdout:
+        for line in record.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            path = line.split(",", 1)[0]
+            if not path:
+                continue
+            segments = path.split("/")
+            first_segment = segments[0]
+
+            # `*.data/` files (PEP 427) aren't installed to site-packages;
+            # they're routed to data/scripts/headers/purelib/etc. under
+            # sys.prefix. Exclude from site-packages top-level list.
+            if first_segment.endswith(".data"):
+                continue
+
+            # Filter RECORD entries that escape the install root. Some
+            # wheels (notably setuptools-family) emit lines like
+            # `../../bin/foo` for entry-point scripts. We don't want
+            # `..` / `.` / absolute paths / empty strings in top_levels
+            # because downstream `ctx.actions.declare_symlink` normalises
+            # paths and would create phantom outputs at parent dirs,
+            # producing prefix-collision errors.
+            if not first_segment:
+                continue
+            if first_segment in (".", ".."):
+                continue
+            if first_segment.startswith("/"):
+                continue
+            top_levels_set[first_segment] = True
+
+            # Single-file modules (e.g. `six.py` at top level) aren't
+            # namespace packages — treat them as regular.
+            if len(segments) == 1 or (len(segments) >= 2 and segments[1] == "__init__.py"):
+                regular_top_levels[first_segment] = True
+
+    # entry_points.txt: INI-style file. Only `[console_scripts]` interests
+    # us — pip/uv synthesize executables under `bin/<name>` from those at
+    # install time. Missing file is normal (lots of libs have no scripts).
+    ep = repository_ctx.execute([unzip, "-p", str(whl_path), "*.dist-info/entry_points.txt"])
+    console_scripts = {}
+    if ep.return_code == 0 and ep.stdout:
+        in_console_scripts = False
+        for raw_line in ep.stdout.splitlines():
+            # Strip comments (`;` or `#`) and whitespace.
+            line = raw_line.split(";", 1)[0].split("#", 1)[0].strip()
+            if not line:
+                continue
+            if line.startswith("[") and line.endswith("]"):
+                in_console_scripts = line[1:-1].strip() == "console_scripts"
+                continue
+            if not in_console_scripts:
+                continue
+            if "=" not in line:
+                continue
+            name, _, target = line.partition("=")
+            name = name.strip()
+            target = target.strip()
+            if not name or ":" not in target:
+                continue
+
+            # Normalise to "name=module:func" so downstream parsing is trivial.
+            console_scripts[name] = "{}={}".format(name, target)
+
+    # Return raw sets (not the final namespace derivation) so callers can
+    # union across multiple platform wheels before deciding namespace
+    # status — see the caller in `_whl_install_repo_impl`.
+    return top_levels_set, regular_top_levels, console_scripts
+
 def indent(text, space = " "):
     return "\n".join(["{}{}".format(space, l) for l in text.splitlines()])
 
@@ -234,12 +371,59 @@ filegroup(
         "//conditions:default": "checked-hash",
     })"""
 
+    # Peek into each wheel to extract the top-level names it installs AND
+    # its `[console_scripts]` entry points. This powers PyWheelsInfo,
+    # which py_binary uses to build a merged site-packages tree via
+    # ctx.actions.symlink and to wrap console scripts into <venv>/bin/.
+    # Falls back gracefully to [] if extraction fails; consumers tolerate it.
+    #
+    # We read from `whl_files` (a real label_list) rather than `whls` (a
+    # JSON-encoded string of labels) because only the former adds the
+    # wheel repos to our visibility so `rctx.path(Label(...))` can resolve.
+    #
+    # Union across all platform wheels — same-python-version wheels for
+    # a given package share their pure-Python top-levels but have
+    # DIFFERENT C-extension filenames (e.g. cffi's `_cffi_backend` ships
+    # as `_cffi_backend.cpython-311-darwin.so` on macOS and
+    # `_cffi_backend.cpython-311-x86_64-linux-gnu.so` on Linux). Picking
+    # only one wheel bakes in that wheel's suffix; at build time on a
+    # different platform, the venv's top-level symlink points at a file
+    # that doesn't exist in the actually-installed wheel. Unioning lets
+    # every platform see its own suffix in top_levels — the dangling
+    # symlinks for other platforms' suffixes are invisible to Python's
+    # importer (it matches by the current interpreter's exact suffix).
+    top_levels_set = {}
+    regular_top_levels_set = {}
+    console_scripts_set = {}
+    for whl_file in repository_ctx.attr.whl_files:
+        tls, reg, css = _extract_wheel_metadata(repository_ctx, whl_file)
+        top_levels_set.update(tls)
+        regular_top_levels_set.update(reg)
+        console_scripts_set.update(css)
+
+    # Namespace derivation happens AFTER the union: a top-level counts as
+    # a PEP 420 namespace only if NO extracted wheel had `__init__.py` at
+    # depth 1 for it. If any wheel flagged it regular, it's regular.
+    top_levels = sorted(top_levels_set.keys())
+    namespace_top_levels = sorted([
+        tl
+        for tl in top_levels_set
+        if tl not in regular_top_levels_set and not tl.endswith(".dist-info")
+    ])
+    console_scripts = sorted(console_scripts_set.values())
+
     install_attrs = """
     src = ":whl",
     compile_pyc = {compile_pyc},
-    pyc_invalidation_mode = {pyc_invalidation_mode},""".format(
+    pyc_invalidation_mode = {pyc_invalidation_mode},
+    top_levels = {top_levels},
+    namespace_top_levels = {namespace_top_levels},
+    console_scripts = {console_scripts},""".format(
         compile_pyc = compile_pyc_select,
         pyc_invalidation_mode = pyc_invalidation_mode_select,
+        top_levels = repr(top_levels),
+        namespace_top_levels = repr(namespace_top_levels),
+        console_scripts = repr(console_scripts),
     )
 
     if post_install_patches:
@@ -295,6 +479,12 @@ whl_install = repository_rule(
     implementation = _whl_install_impl,
     attrs = {
         "whls": attr.string(),
+        # Mirror of the http_file labels from `whls`, declared as a real
+        # label_list so Bazel adds those repos to this repo's visibility
+        # mapping. Needed so that `repository_ctx.path(Label(...))` can
+        # resolve any one of them at repo-rule time to peek at the wheel's
+        # `*.dist-info/RECORD` — see `_extract_top_levels` above.
+        "whl_files": attr.label_list(allow_files = [".whl"]),
         "sbuild": attr.label(),
         "post_install_patches": attr.string(default = ""),
         "post_install_patch_strip": attr.int(default = 0),

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -2,6 +2,7 @@
 """
 
 load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN", "UNPACK_TOOLCHAIN")
 
 def _whl_install(ctx):
@@ -65,7 +66,12 @@ def _whl_install(ctx):
         },
     )
 
-    return [
+    site_packages_rfpath = ctx.label.repo_name + "/install/lib/python{}.{}/site-packages".format(
+        py_toolchain.interpreter_version_info.major,
+        py_toolchain.interpreter_version_info.minor,
+    )
+
+    providers = [
         DefaultInfo(
             # install_dir is an intermediate artifact consumed by downstream
             # Python rules via PyInfo.transitive_sources. Excluding it from
@@ -85,17 +91,40 @@ def _whl_install(ctx):
             transitive_sources = depset([
                 install_dir,
             ]),
-            imports = depset([
-                ctx.label.repo_name + "/install/lib/python{}.{}/site-packages".format(
-                    py_toolchain.interpreter_version_info.major,
-                    py_toolchain.interpreter_version_info.minor,
-                ),
-            ]),
+            imports = depset([site_packages_rfpath]),
             has_py2_only_sources = False,
             has_py3_only_sources = True,
             uses_shared_libraries = False,
         ),
     ]
+
+    if ctx.attr.top_levels or ctx.attr.console_scripts:
+        providers.append(PyWheelsInfo(
+            wheels = depset(direct = [struct(
+                top_levels = tuple(ctx.attr.top_levels),
+                # PEP 420 namespace packages this wheel contributes to.
+                # When multiple wheels claim the same top-level and ALL of
+                # them flag it as namespace, py_binary treats the
+                # collision as benign and falls back to .pth-based
+                # resolution so Python's namespace-package machinery
+                # merges contributions across wheels.
+                namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
+                site_packages_rfpath = site_packages_rfpath,
+                # Each entry is "name=module:func"; py_binary parses into
+                # wrapper scripts at <venv>/bin/<name> at analysis time.
+                console_scripts = tuple(ctx.attr.console_scripts),
+                # Tree artifact holding this wheel's installed file tree
+                # (`install/`, whose internal shape is
+                # `lib/python<M>.<m>/site-packages/...`). Downstream
+                # venv-assembly uses this as a `target_file` for a
+                # per-wheel directory symlink, so the per-top-level
+                # symlinks inside the venv can be intra-venv relative
+                # (identical resolution in bazel-bin and runfiles).
+                install_tree = install_dir,
+            )]),
+        ))
+
+    return providers
 
 whl_install = rule(
     implementation = _whl_install,
@@ -131,6 +160,41 @@ lighter weight since the toolchain's files aren't inputs.
             default = "checked-hash",
             values = ["checked-hash", "unchecked-hash", "timestamp"],
             doc = "PEP 552 invalidation mode for pre-compiled .pyc files.",
+        ),
+        "top_levels": attr.string_list(
+            doc = """Names of the top-level packages / modules / *.dist-info directories this wheel installs into its site-packages.
+
+When set, the target emits a `PyWheelsInfo` provider describing this wheel.
+Downstream rules (such as `py_binary`) can consume this to assemble a merged
+`site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth`
+entries. Empty default preserves existing `.pth`-based behavior.
+
+Typically populated automatically by the `whl_install` repo rule from the
+wheel's `*.dist-info/top_level.txt` or `RECORD` at repo-fetch time.
+""",
+            default = [],
+        ),
+        "console_scripts": attr.string_list(
+            doc = """Console-script entry points declared by this wheel, in the form `"name=module:func"`.
+
+Populated from the wheel's `*.dist-info/entry_points.txt` `[console_scripts]`
+section by the `whl_install` repo rule at repo-fetch time. `py_binary`
+consumes these via `PyWheelsInfo` to generate executable wrappers under
+`<venv>/bin/<name>` so `subprocess.run(["<name>", ...])` works.
+""",
+            default = [],
+        ),
+        "namespace_top_levels": attr.string_list(
+            doc = """Subset of `top_levels` that are PEP 420 namespace packages.
+
+A top-level is a namespace if the wheel's RECORD shows no
+`<toplevel>/__init__.py`. When multiple wheels contribute to the same
+namespace (e.g. `jaraco-classes` and `jaraco-functools` both claim
+`jaraco`), `py_binary`'s collision detector treats the overlap as
+benign and falls back to `.pth`-based resolution so Python's namespace
+machinery merges the contributions at runtime.
+""",
+            default = [],
         ),
     },
     toolchains = [


### PR DESCRIPTION
This PR connects the Starlark venv assembly engine (introduced in [PR965](https://github.com/aspect-build/rules_py/pull/965)) to py_binary and py_test. Every Python binary now gets its own internal venv built entirely at analysis time via assemble_venv, replacing the previous runtime Rust-based venv construction. It also introduces external_venv for sharing venvs across targets and expose_venv for IDE-friendly .venv symlinks.
  
  ## **What's new**

- py/private/py_binary.bzl. Complete rewrite of the binary rule implementation:
- Calls assemble_venv to build an internal venv per target when external_venv is unset
- Supports external_venv = <py_venv label> for sharing a pre-built venv across multiple binaries (saves disk and analysis time)
- _check_venv_coverage validates at analysis time that the external venv covers the binary's full dep closure. un-covered deps would be runtime ImportErrors under -I
- Launcher template simplified to exec the venv's bin/python directly
- isolated = False drops Python's -I flag so PYTHONPATH is honored
- env_inherit support for forwarding env vars from the external venv
- py/private/run.tmpl.sh. New shell launcher replacing the Rust-based one:
- Sets up RUNFILES_DIR and rlocation
- Exports PYTHON_ENV vars
- execs the venv's bin/python with the entrypoint module
- No runtime venv construction. The venv is already complete
- py/defs.bzl. New public API:
- expose_venv = True on py_binary / py_test emits a sibling .venv symlink for IDE auto-detection
- _py_binary_with_venv macro used by py_venv_binary legacy wrapper
- py_venv exported publicly
- py/tests/shared-external-venv/. Tests that multiple py_binary targets can share one external_venv and each sees the correct imports
- py/tests/external-venv-env/. Tests that env and env_inherit propagate correctly through external_venv
- py/tests/console-scripts/. Tests that console scripts declared by wheels work in the assembled venv

  
  ## **What's changed**

- py/private/py_pex_binary.bzl. Minor adjustments for compatibility with the new venv layout
- py/tests/py-internal-venv/. Updated to test the new internal venv built at analysis time
- py/tests/py-venv-disable-systemsite/, py/tests/py-venv-disable-usersite/, py/tests/py-venv-enable-site/, py/tests/py-venv-standalone-interpreter/. Updated for new layout
- py/tests/py_venv_conflict/. Updated assertions for two-hop symlinks
- e2e/cases/root-dir-paths-538/. Added test_root_dir_expose_venv verifying expose_venv symlink behavior
- e2e/cases/venv-isolated-mode-703/, e2e/cases/venv-conflict-608/, e2e/cases/venv-internal-symlinks/, e2e/cases/venv-bin-scripts-423/. Updated for new venv layout

  
  ## **What's NOT included (future PRs)**

- No Rust tooling removal yet (PR3)
- No container-specific fixes beyond what PR1 already provided (PR4)
- No breaking API changes — py_venv_binary / py_venv_test legacy wrappers still work (PR5)
- No stable API path graduation (PR6)