### PR TITLE
test: ensure forward-compatible version of aspect_bazel_lib in e2e tests

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -18,6 +18,12 @@ local_path_override(
     path = "..",
 )
 
+# Ensure any transitive "aspect_bazel_lib" is latest to be forward compatible with bazel_lib 3+
+single_version_override(
+    module_name = "aspect_bazel_lib",
+    version = "2.22.5",
+)
+
 # Python interpreters provisioned from python-build-standalone via aspect_rules_py
 interpreters = use_extension("@aspect_rules_py//py/unstable:extension.bzl", "python_interpreters")
 interpreters.configure(


### PR DESCRIPTION
Otherwise there are issues on bazel 9.1 with aspect_bazel_lib coreutil toolchains: https://buildkite.com/bazel/bcr-presubmit/builds/33917#019df906-49fe-408f-b81d-13a8ea5e571b

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
