### PR TITLE
fix: ensure wheels in lockfiles have hashes (#962)

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -457,6 +457,19 @@ uv.project(
 )
 # }}}
 
+# For cases/uv-dep-hashes
+# This test verifies that we can handle uv.lock wheel entries that don't have
+# `hash` fields.
+# {{{
+uv.declare_hub(hub_name = "pypi-pytorch")
+uv.project(
+    hub_name = "pypi-pytorch",
+    lock = "//cases/uv-dep-hashes:uv.lock",
+    pyproject = "//cases/uv-dep-hashes:pyproject.toml",
+)
+use_repo(uv, "pypi-pytorch")
+# }}}
+
 use_repo(uv, "pypi")
 
 register_toolchains("@uv//:all")

--- a/e2e/cases/uv-dep-hashes/BUILD.bazel
+++ b/e2e/cases/uv-dep-hashes/BUILD.bazel
@@ -1,0 +1,21 @@
+# Regression test: uv.lock entries whose wheels lack a `hash` field must not
+# crash module-extension evaluation, and the resulting wheel must still install.
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+py_venv_test(
+    name = "test_import",
+    srcs = ["test.py"],
+    main = "test.py",
+    python_version = "3.11",
+    venv = "uv-dep-hashes",
+    deps = ["@pypi-pytorch//colorama"],
+)
+
+# Guard the regression: if uv.lock is regenerated and gains a `hash` for the
+# colorama wheel, this test fails so the regression case stays meaningful.
+sh_test(
+    name = "test_lockfile_hashless",
+    srcs = ["test_lockfile_hashless.sh"],
+    data = ["uv.lock"],
+)

--- a/e2e/cases/uv-dep-hashes/pyproject.toml
+++ b/e2e/cases/uv-dep-hashes/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "uv-dep-hashes"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = "==3.11.*"
+dependencies = ["colorama"]

--- a/e2e/cases/uv-dep-hashes/test.py
+++ b/e2e/cases/uv-dep-hashes/test.py
@@ -1,0 +1,10 @@
+import colorama
+
+
+def test_imported():
+    assert hasattr(colorama, "Fore")
+
+
+if __name__ == "__main__":
+    test_imported()
+    print("OK")

--- a/e2e/cases/uv-dep-hashes/test_lockfile_hashless.sh
+++ b/e2e/cases/uv-dep-hashes/test_lockfile_hashless.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify the colorama wheel entry in uv.lock has no `hash` field. If uv.lock is
+# regenerated and gains a hash for it, this guard fails so the companion
+# regression test (test_import) doesn't silently stop exercising the
+# hashless-wheel code path.
+
+LOCK="${TEST_SRCDIR}/_main/cases/uv-dep-hashes/uv.lock"
+
+# Extract the colorama [[package]] block, then check its wheel line for `hash`.
+block="$(awk '/^\[\[package\]\]/{flag=0} /^name = "colorama"/{flag=1} flag' "$LOCK")"
+
+if echo "$block" | grep -E '^\s*\{ url = .* hash =' >/dev/null; then
+    echo "FAIL: colorama wheel entry in uv.lock has a hash; regression test invalidated."
+    echo "Either remove the hash to keep the test meaningful, or delete this whole case."
+    echo "--- colorama block ---"
+    echo "$block"
+    exit 1
+fi
+
+echo "PASS: colorama wheel entry in uv.lock is hashless"

--- a/e2e/cases/uv-dep-hashes/uv.lock
+++ b/e2e/cases/uv-dep-hashes/uv.lock
@@ -1,0 +1,29 @@
+version = 1
+revision = 3
+requires-python = "==3.11.*"
+
+# colorama's wheel entry intentionally omits the `hash` field.
+# This reproduces an issue where uv emits hashless wheel entries (e.g. for
+# packages from `find-links` registries). The companion sh_test guards against
+# the lockfile being regenerated and gaining a hash, which would silently
+# void this regression test.
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl" },
+]
+
+[[package]]
+name = "uv-dep-hashes"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "colorama" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "colorama" },
+]

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -409,7 +409,7 @@ def _parse_projects(module_ctx, hub_specs):
 
                 install_cfgs[k] = struct(
                     whls = {} if is_no_binary else {
-                        whl["url"].split("/")[-1].split("?")[0].split("#")[0]: bdist_table.get(whl["hash"])
+                        whl["url"].split("/")[-1].split("?")[0].split("#")[0]: bdist_table.get(whl["url"])
                         for whl in package.get("wheels", [])
                     },
                     sbuild = "@{}//:whl".format(sbuild_id) if has_sbuild else None,
@@ -534,7 +534,7 @@ def _uv_impl(module_ctx):
 
     for bdist_name, bdist_cfg in cfg.bdist_cfgs.items():
         sha256 = None
-        if "hash" in bdist_cfg:
+        if "hash" in bdist_cfg and bdist_cfg["hash"].startswith("sha256:"):
             sha256 = bdist_cfg["hash"][len("sha256:"):]
 
         http_file(

--- a/uv/private/extension/lockfile.bzl
+++ b/uv/private/extension/lockfile.bzl
@@ -190,21 +190,23 @@ def collect_bdists(lock_data):
         A tuple containing:
         - A dictionary mapping repository names for the wheels to their bdist
           specifications.
-        - A dictionary mapping the hash of each wheel to its repository label.
+        - A dictionary mapping the URL of each wheel to its repository label.
     """
     bdist_specs = {}
     bdist_table = {}
     for package in lock_data.get("package", []):
         for bdist in package.get("wheels", []):
-            identifier = None
+            # Some lockfile sources (e.g. find-links registries) emit wheel
+            # entries without a `hash` field. Fall back to hashing the URL so
+            # the repo name is still stable; key the table by URL since that
+            # is the only field guaranteed to be present.
             if "hash" in bdist:
                 identifier = bdist["hash"].split(":")[1][:16]
             else:
                 identifier = sha1(bdist["url"])[:16]
-
             bdist_repo_name = "whl__{}__{}".format(package["name"], identifier)
             bdist_specs[bdist_repo_name] = bdist
-            bdist_table[bdist["hash"]] = "@{}//file".format(bdist_repo_name)
+            bdist_table[bdist["url"]] = "@{}//file".format(bdist_repo_name)
 
     return bdist_specs, bdist_table
 


### PR DESCRIPTION
It is possible for a `package.wheels` entry to not have a `hash` field, for unclear reasons. This causes various parts of rules_py to break because we assume all wheels have a hash. To fix this, `normalize_deps` calculates a hash for any wheel that is missing one.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
