### PR TITLE
test: various config between py_venv() and py_venv_exec() targets

### DIFF
--- a/py/tests/py-venv-multi-exec/BUILD.bazel
+++ b/py/tests/py-venv-multi-exec/BUILD.bazel
@@ -1,0 +1,317 @@
+load("//py:defs.bzl", "py_venv")
+load("//py/private/py_venv:py_venv_exec.bzl", "py_venv_exec_test")
+load(":env_inherit_test.bzl", "env_inherit_test")
+
+# A single py_venv exec'd through multiple py_venv_exec consumers,
+# each differing in `main`, `env`, `args`, `data`, or other launcher-
+# level config. Demonstrates that the venv-shaping attrs (srcs, deps,
+# imports, env, env_inherit) can be declared once and reused across
+# many launchers.
+#
+# Entry scripts dispatch on BAZEL_TARGET_NAME to assert per-consumer
+# expectations, so each test target reduces to "pick the main + the
+# launcher knob to vary".
+
+py_venv(
+    name = "shared_venv",
+    testonly = True,
+    srcs = [
+        "entry_a.py",
+        "entry_args.py",
+        "entry_b.py",
+        "entry_data.py",
+        "entry_env.py",
+        "entry_no_optimize.py",
+        "entry_wheel.py",
+        "shared_lib.py",
+    ],
+    env = {
+        "FROM_VENV": "venv-value",
+        "OVERRIDE_ME": "venv-value",
+    },
+    # Forwards `VAR_FROM_VENV` from the test invocation env to every
+    # consumer; consumers' own env_inherit lists are merged on top
+    # (extends, doesn't replace).
+    env_inherit = ["VAR_FROM_VENV"],
+    imports = ["."],
+    # Affects only the venv's own REPL launcher; consumers don't pick
+    # this up (see `:test_venv_options_no_leak` for the seam).
+    interpreter_options = ["-O"],
+    visibility = [":__subpackages__"],
+    deps = [
+        "@pypi//cowsay",
+    ],
+)
+
+# Same shared venv, two different `main` entry points. Both reach
+# `shared_lib` via the venv's sys.path.
+py_venv_exec_test(
+    name = "test_entry_a",
+    main = "entry_a.py",
+    venv = ":shared_venv",
+)
+
+py_venv_exec_test(
+    name = "test_entry_b",
+    main = "entry_b.py",
+    venv = ":shared_venv",
+)
+
+# Same main, different consumer-level `env`: each sets MODE to its own
+# value while inheriting FROM_VENV / OVERRIDE_ME from the shared venv.
+# `args` carry the per-consumer expectations (KEY=VALUE or !KEY).
+py_venv_exec_test(
+    name = "test_env_x",
+    args = [
+        "FROM_VENV=venv-value",
+        "OVERRIDE_ME=venv-value",
+        "MODE=x",
+    ],
+    env = {"MODE": "x"},
+    main = "entry_env.py",
+    venv = ":shared_venv",
+)
+
+py_venv_exec_test(
+    name = "test_env_y",
+    args = [
+        "FROM_VENV=venv-value",
+        "OVERRIDE_ME=venv-value",
+        "MODE=y",
+    ],
+    env = {"MODE": "y"},
+    main = "entry_env.py",
+    venv = ":shared_venv",
+)
+
+# Consumer sets no `env` of its own — both FROM_VENV and OVERRIDE_ME
+# come from `:shared_venv` via its RunEnvironmentInfo.
+py_venv_exec_test(
+    name = "test_inherit_env",
+    args = [
+        "FROM_VENV=venv-value",
+        "OVERRIDE_ME=venv-value",
+        "!MODE",
+    ],
+    main = "entry_env.py",
+    venv = ":shared_venv",
+)
+
+# Consumer overrides a venv-declared key (binary wins on conflicts);
+# untouched venv-only keys still flow through unchanged.
+py_venv_exec_test(
+    name = "test_override_env",
+    args = [
+        "FROM_VENV=venv-value",
+        "OVERRIDE_ME=binary-value",
+        "!MODE",
+    ],
+    env = {"OVERRIDE_ME": "binary-value"},
+    main = "entry_env.py",
+    venv = ":shared_venv",
+)
+
+# Consumer adds a brand-new key (MODE) and overrides a venv key
+# (OVERRIDE_ME) in the same `env` dict.
+py_venv_exec_test(
+    name = "test_env_override",
+    args = [
+        "FROM_VENV=venv-value",
+        "OVERRIDE_ME=binary-value",
+        "MODE=override",
+    ],
+    env = {
+        "MODE": "override",
+        "OVERRIDE_ME": "binary-value",
+    },
+    main = "entry_env.py",
+    venv = ":shared_venv",
+)
+
+# `interpreter_options = ["-O"]` is a launcher-level knob: the shared
+# venv is unchanged, only this consumer's Python runs with __debug__ off.
+py_venv_exec_test(
+    name = "test_optimize",
+    interpreter_options = ["-O"],
+    main = "entry_a.py",
+    venv = ":shared_venv",
+)
+
+# `isolated = False` drops the launcher's `-I` flag for this consumer
+# only — the shared venv is unaffected.
+py_venv_exec_test(
+    name = "test_non_isolated",
+    isolated = False,
+    main = "entry_a.py",
+    venv = ":shared_venv",
+)
+
+# Same main, different `args` lists. The launcher forwards them via
+# `"$@"`, surfacing as `sys.argv[1:]` in the script.
+py_venv_exec_test(
+    name = "test_args_one",
+    args = ["alpha"],
+    main = "entry_args.py",
+    venv = ":shared_venv",
+)
+
+py_venv_exec_test(
+    name = "test_args_many",
+    args = [
+        "one",
+        "two",
+        "three",
+    ],
+    main = "entry_args.py",
+    venv = ":shared_venv",
+)
+
+# Args containing spaces need inner quoting — Bazel tokenizes `"$@"`
+# after Make-variable expansion, so the inner quotes preserve the space
+# as a single argv entry.
+py_venv_exec_test(
+    name = "test_args_with_spaces",
+    args = [
+        "'hello world'",
+        "'another arg'",
+    ],
+    main = "entry_args.py",
+    venv = ":shared_venv",
+)
+
+# Empty `args` — sys.argv[1:] should be empty.
+py_venv_exec_test(
+    name = "test_args_empty",
+    args = [],
+    main = "entry_args.py",
+    venv = ":shared_venv",
+)
+
+# Two consumers sharing the same wheel install (`@pypi//cowsay`) on
+# `:shared_venv`. The wheel resolves once at venv-assembly time; every
+# consumer imports it from the same site-packages without rebuilding.
+py_venv_exec_test(
+    name = "test_wheel_a",
+    main = "entry_wheel.py",
+    venv = ":shared_venv",
+)
+
+py_venv_exec_test(
+    name = "test_wheel_b",
+    main = "entry_wheel.py",
+    venv = ":shared_venv",
+)
+
+# Per-consumer `data` runfiles. Each consumer ships a different file
+# (forwarded as DATA_PATH via `$(rootpath ...)`) while sharing the
+# same venv — the launcher's `data` slot is independent of the venv's.
+py_venv_exec_test(
+    name = "test_data_alpha",
+    data = ["data_alpha.txt"],
+    env = {"DATA_PATH": "$(rootpath :data_alpha.txt)"},
+    main = "entry_data.py",
+    venv = ":shared_venv",
+)
+
+py_venv_exec_test(
+    name = "test_data_beta",
+    data = ["data_beta.txt"],
+    env = {"DATA_PATH": "$(rootpath :data_beta.txt)"},
+    main = "entry_data.py",
+    venv = ":shared_venv",
+)
+
+# `$(location :file)` and `$(MAKE_VAR)` expansion in the launcher's
+# `env` dict. SOME_VAR comes from `--define=SOME_VAR=SOME_VALUE` in
+# the workspace .bazelrc. `args` carry the expected post-expansion
+# values for entry_env.py to assert.
+py_venv_exec_test(
+    name = "test_expand_env",
+    args = [
+        "PAYLOAD_PATH=py/tests/py-venv-multi-exec/payload.txt",
+        "SOME_DEFINE=SOME_VALUE",
+    ],
+    data = ["payload.txt"],
+    env = {
+        "PAYLOAD_PATH": "$(rootpath :payload.txt)",
+        "SOME_DEFINE": "$(SOME_VAR)",
+    },
+    main = "entry_env.py",
+    venv = ":shared_venv",
+)
+
+# Same expansion machinery applied to the launcher's `args` attribute
+# (Bazel-native, not py_venv_exec-specific) — the entries surface as
+# `sys.argv[1:]` after expansion. entry_args.py asserts the expected
+# post-expansion shape via its target-name dispatch table.
+py_venv_exec_test(
+    name = "test_expand_args",
+    args = [
+        "$(rootpath :payload.txt)",
+        "$(SOME_VAR)",
+    ],
+    data = ["payload.txt"],
+    main = "entry_args.py",
+    venv = ":shared_venv",
+)
+
+# Documents the seam for venv-level `interpreter_options`: those flags
+# only affect `bazel run :shared_venv`'s REPL launcher, not consumers.
+# `:shared_venv` declares `interpreter_options = ["-O"]`; this consumer
+# sets none of its own and therefore runs with `__debug__ == True`.
+py_venv_exec_test(
+    name = "test_venv_options_no_leak",
+    main = "entry_no_optimize.py",
+    venv = ":shared_venv",
+)
+
+# env_inherit propagation: venv lists `VAR_FROM_VENV`, this consumer
+# adds `VAR_FROM_EXEC`. The merged RunEnvironmentInfo.inherited_environment
+# should contain both names (consumer extends, doesn't replace).
+# Validated by an analysistest below — see env_inherit_test.bzl for why
+# this isn't a runtime test.
+py_venv_exec_test(
+    name = "_env_inherit_inner",
+    env_inherit = ["VAR_FROM_EXEC"],
+    main = "entry_b.py",
+    tags = ["manual"],
+    venv = ":shared_venv",
+)
+
+env_inherit_test(
+    name = "test_env_inherit",
+    target_under_test = ":_env_inherit_inner",
+)
+
+# `main` is decoupled from the venv's `srcs` — the launcher attaches
+# `main` to its own runfiles, independent of the venv's source closure.
+# `entry_outside_srcs.py` is intentionally NOT in `:shared_venv.srcs`
+# but can still `import shared_lib` (provided by the venv's sys.path)
+# and `import cowsay` (provided by the venv's deps).
+py_venv_exec_test(
+    name = "test_main_outside_srcs",
+    main = "entry_outside_srcs.py",
+    venv = ":shared_venv",
+)
+
+# Generated `main` — the launcher accepts a label that points at a
+# genrule output, not just a source file. Real-world use: configurable
+# entrypoints stamped at build time.
+genrule(
+    name = "gen_main",
+    testonly = True,
+    outs = ["gen_main.py"],
+    cmd = """cat > $@ <<'EOF'
+import shared_lib
+
+assert shared_lib.GREETING == "hello from the shared venv"
+print("gen_main ok")
+EOF
+""",
+)
+
+py_venv_exec_test(
+    name = "test_gen_main",
+    main = ":gen_main",
+    venv = ":shared_venv",
+)

--- a/py/tests/py-venv-multi-exec/cross-pkg/BUILD.bazel
+++ b/py/tests/py-venv-multi-exec/cross-pkg/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//py/private/py_venv:py_venv_exec.bzl", "py_venv_exec_test")
+
+# A py_venv_exec_test consuming a `:shared_venv` defined in a sibling
+# package. Exercises cross-package visibility of the venv label and
+# rlocation paths spanning two packages: the venv's runfiles tree
+# lives under `_main/py/tests/py-venv-multi-exec/...`, while this
+# launcher lives in this package.
+py_venv_exec_test(
+    name = "test_cross_pkg",
+    main = "entry_cross_pkg.py",
+    venv = "//py/tests/py-venv-multi-exec:shared_venv",
+)

--- a/py/tests/py-venv-multi-exec/cross-pkg/entry_cross_pkg.py
+++ b/py/tests/py-venv-multi-exec/cross-pkg/entry_cross_pkg.py
@@ -1,0 +1,11 @@
+import shared_lib
+import cowsay
+
+# This consumer lives in a different package than `:shared_venv`.
+# Imports still resolve through the venv's sys.path / wheel deps —
+# the launcher's exec'd python uses the venv's interpreter regardless
+# of where the launcher rule lives.
+assert shared_lib.GREETING == "hello from the shared venv"
+assert hasattr(cowsay, "get_output_string")
+
+print("entry_cross_pkg ok")

--- a/py/tests/py-venv-multi-exec/data_alpha.txt
+++ b/py/tests/py-venv-multi-exec/data_alpha.txt
@@ -1,0 +1,1 @@
+alpha-payload

--- a/py/tests/py-venv-multi-exec/data_beta.txt
+++ b/py/tests/py-venv-multi-exec/data_beta.txt
@@ -1,0 +1,1 @@
+beta-payload

--- a/py/tests/py-venv-multi-exec/entry_a.py
+++ b/py/tests/py-venv-multi-exec/entry_a.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+import shared_lib
+
+assert shared_lib.GREETING == "hello from the shared venv"
+
+target = os.environ["BAZEL_TARGET_NAME"]
+
+if target == "test_optimize":
+    assert not __debug__, f"expected -O to disable __debug__, got __debug__={__debug__}"
+elif target == "test_non_isolated":
+    assert sys.flags.isolated == 0, f"expected isolated=0 (-I dropped), got {sys.flags.isolated}"
+else:
+    assert __debug__, "expected default debug mode"
+    assert sys.flags.isolated == 1, f"expected isolated=1, got {sys.flags.isolated}"
+
+print(f"entry_a ok ({target})")

--- a/py/tests/py-venv-multi-exec/entry_args.py
+++ b/py/tests/py-venv-multi-exec/entry_args.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+target = os.environ["BAZEL_TARGET_NAME"]
+
+# sys.argv[0] is the script path; the rest come from the launcher's
+# `args` attribute (passed via `"$@"` in run.tmpl.sh).
+actual = sys.argv[1:]
+
+expected_by_target = {
+    "test_args_one": ["alpha"],
+    "test_args_many": ["one", "two", "three"],
+    "test_args_with_spaces": ["hello world", "another arg"],
+    "test_args_empty": [],
+    # `args = ["$(rootpath :payload.txt)", "$(SOME_VAR)"]` — verifies
+    # `$(location)` / `$(MAKE_VAR)` expansion in the launcher's args.
+    "test_expand_args": [
+        "py/tests/py-venv-multi-exec/payload.txt",
+        "SOME_VALUE",
+    ],
+}
+
+expected = expected_by_target.get(target)
+assert expected is not None, f"unexpected BAZEL_TARGET_NAME: {target}"
+assert actual == expected, f"expected argv={expected!r}, got {actual!r}"
+
+print(f"entry_args ok ({target}): {actual!r}")

--- a/py/tests/py-venv-multi-exec/entry_b.py
+++ b/py/tests/py-venv-multi-exec/entry_b.py
@@ -1,0 +1,4 @@
+import shared_lib
+
+assert shared_lib.GREETING == "hello from the shared venv"
+print("entry_b ok")

--- a/py/tests/py-venv-multi-exec/entry_data.py
+++ b/py/tests/py-venv-multi-exec/entry_data.py
@@ -1,0 +1,23 @@
+import os
+
+target = os.environ["BAZEL_TARGET_NAME"]
+
+# Each consumer sets its own `data = [...]` and forwards the file's
+# runfile path via env. The launcher's `data` attr is independent of
+# the venv — different consumers can ship different runfiles while
+# sharing the same venv.
+EXPECTATIONS = {
+    "test_data_alpha": "alpha-payload\n",
+    "test_data_beta":  "beta-payload\n",
+}
+
+expected = EXPECTATIONS.get(target)
+assert expected is not None, f"unexpected BAZEL_TARGET_NAME: {target}"
+
+# DATA_PATH is set per-target via `$(rootpath :data_*.txt)`; the cwd
+# at test time is the runfiles root, so a relative open() resolves it.
+data_path = os.environ["DATA_PATH"]
+content = open(data_path).read()
+assert content == expected, f"expected {expected!r}, got {content!r}"
+
+print(f"entry_data ok ({target}): {data_path}")

--- a/py/tests/py-venv-multi-exec/entry_env.py
+++ b/py/tests/py-venv-multi-exec/entry_env.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+# Generic env-assertion runner. Each argv entry is one of:
+#   KEY=VALUE  → assert os.environ[KEY] == VALUE
+#   !KEY       → assert KEY not in os.environ
+#
+# Driven by the `args` attr on each consumer, so per-target
+# expectations live next to the `env =` declaration in BUILD.bazel.
+for spec in sys.argv[1:]:
+    if spec.startswith("!"):
+        key = spec[1:]
+        assert key not in os.environ, (
+            f"{key} should be unset, got {os.environ.get(key)!r}"
+        )
+    else:
+        key, _, want = spec.partition("=")
+        got = os.environ.get(key)
+        assert got == want, f"{key}: expected {want!r}, got {got!r}"
+
+print(f"entry_env ok ({os.environ['BAZEL_TARGET_NAME']})")

--- a/py/tests/py-venv-multi-exec/entry_no_optimize.py
+++ b/py/tests/py-venv-multi-exec/entry_no_optimize.py
@@ -1,0 +1,18 @@
+# `:shared_venv` sets `interpreter_options = ["-O"]`, which only
+# affects the venv's own REPL launcher (`bazel run :shared_venv`).
+# py_venv_exec consumers don't inherit those flags — they must set
+# their own `interpreter_options` to opt in. This consumer leaves
+# `interpreter_options` at default; if the venv's `-O` were leaking
+# through, `__debug__` would be False here.
+#
+# NB: must use an explicit `raise`, not `assert`. `-O` strips assert
+# statements at compile time, so under the regression we're trying to
+# detect, an `assert __debug__` would be removed and the test would
+# pass silently.
+if not __debug__:
+    raise SystemExit(
+        "expected __debug__=True — venv-level interpreter_options should "
+        "not leak into py_venv_exec consumers",
+    )
+
+print("entry_no_optimize ok")

--- a/py/tests/py-venv-multi-exec/entry_outside_srcs.py
+++ b/py/tests/py-venv-multi-exec/entry_outside_srcs.py
@@ -1,0 +1,11 @@
+import shared_lib
+import cowsay
+
+# This script is the consumer's `main =` but is NOT listed in
+# `:shared_venv.srcs`. Both imports below resolve through the venv —
+# `shared_lib` from the venv's sys.path, `cowsay` from its wheel deps —
+# proving that `main` and the venv's source closure are independent.
+assert shared_lib.GREETING == "hello from the shared venv"
+assert hasattr(cowsay, "get_output_string")
+
+print("entry_outside_srcs ok")

--- a/py/tests/py-venv-multi-exec/entry_wheel.py
+++ b/py/tests/py-venv-multi-exec/entry_wheel.py
@@ -1,0 +1,13 @@
+import os
+
+import cowsay
+
+target = os.environ["BAZEL_TARGET_NAME"]
+
+# Both consumers share the same wheel install via `:shared_venv`'s
+# deps — the wheel resolves once at venv-assembly time.
+output = cowsay.get_output_string("cow", f"hello from {target}")
+assert "hello from" in output
+assert target in output
+
+print(f"entry_wheel ok ({target})")

--- a/py/tests/py-venv-multi-exec/env_inherit_test.bzl
+++ b/py/tests/py-venv-multi-exec/env_inherit_test.bzl
@@ -1,0 +1,25 @@
+"""Analysis-time test: env_inherit on a py_venv merges with env_inherit on
+a py_venv_exec_test consumer (extends, doesn't replace).
+
+A runtime test can't validate this without `bazel test --test_env=...`
+setup, since `bazel test` scrubs user-shell env vars and only consults
+`RunEnvironmentInfo.inherited_environment` to decide what to forward.
+Inspecting the provider directly at analysis time gets us the same
+invariant without depending on the test runner's env handling.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _env_inherit_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    inherited = list(target[RunEnvironmentInfo].inherited_environment)
+    asserts.equals(
+        env,
+        ["VAR_FROM_VENV", "VAR_FROM_EXEC"],
+        inherited,
+        "consumer env_inherit should extend the venv's list, not replace",
+    )
+    return analysistest.end(env)
+
+env_inherit_test = analysistest.make(_env_inherit_test_impl)

--- a/py/tests/py-venv-multi-exec/payload.txt
+++ b/py/tests/py-venv-multi-exec/payload.txt
@@ -1,0 +1,1 @@
+payload-content

--- a/py/tests/py-venv-multi-exec/shared_lib.py
+++ b/py/tests/py-venv-multi-exec/shared_lib.py
@@ -1,0 +1,1 @@
+GREETING = "hello from the shared venv"


### PR DESCRIPTION
While `py_venv_exec` is not public ATM I think it is worth testing all the different combos+scenarios possible between `py_venv` and the execution of stuff from it.

### Changes are visible to end-users: no

### Test plan

- New test cases added
