### PR TITLE
refactor: rename venv attribute/flag to dep_group

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@ common --incompatible_disallow_empty_glob=False
 common --define=SOME_VAR=SOME_VALUE
 
 # Set the default virtualenv to 'default'
-common --@pypi//venv=aspect_rules_py
+common --@pypi//dep_group=aspect_rules_py
 
 common --incompatible_enable_cc_toolchain_resolution
 common --@llvm//config:experimental_stub_libgcc_s

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ RBE) environments.
 | Site-packages layout      | Standard `site-packages` layout (flag-enabled)                                                          | Standard `site-packages` symlink tree                                                                                    |
 | Cross-compilation         | Limited                                                                                                 | Native platform transitions (e.g. arm64 image on amd64 host)                                                             |
 | Virtual dependencies      | No                                                                                                      | `virtual_deps` — swap implementations at binary level                                                                    |
-| PEP 735 dependency groups | No                                                                                                      | `--@pypi//venv=prod` flag                                                                                                |
+| PEP 735 dependency groups | No                                                                                                      | `--@pypi//dep_group=prod` flag                                                                                                |
 
 > [!NOTE]
 > **rules_python's uv support**: `rules_python`'s uv integration runs `uv pip compile` as a build action to
@@ -220,7 +220,7 @@ Switch between dependency groups:
 bazel run //:app
 
 # Use only production dependencies
-bazel run //:app --@pypi//venv=prod
+bazel run //:app --@pypi//dep_group=prod
 ```
 
 ## Virtual Dependencies

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -11,7 +11,7 @@ number of additional features.
 **Configurable dependencies** - Uv allows for multiple lockfile states (called
 venvs) to be registered into a single hub. Your build can be configured to
 choose between registered venvs. It's as simple as flipping the
-`--@<hub>//venv=<venv name>` flag. Binaries can also set the `venv=<venv name>`
+`--@<hub>//dep_group=<dep_group name>` flag. Binaries can also set the `dep_group=<dep_group name>`
 attribute.
 
 **Effortless Crossbuilds** - Uv delays building and installing packages until
@@ -111,7 +111,7 @@ If no dependency groups are listed, an implicit default group with the name of t
 
 ```
 # .bazelrc
-common --@pypi//venv=dummy
+common --@pypi//dep_group=dummy
 ```
 
 Individual targets can request different venvs if multiple venvs are configured.
@@ -130,7 +130,7 @@ py_binary(
    name = "say_vendored",
    srcs = ["__main__.py_"],
    deps = ["@pypi//cowsay"],
-   venv = "vendored_say",    # Change the default venv choice
+   dep_group = "vendored_say",    # Change the default dep_group choice
 )
 ```
 
@@ -219,7 +219,7 @@ py_venv_binary(
     srcs = ["__main__.py"],
     main = "__main__.py",
     python_version = "3.12",
-    venv = "psql",
+    dep_group = "psql",
     deps = [
         "@pypi//psycopg2_binary",
     ],
@@ -376,7 +376,7 @@ available.
 et. all, the venv flag has to be statically known. This means we get one global
 "current venv" flag, no matter how many hubs you have.
 
-It only really makes sense to use the `--@pypi//venv=default` flag as part of
+It only really makes sense to use the `--@pypi//dep_group=default` flag as part of
 your `.bazelrc`, because then the scope of where that default is applied is well
 bounded to your repository with your hub.
 

--- a/e2e/.bazelrc
+++ b/e2e/.bazelrc
@@ -14,7 +14,7 @@ common:linux --platforms=//:linux_gnu
 common:linux --host_platform=//:linux_gnu
 
 # Configure a default venv
-# common --@pypi//venv=say
+# common --@pypi//dep_group=say
 
 # Enable path mapping so WhlInstall actions are exercised with
 # supports-path-mapping. Actions that declare the execution requirement get

--- a/e2e/cases/cross-repo-610/BUILD.bazel
+++ b/e2e/cases/cross-repo-610/BUILD.bazel
@@ -9,7 +9,7 @@ py_venv_test(
         ".",
     ],
     main = "test.py",
-    venv = "say",
+    dep_group = "say",
     deps = [
         "@pypi//cowsay",
         "@subrepo_a//:foo",

--- a/e2e/cases/cross-repo-610/BUILD.bazel
+++ b/e2e/cases/cross-repo-610/BUILD.bazel
@@ -5,11 +5,11 @@ py_venv_test(
     srcs = [
         "test.py",
     ],
+    dep_group = "say",
     imports = [
         ".",
     ],
     main = "test.py",
-    dep_group = "say",
     deps = [
         "@pypi//cowsay",
         "@subrepo_a//:foo",

--- a/e2e/cases/firebase-admin-import/BUILD.bazel
+++ b/e2e/cases/firebase-admin-import/BUILD.bazel
@@ -37,8 +37,8 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 py_test(
     name = "test",
     srcs = ["test.py"],
-    main = "test.py",
     dep_group = "firebase-admin-import",
+    main = "test.py",
     deps = [
         "@pypi//firebase_admin",
     ],
@@ -54,8 +54,8 @@ py_test(
 py_binary(
     name = "firebase_importer",
     srcs = ["test.py"],
-    main = "test.py",
     dep_group = "firebase-admin-import",
+    main = "test.py",
     deps = [
         "@pypi//firebase_admin",
     ],

--- a/e2e/cases/firebase-admin-import/BUILD.bazel
+++ b/e2e/cases/firebase-admin-import/BUILD.bazel
@@ -38,7 +38,7 @@ py_test(
     name = "test",
     srcs = ["test.py"],
     main = "test.py",
-    venv = "firebase-admin-import",
+    dep_group = "firebase-admin-import",
     deps = [
         "@pypi//firebase_admin",
     ],
@@ -55,7 +55,7 @@ py_binary(
     name = "firebase_importer",
     srcs = ["test.py"],
     main = "test.py",
-    venv = "firebase-admin-import",
+    dep_group = "firebase-admin-import",
     deps = [
         "@pypi//firebase_admin",
     ],

--- a/e2e/cases/freethreaded-805/BUILD.bazel
+++ b/e2e/cases/freethreaded-805/BUILD.bazel
@@ -28,7 +28,7 @@ py_venv_test(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
-    venv = "freethreaded-test",
+    dep_group = "freethreaded-test",
     deps = [
         "@pypi//regex",
     ],

--- a/e2e/cases/freethreaded-805/BUILD.bazel
+++ b/e2e/cases/freethreaded-805/BUILD.bazel
@@ -16,6 +16,7 @@ platform(
 py_venv_test(
     name = "test_bin",
     srcs = ["test.py"],
+    dep_group = "freethreaded-test",
     main = "test.py",
     python_version = "3.13",
     tags = ["manual"],
@@ -28,7 +29,6 @@ py_venv_test(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
-    dep_group = "freethreaded-test",
     deps = [
         "@pypi//regex",
     ],

--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -27,7 +27,7 @@ platform(
 py_binary(
     name = "my_app_bin",
     srcs = ["__main__.py"],
-    venv = "images",
+    dep_group = "images",
     deps = [
         "//cases/oci/py_image_layer/branding",
         "@aspect_rules_py//py/tests/internal-deps/adder",

--- a/e2e/cases/oci/py_venv_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_venv_image_layer/BUILD.bazel
@@ -44,7 +44,7 @@ py_venv_binary(
     srcs = ["__main__.py"],
     main = "__main__.py",
     tags = ["manual"],
-    venv = "venv_images",
+    dep_group = "venv_images",
     deps = [
         "//cases/oci/py_image_layer/branding",
         "@aspect_rules_py//py/tests/internal-deps/adder",

--- a/e2e/cases/oci/py_venv_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_venv_image_layer/BUILD.bazel
@@ -42,9 +42,9 @@ platform(
 py_venv_binary(
     name = "my_app_bin",
     srcs = ["__main__.py"],
+    dep_group = "venv_images",
     main = "__main__.py",
     tags = ["manual"],
-    dep_group = "venv_images",
     deps = [
         "//cases/oci/py_image_layer/branding",
         "@aspect_rules_py//py/tests/internal-deps/adder",

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -8,7 +8,7 @@ py_venv_test(
     main = "__test__.py",
     package_collisions = "warning",
     python_version = "3.11",
-    venv = "pth-namespace-547",
+    dep_group = "pth-namespace-547",
     deps = [
         "@pypi//jaraco_classes",
         "@pypi//jaraco_functools",
@@ -20,7 +20,7 @@ py_test(
     name = "test_legacy",
     srcs = ["__test__.py"],
     main = "__test__.py",
-    venv = "pth-namespace-547",
+    dep_group = "pth-namespace-547",
     deps = [
         "@pypi//jaraco_classes",
         "@pypi//jaraco_functools",

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -5,10 +5,10 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_venv_test(
     name = "test",
     srcs = ["__test__.py"],
+    dep_group = "pth-namespace-547",
     main = "__test__.py",
     package_collisions = "warning",
     python_version = "3.11",
-    dep_group = "pth-namespace-547",
     deps = [
         "@pypi//jaraco_classes",
         "@pypi//jaraco_functools",
@@ -19,8 +19,8 @@ py_venv_test(
 py_test(
     name = "test_legacy",
     srcs = ["__test__.py"],
-    main = "__test__.py",
     dep_group = "pth-namespace-547",
+    main = "__test__.py",
     deps = [
         "@pypi//jaraco_classes",
         "@pypi//jaraco_functools",

--- a/e2e/cases/pytest-main-867/BUILD.bazel
+++ b/e2e/cases/pytest-main-867/BUILD.bazel
@@ -6,7 +6,7 @@ py_test(
     name = "test_example",
     srcs = ["test_example.py"],
     pytest_main = True,
-    venv = "pytest-main-867",
+    dep_group = "pytest-main-867",
     deps = ["@pypi//pytest"],
 )
 
@@ -16,7 +16,7 @@ py_test(
     name = "test_naming_regression",
     srcs = ["test_example.py"],
     pytest_main = True,
-    venv = "pytest-main-867",
+    dep_group = "pytest-main-867",
     deps = ["@pypi//pytest"],
 )
 
@@ -30,7 +30,7 @@ py_test(
         "test_b.py",
     ],
     pytest_main = True,
-    venv = "pytest-main-867",
+    dep_group = "pytest-main-867",
     deps = ["@pypi//pytest"],
 )
 
@@ -40,7 +40,7 @@ py_test(
     name = "test_collection_check",
     srcs = ["test_collection_check.py"],
     pytest_main = True,
-    venv = "pytest-main-867",
+    dep_group = "pytest-main-867",
     deps = ["@pypi//pytest"],
 )
 
@@ -59,7 +59,7 @@ py_test(
         ":test_direct_main",
     ],
     main = ":__test__test_direct_main__.py",
-    venv = "pytest-main-867",
+    dep_group = "pytest-main-867",
     deps = [
         ":test_direct_main",
         "@pypi//pytest",

--- a/e2e/cases/pytest-main-867/BUILD.bazel
+++ b/e2e/cases/pytest-main-867/BUILD.bazel
@@ -5,8 +5,8 @@ load("@aspect_rules_py//py:defs.bzl", "py_pytest_main", "py_test")
 py_test(
     name = "test_example",
     srcs = ["test_example.py"],
-    pytest_main = True,
     dep_group = "pytest-main-867",
+    pytest_main = True,
     deps = ["@pypi//pytest"],
 )
 
@@ -15,8 +15,8 @@ py_test(
 py_test(
     name = "test_naming_regression",
     srcs = ["test_example.py"],
-    pytest_main = True,
     dep_group = "pytest-main-867",
+    pytest_main = True,
     deps = ["@pypi//pytest"],
 )
 
@@ -29,8 +29,8 @@ py_test(
         "test_a.py",
         "test_b.py",
     ],
-    pytest_main = True,
     dep_group = "pytest-main-867",
+    pytest_main = True,
     deps = ["@pypi//pytest"],
 )
 
@@ -39,8 +39,8 @@ py_test(
 py_test(
     name = "test_collection_check",
     srcs = ["test_collection_check.py"],
-    pytest_main = True,
     dep_group = "pytest-main-867",
+    pytest_main = True,
     deps = ["@pypi//pytest"],
 )
 
@@ -58,8 +58,8 @@ py_test(
         "test_a.py",
         ":test_direct_main",
     ],
-    main = ":__test__test_direct_main__.py",
     dep_group = "pytest-main-867",
+    main = ":__test__test_direct_main__.py",
     deps = [
         ":test_direct_main",
         "@pypi//pytest",

--- a/e2e/cases/pytest-mock-530/BUILD.bazel
+++ b/e2e/cases/pytest-mock-530/BUILD.bazel
@@ -5,8 +5,8 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_test(
     name = "test_mock_py_test",
     srcs = ["test_mock.py"],
-    pytest_main = True,
     dep_group = "pytest-mock-530",
+    pytest_main = True,
     deps = [
         "@pypi//pytest",
         "@pypi//pytest_mock",
@@ -19,8 +19,8 @@ py_venv_test(
         "__test__.py",
         "test_mock.py",
     ],
-    main = "__test__.py",
     dep_group = "pytest-mock-530",
+    main = "__test__.py",
     deps = [
         "@pypi//pytest",
         "@pypi//pytest_mock",

--- a/e2e/cases/pytest-mock-530/BUILD.bazel
+++ b/e2e/cases/pytest-mock-530/BUILD.bazel
@@ -6,7 +6,7 @@ py_test(
     name = "test_mock_py_test",
     srcs = ["test_mock.py"],
     pytest_main = True,
-    venv = "pytest-mock-530",
+    dep_group = "pytest-mock-530",
     deps = [
         "@pypi//pytest",
         "@pypi//pytest_mock",
@@ -20,7 +20,7 @@ py_venv_test(
         "test_mock.py",
     ],
     main = "__test__.py",
-    venv = "pytest-mock-530",
+    dep_group = "pytest-mock-530",
     deps = [
         "@pypi//pytest",
         "@pypi//pytest_mock",

--- a/e2e/cases/pytest-subdir-imports/BUILD.bazel
+++ b/e2e/cases/pytest-subdir-imports/BUILD.bazel
@@ -9,8 +9,8 @@ py_library(
 py_test(
     name = "test_subdir_import",
     srcs = ["tests/test_subdir.py"],
-    pytest_main = True,
     dep_group = "pytest-subdir-imports",
+    pytest_main = True,
     deps = [
         ":lib",
         "@pypi//pytest",

--- a/e2e/cases/pytest-subdir-imports/BUILD.bazel
+++ b/e2e/cases/pytest-subdir-imports/BUILD.bazel
@@ -10,7 +10,7 @@ py_test(
     name = "test_subdir_import",
     srcs = ["tests/test_subdir.py"],
     pytest_main = True,
-    venv = "pytest-subdir-imports",
+    dep_group = "pytest-subdir-imports",
     deps = [
         ":lib",
         "@pypi//pytest",

--- a/e2e/cases/pytest-xdist-integration/BUILD.bazel
+++ b/e2e/cases/pytest-xdist-integration/BUILD.bazel
@@ -13,8 +13,8 @@ py_test(
         "-n",
         "2",
     ],
-    pytest_main = True,
     dep_group = "pytest-xdist-integration",
+    pytest_main = True,
     deps = [
         "@pypi//pytest",
         "@pypi//pytest_xdist",

--- a/e2e/cases/pytest-xdist-integration/BUILD.bazel
+++ b/e2e/cases/pytest-xdist-integration/BUILD.bazel
@@ -14,7 +14,7 @@ py_test(
         "2",
     ],
     pytest_main = True,
-    venv = "pytest-xdist-integration",
+    dep_group = "pytest-xdist-integration",
     deps = [
         "@pypi//pytest",
         "@pypi//pytest_xdist",

--- a/e2e/cases/unconstrained-dependencies/BUILD.bazel
+++ b/e2e/cases/unconstrained-dependencies/BUILD.bazel
@@ -18,7 +18,7 @@ py_library(
 py_binary(
     name = "print_python_package_version_main",
     srcs = ["print_python_package_version.py"],
-    venv = "depctx_py_main_uv",
+    dep_group = "depctx_py_main_uv",
     deps = [
         ":get_python_package_version",
     ],
@@ -28,7 +28,7 @@ py_binary(
 py_binary(
     name = "print_python_package_version_humble",
     srcs = ["print_python_package_version.py"],
-    venv = "depctx_py_humble_uv",
+    dep_group = "depctx_py_humble_uv",
     deps = [
         ":get_python_package_version",
     ],
@@ -39,7 +39,7 @@ py_test(
     size = "small",
     srcs = ["get_python_package_version_main_test.py"],
     pytest_main = True,
-    venv = "depctx_py_main_uv",
+    dep_group = "depctx_py_main_uv",
     deps = [
         ":get_python_package_version",
         "@pypi//pytest",
@@ -51,7 +51,7 @@ py_test(
     size = "small",
     srcs = ["get_python_package_version_humble_test.py"],
     pytest_main = True,
-    venv = "depctx_py_humble_uv",
+    dep_group = "depctx_py_humble_uv",
     deps = [
         ":get_python_package_version",
         "@pypi//pytest",

--- a/e2e/cases/unconstrained-dependencies/BUILD.bazel
+++ b/e2e/cases/unconstrained-dependencies/BUILD.bazel
@@ -38,8 +38,8 @@ py_test(
     name = "get_python_package_version_main_test",
     size = "small",
     srcs = ["get_python_package_version_main_test.py"],
-    pytest_main = True,
     dep_group = "depctx_py_main_uv",
+    pytest_main = True,
     deps = [
         ":get_python_package_version",
         "@pypi//pytest",
@@ -50,8 +50,8 @@ py_test(
     name = "get_python_package_version_humble_test",
     size = "small",
     srcs = ["get_python_package_version_humble_test.py"],
-    pytest_main = True,
     dep_group = "depctx_py_humble_uv",
+    pytest_main = True,
     deps = [
         ":get_python_package_version",
         "@pypi//pytest",

--- a/e2e/cases/uv-abi3-compat-853/BUILD.bazel
+++ b/e2e/cases/uv-abi3-compat-853/BUILD.bazel
@@ -7,9 +7,9 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_venv_test(
     name = "test_import",
     srcs = ["test_abi3.py"],
+    dep_group = "abi3-compat",
     main = "test_abi3.py",
     python_version = "3.12",
     target_compatible_with = ["@platforms//os:linux"],
-    dep_group = "abi3-compat",
     deps = ["@pypi//cryptography"],
 )

--- a/e2e/cases/uv-abi3-compat-853/BUILD.bazel
+++ b/e2e/cases/uv-abi3-compat-853/BUILD.bazel
@@ -10,6 +10,6 @@ py_venv_test(
     main = "test_abi3.py",
     python_version = "3.12",
     target_compatible_with = ["@platforms//os:linux"],
-    venv = "abi3-compat",
+    dep_group = "abi3-compat",
     deps = ["@pypi//cryptography"],
 )

--- a/e2e/cases/uv-conflict-817/BUILD.bazel
+++ b/e2e/cases/uv-conflict-817/BUILD.bazel
@@ -4,7 +4,7 @@ py_venv_test(
     name = "test_a",
     srcs = ["test_a.py"],
     main = "test_a.py",
-    venv = "ambig-a",
+    dep_group = "ambig-a",
     deps = [
         "@pypi//packaging",
     ],
@@ -14,7 +14,7 @@ py_venv_test(
     name = "test_b",
     srcs = ["test_b.py"],
     main = "test_b.py",
-    venv = "ambig-b",
+    dep_group = "ambig-b",
     deps = [
         "@pypi//packaging",
     ],

--- a/e2e/cases/uv-conflict-817/BUILD.bazel
+++ b/e2e/cases/uv-conflict-817/BUILD.bazel
@@ -3,8 +3,8 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_venv_test(
     name = "test_a",
     srcs = ["test_a.py"],
-    main = "test_a.py",
     dep_group = "ambig-a",
+    main = "test_a.py",
     deps = [
         "@pypi//packaging",
     ],
@@ -13,8 +13,8 @@ py_venv_test(
 py_venv_test(
     name = "test_b",
     srcs = ["test_b.py"],
-    main = "test_b.py",
     dep_group = "ambig-b",
+    main = "test_b.py",
     deps = [
         "@pypi//packaging",
     ],

--- a/e2e/cases/uv-conflict-gte/BUILD.bazel
+++ b/e2e/cases/uv-conflict-gte/BUILD.bazel
@@ -3,8 +3,8 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_venv_test(
     name = "test_a",
     srcs = ["test_a.py"],
-    main = "test_a.py",
     dep_group = "group-a",
+    main = "test_a.py",
     deps = [
         "@pypi//packaging",
     ],
@@ -13,8 +13,8 @@ py_venv_test(
 py_venv_test(
     name = "test_b",
     srcs = ["test_b.py"],
-    main = "test_b.py",
     dep_group = "group-b",
+    main = "test_b.py",
     deps = [
         "@pypi//packaging",
     ],

--- a/e2e/cases/uv-conflict-gte/BUILD.bazel
+++ b/e2e/cases/uv-conflict-gte/BUILD.bazel
@@ -4,7 +4,7 @@ py_venv_test(
     name = "test_a",
     srcs = ["test_a.py"],
     main = "test_a.py",
-    venv = "group-a",
+    dep_group = "group-a",
     deps = [
         "@pypi//packaging",
     ],
@@ -14,7 +14,7 @@ py_venv_test(
     name = "test_b",
     srcs = ["test_b.py"],
     main = "test_b.py",
-    venv = "group-b",
+    dep_group = "group-b",
     deps = [
         "@pypi//packaging",
     ],

--- a/e2e/cases/uv-conflict-max-863/BUILD.bazel
+++ b/e2e/cases/uv-conflict-max-863/BUILD.bazel
@@ -3,8 +3,8 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_venv_test(
     name = "test_a",
     srcs = ["test_a.py"],
-    main = "test_a.py",
     dep_group = "max-a",
+    main = "test_a.py",
     deps = [
         "@pypi//packaging",
     ],
@@ -13,8 +13,8 @@ py_venv_test(
 py_venv_test(
     name = "test_b",
     srcs = ["test_b.py"],
-    main = "test_b.py",
     dep_group = "max-b",
+    main = "test_b.py",
     deps = [
         "@pypi//packaging",
     ],

--- a/e2e/cases/uv-conflict-max-863/BUILD.bazel
+++ b/e2e/cases/uv-conflict-max-863/BUILD.bazel
@@ -4,7 +4,7 @@ py_venv_test(
     name = "test_a",
     srcs = ["test_a.py"],
     main = "test_a.py",
-    venv = "max-a",
+    dep_group = "max-a",
     deps = [
         "@pypi//packaging",
     ],
@@ -14,7 +14,7 @@ py_venv_test(
     name = "test_b",
     srcs = ["test_b.py"],
     main = "test_b.py",
-    venv = "max-b",
+    dep_group = "max-b",
     deps = [
         "@pypi//packaging",
     ],

--- a/e2e/cases/uv-conflict-tilde-856/BUILD.bazel
+++ b/e2e/cases/uv-conflict-tilde-856/BUILD.bazel
@@ -4,7 +4,7 @@ py_venv_test(
     name = "test_a",
     srcs = ["test_a.py"],
     main = "test_a.py",
-    venv = "tilde-a",
+    dep_group = "tilde-a",
     deps = [
         "@pypi//packaging",
     ],
@@ -14,7 +14,7 @@ py_venv_test(
     name = "test_b",
     srcs = ["test_b.py"],
     main = "test_b.py",
-    venv = "tilde-b",
+    dep_group = "tilde-b",
     deps = [
         "@pypi//packaging",
     ],

--- a/e2e/cases/uv-conflict-tilde-856/BUILD.bazel
+++ b/e2e/cases/uv-conflict-tilde-856/BUILD.bazel
@@ -3,8 +3,8 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_venv_test(
     name = "test_a",
     srcs = ["test_a.py"],
-    main = "test_a.py",
     dep_group = "tilde-a",
+    main = "test_a.py",
     deps = [
         "@pypi//packaging",
     ],
@@ -13,8 +13,8 @@ py_venv_test(
 py_venv_test(
     name = "test_b",
     srcs = ["test_b.py"],
-    main = "test_b.py",
     dep_group = "tilde-b",
+    main = "test_b.py",
     deps = [
         "@pypi//packaging",
     ],

--- a/e2e/cases/uv-deps-650/airflow/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/airflow/BUILD.bazel
@@ -5,9 +5,9 @@ py_venv_test(
     srcs = [
         "__test__.py",
     ],
+    dep_group = "airflow",
     main = "__test__.py",
     python_version = "3.13",
-    dep_group = "airflow",
     deps = [
         "@pypi//apache_airflow",
     ],

--- a/e2e/cases/uv-deps-650/airflow/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/airflow/BUILD.bazel
@@ -7,7 +7,7 @@ py_venv_test(
     ],
     main = "__test__.py",
     python_version = "3.13",
-    venv = "airflow",
+    dep_group = "airflow",
     deps = [
         "@pypi//apache_airflow",
     ],

--- a/e2e/cases/uv-deps-650/crossbuild/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/crossbuild/BUILD.bazel
@@ -44,7 +44,7 @@ py_venv_binary(
     srcs = ["__main__.py"],
     main = "__main__.py",
     python_version = "3.12",
-    venv = "psql",
+    dep_group = "psql",
     deps = [
         "@pypi//psycopg2_binary",
     ],

--- a/e2e/cases/uv-deps-650/crossbuild/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/crossbuild/BUILD.bazel
@@ -42,9 +42,9 @@ platform(
 py_venv_binary(
     name = "app_bin",
     srcs = ["__main__.py"],
+    dep_group = "psql",
     main = "__main__.py",
     python_version = "3.12",
-    dep_group = "psql",
     deps = [
         "@pypi//psycopg2_binary",
     ],

--- a/e2e/cases/uv-deps-650/extras/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/extras/BUILD.bazel
@@ -7,7 +7,7 @@ py_venv_test(
     ],
     main = "__test__.py",
     python_version = "3.11",
-    venv = "extras",
+    dep_group = "extras",
     deps = [
         "@pypi//requests",
     ],

--- a/e2e/cases/uv-deps-650/extras/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/extras/BUILD.bazel
@@ -5,9 +5,9 @@ py_venv_test(
     srcs = [
         "__test__.py",
     ],
+    dep_group = "extras",
     main = "__test__.py",
     python_version = "3.11",
-    dep_group = "extras",
     deps = [
         "@pypi//requests",
     ],

--- a/e2e/cases/uv-deps-650/say/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/say/BUILD.bazel
@@ -5,9 +5,9 @@ py_venv_test(
     srcs = [
         "__test__.py",
     ],
+    dep_group = "say",
     main = "__test__.py",
     python_version = "3.11",
-    dep_group = "say",
     deps = [
         "@pypi//cowsay",
     ],

--- a/e2e/cases/uv-deps-650/say/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/say/BUILD.bazel
@@ -7,7 +7,7 @@ py_venv_test(
     ],
     main = "__test__.py",
     python_version = "3.11",
-    venv = "say",
+    dep_group = "say",
     deps = [
         "@pypi//cowsay",
     ],

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -7,7 +7,7 @@ py_venv_test(
     ],
     main = "__test__.py",
     python_version = "3.11",
-    venv = "dev",
+    dep_group = "dev",
     deps = [
         "@pypi//pytest",
         "@pypi//setuptools",

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -5,9 +5,9 @@ py_venv_test(
     srcs = [
         "__test__.py",
     ],
+    dep_group = "dev",
     main = "__test__.py",
     python_version = "3.11",
-    dep_group = "dev",
     deps = [
         "@pypi//pytest",
         "@pypi//setuptools",

--- a/e2e/cases/uv-legacy-deps-750/BUILD.bazel
+++ b/e2e/cases/uv-legacy-deps-750/BUILD.bazel
@@ -7,7 +7,7 @@ py_venv_test(
     ],
     main = "__test__.py",
     python_version = "3.11",
-    venv = "googlemaps",
+    dep_group = "googlemaps",
     deps = [
         "@pypi//googlemaps",
     ],

--- a/e2e/cases/uv-legacy-deps-750/BUILD.bazel
+++ b/e2e/cases/uv-legacy-deps-750/BUILD.bazel
@@ -5,9 +5,9 @@ py_venv_test(
     srcs = [
         "__test__.py",
     ],
+    dep_group = "googlemaps",
     main = "__test__.py",
     python_version = "3.11",
-    dep_group = "googlemaps",
     deps = [
         "@pypi//googlemaps",
     ],

--- a/e2e/cases/uv-patching-829/BUILD.bazel
+++ b/e2e/cases/uv-patching-829/BUILD.bazel
@@ -5,7 +5,7 @@ py_venv_test(
     srcs = ["__test__.py"],
     main = "__test__.py",
     python_version = "3.11",
-    venv = "patching",
+    dep_group = "patching",
     deps = [
         "@pypi//cowsay",
     ],

--- a/e2e/cases/uv-patching-829/BUILD.bazel
+++ b/e2e/cases/uv-patching-829/BUILD.bazel
@@ -3,9 +3,9 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_venv_test(
     name = "test",
     srcs = ["__test__.py"],
+    dep_group = "patching",
     main = "__test__.py",
     python_version = "3.11",
-    dep_group = "patching",
     deps = [
         "@pypi//cowsay",
     ],

--- a/e2e/cases/uv-plus-version/BUILD.bazel
+++ b/e2e/cases/uv-plus-version/BUILD.bazel
@@ -5,7 +5,7 @@ py_venv_test(
     srcs = ["__test__.py"],
     main = "__test__.py",
     python_version = "3.12",
-    venv = "plus-version",
+    dep_group = "plus-version",
     deps = [
         "@pypi//jaxlib",
     ],

--- a/e2e/cases/uv-plus-version/BUILD.bazel
+++ b/e2e/cases/uv-plus-version/BUILD.bazel
@@ -3,9 +3,9 @@ load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 py_venv_test(
     name = "test",
     srcs = ["__test__.py"],
+    dep_group = "plus-version",
     main = "__test__.py",
     python_version = "3.12",
-    dep_group = "plus-version",
     deps = [
         "@pypi//jaxlib",
     ],

--- a/e2e/cases/uv-whl-install-output-group/BUILD.bazel
+++ b/e2e/cases/uv-whl-install-output-group/BUILD.bazel
@@ -23,6 +23,6 @@ py_venv_test(
     data = [":iniconfig_install_dir"],
     main = "test.py",
     python_version = "3.11",
-    venv = "uv-whl-install-output-group",
+    dep_group = "uv-whl-install-output-group",
     deps = ["@pypi//iniconfig"],
 )

--- a/e2e/cases/uv-whl-install-output-group/BUILD.bazel
+++ b/e2e/cases/uv-whl-install-output-group/BUILD.bazel
@@ -21,8 +21,8 @@ py_venv_test(
     name = "test",
     srcs = ["test.py"],
     data = [":iniconfig_install_dir"],
+    dep_group = "uv-whl-install-output-group",
     main = "test.py",
     python_version = "3.11",
-    dep_group = "uv-whl-install-output-group",
     deps = ["@pypi//iniconfig"],
 )

--- a/e2e/cases/uv-workspace-789/BUILD.bazel
+++ b/e2e/cases/uv-workspace-789/BUILD.bazel
@@ -6,7 +6,7 @@ py_venv_test(
         "__test__.py",
     ],
     main = "__test__.py",
-    venv = "workspace",
+    dep_group = "workspace",
     deps = [
         "@pypi//foo",  # Firstparty package
         "@pypi//pi",  # Firstparty package

--- a/e2e/cases/uv-workspace-789/BUILD.bazel
+++ b/e2e/cases/uv-workspace-789/BUILD.bazel
@@ -5,8 +5,8 @@ py_venv_test(
     srcs = [
         "__test__.py",
     ],
-    main = "__test__.py",
     dep_group = "workspace",
+    main = "__test__.py",
     deps = [
         "@pypi//foo",  # Firstparty package
         "@pypi//pi",  # Firstparty package

--- a/e2e/cases/venv-bin-scripts-423/BUILD.bazel
+++ b/e2e/cases/venv-bin-scripts-423/BUILD.bazel
@@ -5,7 +5,7 @@ py_test(
     srcs = ["__test__.py"],
     main = "__test__.py",
     python_version = "3.11",
-    venv = "venv-bin-scripts-423",
+    dep_group = "venv-bin-scripts-423",
     deps = [
         "@pypi//dice",
     ],
@@ -17,7 +17,7 @@ py_test(
     isolated = False,
     main = "__test__.py",
     python_version = "3.11",
-    venv = "venv-bin-scripts-423",
+    dep_group = "venv-bin-scripts-423",
     deps = [
         "@pypi//dice",
     ],

--- a/e2e/cases/venv-bin-scripts-423/BUILD.bazel
+++ b/e2e/cases/venv-bin-scripts-423/BUILD.bazel
@@ -3,9 +3,9 @@ load("@aspect_rules_py//py:defs.bzl", "py_test")
 py_test(
     name = "test",
     srcs = ["__test__.py"],
+    dep_group = "venv-bin-scripts-423",
     main = "__test__.py",
     python_version = "3.11",
-    dep_group = "venv-bin-scripts-423",
     deps = [
         "@pypi//dice",
     ],
@@ -14,10 +14,10 @@ py_test(
 py_test(
     name = "test_non_isolated",
     srcs = ["__test__.py"],
+    dep_group = "venv-bin-scripts-423",
     isolated = False,
     main = "__test__.py",
     python_version = "3.11",
-    dep_group = "venv-bin-scripts-423",
     deps = [
         "@pypi//dice",
     ],

--- a/e2e/cases/venv-internal-symlinks/BUILD.bazel
+++ b/e2e/cases/venv-internal-symlinks/BUILD.bazel
@@ -7,7 +7,7 @@ py_test(
     isolated = False,
     main = "test_babel.py",
     python_version = "3.11",
-    venv = "venv-internal-symlinks",
+    dep_group = "venv-internal-symlinks",
     deps = [
         "@pypi//babel",
     ],
@@ -17,7 +17,7 @@ py_test(
     name = "test_internal_symlinks_legacy",
     srcs = ["test_babel.py"],
     main = "test_babel.py",
-    venv = "venv-internal-symlinks",
+    dep_group = "venv-internal-symlinks",
     deps = [
         "@pypi//babel",
     ],

--- a/e2e/cases/venv-internal-symlinks/BUILD.bazel
+++ b/e2e/cases/venv-internal-symlinks/BUILD.bazel
@@ -3,11 +3,11 @@ load("@aspect_rules_py//py:defs.bzl", "py_test")
 py_test(
     name = "test_internal_symlinks",
     srcs = ["test_babel.py"],
+    dep_group = "venv-internal-symlinks",
     expose_venv = True,
     isolated = False,
     main = "test_babel.py",
     python_version = "3.11",
-    dep_group = "venv-internal-symlinks",
     deps = [
         "@pypi//babel",
     ],
@@ -16,8 +16,8 @@ py_test(
 py_test(
     name = "test_internal_symlinks_legacy",
     srcs = ["test_babel.py"],
-    main = "test_babel.py",
     dep_group = "venv-internal-symlinks",
+    main = "test_babel.py",
     deps = [
         "@pypi//babel",
     ],

--- a/e2e/cases/venv-isolated-mode-703/BUILD.bazel
+++ b/e2e/cases/venv-isolated-mode-703/BUILD.bazel
@@ -3,9 +3,9 @@ load("@aspect_rules_py//py:defs.bzl", "py_test")
 py_test(
     name = "test",
     srcs = ["__test__.py"],
+    dep_group = "venv-isolated-mode-703",
     expose_venv = True,
     isolated = False,
     main = "__test__.py",
     python_version = "3.11",
-    dep_group = "venv-isolated-mode-703",
 )

--- a/e2e/cases/venv-isolated-mode-703/BUILD.bazel
+++ b/e2e/cases/venv-isolated-mode-703/BUILD.bazel
@@ -7,5 +7,5 @@ py_test(
     isolated = False,
     main = "__test__.py",
     python_version = "3.11",
-    venv = "venv-isolated-mode-703",
+    dep_group = "venv-isolated-mode-703",
 )

--- a/examples/debugger/.bazelrc
+++ b/examples/debugger/.bazelrc
@@ -7,9 +7,9 @@ common --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 common --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 
 # Default to debug venv — includes debugpy
-common --@pypi//venv=debug
+common --@pypi//dep_group=debug
 
 # Release config: strip debug deps
-common:release --@pypi//venv=prod
+common:release --@pypi//dep_group=prod
 common:release --//:mode=prod
 common:release --stamp

--- a/examples/debugger/README.md
+++ b/examples/debugger/README.md
@@ -60,9 +60,9 @@ directly and `debugpy` is absent.
 ### 4. Venv selection via `.bazelrc`
 
 ```
-common --@pypi//venv=debug
+common --@pypi//dep_group=debug
 
-common:release --@pypi//venv=prod
+common:release --@pypi//dep_group=prod
 common:release --//:mode=prod
 ```
 

--- a/examples/dev_deps/.bazelrc
+++ b/examples/dev_deps/.bazelrc
@@ -7,9 +7,9 @@ common --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 common --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 
 # Default to dev venv — includes debug/test tools
-common --@pypi//venv=dev
+common --@pypi//dep_group=dev
 
 # Release config: strip dev deps, enable stamping
-common:release --@pypi//venv=prod
+common:release --@pypi//dep_group=prod
 common:release --//:mode=prod
 common:release --stamp

--- a/examples/dev_deps/README.md
+++ b/examples/dev_deps/README.md
@@ -37,15 +37,15 @@ single lockfile.
 
 ```
 # Default: dev venv, includes ipdb/pytest
-common --@pypi//venv=dev
+common --@pypi//dep_group=dev
 
 # Release config: prod venv only, enable stamping
-common:release --@pypi//venv=prod
+common:release --@pypi//dep_group=prod
 common:release --//:mode=prod
 common:release --stamp
 ```
 
-The `--@pypi//venv=` flag controls which dependency group the hub makes
+The `--@pypi//dep_group=` flag controls which dependency group the hub makes
 available. The default is `dev` (everything importable). `--config=release`
 switches to `prod` (runtime deps only).
 
@@ -110,7 +110,7 @@ bazel run //:app --config=release
 
 The venv flag and the mode flag work together:
 
-| `.bazelrc` config  | `--@pypi//venv=` | `--//:mode=` | Effect                                                       |
+| `.bazelrc` config  | `--@pypi//dep_group=` | `--//:mode=` | Effect                                                       |
 | ------------------ | ---------------- | ------------ | ------------------------------------------------------------ |
 | _(default)_        | `dev`            | `dev`        | Hub exposes all packages; `select()` includes dev_deps       |
 | `--config=release` | `prod`           | `prod`       | Hub exposes only prod packages; `select()` excludes dev_deps |

--- a/examples/dev_deps/defs.bzl
+++ b/examples/dev_deps/defs.bzl
@@ -8,8 +8,8 @@ def py_dev_binary(name, deps = [], dev_deps = [], **kwargs):
     The default mode is "dev": all dependencies (including dev_deps) are
     linked.  In release/prod mode the dev_deps are stripped.
 
-    The active venv is controlled separately via --@pypi//venv (see
-    .bazelrc) so that the hub makes the right set of packages available.
+    The active dep_group is controlled separately via --@pypi//dep_group
+    (see .bazelrc) so that the hub makes the right set of packages available.
 
     Args:
         name: Target name.

--- a/examples/py_venv/BUILD.bazel
+++ b/examples/py_venv/BUILD.bazel
@@ -22,11 +22,11 @@ py_venv_binary(
     srcs = [
         ":stamped",
     ],
+    dep_group = ":venv",
     imports = [
         ".",
     ],
     main = ":stamped",
-    dep_group = ":venv",
 )
 
 py_venv_binary(

--- a/examples/py_venv/BUILD.bazel
+++ b/examples/py_venv/BUILD.bazel
@@ -26,7 +26,7 @@ py_venv_binary(
         ".",
     ],
     main = ":stamped",
-    venv = ":venv",
+    dep_group = ":venv",
 )
 
 py_venv_binary(

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -4,7 +4,6 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private:pth.bzl", "make_imports_depset")
-load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "UNPACK_TOOLCHAIN")
 

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -172,11 +172,11 @@ def _py_venv_rule_impl(ctx):
     ]
 
 _attrs = dict({
-    "venv": attr.string(
-        doc = """The name of a configured virtualenv within which to resolve dependencies.
+    "dep_group": attr.string(
+        doc = """The name of a configured dependency group within which to resolve dependencies.
 
 Default value.
-May be overridden with the --@pip//venv=<> CLI flag.
+May be overridden with the --@pip//dep_group=<> CLI flag.
 Only works with the experimental Aspect pip machinery.
 """,
     ),
@@ -373,7 +373,7 @@ _VENV_ONLY_ATTRS = [
     "package_collisions",
     "include_system_site_packages",
     "include_user_site_packages",
-    "venv",
+    "dep_group",
     "python_version",
 ]
 _SHARED_ATTRS = [

--- a/py/private/transitions.bzl
+++ b/py/private/transitions.bzl
@@ -1,6 +1,6 @@
 """Common transition implementation used by the various terminals."""
 
-VENV_FLAG = "@aspect_rules_py//uv/private/constraints/venv:venv"
+DEP_GROUP_FLAG = "@aspect_rules_py//uv/private/constraints/dep_group:dep_group"
 
 # Our own python_version flag, replacing the rules_python one.
 PYTHON_VERSION_FLAG = "@aspect_rules_py//py/private/interpreter:python_version"
@@ -24,15 +24,15 @@ def _python_transition_impl(settings, attr):
     acc[PYTHON_VERSION_FLAG] = version
     acc[_RPY_VERSION_FLAG] = version
 
-    # Set the venv transition. The attr is only present on `py_venv`
+    # Set the dep_group transition. The attr is only present on `py_venv`
     # (rules without it propagate the inherited setting; `py_venv_exec`
     # is config-agnostic — its runfiles inherit the venv's wheels at
-    # whatever VENV_FLAG the venv resolved under).
-    venv = getattr(attr, "venv", None)
-    if venv:
-        acc[VENV_FLAG] = str(venv)
+    # whatever DEP_GROUP_FLAG the venv resolved under).
+    dep_group = getattr(attr, "dep_group", None)
+    if dep_group:
+        acc[DEP_GROUP_FLAG] = str(dep_group)
     else:
-        acc[VENV_FLAG] = settings[VENV_FLAG]
+        acc[DEP_GROUP_FLAG] = settings[DEP_GROUP_FLAG]
 
     # Propagate interpreter feature flags
     acc[_FREETHREADED_FLAG] = settings[_FREETHREADED_FLAG]
@@ -44,13 +44,13 @@ python_transition = transition(
     inputs = [
         PYTHON_VERSION_FLAG,
         _RPY_VERSION_FLAG,
-        VENV_FLAG,
+        DEP_GROUP_FLAG,
         _FREETHREADED_FLAG,
     ],
     outputs = [
         PYTHON_VERSION_FLAG,
         _RPY_VERSION_FLAG,
-        VENV_FLAG,
+        DEP_GROUP_FLAG,
         _FREETHREADED_FLAG,
     ],
 )

--- a/py/toolchains.bzl
+++ b/py/toolchains.bzl
@@ -3,7 +3,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("//py/private/release:version.bzl", "IS_PRERELEASE")
 load("//py/private/toolchain:repo.bzl", "prebuilt_tool_repo", "prerelease_toolchains_repo", "toolchains_repo")
-load("//py/private/toolchain:tools.bzl", "TOOLCHAIN_PLATFORMS", "TOOL_CFGS")
+load("//py/private/toolchain:tools.bzl", "TOOLCHAIN_PLATFORMS")
 
 DEFAULT_TOOLS_REPOSITORY = "rules_py_tools"
 

--- a/uv/private/constraints/dep_group/BUILD.bazel
+++ b/uv/private/constraints/dep_group/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 string_flag(
-    name = "venv",
+    name = "dep_group",
     build_setting_default = "",
     # "universal" causes this flag to propagate through exec transitions so
-    # that the venv selection is consistent across all platforms.
+    # that the dep-group selection is consistent across all platforms.
     # Required when --incompatible_exclude_starlark_flags_from_exec_config is
     # active (will be default in Bazel 10; bazelbuild/bazel#26909).
     scope = "universal",

--- a/uv/private/gazelle_manifest/defs.bzl
+++ b/uv/private/gazelle_manifest/defs.bzl
@@ -82,7 +82,7 @@ def gazelle_python_manifest(name, hub, venvs = [], lockfile = None):
                 "@platforms//host",
             ],
             flags = [
-                "--@{}//venv={}".format(hub, venv),
+                "--@{}//dep_group={}".format(hub, venv),
             ],
         )
         platform_transition_filegroup(

--- a/uv/private/uv_hub/repository.bzl
+++ b/uv/private/uv_hub/repository.bzl
@@ -25,33 +25,33 @@ def _hub_impl(repository_ctx):
     packages = json.decode(repository_ctx.attr.packages)
 
     ################################################################################
-    # Lay down the //venv:BUILD.bazel file with config flags
+    # Lay down the //dep_group:BUILD.bazel file with config flags
     #
     # We do this first because everything else hangs off of these config_settings.
     content = [
         """\
 alias(
-    name = "venv",
-    actual = "@aspect_rules_py//uv/private/constraints/venv:venv",
+    name = "dep_group",
+    actual = "@aspect_rules_py//uv/private/constraints/dep_group:dep_group",
     visibility = ["//visibility:public"],
 )
 """,
     ]
 
-    # Lay down the venv config settings
+    # Lay down the dep_group config settings
     for name in repository_ctx.attr.configurations:
         content.append(
             """
 config_setting(
     name = "{name}",
     flag_values = {{
-        "@aspect_rules_py//uv/private/constraints/venv:venv": "{name}",
+        "@aspect_rules_py//uv/private/constraints/dep_group:dep_group": "{name}",
     }},
     visibility = ["//visibility:public"],
 )
 """.format(name = name),
         )
-    repository_ctx.file("venv/BUILD.bazel", content = "\n".join(content))
+    repository_ctx.file("dep_group/BUILD.bazel", content = "\n".join(content))
 
     ################################################################################
     # Lay down the //:BUILD.bazel file
@@ -62,7 +62,7 @@ load("@aspect_rules_py//py:defs.bzl", "py_library")
     ]
 
     index_select_clauses = {
-        "//venv:" + cfg: ["@{}//:gazelle_index_whls".format(project_id)]
+        "//dep_group:" + cfg: ["@{}//:gazelle_index_whls".format(project_id)]
         for cfg, project_id in repository_ctx.attr.configurations.items()
     }
 
@@ -90,11 +90,11 @@ load("//:defs.bzl", "compatible_with")
         ]
 
         select_spec = {
-            "//venv:{}".format(cfg): l
+            "//dep_group:{}".format(cfg): l
             for cfg, l in specs.items()
         }
 
-        error = "Available only in venvs: " + ", ".join(specs.keys())  # Simplified error string
+        error = "Available only in dep_groups: " + ", ".join(specs.keys())  # Simplified error string
 
         # FIXME: Add support for entrypoints?
         # FIXME: Create a narrower dist-info rule
@@ -143,7 +143,7 @@ def compatible_with(venvs, extra_constraints = []):
       fail("Errant virtualenv reference %r" % v)
 
   return {{
-    Label("//venv:" + it): extra_constraints
+    Label("//dep_group:" + it): extra_constraints
     for it in venvs
   }} | {{
     "//conditions:default": ["@platforms//:incompatible"],
@@ -155,7 +155,7 @@ def incompatible_with(venvs, extra_constraints = []):
       fail("Errant virtualenv reference %r" % v)
 
   return {{
-    Label("//venv:" + it): ["@platforms//:incompatible"]
+    Label("//dep_group:" + it): ["@platforms//:incompatible"]
     for it in venvs
   }} | {{
     "//conditions:default": extra_constraints,

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -84,9 +84,9 @@ alias(
             return ":" + cond_id
 
     ################################################################################
-    # Lay down the //private/venv:BUILD.bazel file with config flags
+    # Lay down the //private/dep_group:BUILD.bazel file with config flags
     #
-    # This mirrors the uv_hub's venv, but is internal to the project.
+    # This mirrors the uv_hub's dep_group, but is internal to the project.
     venv_content = []
 
     # Collect all unique cfgs first
@@ -101,13 +101,13 @@ alias(
 config_setting(
     name = "{name}",
     flag_values = {{
-        "@aspect_rules_py//uv/private/constraints/venv:venv": "{name}",
+        "@aspect_rules_py//uv/private/constraints/dep_group:dep_group": "{name}",
     }},
     visibility = ["//visibility:public"],
 )
 """.format(name = cfg_name),
         )
-    repository_ctx.file("private/venv/BUILD.bazel", content = "\n".join(venv_content))
+    repository_ctx.file("private/dep_group/BUILD.bazel", content = "\n".join(venv_content))
 
     ################################################################################
     # Lay down the surface-level targets
@@ -125,7 +125,7 @@ load("@aspect_rules_py//py:defs.bzl", "py_library")
         # FIXME: Handle markers for distinct versions
         for cfg, scc_cfgs in cfgs.items():
             cfg_name = "_package_{}_{}".format(package, cfg)
-            main_arms["//private/venv:" + cfg] = ":" + cfg_name
+            main_arms["//private/dep_group:" + cfg] = ":" + cfg_name
 
             cfg_arms = {}
 
@@ -176,7 +176,7 @@ alias(
     all_requirements = {}
     for package, cfgs in dep_to_scc.items():
         for cfg in cfgs.keys():
-            all_requirements.setdefault("//private/venv:" + cfg, []).append("//:" + package)
+            all_requirements.setdefault("//private/dep_group:" + cfg, []).append("//:" + package)
 
     content.append("""
 filegroup(


### PR DESCRIPTION
## Summary

Pure rename of the experimental `aspect_rules_py//uv` `venv` attribute on `py_binary` / `py_test` / `py_venv` and the `string_flag` it transitions through, to `dep_group`.

The current `venv` name collides conceptually with `external_venv`, `expose_venv`, and `venv_dir_basename` — none of which are about resolving deps. `dep_group` (matching PEP 735 nomenclature) makes the intent unambiguous.

This is the first of two PRs. **PR1 is mechanical and zero-behavior-change.** PR2 will use the freed-up `venv` term and restructure shared-hub layouts to allow same-named groups across projects (`+web:requests` qualified labels, ambiguous-stub generation). The architectural change is described in [`/Users/greg/aspect/claude-1/dapper-splashing-marshmallow.md`](https://github.com/aspect-build/rules_py/blob/pr1-rename-venv-to-dep-group/dapper-splashing-marshmallow.md) — design doc lives outside the repo for now.

### What changed

- **Attribute**: `attr.venv` on `py_venv` rule → `attr.dep_group`
- **Transition constant**: `VENV_FLAG` → `DEP_GROUP_FLAG` in `py/private/transitions.bzl`
- **Canonical `string_flag`**: `//uv/private/constraints/venv:venv` → `//uv/private/constraints/dep_group:dep_group`
- **Hub-generated package path**: `//venv` → `//dep_group`, so the user-facing CLI flag becomes `--@<hub>//dep_group=<name>` (was `--@<hub>//venv=<name>`)
- **Project repo internal path**: `//private/venv` → `//private/dep_group`
- **Migration**: 45 occurrences across 29 e2e BUILD files; docs (`uv.md`, `README.md`, examples READMEs); root `.bazelrc` and `e2e/.bazelrc`

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

### Suggested release notes

- BREAKING (`uv`): Rename `venv` attribute on `py_binary` / `py_test` / `py_venv` to `dep_group`. Migrate by renaming the attribute on each call site.
- BREAKING (`uv`): Rename hub CLI flag `--@<hub>//venv=<name>` to `--@<hub>//dep_group=<name>`. Update `.bazelrc` references.
- BREAKING (`uv`): Rename canonical flag `@aspect_rules_py//uv/private/constraints/venv:venv` to `@aspect_rules_py//uv/private/constraints/dep_group:dep_group`.

### Test plan

- Covered by existing test cases — all 133 tests in main repo pass; e2e workspace tests pass
- No behavior change is intended; the rename is mechanical
