### PR TITLE
fix(uv): flush marker identifiers before parentheses

### DIFF
--- a/uv/private/markers/pep508_evaluate.bzl
+++ b/uv/private/markers/pep508_evaluate.bzl
@@ -94,10 +94,7 @@ def tokenize(marker):
             return tokens
 
         char = marker[0]
-        if char in _BRACKETS:
-            state = _STATE.NONE
-            token = char
-        elif state == _STATE.STRING and char in _QUOTES:
+        if state == _STATE.STRING and char in _QUOTES:
             state = _STATE.NONE
             token = '"{}"'.format(token)
         elif (
@@ -106,6 +103,9 @@ def tokenize(marker):
         ):
             state = _STATE.NONE
             continue  # Skip consuming the char below
+        elif char in _BRACKETS:
+            state = _STATE.NONE
+            token = char
         elif state == _STATE.NONE:
             # Transition from _STATE.NONE to something or stay in NONE
             if char in _QUOTES:

--- a/uv/private/markers/pep508_evaluate_test.bzl
+++ b/uv/private/markers/pep508_evaluate_test.bzl
@@ -59,6 +59,11 @@ def _evaluate_test_impl(ctx):
     asserts.true(env, evaluate("((sys_platform == 'linux'))", env = _LINUX_ENV))
     asserts.true(env, evaluate("((sys_platform == 'linux') and (platform_machine == 'x86_64')) or sys_platform == 'win32'", env = _LINUX_ENV))
 
+    # Identifier immediately followed by ')'
+    asserts.true(env, evaluate("('linux' in sys_platform)", env = _LINUX_ENV))
+    asserts.true(env, evaluate("('win32' not in sys_platform)", env = _LINUX_ENV))
+    asserts.true(env, evaluate("(python_version >= '3.10' and 'linux' in sys_platform)", env = _LINUX_ENV))
+
     return unittest.end(env)
 
 evaluate_test = unittest.make(


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
