### PR TITLE
refactor: split py_venv binary vs lib rules

### DIFF
--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
@@ -39,7 +39,6 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        1274 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_bin.venv
   - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3-3.11

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
@@ -31,7 +31,6 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        1274 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_bin.venv
   - -rwxr-xr-x  0 0      0          42 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/__init__.py
   - -rwxr-xr-x  0 0      0          31 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/palette.txt
   - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
@@ -40,7 +40,6 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info -> ../../../../../../../../aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        1280 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_multi_bin.venv
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3-3.11
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/idle3 -> idle3.11

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
@@ -46,7 +46,6 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../../../../../../aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0          66 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/__main__.py
-  - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/_app_bin.venv
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.12
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_x86_64_unknown_linux_gnu/bin/2to3-3.12
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_x86_64_unknown_linux_gnu/bin/idle3 -> idle3.12

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
@@ -46,7 +46,6 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../../../../../../aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs
   - -rwxr-xr-x  0 0      0         247 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0          66 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/__main__.py
-  - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/_app_bin.venv
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_aarch64_unknown_linux_gnu/bin/2to3 -> 2to3-3.12
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_aarch64_unknown_linux_gnu/bin/2to3-3.12
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_aarch64_unknown_linux_gnu/bin/idle3 -> idle3.12

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -32,7 +32,7 @@ load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_version_transition")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
 load(":py_venv_exec.bzl", _py_venv_exec = "py_venv_exec")
-load(":types.bzl", "VirtualenvInfo")
+load(":types.bzl", "VirtualenvInfo", "venv_root")
 load(":venv.bzl", "assemble_venv")
 
 def _interpreter_flags(ctx, include_main = False):
@@ -138,8 +138,7 @@ def _py_venv_rule_impl(ctx):
 
     # `VIRTUAL_ENV` as the venv root's rootpath. `venv.tmpl.sh`
     # overrides with its own absolute value when invoked directly.
-    # `rsplit` drops the trailing `bin/python` to leave the venv root.
-    passed_env["VIRTUAL_ENV"] = shared.venv.bin_python.short_path.rsplit("/", 2)[0]
+    passed_env["VIRTUAL_ENV"] = venv_root(shared.venv.bin_python)
 
     return [
         DefaultInfo(
@@ -176,7 +175,9 @@ def _py_venv_rule_impl(ctx):
         ),
     ]
 
-_attrs = dict({
+# Attrs read by both the executable and lib variants — venv assembly,
+# package-collision detection, py_library inputs.
+_lib_attrs = dict({
     "dep_group": attr.string(
         default = "",
         doc = """The name of a configured dependency group within which to resolve dependencies.
@@ -207,10 +208,6 @@ not reinsert a wheel.
         default = "warning",
         values = ["error", "warning", "ignore"],
     ),
-    "interpreter_options": attr.string_list(
-        doc = "Additional options to pass to the Python interpreter.",
-        default = [],
-    ),
     "include_system_site_packages": attr.bool(
         default = False,
         doc = """`pyvenv.cfg` feature flag for the `include-system-site-packages` key.""",
@@ -219,28 +216,9 @@ not reinsert a wheel.
         default = False,
         doc = """`pyvenv.cfg` feature flag for the `aspect-include-user-site-packages` extension key.""",
     ),
-    "debug": attr.bool(
-        default = False,
-    ),
-    "env": attr.string_dict(
-        doc = """Environment variables to set when running the venv (and the
-sibling py_binary/py_test consumer when `expose_venv = True` is used).
-Binary-level `env` wins on key conflicts.""",
-        default = {},
-    ),
-    "env_inherit": attr.string_list(
-        doc = """Names of environment variables to pass through from the invoking
-environment. Forwarded to the sibling py_binary/py_test consumer
-(when `expose_venv = True` is used) alongside `env`.""",
-        default = [],
-    ),
     # Required for py_version attribute
     "_allowlist_function_transition": attr.label(
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-    ),
-    "_run_tmpl": attr.label(
-        allow_single_file = True,
-        default = ":venv.tmpl.sh",
     ),
     "_runfiles_lib": attr.label(
         default = "@bazel_tools//tools/bash/runfiles",
@@ -268,7 +246,35 @@ environment. Forwarded to the sibling py_binary/py_test consumer
     ),
 })
 
-_attrs.update(**_py_library.attrs)
+_lib_attrs.update(**_py_library.attrs)
+
+# Attrs only the executable variant reads — launcher template, REPL
+# flags, env vars forwarded via RunEnvironmentInfo.
+_attrs = _lib_attrs | dict({
+    "interpreter_options": attr.string_list(
+        doc = "Additional options to pass to the Python interpreter.",
+        default = [],
+    ),
+    "debug": attr.bool(
+        default = False,
+    ),
+    "env": attr.string_dict(
+        doc = """Environment variables to set when running the venv (and the
+sibling py_binary/py_test consumer when `expose_venv = True` is used).
+Binary-level `env` wins on key conflicts.""",
+        default = {},
+    ),
+    "env_inherit": attr.string_list(
+        doc = """Names of environment variables to pass through from the invoking
+environment. Forwarded to the sibling py_binary/py_test consumer
+(when `expose_venv = True` is used) alongside `env`.""",
+        default = [],
+    ),
+    "_run_tmpl": attr.label(
+        allow_single_file = True,
+        default = ":venv.tmpl.sh",
+    ),
+})
 
 _py_venv = rule(
     doc = """Build a Python virtual environment and execute its interpreter.""",
@@ -283,6 +289,44 @@ _py_venv = rule(
         config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
     ],
     executable = True,
+    cfg = python_version_transition,
+)
+
+def _py_venv_lib_rule_impl(ctx):
+    """Non-executable variant of `_py_venv` — same providers but no
+    launcher and no RunEnvironmentInfo (Bazel rejects it on
+    non-executable targets; py_venv_exec.bzl gates its read on
+    `if RunEnvironmentInfo in venv`)."""
+    shared = _assemble_shared(ctx)
+    return [
+        DefaultInfo(runfiles = shared.runfiles),
+        VirtualenvInfo(
+            bin_python = shared.venv.bin_python,
+            venv_name = shared.venv.venv_name,
+            imports = shared.imports_depset,
+            wheels = shared.wheels_depset,
+            transitive_sources = shared.srcs_depset,
+        ),
+        coverage_common.instrumented_files_info(
+            ctx,
+            source_attributes = ["srcs"],
+            dependency_attributes = ["deps"],
+            extensions = ["py"],
+        ),
+    ]
+
+# Internal-only non-executable variant. Uses `_lib_attrs` — the
+# launcher-only attrs (`debug`, `interpreter_options`, `_run_tmpl`,
+# `env`, `env_inherit`) aren't part of its rule contract.
+_py_venv_lib = rule(
+    implementation = _py_venv_lib_rule_impl,
+    attrs = _lib_attrs,
+    toolchains = [
+        PY_TOOLCHAIN,
+        # Same optional exec-tools dependency as `_py_venv`: assemble_venv
+        # needs it to run the site_merge action when a package spans wheels.
+        config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
+    ],
     cfg = python_version_transition,
 )
 
@@ -312,27 +356,36 @@ _VENV_ONLY_ATTRS = [
     "include_user_site_packages",
     "python_version",
     "dep_group",
-    "env",
-    "env_inherit",
 ]
+
+# Shared attrs are only forwarded when the venv is the executable
+# variant (`expose_venv = True`). The lib variant doesn't read them, so
+# leave them on the launcher kwargs only.
 _SHARED_ATTRS = [
     # Launcher constructs `python <flags> main.py`; venv forwards them
     # to its REPL so `bazel run :name.venv` matches the binary's flags.
     "interpreter_options",
+    # Forwarded so `bazel run :name.venv` sees the same env as `bazel
+    # run :name`. The launcher reads venv's RunEnvironmentInfo too, so
+    # the duplicate set is harmless (same keys, same values).
+    "env",
+    "env_inherit",
 ]
 
-def _split_kwargs_for_venv(kwargs):
-    """Build the kwargs dict to pass to `py_venv`. `kwargs` is mutated:
-    venv-only attrs are popped; shared attrs are copied (left in
-    `kwargs` so they also reach the launcher).
+def _split_kwargs_for_venv(kwargs, expose_venv):
+    """Build the kwargs dict to pass to the venv rule. `kwargs` is
+    mutated: venv-only attrs are popped; shared attrs are copied (left
+    in `kwargs` so they also reach the launcher) — but only for the
+    executable variant.
     """
     venv_kwargs = {}
     for name in _VENV_ONLY_ATTRS:
         if name in kwargs:
             venv_kwargs[name] = kwargs.pop(name)
-    for name in _SHARED_ATTRS:
-        if name in kwargs:
-            venv_kwargs[name] = kwargs[name]
+    if expose_venv:
+        for name in _SHARED_ATTRS:
+            if name in kwargs:
+                venv_kwargs[name] = kwargs[name]
     return venv_kwargs
 
 def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], imports = [], tags = None, testonly = None, visibility = None, isolated = True, expose_venv = None, expose_venv_link = False, **kwargs):
@@ -365,7 +418,7 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], im
     else:
         expose_venv = bool(expose_venv)
 
-    venv_kwargs = _split_kwargs_for_venv(kwargs)
+    venv_kwargs = _split_kwargs_for_venv(kwargs, expose_venv)
     venv_kwargs["srcs"] = srcs
     venv_kwargs["deps"] = deps
     venv_kwargs["imports"] = imports
@@ -378,12 +431,14 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], im
         venv_label = "{}.venv".format(name)
         venv_visibility = visibility
         venv_tags = None
+        venv_rule = py_venv
     else:
         venv_label = "_{}.venv".format(safe_name)
         venv_visibility = ["//visibility:private"]
         venv_tags = ["manual"]
+        venv_rule = _py_venv_lib
 
-    py_venv(
+    venv_rule(
         name = venv_label,
         testonly = testonly,
         visibility = venv_visibility,

--- a/py/private/py_venv/py_venv_exec.bzl
+++ b/py/private/py_venv/py_venv_exec.bzl
@@ -10,7 +10,7 @@ load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variabl
 load("@hermetic_launcher//launcher:lib.bzl", "launcher")
 load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
-load(":types.bzl", "VirtualenvInfo")
+load(":types.bzl", "VirtualenvInfo", "venv_root")
 
 # Identifiers the launcher always sets to the analysing rule's contextual
 # values. Excluded from `inherited_environment` so that a stray
@@ -53,13 +53,22 @@ def _py_venv_exec_impl(ctx):
         venv_env = venv[RunEnvironmentInfo]
         passed_env = dict(venv_env.environment)
         inherited_env = list(venv_env.inherited_environment)
+
+    # Owned by the rule. The lib venv variant carries no `env` to guard,
+    # so guard here to match the executable variant's check.
+    if "VIRTUAL_ENV" in ctx.attr.env:
+        fail("py_binary/py_test {}: `VIRTUAL_ENV` is set by the rule and cannot be overridden via `env`.".format(ctx.label))
+
+    # Set here so it's present even for the lib venv variant, which has
+    # no RunEnvironmentInfo to carry it.
+    passed_env["VIRTUAL_ENV"] = venv_root(vinfo.bin_python)
     for k, v in ctx.attr.env.items():
         passed_env[k] = expand_variables(
             ctx,
             expand_locations(ctx, v, ctx.attr.data),
             attribute_name = "env",
         )
-    for name in getattr(ctx.attr, "env_inherit", []):
+    for name in ctx.attr.env_inherit:
         if name not in inherited_env:
             inherited_env.append(name)
     passed_env["BAZEL_TARGET"] = str(ctx.label).lstrip("@")
@@ -144,6 +153,10 @@ _attrs = dict({
         doc = "Environment variables to set when running the binary.",
         default = {},
     ),
+    "env_inherit": attr.string_list(
+        doc = "Names of environment variables to pass through from the invoking environment.",
+        default = [],
+    ),
     "main": attr.label(
         allow_single_file = True,
         doc = """
@@ -216,10 +229,6 @@ https://pypi.org/project/bazel-runfiles/.
 })
 
 _test_attrs = dict({
-    "env_inherit": attr.string_list(
-        doc = "Specifies additional environment variables to inherit from the external environment when the test is executed by bazel test.",
-        default = [],
-    ),
     # Magic attribute to make coverage --combined_report flag work.
     # There's no docs about this.
     # See https://github.com/bazelbuild/bazel/blob/fde4b67009d377a3543a3dc8481147307bd37d36/tools/test/collect_coverage.sh#L186-L194

--- a/py/private/py_venv/types.bzl
+++ b/py/private/py_venv/types.bzl
@@ -1,5 +1,11 @@
 """quasi-public types."""
 
+def venv_root(bin_python):
+    """The venv root's runfiles-relative rootpath, derived from the
+    `bin/python` symlink's short_path (drop the trailing `bin/python`).
+    The value `py_venv` and its launcher export as `VIRTUAL_ENV`."""
+    return bin_python.short_path.rsplit("/", 2)[0]
+
 VirtualenvInfo = provider(
     doc = """Provider emitted by `py_venv` identifying a materialised
 virtualenv for downstream consumers.

--- a/py/tests/expose-venv-api/BUILD.bazel
+++ b/py/tests/expose-venv-api/BUILD.bazel
@@ -51,6 +51,26 @@ py_binary(
     ],
 )
 
+# Regression: `env_inherit` on a py_binary must analyse in both expose
+# modes (the binary launcher carries the attr; the venv split routes it
+# to the launcher, not the sibling venv).
+py_binary(
+    name = "env_inherit_bin",
+    srcs = ["main.py"],
+    env = {"FOO": "bar"},
+    env_inherit = ["PATH"],
+    main = "main.py",
+)
+
+py_binary(
+    name = "env_inherit_exposed_bin",
+    srcs = ["main.py"],
+    env = {"FOO": "bar"},
+    env_inherit = ["PATH"],
+    expose_venv = True,
+    main = "main.py",
+)
+
 # `expose_venv_link = True` implies `expose_venv = True` and additionally
 # emits a `:{name}.venv_link` py_venv_link.
 py_binary(
@@ -78,6 +98,9 @@ build_test(
         ":legacy_shape_bin.venv",
         ":venv_shaping_bin",
         ":venv_shaping_bin.venv",
+        ":env_inherit_bin",
+        ":env_inherit_exposed_bin",
+        ":env_inherit_exposed_bin.venv",
         ":link_bin",
         ":link_bin.venv",
         ":link_bin.venv_link",


### PR DESCRIPTION
This way if the `py_venv` is not being exposed via `py_binary(expose_venv)` it will be a simpler rule only exporting the `VirtualenvInfo` and runfiles, no `RunEnvironmentInfo` or `DefaultInfo(files)`

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
