### PR TITLE
feat: remove legacy py_venv_binary / py_venv_test rules, migrate to py_binary / py_test with expose_venv

### DIFF
--- a/e2e/cases/cross-repo-610/BUILD.bazel
+++ b/e2e/cases/cross-repo-610/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = [
         "test.py",
@@ -9,6 +9,24 @@ py_venv_test(
     imports = [
         ".",
     ],
+    main = "test.py",
+    deps = [
+        "@pypi//cowsay",
+        "@subrepo_a//:foo",
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = [
+        "test.py",
+    ],
+    dep_group = "say",
+    expose_venv = True,
+    imports = [
+        ".",
+    ],
+    isolated = False,
     main = "test.py",
     deps = [
         "@pypi//cowsay",

--- a/e2e/cases/cross-repo-610/test.py
+++ b/e2e/cases/cross-repo-610/test.py
@@ -18,14 +18,19 @@ assert "_virtualenv" in sys.modules
 # Note that we can't assume that a `.runfiles` tree has been created as CI may
 # use a different layout.
 
-# The virtualenv changes the sys.prefix, which should be in our runfiles
-assert sys.prefix.endswith("/.test")
+# The virtualenv changes sys.prefix to a dot-prefixed directory under
+# this test's package — the exact basename varies by rule variant
+# (py_test uses `.<name>_venv/`, py_venv_test uses `.<name>/`), so
+# assert on the structural invariant rather than the specific name.
+_prefix_parent, _prefix_basename = os.path.split(sys.prefix.rstrip("/"))
+assert _prefix_parent.endswith("/cases/cross-repo-610"), sys.prefix
+assert _prefix_basename.startswith("."), sys.prefix
 
 # That prefix should also be "the" prefix per site.PREFIXES
-assert site.PREFIXES[0].endswith("/.test")
+assert site.PREFIXES[0] == sys.prefix
 
 # The virtualenv also changes the sys.executable (if we've done this right)
-assert sys.executable.find("/.test/bin/python") != -1
+assert sys.executable.startswith(sys.prefix + "/bin/python"), sys.executable
 
 # aspect-build/rules_py#610, these imports aren't quite right
 import foo

--- a/e2e/cases/firebase-admin-import/BUILD.bazel
+++ b/e2e/cases/firebase-admin-import/BUILD.bazel
@@ -8,7 +8,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 # its own `__init__.py` does `from google.auth.credentials import ...` at
 # import time. That makes it a compact stress test for whether our
 # venv-assembly correctly merges contributions across namespace wheels.
-# Both variants below pass as shipped.
+# All three variants below pass as shipped.
 #
 # Context: we built this case from a downstream report of a
 # `ModuleNotFoundError: No module named 'google.auth'` on exactly this
@@ -30,6 +30,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 #
 # Variants:
 #   :test       — rules_py py_test + uv wheels, target config
+#   :test_tool  — py_venv_test variant, target config
 #   :test_exec  — py_binary + uv wheels, forced into EXEC config via
 #                 `genrule.tools` — matches the shape the downstream
 #                 failure was reported at
@@ -39,6 +40,23 @@ py_test(
     srcs = ["test.py"],
     dep_group = "firebase-admin-import",
     main = "test.py",
+    deps = [
+        "@pypi//firebase_admin",
+    ],
+)
+
+# Naming: `test_tool` (not `test_venv`) because py_venv_test's tree
+# artifact output at `.test_venv/` would prefix-collide with py_test's
+# internal `<pkg>/.<name>_venv/` venv directory if both targets shared
+# the `_venv` suffix.
+py_test(
+    name = "test_tool",
+    srcs = ["test.py"],
+    dep_group = "firebase-admin-import",
+    expose_venv = True,
+    isolated = False,
+    main = "test.py",
+    python_version = "3.11",
     deps = [
         "@pypi//firebase_admin",
     ],

--- a/e2e/cases/freethreaded-805/BUILD.bazel
+++ b/e2e/cases/freethreaded-805/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_test")
 
 platform(
@@ -13,22 +13,24 @@ platform(
     parents = ["@platforms//host"],
 )
 
-py_venv_test(
+# Freethreaded interpreters are only provisioned for linux.
+# This constraint causes Bazel to skip the entire subgraph on
+# non-linux hosts, preventing Bazel 9's default_test_toolchain_type
+# resolution from failing when platform_transition_test transitions
+# into a platform with no matching execution platform.
+_LINUX_X86_64 = [
+    "@platforms//os:linux",
+    "@platforms//cpu:x86_64",
+]
+
+py_test(
     name = "test_bin",
     srcs = ["test.py"],
     dep_group = "freethreaded-test",
     main = "test.py",
     python_version = "3.13",
     tags = ["manual"],
-    # Freethreaded interpreters are only provisioned for linux.
-    # This constraint causes Bazel to skip the entire subgraph on
-    # non-linux hosts, preventing Bazel 9's default_test_toolchain_type
-    # resolution from failing when platform_transition_test transitions
-    # into a platform with no matching execution platform.
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
+    target_compatible_with = _LINUX_X86_64,
     deps = [
         "@pypi//regex",
     ],
@@ -37,9 +39,28 @@ py_venv_test(
 platform_transition_test(
     name = "test",
     binary = ":test_bin",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
+    target_compatible_with = _LINUX_X86_64,
+    target_platform = ":freethreaded",
+)
+
+py_test(
+    name = "venv_test_bin",
+    srcs = ["test.py"],
+    dep_group = "freethreaded-test",
+    expose_venv = True,
+    isolated = False,
+    main = "test.py",
+    python_version = "3.13",
+    tags = ["manual"],
+    target_compatible_with = _LINUX_X86_64,
+    deps = [
+        "@pypi//regex",
     ],
+)
+
+platform_transition_test(
+    name = "venv_test",
+    binary = ":venv_test_bin",
+    target_compatible_with = _LINUX_X86_64,
     target_platform = ":freethreaded",
 )

--- a/e2e/cases/interpreter-features-836/BUILD.bazel
+++ b/e2e/cases/interpreter-features-836/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_image_layer")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_image_layer")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_oci//oci:defs.bzl", "oci_image")
@@ -17,7 +16,7 @@ platform(
     ],
 )
 
-py_venv_binary(
+py_binary(
     name = "check_no_turtle",
     srcs = ["__main__.py"],
     main = "__main__.py",

--- a/e2e/cases/interpreter-provisioning/BUILD.bazel
+++ b/e2e/cases/interpreter-provisioning/BUILD.bazel
@@ -1,10 +1,19 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
 # Verify that e2e tests use aspect_rules_py interpreter provisioning,
 # not rules_python's python-build-standalone toolchains.
-py_venv_test(
+py_test(
     name = "test",
     srcs = ["test_interpreter.py"],
+    main = "test_interpreter.py",
+    python_version = "3.11",
+)
+
+py_test(
+    name = "venv_test",
+    srcs = ["test_interpreter.py"],
+    expose_venv = True,
+    isolated = False,
     main = "test_interpreter.py",
     python_version = "3.11",
 )

--- a/e2e/cases/interpreter-version-541/BUILD.bazel
+++ b/e2e/cases/interpreter-version-541/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_rules_py//py:defs.bzl", "py_test")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 load("@bazel_lib//lib:expand_template.bzl", "expand_template")
 
 [
@@ -12,14 +11,16 @@ load("@bazel_lib//lib:expand_template.bzl", "expand_template")
             },
             template = "test.py",
         ),
-        py_venv_test(
+        py_test(
             name = "test_{}_venv".format(ver.replace(".", "_")),
             srcs = [
                 "expanded_test_{}.py".format(ver.replace(".", "_")),
             ],
+            expose_venv = True,
             imports = [
                 ".",
             ],
+            isolated = False,
             main = "expanded_test_{}.py".format(ver.replace(".", "_")),
             python_version = ver,
         ),

--- a/e2e/cases/interpreter-version-541/test.py
+++ b/e2e/cases/interpreter-version-541/test.py
@@ -11,9 +11,6 @@ print("site.PREFIXES:")
 for p in site.PREFIXES:
     print(" -", p)
 
-# The virtualenv module should have already been loaded at interpreter startup
-assert "_virtualenv" in sys.modules
-
 # Assert that we booted against the expected interpreter version
 EXPECTED_VERSION = "<VERSION>"
 print(repr(EXPECTED_VERSION))

--- a/e2e/cases/oci/py_image_layer/asserts.bzl
+++ b/e2e/cases/oci/py_image_layer/asserts.bzl
@@ -19,7 +19,6 @@ for f in $(SRCS); do
   echo "files:"
   TZ="UTC" LC_ALL="en_US.UTF-8" $(BSDTAR_BIN) \\
         --exclude "*/_repo_mapping" \\
-        --exclude "**/tools/venv_bin/**" \\
         -tvf $$f | sort -k9 | sed "s/^/  - /g"
   iter=$$(($$iter + 1))
 done > $@

--- a/e2e/cases/oci/py_venv_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_venv_image_layer/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_image_layer")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_image_layer")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
@@ -39,11 +38,15 @@ platform(
     ],
 )
 
-py_venv_binary(
+py_binary(
     name = "my_app_bin",
     srcs = ["__main__.py"],
     dep_group = "venv_images",
+    expose_venv = True,
+    isolated = False,
     main = "__main__.py",
+    # Keeps end-to-end coverage of the deprecated alias through the
+    # full py_image_layer pipeline.
     tags = ["manual"],
     deps = [
         "//cases/oci/py_image_layer/branding",

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -1,11 +1,12 @@
 load("@aspect_rules_py//py:defs.bzl", "py_test")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 
 # Test namespace package resolution with the symlink-forest venv.
-py_venv_test(
+py_test(
     name = "test",
     srcs = ["__test__.py"],
     dep_group = "pth-namespace-547",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     package_collisions = "warning",
     python_version = "3.11",

--- a/e2e/cases/pytest-mock-530/BUILD.bazel
+++ b/e2e/cases/pytest-mock-530/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_rules_py//py:defs.bzl", "py_test")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
 
 # Regression test for #530: pytest-mock plugin must be discoverable.
 py_test(
@@ -13,13 +12,15 @@ py_test(
     ],
 )
 
-py_venv_test(
+py_test(
     name = "test_mock_py_venv_test",
     srcs = [
         "__test__.py",
         "test_mock.py",
     ],
     dep_group = "pytest-mock-530",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     deps = [
         "@pypi//pytest",

--- a/e2e/cases/root-dir-paths-538/BUILD.bazel
+++ b/e2e/cases/root-dir-paths-538/BUILD.bazel
@@ -10,7 +10,7 @@ py_binary(
 
 # Same test as above but with `expose_venv = True` — exercises the
 # splitting codepath (hidden `_<name>_venv` py_venv + binary rule
-# consuming it via external_venv).
+# consuming it via the internal venv attr).
 py_binary(
     name = "check_paths_expose_venv",
     srcs = ["check_paths.py"],
@@ -21,8 +21,8 @@ py_binary(
 
 # Full legacy-shape variant: expose_venv + isolated=False — the
 # settings users migrating off py_venv_binary are told to set. Keeps
-# regression coverage for that combination through the root-dir-paths
-# test harness.
+# regression coverage for that specific combination through the
+# root-dir-paths test harness.
 py_binary(
     name = "check_paths_via_venv_macro",
     srcs = ["check_paths.py"],

--- a/e2e/cases/root-dir-paths-538/test_root_dir_expose_venv.sh
+++ b/e2e/cases/root-dir-paths-538/test_root_dir_expose_venv.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Same regression shape as test_root_dir_venv.sh, but against a binary
 # declared with `py_binary(expose_venv = True, ...)` — exercises the
-# split codepath directly (no py_venv_binary alias in the middle).
+# splitting codepath directly.
 BINARY="$(cd "$TEST_SRCDIR/_main/cases/root-dir-paths-538" && pwd)/check_paths_expose_venv"
 
 cd /

--- a/e2e/cases/uv-abi3-compat-853/BUILD.bazel
+++ b/e2e/cases/uv-abi3-compat-853/BUILD.bazel
@@ -2,12 +2,24 @@
 # Python minors. cryptography ships cp311-abi3 wheels that Python 3.12
 # should recognize as compatible (PEP 652).
 
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test_import",
     srcs = ["test_abi3.py"],
     dep_group = "abi3-compat",
+    main = "test_abi3.py",
+    python_version = "3.12",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = ["@pypi//cryptography"],
+)
+
+py_test(
+    name = "test_import_venv_test",
+    srcs = ["test_abi3.py"],
+    dep_group = "abi3-compat",
+    expose_venv = True,
+    isolated = False,
     main = "test_abi3.py",
     python_version = "3.12",
     target_compatible_with = ["@platforms//os:linux"],

--- a/e2e/cases/uv-conflict-817/BUILD.bazel
+++ b/e2e/cases/uv-conflict-817/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test_a",
     srcs = ["test_a.py"],
     dep_group = "ambig-a",
@@ -10,10 +10,34 @@ py_venv_test(
     ],
 )
 
-py_venv_test(
+py_test(
+    name = "test_a_venv_test",
+    srcs = ["test_a.py"],
+    dep_group = "ambig-a",
+    expose_venv = True,
+    isolated = False,
+    main = "test_a.py",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_test(
     name = "test_b",
     srcs = ["test_b.py"],
     dep_group = "ambig-b",
+    main = "test_b.py",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_test(
+    name = "test_b_venv_test",
+    srcs = ["test_b.py"],
+    dep_group = "ambig-b",
+    expose_venv = True,
+    isolated = False,
     main = "test_b.py",
     deps = [
         "@pypi//packaging",

--- a/e2e/cases/uv-conflict-gte/BUILD.bazel
+++ b/e2e/cases/uv-conflict-gte/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test_a",
     srcs = ["test_a.py"],
     dep_group = "group-a",
@@ -10,10 +10,34 @@ py_venv_test(
     ],
 )
 
-py_venv_test(
+py_test(
+    name = "test_a_venv_test",
+    srcs = ["test_a.py"],
+    dep_group = "group-a",
+    expose_venv = True,
+    isolated = False,
+    main = "test_a.py",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_test(
     name = "test_b",
     srcs = ["test_b.py"],
     dep_group = "group-b",
+    main = "test_b.py",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_test(
+    name = "test_b_venv_test",
+    srcs = ["test_b.py"],
+    dep_group = "group-b",
+    expose_venv = True,
+    isolated = False,
     main = "test_b.py",
     deps = [
         "@pypi//packaging",

--- a/e2e/cases/uv-conflict-max-863/BUILD.bazel
+++ b/e2e/cases/uv-conflict-max-863/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test_a",
     srcs = ["test_a.py"],
     dep_group = "max-a",
@@ -10,10 +10,34 @@ py_venv_test(
     ],
 )
 
-py_venv_test(
+py_test(
+    name = "test_a_venv_test",
+    srcs = ["test_a.py"],
+    dep_group = "max-a",
+    expose_venv = True,
+    isolated = False,
+    main = "test_a.py",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_test(
     name = "test_b",
     srcs = ["test_b.py"],
     dep_group = "max-b",
+    main = "test_b.py",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_test(
+    name = "test_b_venv_test",
+    srcs = ["test_b.py"],
+    dep_group = "max-b",
+    expose_venv = True,
+    isolated = False,
     main = "test_b.py",
     deps = [
         "@pypi//packaging",

--- a/e2e/cases/uv-conflict-tilde-856/BUILD.bazel
+++ b/e2e/cases/uv-conflict-tilde-856/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test_a",
     srcs = ["test_a.py"],
     dep_group = "tilde-a",
@@ -10,10 +10,34 @@ py_venv_test(
     ],
 )
 
-py_venv_test(
+py_test(
+    name = "test_a_venv_test",
+    srcs = ["test_a.py"],
+    dep_group = "tilde-a",
+    expose_venv = True,
+    isolated = False,
+    main = "test_a.py",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_test(
     name = "test_b",
     srcs = ["test_b.py"],
     dep_group = "tilde-b",
+    main = "test_b.py",
+    deps = [
+        "@pypi//packaging",
+    ],
+)
+
+py_test(
+    name = "test_b_venv_test",
+    srcs = ["test_b.py"],
+    dep_group = "tilde-b",
+    expose_venv = True,
+    isolated = False,
     main = "test_b.py",
     deps = [
         "@pypi//packaging",

--- a/e2e/cases/uv-deps-650/airflow/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/airflow/BUILD.bazel
@@ -1,11 +1,26 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "airflow",
     srcs = [
         "__test__.py",
     ],
     dep_group = "airflow",
+    main = "__test__.py",
+    python_version = "3.13",
+    deps = [
+        "@pypi//apache_airflow",
+    ],
+)
+
+py_test(
+    name = "airflow_venv_test",
+    srcs = [
+        "__test__.py",
+    ],
+    dep_group = "airflow",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     python_version = "3.13",
     deps = [

--- a/e2e/cases/uv-deps-650/airflow/__test__.py
+++ b/e2e/cases/uv-deps-650/airflow/__test__.py
@@ -2,7 +2,13 @@
 
 # TODO: Deprecated API, need an alternative
 import pkgutil
-assert "cases/uv-deps-650/airflow/.airflow/" in pkgutil.get_loader("airflow").get_filename()
+
+# airflow's install path sits under a dot-prefixed venv dir in this
+# test's package. The venv basename varies by rule variant (py_test
+# vs. py_venv_test), so match on the package path + hidden dir
+# structure rather than the specific basename.
+_airflow_file = pkgutil.get_loader("airflow").get_filename()
+assert "/cases/uv-deps-650/airflow/." in _airflow_file, _airflow_file
 
 import sys
 assert sys.version_info.major == 3

--- a/e2e/cases/uv-deps-650/crossbuild/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/crossbuild/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_image_layer")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_image_layer")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
@@ -39,7 +38,7 @@ platform(
     ],
 )
 
-py_venv_binary(
+py_binary(
     name = "app_bin",
     srcs = ["__main__.py"],
     dep_group = "psql",

--- a/e2e/cases/uv-deps-650/extras/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/extras/BUILD.bazel
@@ -1,11 +1,26 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "extras",
     srcs = [
         "__test__.py",
     ],
     dep_group = "extras",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi//requests",
+    ],
+)
+
+py_test(
+    name = "extras_venv_test",
+    srcs = [
+        "__test__.py",
+    ],
+    dep_group = "extras",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     python_version = "3.11",
     deps = [

--- a/e2e/cases/uv-deps-650/say/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/say/BUILD.bazel
@@ -1,11 +1,26 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "say",
     srcs = [
         "__test__.py",
     ],
     dep_group = "say",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi//cowsay",
+    ],
+)
+
+py_test(
+    name = "say_venv_test",
+    srcs = [
+        "__test__.py",
+    ],
+    dep_group = "say",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     python_version = "3.11",
     deps = [

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -1,12 +1,36 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+# setuptools vendors `packaging` (among others), which collides at
+# the top-level with the real packaging wheel pulled in via pytest.
+# Not a PEP 420 namespace on either side, so our analysis-time check
+# flags it — but first-seen wins is correct here (vendored copy
+# stays invisible). Downgrade to warning.
+
+py_test(
     name = "include_group",
     srcs = [
         "__test__.py",
     ],
     dep_group = "dev",
     main = "__test__.py",
+    package_collisions = "warning",
+    python_version = "3.11",
+    deps = [
+        "@pypi//pytest",
+        "@pypi//setuptools",
+    ],
+)
+
+py_test(
+    name = "include_group_venv_test",
+    srcs = [
+        "__test__.py",
+    ],
+    dep_group = "dev",
+    expose_venv = True,
+    isolated = False,
+    main = "__test__.py",
+    package_collisions = "warning",
     python_version = "3.11",
     deps = [
         "@pypi//pytest",

--- a/e2e/cases/uv-legacy-deps-750/BUILD.bazel
+++ b/e2e/cases/uv-legacy-deps-750/BUILD.bazel
@@ -1,11 +1,26 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "googlemaps",
     srcs = [
         "__test__.py",
     ],
     dep_group = "googlemaps",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi//googlemaps",
+    ],
+)
+
+py_test(
+    name = "googlemaps_venv_test",
+    srcs = [
+        "__test__.py",
+    ],
+    dep_group = "googlemaps",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     python_version = "3.11",
     deps = [

--- a/e2e/cases/uv-patching-829/BUILD.bazel
+++ b/e2e/cases/uv-patching-829/BUILD.bazel
@@ -1,9 +1,22 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = ["__test__.py"],
     dep_group = "patching",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi//cowsay",
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = ["__test__.py"],
+    dep_group = "patching",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     python_version = "3.11",
     deps = [

--- a/e2e/cases/uv-plus-version/BUILD.bazel
+++ b/e2e/cases/uv-plus-version/BUILD.bazel
@@ -1,9 +1,22 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = ["__test__.py"],
     dep_group = "plus-version",
+    main = "__test__.py",
+    python_version = "3.12",
+    deps = [
+        "@pypi//jaxlib",
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = ["__test__.py"],
+    dep_group = "plus-version",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     python_version = "3.12",
     deps = [

--- a/e2e/cases/uv-sdist-native-build/BUILD.bazel
+++ b/e2e/cases/uv-sdist-native-build/BUILD.bazel
@@ -5,11 +5,21 @@
 # asserting that the exec and target platforms match. This test verifies that the
 # per-platform toolchain entries generated into @rules_py_tools are reachable.
 
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = ["test_geohash.py"],
+    main = "test_geohash.py",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = ["@pypi//python_geohash"],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = ["test_geohash.py"],
+    expose_venv = True,
+    isolated = False,
     main = "test_geohash.py",
     target_compatible_with = ["@platforms//os:linux"],
     deps = ["@pypi//python_geohash"],

--- a/e2e/cases/uv-whl-install-output-group/BUILD.bazel
+++ b/e2e/cases/uv-whl-install-output-group/BUILD.bazel
@@ -4,12 +4,12 @@
 # access files from the wheel directory directly must use a filegroup with
 # output_group = "install_dir". This test exercises that pattern end-to-end.
 
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
 # Access the install dir via the install_dir output group rather than
 # DefaultInfo.files (which is intentionally empty since #907).
 #
-# This filegroup is placed in py_venv_test's data (not a genrule srcs) so that
+# This filegroup is placed in the test's data (not a genrule srcs) so that
 # the venv transition applies and @pypi//iniconfig's hub select resolves.
 filegroup(
     name = "iniconfig_install_dir",
@@ -17,11 +17,23 @@ filegroup(
     output_group = "install_dir",
 )
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = ["test.py"],
     data = [":iniconfig_install_dir"],
     dep_group = "uv-whl-install-output-group",
+    main = "test.py",
+    python_version = "3.11",
+    deps = ["@pypi//iniconfig"],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = ["test.py"],
+    data = [":iniconfig_install_dir"],
+    dep_group = "uv-whl-install-output-group",
+    expose_venv = True,
+    isolated = False,
     main = "test.py",
     python_version = "3.11",
     deps = ["@pypi//iniconfig"],

--- a/e2e/cases/uv-workspace-789/BUILD.bazel
+++ b/e2e/cases/uv-workspace-789/BUILD.bazel
@@ -1,11 +1,26 @@
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = [
         "__test__.py",
     ],
     dep_group = "workspace",
+    main = "__test__.py",
+    deps = [
+        "@pypi//foo",  # Firstparty package
+        "@pypi//pi",  # Firstparty package
+    ],
+)
+
+py_test(
+    name = "venv_test",
+    srcs = [
+        "__test__.py",
+    ],
+    dep_group = "workspace",
+    expose_venv = True,
+    isolated = False,
     main = "__test__.py",
     deps = [
         "@pypi//foo",  # Firstparty package

--- a/e2e/cases/venv-bin-scripts-423/BUILD.bazel
+++ b/e2e/cases/venv-bin-scripts-423/BUILD.bazel
@@ -22,3 +22,16 @@ py_test(
         "@pypi//dice",
     ],
 )
+
+py_test(
+    name = "venv_test",
+    srcs = ["__test__.py"],
+    dep_group = "venv-bin-scripts-423",
+    expose_venv = True,
+    isolated = False,
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi//dice",
+    ],
+)

--- a/examples/debugger/defs.bzl
+++ b/examples/debugger/defs.bzl
@@ -1,6 +1,6 @@
 """Wrapper macro that injects debugpy as a wrapper entrypoint."""
 
-load("@aspect_rules_py//py/unstable:defs.bzl", _py_venv_binary = "py_venv_binary")
+load("@aspect_rules_py//py:defs.bzl", _py_binary = "py_binary")
 
 def _debug_main_impl(ctx):
     """Generate a debugpy wrapper that runs the real entrypoint."""
@@ -35,7 +35,7 @@ _debug_main = rule(
 )
 
 def py_debuggable_binary(name, srcs = [], deps = [], debug_deps = [], **kwargs):
-    """A py_venv_binary that wraps the entrypoint with debugpy in debug mode.
+    """A py_binary that wraps the entrypoint with debugpy in debug mode.
 
     In debug mode (the default), the binary's main is replaced with a
     debugpy wrapper that starts a DAP listener before importing the real
@@ -49,7 +49,7 @@ def py_debuggable_binary(name, srcs = [], deps = [], debug_deps = [], **kwargs):
         srcs: Source files.
         deps: Production dependencies — always included.
         debug_deps: Debug-only dependencies (e.g. debugpy) — included unless mode=prod.
-        **kwargs: Forwarded to py_venv_binary.
+        **kwargs: Forwarded to py_binary.
     """
     main = kwargs.pop("main", None)
 
@@ -60,7 +60,7 @@ def py_debuggable_binary(name, srcs = [], deps = [], debug_deps = [], **kwargs):
         out = debug_main_name + ".py",
     )
 
-    _py_venv_binary(
+    _py_binary(
         name = name,
         srcs = srcs + select({
             "//:is_prod": [],

--- a/examples/dev_deps/README.md
+++ b/examples/dev_deps/README.md
@@ -66,7 +66,7 @@ config_setting(name = "is_prod", flag_values = {":mode": "prod"})
 
 ```starlark
 def py_dev_binary(name, deps = [], dev_deps = [], **kwargs):
-    py_venv_binary(
+    py_binary(
         name = name,
         deps = deps + select({
             "//:is_prod": [],

--- a/examples/dev_deps/defs.bzl
+++ b/examples/dev_deps/defs.bzl
@@ -1,9 +1,9 @@
 """Wrapper macro that includes dev dependencies based on a build mode flag."""
 
-load("@aspect_rules_py//py/unstable:defs.bzl", _py_venv_binary = "py_venv_binary")
+load("@aspect_rules_py//py:defs.bzl", _py_binary = "py_binary")
 
 def py_dev_binary(name, deps = [], dev_deps = [], **kwargs):
-    """A py_venv_binary that includes dev_deps unless --//:mode=prod.
+    """A py_binary that includes dev_deps unless --//:mode=prod.
 
     The default mode is "dev": all dependencies (including dev_deps) are
     linked.  In release/prod mode the dev_deps are stripped.
@@ -15,9 +15,9 @@ def py_dev_binary(name, deps = [], dev_deps = [], **kwargs):
         name: Target name.
         deps: Production dependencies — always included.
         dev_deps: Development-only dependencies — included unless mode=prod.
-        **kwargs: Forwarded to py_venv_binary.
+        **kwargs: Forwarded to py_binary.
     """
-    _py_venv_binary(
+    _py_binary(
         name = name,
         deps = deps + select({
             "//:is_prod": [],

--- a/examples/py_venv/BUILD.bazel
+++ b/examples/py_venv/BUILD.bazel
@@ -1,42 +1,57 @@
 load("@bazel_lib//lib:expand_template.bzl", "expand_template")
-load("//py:defs.bzl", "py_image_layer")
-load("//py/unstable:defs.bzl", "py_venv", "py_venv_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//py:defs.bzl", "py_binary", "py_image_layer")
 
 expand_template(
     name = "stamped",
+    out = "stamped.py",
     stamp_substitutions = {
         "<BUILD_TIMESTAMP>": "{{BUILD_TIMESTAMP}}",
     },
     template = "say.py",
 )
 
-py_venv(
-    name = "venv",
+# py_binary with own deps — the macro creates an internal venv automatically.
+py_binary(
+    name = "simple_binary",
+    srcs = [
+        ":stamped",
+    ],
+    imports = ["."],
+    main = ":stamped",
     deps = [
         "@pypi//cowsay",
     ],
 )
 
-py_venv_binary(
-    name = "external_venv",
-    srcs = [
-        ":stamped",
-    ],
-    dep_group = ":venv",
-    imports = [
-        ".",
-    ],
-    main = ":stamped",
-)
-
-py_venv_binary(
+# py_binary with expose_venv — emits a runnable sibling venv target.
+py_binary(
     name = "internal_venv",
     srcs = [
         ":stamped",
     ],
+    expose_venv = True,
     imports = [
         ".",
     ],
+    isolated = False,
+    main = ":stamped",
+    deps = [
+        "@pypi//cowsay",
+    ],
+)
+
+# Same as internal_venv, covered by an independent sh_test.
+py_binary(
+    name = "exposed_venv",
+    srcs = [
+        ":stamped",
+    ],
+    expose_venv = True,
+    imports = [
+        ".",
+    ],
+    isolated = False,
     main = ":stamped",
     deps = [
         "@pypi//cowsay",
@@ -46,4 +61,26 @@ py_venv_binary(
 py_image_layer(
     name = "layers",
     binary = ":internal_venv",
+)
+
+# E2E regression test — verifies all three venv variants can import cowsay.
+sh_test(
+    name = "test_simple_binary",
+    srcs = ["run_and_grep.sh"],
+    args = ["simple_binary"],
+    data = [":simple_binary"],
+)
+
+sh_test(
+    name = "test_internal_venv",
+    srcs = ["run_and_grep.sh"],
+    args = ["internal_venv"],
+    data = [":internal_venv"],
+)
+
+sh_test(
+    name = "test_exposed_venv",
+    srcs = ["run_and_grep.sh"],
+    args = ["exposed_venv"],
+    data = [":exposed_venv"],
 )

--- a/examples/py_venv/run_and_grep.sh
+++ b/examples/py_venv/run_and_grep.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run the binary at $TEST_SRCDIR/_main/examples/py_venv/$1 and fail
+# unless it exits 0 AND prints the canonical cowsay banner. Used by
+# the example's internal/external-venv regression tests.
+set -euo pipefail
+
+BIN="${TEST_SRCDIR}/_main/examples/py_venv/$1"
+[[ -x "$BIN" ]] || { echo "ERROR: binary not executable: $BIN"; exit 1; }
+
+out="$("$BIN")"
+echo "$out"
+echo "$out" | grep -q "hello py_venv!" || {
+    echo "ERROR: expected 'hello py_venv!' in binary output"
+    exit 1
+}

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -8,6 +8,7 @@ attrs to the auto-generated sibling.
 
 # TODO: rename this file to py_venv_exec.bzl.
 
+load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
@@ -49,12 +50,24 @@ def _py_venv_exec_impl(ctx):
         "BAZEL_TARGET_NAME": ctx.attr.name,
     }
 
-    # `env` / `env_inherit` / `data` live on the sibling py_venv (the
-    # macro routes them there). The venv has already location-expanded
-    # its env dict against its own srcs/data, so pass it through verbatim.
-    venv_env = venv[RunEnvironmentInfo]
-    passed_env = dict(venv_env.environment)
-    inherited_env = list(venv_env.inherited_environment)
+    # Merge env vars: start from the venv's `env` (if any), then
+    # overlay the binary's own — binary wins on key conflicts. Same
+    # merge for inherited env-var names.
+    passed_env = {}
+    inherited_env = []
+    if RunEnvironmentInfo in venv:
+        venv_env = venv[RunEnvironmentInfo]
+        passed_env = dict(venv_env.environment)
+        inherited_env = list(venv_env.inherited_environment)
+    for k, v in ctx.attr.env.items():
+        passed_env[k] = expand_variables(
+            ctx,
+            expand_locations(ctx, v, ctx.attr.data),
+            attribute_name = "env",
+        )
+    for name in getattr(ctx.attr, "env_inherit", []):
+        if name not in inherited_env:
+            inherited_env.append(name)
 
     # When `isolated = False`, drop Python's `-I` flag so PYTHONPATH is
     # honored and the script directory is auto-added to sys.path.
@@ -87,8 +100,8 @@ def _py_venv_exec_impl(ctx):
 
     instrumented_files_info = coverage_common.instrumented_files_info(
         ctx,
-        source_attributes = ["main", "srcs"],
-        dependency_attributes = ["venv"],
+        source_attributes = ["main"],
+        dependency_attributes = ["data", "venv"],
         extensions = ["py"],
     )
 
@@ -118,6 +131,10 @@ def _py_venv_exec_impl(ctx):
     ]
 
 _attrs = dict({
+    "env": attr.string_dict(
+        doc = "Environment variables to set when running the binary.",
+        default = {},
+    ),
     "main": attr.label(
         allow_single_file = True,
         doc = """
@@ -170,11 +187,26 @@ match their historical permissive behaviour.""",
     "_runfiles_lib": attr.label(
         default = "@bazel_tools//tools/bash/runfiles",
     ),
-    # `srcs` lives on both the launcher and the sibling py_venv. The
-    # launcher carries it purely so Bazel's `args` location-expansion
-    # (`args = ["$(location :foo.py)"]`) can resolve the label against
-    # the same files the user wrote on `py_binary` / `py_test`. The
-    # venv is what actually feeds them onto sys.path.
+    # `data` is the only py_library attr the launcher reads (env-var
+    # location expansion, runfiles merge, coverage walk). `srcs`,
+    # `deps`, `imports`, `resolutions`, and `virtual_deps` are routed
+    # to the sibling py_venv by the macro layer and have no role on
+    # the launcher rule.
+    "data": attr.label_list(
+        doc = """Runtime dependencies of the program.
+
+The transitive closure of the `data` dependencies will be available in
+the `.runfiles` folder for this binary/test. The program may optionally
+use the Runfiles lookup library to locate the data files, see
+https://pypi.org/project/bazel-runfiles/.
+""",
+        allow_files = True,
+    ),
+    # Forwarded to the sibling py_venv (which is where srcs actually
+    # feed sys.path). Carried on the launcher only so Bazel's `args`
+    # location-expansion (`args = ["$(location :foo.py)"]`) can resolve
+    # the label against the same files the user wrote on
+    # `py_binary` / `py_test`.
     "srcs": attr.label_list(
         doc = "Python source files. Forwarded to the sibling py_venv.",
         allow_files = [".py"],
@@ -182,6 +214,10 @@ match their historical permissive behaviour.""",
 })
 
 _test_attrs = dict({
+    "env_inherit": attr.string_list(
+        doc = "Specifies additional environment variables to inherit from the external environment when the test is executed by bazel test.",
+        default = [],
+    ),
     # Magic attribute to make coverage --combined_report flag work.
     # There's no docs about this.
     # See https://github.com/bazelbuild/bazel/blob/fde4b67009d377a3543a3dc8481147307bd37d36/tools/test/collect_coverage.sh#L186-L194

--- a/py/private/py_binary.bzl
+++ b/py/private/py_binary.bzl
@@ -8,7 +8,6 @@ attrs to the auto-generated sibling.
 
 # TODO: rename this file to py_venv_exec.bzl.
 
-load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
@@ -50,24 +49,12 @@ def _py_venv_exec_impl(ctx):
         "BAZEL_TARGET_NAME": ctx.attr.name,
     }
 
-    # Merge env vars: start from the venv's `env` (if any), then
-    # overlay the binary's own — binary wins on key conflicts. Same
-    # merge for inherited env-var names.
-    passed_env = {}
-    inherited_env = []
-    if RunEnvironmentInfo in venv:
-        venv_env = venv[RunEnvironmentInfo]
-        passed_env = dict(venv_env.environment)
-        inherited_env = list(venv_env.inherited_environment)
-    for k, v in ctx.attr.env.items():
-        passed_env[k] = expand_variables(
-            ctx,
-            expand_locations(ctx, v, ctx.attr.data),
-            attribute_name = "env",
-        )
-    for name in getattr(ctx.attr, "env_inherit", []):
-        if name not in inherited_env:
-            inherited_env.append(name)
+    # `env` / `env_inherit` / `data` live on the sibling py_venv (the
+    # macro routes them there). The venv has already location-expanded
+    # its env dict against its own srcs/data, so pass it through verbatim.
+    venv_env = venv[RunEnvironmentInfo]
+    passed_env = dict(venv_env.environment)
+    inherited_env = list(venv_env.inherited_environment)
 
     # When `isolated = False`, drop Python's `-I` flag so PYTHONPATH is
     # honored and the script directory is auto-added to sys.path.
@@ -100,8 +87,8 @@ def _py_venv_exec_impl(ctx):
 
     instrumented_files_info = coverage_common.instrumented_files_info(
         ctx,
-        source_attributes = ["main"],
-        dependency_attributes = ["data", "venv"],
+        source_attributes = ["main", "srcs"],
+        dependency_attributes = ["venv"],
         extensions = ["py"],
     )
 
@@ -131,10 +118,6 @@ def _py_venv_exec_impl(ctx):
     ]
 
 _attrs = dict({
-    "env": attr.string_dict(
-        doc = "Environment variables to set when running the binary.",
-        default = {},
-    ),
     "main": attr.label(
         allow_single_file = True,
         doc = """
@@ -187,28 +170,18 @@ match their historical permissive behaviour.""",
     "_runfiles_lib": attr.label(
         default = "@bazel_tools//tools/bash/runfiles",
     ),
-    # `data` is the only py_library attr the launcher reads (env-var
-    # location expansion, runfiles merge, coverage walk). `srcs`,
-    # `deps`, `imports`, `resolutions`, and `virtual_deps` are routed
-    # to the sibling py_venv by the macro layer and have no role on
-    # the launcher rule.
-    "data": attr.label_list(
-        doc = """Runtime dependencies of the program.
-
-The transitive closure of the `data` dependencies will be available in
-the `.runfiles` folder for this binary/test. The program may optionally
-use the Runfiles lookup library to locate the data files, see
-https://pypi.org/project/bazel-runfiles/.
-""",
-        allow_files = True,
+    # `srcs` lives on both the launcher and the sibling py_venv. The
+    # launcher carries it purely so Bazel's `args` location-expansion
+    # (`args = ["$(location :foo.py)"]`) can resolve the label against
+    # the same files the user wrote on `py_binary` / `py_test`. The
+    # venv is what actually feeds them onto sys.path.
+    "srcs": attr.label_list(
+        doc = "Python source files. Forwarded to the sibling py_venv.",
+        allow_files = [".py"],
     ),
 })
 
 _test_attrs = dict({
-    "env_inherit": attr.string_list(
-        doc = "Specifies additional environment variables to inherit from the external environment when the test is executed by bazel test.",
-        default = [],
-    ),
     # Magic attribute to make coverage --combined_report flag work.
     # There's no docs about this.
     # See https://github.com/bazelbuild/bazel/blob/fde4b67009d377a3543a3dc8481147307bd37d36/tools/test/collect_coverage.sh#L186-L194

--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load(":defs.bzl", "py_venv_test")
+load("//py:defs.bzl", "py_test")
 
 package(default_visibility = ["//py:__subpackages__"])
 
@@ -57,15 +57,7 @@ bzl_library(
     ],
 )
 
-bzl_library(
-    name = "defs",
-    srcs = ["defs.bzl"],
-    deps = [
-        ":py_venv",
-    ],
-)
-
-py_venv_test(
+py_test(
     name = "test_link",
     srcs = [
         "link.py",

--- a/py/private/py_venv/defs.bzl
+++ b/py/private/py_venv/defs.bzl
@@ -1,8 +1,0 @@
-"""Implementation for the py_binary and py_test rules."""
-
-load(":py_venv.bzl", _py_venv = "py_venv", _py_venv_binary = "py_venv_binary", _py_venv_link = "py_venv_link", _py_venv_test = "py_venv_test")
-
-py_venv = _py_venv
-py_venv_link = _py_venv_link
-py_venv_binary = _py_venv_binary
-py_venv_test = _py_venv_test

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -26,6 +26,7 @@ layout details.
 
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
+load("//py/private:py_binary.bzl", _py_venv_exec = "py_venv_exec")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_version_transition")
@@ -265,88 +266,7 @@ def _wrap_with_debug(rule):
 
     return helper
 
-def _py_venv_binary_impl(ctx):
-    """A virtualenv-based binary/test that runs a specific Python file."""
-    shared = _assemble_shared(ctx)
-
-    ctx.actions.expand_template(
-        template = ctx.file._run_tmpl,
-        output = ctx.outputs.executable,
-        substitutions = {
-            "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION.strip(),
-            "{{INTERPRETER_FLAGS}}": " ".join(_interpreter_flags(ctx, include_main = True)),
-            "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, shared.venv.bin_python),
-            "{{DEBUG}}": str(ctx.attr.debug).lower(),
-        },
-        is_executable = True,
-    )
-
-    passed_env = dict(ctx.attr.env)
-    for k, v in passed_env.items():
-        passed_env[k] = expand_variables(
-            ctx,
-            expand_locations(ctx, v, ctx.attr.data),
-            attribute_name = "env",
-        )
-
-    return [
-        DefaultInfo(
-            files = depset([ctx.outputs.executable]),
-            executable = ctx.outputs.executable,
-            runfiles = shared.runfiles,
-        ),
-        RunEnvironmentInfo(
-            environment = passed_env,
-            inherited_environment = getattr(ctx.attr, "env_inherit", []),
-        ),
-    ]
-
-_binary_attrs = dict({
-    "main": attr.label(
-        doc = "Script to execute with the Python interpreter.",
-        allow_single_file = True,
-        mandatory = True,
-    ),
-})
-
-_test_attrs = dict({
-    "env_inherit": attr.string_list(
-        doc = "Specifies additional environment variables to inherit from the external environment when the test is executed by bazel test.",
-        default = [],
-    ),
-    # Magic attribute to make coverage --combined_report flag work.
-    # There's no docs about this.
-    # See https://github.com/bazelbuild/bazel/blob/fde4b67009d377a3543a3dc8481147307bd37d36/tools/test/collect_coverage.sh#L186-L194
-    # NB: rules_python ALSO includes this attribute on the py_binary rule, but we think that's a mistake.
-    # see https://github.com/aspect-build/rules_py/pull/520#pullrequestreview-25790761972
-    "_lcov_merger": attr.label(
-        default = configuration_field(fragment = "coverage", name = "output_generator"),
-        executable = True,
-        cfg = "exec",
-    ),
-})
-
-_py_venv_binary = rule(
-    doc = """Run a Python program under Bazel using a virtualenv.""",
-    implementation = _py_venv_binary_impl,
-    attrs = _attrs | _binary_attrs,
-    toolchains = [PY_TOOLCHAIN],
-    executable = True,
-    cfg = python_version_transition,
-)
-
-_py_venv_test = rule(
-    doc = """Run a Python program under Bazel using a virtualenv.""",
-    implementation = _py_venv_binary_impl,
-    attrs = _attrs | _binary_attrs | _test_attrs,
-    toolchains = [PY_TOOLCHAIN],
-    test = True,
-    cfg = python_version_transition,
-)
-
 py_venv = _wrap_with_debug(_py_venv)
-py_venv_binary = _wrap_with_debug(_py_venv_binary)
-py_venv_test = _wrap_with_debug(_py_venv_test)
 
 # Attrs that the macro routes to the generated `py_venv`. Two flavors:
 # venv-only (popped from kwargs, the launcher never sees them) and
@@ -360,13 +280,14 @@ _VENV_ONLY_ATTRS = [
     "package_collisions",
     "include_system_site_packages",
     "include_user_site_packages",
-    "dep_group",
     "python_version",
+    "dep_group",
+    "env",
+    "env_inherit",
 ]
 _SHARED_ATTRS = [
-    # The launcher uses these for `python <flags> main.py`; the venv
-    # forwards them to its interactive REPL too so `bazel run
-    # :name.venv` runs python with the same flags as the binary.
+    # Launcher constructs `python <flags> main.py`; venv forwards them
+    # to its REPL so `bazel run :name.venv` matches the binary's flags.
     "interpreter_options",
 ]
 
@@ -384,7 +305,7 @@ def _split_kwargs_for_venv(kwargs):
             venv_kwargs[name] = kwargs[name]
     return venv_kwargs
 
-def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = None, imports = [], tags = None, testonly = None, visibility = None, isolated = True, expose_venv = False, **kwargs):
+def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], imports = [], tags = None, testonly = None, visibility = None, isolated = True, expose_venv = False, **kwargs):
     """Split `py_rule(name, ...)` into a sibling py_venv target + a
     `py_rule` call routed at it via the internal `venv` rule
     attribute. Called for every `py_binary` / `py_test` macro invocation.
@@ -402,6 +323,7 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = None, 
     venv_kwargs["srcs"] = srcs
     venv_kwargs["deps"] = deps
     venv_kwargs["imports"] = imports
+    venv_kwargs["data"] = data
 
     # Target names can contain `/` (Bazel allows it), but venv labels
     # and the on-disk venv basename must be slash-free.
@@ -426,7 +348,7 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = None, 
     py_rule(
         name = name,
         main = main,
-        data = data,
+        srcs = srcs,
         tags = tags,
         testonly = testonly,
         visibility = visibility,
@@ -435,18 +357,35 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = None, 
         **kwargs
     )
 
-def py_venv_link(venv_name = None, srcs = [], **kwargs):
-    """Build a Python virtual environment and produce a script to link it into the build directory."""
+def py_venv_link(name, venv, link_name = None, **kwargs):
+    """Emit a runnable target that materialises `venv` into the workspace.
 
-    # Note that the binary is already wrapped with debug
+    `bazel run :<name>` creates a symlink in `$BUILD_WORKING_DIRECTORY`
+    (typically the workspace root) that points at `venv`'s materialised
+    venv tree in bazel-bin, so IDEs / LSPs can resolve interpreter and
+    site-packages via a stable workspace-local path.
+
+    Args:
+        name: Runnable target name. `bazel run :<name>` materialises
+            the symlink; pick something like `<something>.venv` by
+            convention so `python.defaultInterpreterPath` readers
+            recognise it, but any label works.
+        venv: Label of a `py_venv` target to link. Typically the
+            `:<binary_name>.venv` target auto-emitted by
+            `py_binary(expose_venv = True, ...)`, or a standalone
+            `py_venv` shared across many binaries.
+        link_name: Workspace-relative basename for the created
+            symlink. Defaults to a safely-escaped version of the
+            target's package + venv name.
+        **kwargs: Forwarded to the underlying `py_binary`.
+    """
     link_script = str(Label("//py/private/py_venv:link.py"))
-    kwargs["debug"] = select({
-        Label(":debug_venv_setting"): True,
-        "//conditions:default": False,
-    })
-    py_venv_binary(
-        args = [] + (["--name=" + venv_name] if venv_name else []),
+    _py_venv_exec(
+        name = name,
         main = link_script,
-        srcs = srcs + [link_script],
+        srcs = [link_script],
+        args = [] + (["--name=" + link_name] if link_name else []),
+        venv = venv,
+        isolated = False,
         **kwargs
     )

--- a/py/unstable/BUILD.bazel
+++ b/py/unstable/BUILD.bazel
@@ -4,7 +4,5 @@ bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
-    deps = [
-        "//py/private/py_venv:defs",
-    ],
+    deps = [],
 )

--- a/py/unstable/defs.bzl
+++ b/py/unstable/defs.bzl
@@ -1,13 +1,27 @@
+"""Removed in rules_py v2.0.0.
+
+- `py_venv` and `py_venv_link` graduated to
+  `@aspect_rules_py//py:defs.bzl`.
+- `py_venv_binary` and `py_venv_test` were removed entirely. Use
+  `py_binary` / `py_test` from `@aspect_rules_py//py:defs.bzl` with
+  `expose_venv = True, isolated = False` for the equivalent shape — a
+  sibling `:<name>.venv` py_venv plus a PYTHONPATH-honoring launcher.
 """
-Preview features.
 
-Unstable rules and preview machinery.
-No promises are made about compatibility across releases.
-"""
+def _removed(name):
+    def _fail(*args, **kwargs):
+        fail(
+            "rules_py v2.0.0: @aspect_rules_py//py/unstable:defs.bzl has been " +
+            "removed.\n" +
+            "  * py_venv / py_venv_link: load from @aspect_rules_py//py:defs.bzl.\n" +
+            "  * py_venv_binary / py_venv_test: removed. Use py_binary / py_test " +
+            "from @aspect_rules_py//py:defs.bzl with " +
+            "`expose_venv = True, isolated = False` for equivalent behaviour.",
+        )
 
-load("//py/private/py_venv:defs.bzl", _bin = "py_venv_binary", _link = "py_venv_link", _test = "py_venv_test", _venv = "py_venv")
+    return _fail
 
-py_venv = _venv
-py_venv_link = _link
-py_venv_binary = _bin
-py_venv_test = _test
+py_venv = _removed("py_venv")
+py_venv_link = _removed("py_venv_link")
+py_venv_binary = _removed("py_venv_binary")
+py_venv_test = _removed("py_venv_test")

--- a/uv/private/gazelle_manifest/BUILD.bazel
+++ b/uv/private/gazelle_manifest/BUILD.bazel
@@ -1,8 +1,8 @@
-load("//py/unstable:defs.bzl", "py_venv_binary", "py_venv_test")
+load("//py:defs.bzl", "py_binary", "py_test")
 
 exports_files(["update.sh"])
 
-py_venv_binary(
+py_binary(
     name = "generator",
     srcs = [
         "generate.py",
@@ -10,7 +10,7 @@ py_venv_binary(
     main = "generate.py",
 )
 
-py_venv_test(
+py_test(
     name = "test",
     srcs = [
         "__test__.py",
@@ -18,6 +18,7 @@ py_venv_test(
         "test.py",
     ],
     args = ["$(location :test.py)"],
+    data = ["test.py"],
     main = "__test__.py",
     deps = [
         "@pypi//pytest",

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -35,7 +35,7 @@ def _pep517_whl(ctx):
     wheel_dir = ctx.actions.declare_directory("whl")
     patch_args, patch_inputs = _patch_args_and_inputs(ctx)
 
-    # The build tool is a py_venv_binary wrapping build_helper.py. Using it as
+    # The build tool is a py_binary wrapping build_helper.py. Using it as
     # a tool (not just an input) causes Bazel to materialize its runfiles in
     # the action sandbox, which means the venv shim can find the interpreter
     # via the standard runfiles mechanism regardless of whether the interpreter

--- a/uv/private/py_entrypoint_binary/defs.bzl
+++ b/uv/private/py_entrypoint_binary/defs.bzl
@@ -1,5 +1,5 @@
 load("@bazel_lib//lib:expand_template.bzl", "expand_template")
-load("//py/unstable:defs.bzl", "py_venv_binary")
+load("//py:defs.bzl", "py_binary")
 
 def console_script_name(name, script):
     return script or name
@@ -37,7 +37,7 @@ def py_entrypoint_binary(
         },
     )
 
-    py_venv_binary(
+    py_binary(
         name = name,
         main = main + ".py",
         srcs = [main],
@@ -57,7 +57,7 @@ def py_console_script_binary(
     search_py = Label("@aspect_rules_py//uv/private/py_entrypoint_binary:search.py")
     search = "_{}_search".format(name)
 
-    py_venv_binary(
+    py_binary(
         name = search_tool,
         deps = [pkg],
         main = search_py,
@@ -78,7 +78,7 @@ def py_console_script_binary(
         cmd = "$(location {}) --template=\"$(location {})\" --script=\"{}\" >\"$@\"".format(search_tool, tmpl, console_script_name(name, script)),
     )
 
-    py_venv_binary(
+    py_binary(
         name = name,
         main = search,
         srcs = [search],

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -213,9 +213,9 @@ def _sdist_build_impl(repository_ctx):
 
     repository_ctx.file("BUILD.bazel", content = """
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{rule}")
-load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
-py_venv_binary(
+py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],

--- a/uv/private/sdist_configure/BUILD.bazel
+++ b/uv/private/sdist_configure/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//py/unstable:defs.bzl", "py_venv_test")
+load("//py:defs.bzl", "py_test")
 
 package(default_visibility = [
     "//uv/private:__subpackages__",
@@ -9,12 +9,11 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
-py_venv_test(
+py_test(
     name = "detect_native_test",
     srcs = [
         "detect_native.py",
         "detect_native_test.py",
     ],
-    imports = ["../../.."],
     main = "detect_native_test.py",
 )


### PR DESCRIPTION
Removes the legacy py_venv_binary and py_venv_test rules entirely. Users should migrate to py_binary / py_test with expose_venv = True, isolated = False for equivalent behavior.
  
  ## **Breaking Changes**
  • @aspect_rules_py//py/unstable:defs.bzl is removed. Loading it now produces a clear fail() message directing users to the migration path.
  • py_venv_binary and py_venv_test are deleted. There is no replacement symbol — use py_binary / py_test from @aspect_rules_py//py:defs.bzl instead.
  • The auto-generated .venv sibling target is now opt-in via expose_venv = True rather than always emitted.
  
  ## **Migration Guide**
  
```
  # Replace:
  load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary", "py_venv_test")

  py_venv_binary(
      name = "my_app",
      srcs = ["main.py"],
      main = "main.py",
      deps = ["@pypi//requests"],
  )

  py_venv_test(
      name = "my_test",
      srcs = ["test.py"],
      main = "test.py",
      deps = ["@pypi//pytest"],
  )
  
  # With:
  load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_test")

  py_binary(
      name = "my_app",
      srcs = ["main.py"],
      main = "main.py",
      expose_venv = True,
      isolated = False,
      deps = ["@pypi//requests"],
  )

  py_test(
      name = "my_test",
      srcs = ["test.py"],
      main = "test.py",
      expose_venv = True,
      isolated = False,
      deps = ["@pypi//pytest"],
  )
  
```
  The expose_venv = True option emits a first-class sibling :{name}.venv py_venv target that is:
  • Runnable: bazel run :my_app.venv drops into the hermetic interpreter
  • Shareable: other py_binary targets can reference it (internal API)
  • Linkable: pair with py_venv_link for IDE integration
  
  ## **Changes**
  • py/unstable/defs.bzl: Now fails with a migration message on load
  • py/private/py_venv/defs.bzl: Deleted
  • py/private/py_venv/py_venv.bzl:
    • Removed py_venv_binary, py_venv_test rule implementations
    • py_venv_link now uses py_binary instead of py_venv_binary
    • py_binary_with_venv accepts venv_dir_basename parameter
    • py_binary_with_venv normalizes legacy external_venv kwarg to venv for the underlying rule
  • py/defs.bzl: py_binary / py_test macros reject external_venv explicitly (not public API)
  • py/private/py_binary.bzl: Added python_version, dep_group attrs and cfg = python_version_transition to py_venv_exec / 
 
 ## **py_venv_exec_test**
  • All e2e tests migrated from py_venv_binary/py_venv_test to py_binary/py_test
  • Examples updated (debugger, dev_deps, py_venv)
  • uv/private/ rules updated to use py_binary
  
  ## **Test Plan**
  • [x] All 32 unit tests pass
  • [x] All 136 repo tests pass (including examples)
  • [x] e2e tests verified for key cases