### PR TITLE
fix(py): bake launcher env into entrypoint scripts

### DIFF
--- a/py/private/py_venv/py_venv_exec.bzl
+++ b/py/private/py_venv/py_venv_exec.bzl
@@ -82,7 +82,7 @@ def _py_venv_exec_impl(ctx):
             "{{INTERPRETER_FLAGS}}": " ".join(flags),
             "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, vinfo.bin_python),
             "{{ENTRYPOINT}}": to_rlocation_path(ctx, main),
-            "{{PYTHON_ENV}}": "\n".join(_dict_to_exports(default_env)).strip(),
+            "{{PYTHON_ENV}}": "\n".join(_dict_to_exports(default_env | passed_env)).strip(),
         },
         is_executable = True,
     )

--- a/py/tests/py-venv-direct-exec/BUILD.bazel
+++ b/py/tests/py-venv-direct-exec/BUILD.bazel
@@ -1,0 +1,67 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//py:defs.bzl", "py_venv")
+load("//py/private/py_venv:py_venv_exec.bzl", "py_venv_exec")
+
+# Regression: when the generated launcher script is executed directly
+# (e.g. inside an OCI image, not via `bazel run`), the `env = {...}`
+# values must be baked into the script. Routing them only through
+# RunEnvironmentInfo isn't enough — that channel only fires when Bazel
+# itself launches the target.
+#
+# Each sh_test below invokes the py_venv_exec launcher via its runfiles
+# path; from sh_test's perspective the launcher is a tool, so Bazel
+# does NOT apply its RunEnvironmentInfo. The env vars must therefore
+# come from `{{PYTHON_ENV}}` substitution.
+
+# A shared py_venv carries `env`, exec'd via py_venv_exec. The venv's
+# RunEnvironmentInfo env must be baked into the consumer's launcher
+# script.
+py_venv(
+    name = "venv_with_env",
+    srcs = ["assert_env.py"],
+    env = {
+        "VENV_FOO": "from-venv",
+        "OVERRIDE_ME": "venv-value",
+    },
+    visibility = ["//visibility:private"],
+)
+
+py_venv_exec(
+    name = "exec_inherit_env",
+    main = "assert_env.py",
+    venv = ":venv_with_env",
+)
+
+sh_test(
+    name = "test_py_venv_exec_inherits_env_baked",
+    srcs = ["run_direct.sh"],
+    args = [
+        "exec_inherit_env",
+        "VENV_FOO=from-venv",
+        "OVERRIDE_ME=venv-value",
+    ],
+    data = [":exec_inherit_env"],
+)
+
+# Consumer's own `env` overlays the venv's; both must be baked.
+py_venv_exec(
+    name = "exec_override_env",
+    env = {
+        "OVERRIDE_ME": "exec-value",
+        "EXEC_ONLY": "exec-only-value",
+    },
+    main = "assert_env.py",
+    venv = ":venv_with_env",
+)
+
+sh_test(
+    name = "test_py_venv_exec_override_env_baked",
+    srcs = ["run_direct.sh"],
+    args = [
+        "exec_override_env",
+        "VENV_FOO=from-venv",
+        "OVERRIDE_ME=exec-value",
+        "EXEC_ONLY=exec-only-value",
+    ],
+    data = [":exec_override_env"],
+)

--- a/py/tests/py-venv-direct-exec/assert_env.py
+++ b/py/tests/py-venv-direct-exec/assert_env.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+# Each argv entry is KEY=VALUE — assert os.environ[KEY] == VALUE.
+# Driven by sh_test args so per-target expectations live in BUILD.bazel.
+for spec in sys.argv[1:]:
+    key, _, want = spec.partition("=")
+    got = os.environ.get(key)
+    assert got == want, f"{key}: expected {want!r}, got {got!r}"
+
+print(f"assert_env ok ({len(sys.argv) - 1} checks)")

--- a/py/tests/py-venv-direct-exec/run_direct.sh
+++ b/py/tests/py-venv-direct-exec/run_direct.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# $1 — basename of the launcher target (sibling in the runfiles tree).
+# $2..$N — KEY=VALUE specs forwarded as argv to assert_env.py.
+#
+# Invokes the launcher directly, bypassing `bazel run` so
+# RunEnvironmentInfo is NOT applied. Any env vars the script sees must
+# come from substitutions baked into the launcher itself.
+set -euo pipefail
+
+ROOT="$(dirname "$0")"
+launcher_name="$1"
+shift
+
+# Clear any env vars the test runner might have inherited so the
+# launcher is the sole source of these names.
+unset VENV_FOO EXEC_ONLY OVERRIDE_ME
+
+exec "$ROOT/$launcher_name" "$@"


### PR DESCRIPTION
Generated launcher scripts are sometimes executed directly (e.g. inside OCI images) rather than via `bazel run`, which is the only path that applies RunEnvironmentInfo. Export user-provided `env` values alongside `default_env` in the launcher so direct execution sees the same environment as the Bazel wrapper.

Adds regression coverage in py/tests/launcher-direct-exec/ that invokes a py_venv_exec launcher transitively from sh_test (no RunEnvironmentInfo applied) and asserts both venv-level env and consumer-level env are baked into the script.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
