### PR TITLE
fix(uv): normalize architecture aliases during marker

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -484,6 +484,22 @@ uv.project(
 use_repo(uv, "project__single_project_hub", "pypi_single")
 # }}}
 
+# For cases/arch-alias-marker
+# Dedicated hub exercising decide_marker's Python<->Bazel architecture
+# alias normalization. The pyproject pins a dep under a marker that uses
+# only Python-style spellings (arm64/amd64); without the alias
+# normalization in uv/private/markers/defs.bzl the dep is dropped on every
+# mainstream Bazel host.
+# {{{
+uv.declare_hub(hub_name = "pypi_arch_alias_marker")
+uv.project(
+    hub_name = "pypi_arch_alias_marker",
+    lock = "//cases/arch-alias-marker:uv.lock",
+    pyproject = "//cases/arch-alias-marker:pyproject.toml",
+)
+use_repo(uv, "pypi_arch_alias_marker")
+# }}}
+
 use_repo(uv, "aspect_rules_py_pip_configurations", "pypi")
 
 register_toolchains("@uv//:all")

--- a/e2e/cases/arch-alias-marker/BUILD.bazel
+++ b/e2e/cases/arch-alias-marker/BUILD.bazel
@@ -1,0 +1,17 @@
+# End-to-end regression for the architecture alias normalization in
+# uv/private/markers/defs.bzl. The pyproject lists cowsay under a marker
+# that uses only Python-style arch spellings (arm64/amd64). On every
+# mainstream Bazel host, platform_machine emits aarch64 or x86_64, so the
+# marker only matches once decide_marker normalizes the aliases.
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+py_test(
+    name = "arch_alias_marker",
+    srcs = ["__test__.py"],
+    dep_group = "arch_alias_marker",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi_arch_alias_marker//cowsay",
+    ],
+)

--- a/e2e/cases/arch-alias-marker/__test__.py
+++ b/e2e/cases/arch-alias-marker/__test__.py
@@ -1,0 +1,12 @@
+"""End-to-end check that decide_marker normalizes Python arch aliases.
+
+Pyproject declares `cowsay` under a marker using only Python-style spellings
+(`platform_machine == 'arm64' or platform_machine == 'amd64'`). Bazel's
+platform_machine flag emits `aarch64`/`x86_64`, so without the alias
+normalization in uv/private/markers/defs.bzl the dep is selected away on
+every mainstream host and this import fails at runtime.
+"""
+
+import cowsay
+
+cowsay.cow("arch-alias-marker")

--- a/e2e/cases/arch-alias-marker/pyproject.toml
+++ b/e2e/cases/arch-alias-marker/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "arch_alias_marker"
+version = "0.0.0"
+authors = []
+requires-python = ">=3.11"
+dependencies = [
+    # Marker uses only Python-style arch spellings. Bazel's platform_machine
+    # emits aarch64/x86_64, so without the alias normalization in
+    # uv/private/markers/defs.bzl this dep is never pulled in on any host.
+    "cowsay; platform_machine == 'arm64' or platform_machine == 'amd64'",
+]

--- a/e2e/cases/arch-alias-marker/uv.lock
+++ b/e2e/cases/arch-alias-marker/uv.lock
@@ -1,0 +1,22 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "arch-alias-marker"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "cowsay", marker = "platform_machine == 'amd64' or platform_machine == 'arm64'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "cowsay", marker = "platform_machine == 'amd64' or platform_machine == 'arm64'" }]
+
+[[package]]
+name = "cowsay"
+version = "6.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/13/63c0a02c44024ee16f664e0b36eefeb22d54e93531630bd99e237986f534/cowsay-6.1-py3-none-any.whl", hash = "sha256:274b1e6fc1b966d53976333eb90ac94cb07a450a700b455af9fbdf882244b30a", size = 25560, upload-time = "2023-09-25T16:30:01.619Z" },
+]

--- a/uv/private/markers/BUILD.bazel
+++ b/uv/private/markers/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("//py:defs.bzl", "py_test")
 load(":defs.bzl", "configurable_string", "decide_marker")
 load(":pep508_evaluate_test.bzl", "pep508_evaluate_test_suite")
 
@@ -124,6 +125,25 @@ alias(
 )
 
 pep508_evaluate_test_suite()
+
+# End-to-end regression for the architecture alias normalization in
+# decide_marker. The marker uses only Python-style spellings (arm64/amd64);
+# Bazel's platform_machine flag emits aarch64/x86_64. Pre-fix the select()
+# falls through on every host; post-fix one of the alternatives matches.
+decide_marker(
+    name = "_arch_alias_marker",
+    marker = "platform_machine == 'arm64' or platform_machine == 'amd64'",
+)
+
+py_test(
+    name = "marker_arch_alias_test",
+    srcs = ["marker_arch_alias_test.py"],
+    args = select({
+        ":_arch_alias_marker": ["matched"],
+        "//conditions:default": ["did_not_match"],
+    }),
+    main = "marker_arch_alias_test.py",
+)
 
 ### Test markers
 # TODO: Figure out a way to make these actual tests...

--- a/uv/private/markers/defs.bzl
+++ b/uv/private/markers/defs.bzl
@@ -87,6 +87,19 @@ def _decide_marker_impl(ctx):
         else:
             fail("Unable to deref %r" % it)
 
+    aliases = {
+        # Marker values use Python runtime strings, while Bazel platform/config
+        # values skew toward canonical architecture names. Normalize common
+        # synonyms so arm64 wheels selected in uv.lock also match Bazel's
+        # aarch64-based platform settings.
+        "platform_machine": {
+            "arm64": "aarch64",
+            "aarch64": "aarch64",
+            "amd64": "x86_64",
+            "x64": "x86_64",
+        },
+    }
+
     res = _evaluate_marker(
         marker = ctx.attr.marker,
         env = {
@@ -111,6 +124,7 @@ def _decide_marker_impl(ctx):
             "platform_python_implementation": _value(ctx.attr.platform_python_implementation),
             "implementation_name": _value(ctx.attr.implementation_name),
             "implementation_version": _value(ctx.attr.implementation_version),
+            "_aliases": aliases,
         },
     )
 

--- a/uv/private/markers/defs.bzl
+++ b/uv/private/markers/defs.bzl
@@ -69,12 +69,15 @@ load(":pep508_evaluate.bzl", _evaluate_marker = "evaluate")
 # Marker values use Python runtime strings, while Bazel platform/config
 # values skew toward canonical architecture names. Normalize common
 # synonyms so arm64 wheels selected in uv.lock also match Bazel's
-# aarch64-based platform settings.
+# aarch64-based platform settings. Includes the uppercase spellings
+# (`AMD64`, `ARM64`) that `platform.machine()` returns on Windows.
 MARKER_ENV_ALIASES = {
     "platform_machine": {
         "arm64": "aarch64",
+        "ARM64": "aarch64",
         "aarch64": "aarch64",
         "amd64": "x86_64",
+        "AMD64": "x86_64",
         "x64": "x86_64",
     },
 }

--- a/uv/private/markers/defs.bzl
+++ b/uv/private/markers/defs.bzl
@@ -66,6 +66,19 @@ demands it.
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":pep508_evaluate.bzl", _evaluate_marker = "evaluate")
 
+# Marker values use Python runtime strings, while Bazel platform/config
+# values skew toward canonical architecture names. Normalize common
+# synonyms so arm64 wheels selected in uv.lock also match Bazel's
+# aarch64-based platform settings.
+MARKER_ENV_ALIASES = {
+    "platform_machine": {
+        "arm64": "aarch64",
+        "aarch64": "aarch64",
+        "amd64": "x86_64",
+        "x64": "x86_64",
+    },
+}
+
 def _decide_marker_impl(ctx):
     """
     Decide the marker using PEP-508 logic
@@ -86,19 +99,6 @@ def _decide_marker_impl(ctx):
             return it[BuildSettingInfo].value
         else:
             fail("Unable to deref %r" % it)
-
-    aliases = {
-        # Marker values use Python runtime strings, while Bazel platform/config
-        # values skew toward canonical architecture names. Normalize common
-        # synonyms so arm64 wheels selected in uv.lock also match Bazel's
-        # aarch64-based platform settings.
-        "platform_machine": {
-            "arm64": "aarch64",
-            "aarch64": "aarch64",
-            "amd64": "x86_64",
-            "x64": "x86_64",
-        },
-    }
 
     res = _evaluate_marker(
         marker = ctx.attr.marker,
@@ -124,7 +124,7 @@ def _decide_marker_impl(ctx):
             "platform_python_implementation": _value(ctx.attr.platform_python_implementation),
             "implementation_name": _value(ctx.attr.implementation_name),
             "implementation_version": _value(ctx.attr.implementation_version),
-            "_aliases": aliases,
+            "_aliases": MARKER_ENV_ALIASES,
         },
     )
 

--- a/uv/private/markers/marker_arch_alias_test.py
+++ b/uv/private/markers/marker_arch_alias_test.py
@@ -1,0 +1,17 @@
+"""Asserts decide_marker normalizes Python arch aliases to Bazel spellings.
+
+The accompanying BUILD wires `args` through a select() keyed on a
+`decide_marker(marker = "platform_machine == 'arm64' or platform_machine == 'amd64'")`.
+Both alternatives are Python-only spellings; Bazel's platform_machine flag
+emits `aarch64`/`x86_64`. Without the alias normalization in decide_marker
+the select() falls through to the default branch on every host.
+"""
+
+import sys
+
+want = "matched"
+got = sys.argv[1] if len(sys.argv) > 1 else "<none>"
+assert got == want, (
+    "decide_marker did not normalize arm64/amd64 -> aarch64/x86_64; "
+    "select() picked the default branch. got=%r want=%r" % (got, want)
+)

--- a/uv/private/markers/pep508_evaluate_test.bzl
+++ b/uv/private/markers/pep508_evaluate_test.bzl
@@ -84,10 +84,13 @@ def _evaluate_test_impl(ctx):
     # Architecture alias normalization (decide_marker populates _aliases so
     # Python-spelled arch names match Bazel-spelled platform_machine values).
     asserts.true(env, evaluate("platform_machine == 'arm64'", env = _AARCH64_ENV))
+    asserts.true(env, evaluate("platform_machine == 'ARM64'", env = _AARCH64_ENV))
     asserts.true(env, evaluate("'arm64' == platform_machine", env = _AARCH64_ENV))
     asserts.true(env, evaluate("platform_machine == 'aarch64'", env = _AARCH64_ENV))
     asserts.false(env, evaluate("platform_machine == 'arm64'", env = _X86_64_ENV))
+    asserts.false(env, evaluate("platform_machine == 'ARM64'", env = _X86_64_ENV))
     asserts.true(env, evaluate("platform_machine == 'amd64'", env = _X86_64_ENV))
+    asserts.true(env, evaluate("platform_machine == 'AMD64'", env = _X86_64_ENV))
     asserts.true(env, evaluate("platform_machine == 'x64'", env = _X86_64_ENV))
     asserts.true(env, evaluate("platform_machine != 'arm64'", env = _X86_64_ENV))
 

--- a/uv/private/markers/pep508_evaluate_test.bzl
+++ b/uv/private/markers/pep508_evaluate_test.bzl
@@ -1,6 +1,7 @@
 """Tests for pep508_evaluate.bzl."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":defs.bzl", "MARKER_ENV_ALIASES")
 load(":pep508_evaluate.bzl", "evaluate")
 
 _LINUX_ENV = {
@@ -15,6 +16,22 @@ _WINDOWS_ENV = {
     "python_full_version": "3.11.0",
     "python_version": "3.11",
     "sys_platform": "win32",
+}
+
+_AARCH64_ENV = {
+    "platform_machine": "aarch64",
+    "python_full_version": "3.11.0",
+    "python_version": "3.11",
+    "sys_platform": "linux",
+    "_aliases": MARKER_ENV_ALIASES,
+}
+
+_X86_64_ENV = {
+    "platform_machine": "x86_64",
+    "python_full_version": "3.11.0",
+    "python_version": "3.11",
+    "sys_platform": "linux",
+    "_aliases": MARKER_ENV_ALIASES,
 }
 
 def _evaluate_test_impl(ctx):
@@ -63,6 +80,16 @@ def _evaluate_test_impl(ctx):
     asserts.true(env, evaluate("('linux' in sys_platform)", env = _LINUX_ENV))
     asserts.true(env, evaluate("('win32' not in sys_platform)", env = _LINUX_ENV))
     asserts.true(env, evaluate("(python_version >= '3.10' and 'linux' in sys_platform)", env = _LINUX_ENV))
+
+    # Architecture alias normalization (decide_marker populates _aliases so
+    # Python-spelled arch names match Bazel-spelled platform_machine values).
+    asserts.true(env, evaluate("platform_machine == 'arm64'", env = _AARCH64_ENV))
+    asserts.true(env, evaluate("'arm64' == platform_machine", env = _AARCH64_ENV))
+    asserts.true(env, evaluate("platform_machine == 'aarch64'", env = _AARCH64_ENV))
+    asserts.false(env, evaluate("platform_machine == 'arm64'", env = _X86_64_ENV))
+    asserts.true(env, evaluate("platform_machine == 'amd64'", env = _X86_64_ENV))
+    asserts.true(env, evaluate("platform_machine == 'x64'", env = _X86_64_ENV))
+    asserts.true(env, evaluate("platform_machine != 'arm64'", env = _X86_64_ENV))
 
     return unittest.end(env)
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
