### PR TITLE
feat: suppress repository-rule spam behind RULES_PY_UV_VERBOSE flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -45,3 +45,6 @@ common:release --@rules_rust//:extra_rustc_flags=-Cpanic=abort
 # (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
 # rather than user.bazelrc as suggested in the Bazel docs)
 try-import %workspace%/.bazelrc.user
+
+# Uncomment to enable verbose diagnostics for uv repository rules (sdist builds, git archives)
+# common --repo_env=RULES_PY_UV_VERBOSE=1

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -387,6 +387,7 @@ repository rule execution, including:
 - **Native source detection** — confirmation when native (non-Python) sources are detected in an sdist.
 - **Pure-Python fallback** — warnings when an sdist cannot be inspected and a pure-Python build is assumed.
 - **Git archive commands** — the exact `git` command executed and its stdout/stderr.
+- **Package version overrides** — confirmation when a package version is overridden with a local target.
 
 ## Differences and Gotchas
 

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -361,6 +361,33 @@ gazelle_python_manifest(
 )
 ```
 
+## Troubleshooting
+
+### Verbose logging for uv repository rules
+
+To diagnose issues with source distribution (sdist) builds or git archive fetching,
+set the `RULES_PY_UV_VERBOSE` environment variable to any non-empty value:
+
+```bash
+bazel build --repo_env=RULES_PY_UV_VERBOSE=1 //...
+```
+
+You can also set it in your `.bazelrc` to apply to all builds:
+
+```
+# .bazelrc
+common --repo_env=RULES_PY_UV_VERBOSE=1
+```
+
+When enabled, `rules_py` prints additional diagnostic information during
+repository rule execution, including:
+
+- **Sdist inspection failures** — output from the sdist configure tool when it fails.
+- **Missing archives** — warnings when an archive path cannot be resolved from a source label.
+- **Native source detection** — confirmation when native (non-Python) sources are detected in an sdist.
+- **Pure-Python fallback** — warnings when an sdist cannot be inspected and a pure-Python build is assumed.
+- **Git archive commands** — the exact `git` command executed and its stdout/stderr.
+
 ## Differences and Gotchas
 
 **Lock your build tools**. In order to perform sdist builds and support

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -144,6 +144,7 @@ def _parse_projects(module_ctx, hub_specs):
 
     install_cfgs = {}
     install_table = {}
+    override_count = 0
 
     # FIXME: Collect build deps files/annotations
 
@@ -243,7 +244,7 @@ def _parse_projects(module_ctx, hub_specs):
 
                 k = (project_id, normalize_name(override.name), v, "__base__")
                 if has_target:
-                    print("Overriding {}@{} in {} with {}".format(override.name, v, project_name, override.target))
+                    override_count += 1
                     install_table[k] = str(override.target)
 
             # Lazily evaluated cache
@@ -460,6 +461,9 @@ def _parse_projects(module_ctx, hub_specs):
             for package, cfgs in version_activations.items():
                 for cfg in cfgs.keys():
                     hub_cfg.packages.setdefault(package, {})[cfg] = "@{}//:{}".format(project_id, package)
+
+    if override_count:
+        print("uv: {} package(s) overridden".format(override_count))
 
     return struct(
         project_cfgs = project_cfgs,

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -144,7 +144,6 @@ def _parse_projects(module_ctx, hub_specs):
 
     install_cfgs = {}
     install_table = {}
-    override_count = 0
 
     # FIXME: Collect build deps files/annotations
 
@@ -244,7 +243,8 @@ def _parse_projects(module_ctx, hub_specs):
 
                 k = (project_id, normalize_name(override.name), v, "__base__")
                 if has_target:
-                    override_count += 1
+                    if module_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
+                        print("Overriding {}@{} in {} with {}".format(override.name, v, project_name, override.target))
                     install_table[k] = str(override.target)
 
             # Lazily evaluated cache
@@ -461,9 +461,6 @@ def _parse_projects(module_ctx, hub_specs):
             for package, cfgs in version_activations.items():
                 for cfg in cfgs.keys():
                     hub_cfg.packages.setdefault(package, {})[cfg] = "@{}//:{}".format(project_id, package)
-
-    if override_count:
-        print("uv: {} package(s) overridden".format(override_count))
 
     return struct(
         project_cfgs = project_cfgs,

--- a/uv/private/git_archive/repository.bzl
+++ b/uv/private/git_archive/repository.bzl
@@ -65,13 +65,16 @@ filegroup(
         cmd,
     )
 
-    if repository_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
-        print("Git exited {}".format(status.return_code))
-
     if status.return_code != 0:
+        fail("Failed to build the requested git archive! Git exited {}\n\nstdout: {}\n\nstderr: {}".format(
+            status.return_code,
+            status.stdout,
+            status.stderr,
+        ))
+
+    if repository_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
         print(status.stdout)
         print(status.stderr)
-        fail("Failed to build the requested git archive!")
 
     if features.external_deps.extension_metadata_has_reproducible:
         if is_reproducible:

--- a/uv/private/git_archive/repository.bzl
+++ b/uv/private/git_archive/repository.bzl
@@ -57,16 +57,18 @@ filegroup(
         target_ref,
     ]
 
-    print(cmd)
+    if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+        print(cmd)
 
     # Execute the archive command
     status = repository_ctx.execute(
         cmd,
     )
 
-    print("Git exited {}".format(status.return_code))
-    print(status.stdout)
-    print(status.stderr)
+    if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+        print("Git exited {}".format(status.return_code))
+        print(status.stdout)
+        print(status.stderr)
 
     if status.return_code != 0:
         fail("Failed to build the requested git archive!")

--- a/uv/private/git_archive/repository.bzl
+++ b/uv/private/git_archive/repository.bzl
@@ -57,7 +57,7 @@ filegroup(
         target_ref,
     ]
 
-    if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+    if repository_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
         print(cmd)
 
     # Execute the archive command
@@ -65,12 +65,12 @@ filegroup(
         cmd,
     )
 
-    if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+    if repository_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
         print("Git exited {}".format(status.return_code))
-        print(status.stdout)
-        print(status.stderr)
 
     if status.return_code != 0:
+        print(status.stdout)
+        print(status.stderr)
         fail("Failed to build the requested git archive!")
 
     if features.external_deps.extension_metadata_has_reproducible:

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -60,12 +60,13 @@ def _run_configure_tool(repository_ctx, archive_path):
 
     result = repository_ctx.execute(cmd, timeout = 30)
     if result.return_code != 0:
-        # buildifier: disable=print
-        print("WARNING: sdist configure tool failed for {} (exit {}): {}".format(
-            repository_ctx.name,
-            result.return_code,
-            result.stderr,
-        ))
+        if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+            # buildifier: disable=print
+            print("WARNING: sdist configure tool failed for {} (exit {}): {}".format(
+                repository_ctx.name,
+                result.return_code,
+                result.stderr,
+            ))
         return None
 
     return json.decode(result.stdout)
@@ -136,10 +137,11 @@ def _resolve_archive_path(repository_ctx):
             if name.endswith(".tar.gz") or name.endswith(".tar.bz2") or name.endswith(".tar.xz") or name.endswith(".zip") or name.endswith(".tar"):
                 return child
 
-    # buildifier: disable=print
-    print("WARNING: Could not resolve archive path from src label for {}".format(
-        repository_ctx.name,
-    ))
+    if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+        # buildifier: disable=print
+        print("WARNING: Could not resolve archive path from src label for {}".format(
+            repository_ctx.name,
+        ))
     return None
 
 # --- Repository rule implementation ---
@@ -174,7 +176,7 @@ def _sdist_build_impl(repository_ctx):
                 return
 
             is_native = inspection["is_native"]
-            if is_native:
+            if is_native and repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
                 # buildifier: disable=print
                 print("Detected native sources in {}: {} file(s)".format(
                     repository_ctx.name,
@@ -183,10 +185,11 @@ def _sdist_build_impl(repository_ctx):
         else:
             # No tool or tool failed — assume pure-Python. sdist_build
             # validates -none-any so a wrong guess fails loudly at build time.
-            # buildifier: disable=print
-            print("WARNING: Could not inspect sdist for {}; assuming pure-Python".format(
-                repository_ctx.name,
-            ))
+            if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+                # buildifier: disable=print
+                print("WARNING: Could not inspect sdist for {}; assuming pure-Python".format(
+                    repository_ctx.name,
+                ))
             is_native = False
     else:
         is_native = is_native_override == "true"

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -60,7 +60,7 @@ def _run_configure_tool(repository_ctx, archive_path):
 
     result = repository_ctx.execute(cmd, timeout = 30)
     if result.return_code != 0:
-        if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+        if repository_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
             # buildifier: disable=print
             print("WARNING: sdist configure tool failed for {} (exit {}): {}".format(
                 repository_ctx.name,
@@ -137,7 +137,7 @@ def _resolve_archive_path(repository_ctx):
             if name.endswith(".tar.gz") or name.endswith(".tar.bz2") or name.endswith(".tar.xz") or name.endswith(".zip") or name.endswith(".tar"):
                 return child
 
-    if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+    if repository_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
         # buildifier: disable=print
         print("WARNING: Could not resolve archive path from src label for {}".format(
             repository_ctx.name,
@@ -176,7 +176,7 @@ def _sdist_build_impl(repository_ctx):
                 return
 
             is_native = inspection["is_native"]
-            if is_native and repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+            if is_native and repository_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
                 # buildifier: disable=print
                 print("Detected native sources in {}: {} file(s)".format(
                     repository_ctx.name,
@@ -185,7 +185,7 @@ def _sdist_build_impl(repository_ctx):
         else:
             # No tool or tool failed — assume pure-Python. sdist_build
             # validates -none-any so a wrong guess fails loudly at build time.
-            if repository_ctx.os.environ.get("RULES_PY_UV_VERBOSE", ""):
+            if repository_ctx.getenv("RULES_PY_UV_VERBOSE", ""):
                 # buildifier: disable=print
                 print("WARNING: Could not inspect sdist for {}; assuming pure-Python".format(
                     repository_ctx.name,


### PR DESCRIPTION
## Summary
Eliminates unconditional `print()` spam from `sdist_build`, `git_archive`, and the uv module extension by gating diagnostic output behind the `RULES_PY_UV_VERBOSE` environment variable. Also consolidates the `override_package` noise into a single summary line.

## Motivation
Every `bazel build` was emitting multiple warnings and debug prints from repository rules:
- sdist configure-tool failures
- missing archive-path resolutions  
- native-source detections
- pure-Python fallbacks
- per-override `print()` from the module extension
- git-archive command dumps

These messages are useful for debugging but create noise during normal builds. Users should be able to toggle them on without editing `MODULE.bazel`.

## Changes

### `uv/private/extension/defs.bzl`
- Removed the `_extension_tag` with a `verbose` attribute (too intrusive for quick debug).
- Replaced per-override `print()` with an accumulated counter; now prints a single line:
  `uv: N package(s) overridden` only when overrides exist.

### `uv/private/sdist_build/repository.bzl`
- Removed `verbose` attribute from the repository rule.
- Gated the 4 diagnostic prints behind `rctx.os.environ.get("RULES_PY_UV_VERBOSE", "")`.

### `uv/private/git_archive/repository.bzl`
- Removed `verbose` attribute from the repository rule.
- Gated git command/stdout/stderr dumps behind the same env var.

### `docs/uv.md`
- Added **Troubleshooting → Verbose logging for uv repository rules** section documenting the flag and the diagnostics it enables.

### `.bazelrc`
- Added a commented-out example:
