### PR TITLE
fix(py): reset dep_group on data edges

### DIFF
--- a/e2e/cases/multi-project-hub/BUILD.bazel
+++ b/e2e/cases/multi-project-hub/BUILD.bazel
@@ -2,7 +2,8 @@
 # e2e snapshots. Three sub-projects (alpha, beta, gamma) all depend on
 # cowsay, exercising the N>1 select-arm and dep_group config_setting
 # emission that the single-project @pypi_single snapshot cannot cover.
-load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library", "py_test", "py_venv")
+load("@aspect_rules_py//py/private/py_venv:py_venv_exec.bzl", "py_venv_exec_test")
 
 # Alpha defines `[dependency-groups]` (`dev` + hyphenated `unit-tests`)
 # instead of an implicit project-name group, so the snapshot covers both
@@ -49,4 +50,109 @@ py_test(
     deps = [
         "@pypi//cowsay",
     ],
+)
+
+# Within a single uv project, a hub package should be installed once
+# regardless of how many distinct dep_group consumers reach it. Each
+# `record_path_*` binary prints `Path(cowsay.__file__).resolve()` and
+# `:hub_dep_single_compile_test` asserts the recorded paths match.
+[
+    py_binary(
+        name = "record_path_" + group.replace("-", "_"),
+        srcs = ["record_path.py"],
+        dep_group = group,
+        main = "record_path.py",
+        python_version = "3.11",
+        deps = ["@pypi//cowsay"],
+    )
+    for group in [
+        "dev",
+        "unit-tests",
+    ]
+]
+
+py_test(
+    name = "hub_dep_single_compile_test",
+    srcs = ["compare_paths.py"],
+    data = [
+        ":record_path_dev",
+        ":record_path_unit_tests",
+    ],
+    dep_group = "dev",
+    main = "compare_paths.py",
+    python_version = "3.11",
+)
+
+# ---------------------------------------------------------------------------
+# dep_group rule-configuration demos
+#
+# How each public Python rule type wires up `dep_group`. All four
+# variants below import cowsay through alpha's `dev` or `unit-tests`
+# dependency group; passing tests confirm the dep_group was actually
+# applied to the venv that backs the launcher.
+# ---------------------------------------------------------------------------
+
+# 1) py_test — the `dep_group` attr is sugar exposed by the py_test
+#    macro and routed to the auto-generated sibling py_venv.
+py_test(
+    name = "demo_py_test_at_dev",
+    srcs = ["__test__.py"],
+    dep_group = "dev",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = ["@pypi//cowsay"],
+)
+
+# 2) py_venv — `dep_group` lives natively on py_venv. A single venv
+#    target can be declared once at a chosen dep_group and reused by
+#    multiple launchers (see (3)).
+py_venv(
+    name = "demo_venv_at_unit_tests",
+    testonly = True,
+    srcs = ["__test__.py"],
+    dep_group = "unit-tests",
+    python_version = "3.11",
+    visibility = [":__subpackages__"],
+    deps = ["@pypi//cowsay"],
+)
+
+# 3) py_venv_exec / py_venv_exec_test — the launcher rule does NOT
+#    carry `dep_group` itself; it inherits the dep_group of whatever
+#    `py_venv` it points at via the `venv =` attr. Pointing the same
+#    launcher at a different venv swaps the dep_group with no other
+#    attribute changes.
+py_venv_exec_test(
+    name = "demo_py_venv_exec_test_via_unit_tests",
+    srcs = ["__test__.py"],
+    main = "__test__.py",
+    venv = ":demo_venv_at_unit_tests",
+)
+
+# 4) py_library — no `dep_group` attr at all. A library has no opinion
+#    on dep_group; it is configured under whichever dep_group the
+#    consuming binary / test / venv is built at. The same library is
+#    re-used below by two consumers at distinct dep_groups.
+py_library(
+    name = "demo_lib_carrying_cowsay",
+    srcs = ["__test__.py"],
+    testonly = True,
+    deps = ["@pypi//cowsay"],
+)
+
+py_test(
+    name = "demo_lib_consumed_at_dev",
+    srcs = ["__test__.py"],
+    dep_group = "dev",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [":demo_lib_carrying_cowsay"],
+)
+
+py_test(
+    name = "demo_lib_consumed_at_unit_tests",
+    srcs = ["__test__.py"],
+    dep_group = "unit-tests",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [":demo_lib_carrying_cowsay"],
 )

--- a/e2e/cases/multi-project-hub/compare_paths.py
+++ b/e2e/cases/multi-project-hub/compare_paths.py
@@ -1,0 +1,43 @@
+"""Run each `record_path_*` binary and assert they all resolved
+`cowsay.__file__` to the same on-disk path.
+
+A hub package reached from consumers at differing `dep_group` settings
+should still be compiled once. If the @pypi hub recompiles cowsay per
+consumer, each binary's runfiles point at a config-specific install and the
+resolved paths diverge."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+BINARIES = [
+    "record_path_dev",
+    "record_path_unit_tests",
+]
+
+
+def main() -> None:
+    paths = {}
+    for name in BINARIES:
+        binary = Path(__file__).with_name(name)
+        result = subprocess.run(
+            [str(binary)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        paths[name] = result.stdout.strip()
+
+    unique = set(paths.values())
+    if len(unique) != 1:
+        detail = "\n".join("  {} -> {}".format(name, path) for name, path in paths.items())
+        sys.exit(
+            "Expected cowsay to be compiled once across all dep_group consumers, "
+            "but observed multiple resolved install paths:\n" + detail
+        )
+
+    print("OK: single resolved path observed:", next(iter(unique)))
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/cases/multi-project-hub/record_path.py
+++ b/e2e/cases/multi-project-hub/record_path.py
@@ -1,0 +1,9 @@
+"""Print the resolved on-disk location of `cowsay.__file__` for the current
+build configuration. Used by `:hub_dep_single_compile_test` to compare what
+multiple `dep_group` consumers see for the same hub package."""
+
+from pathlib import Path
+
+import cowsay
+
+print(Path(cowsay.__file__).resolve())

--- a/py/tests/reset-data-edges/BUILD.bazel
+++ b/py/tests/reset-data-edges/BUILD.bazel
@@ -1,0 +1,44 @@
+load("//py:defs.bzl", "py_binary", "py_test", "py_library")
+load(":probe.bzl", "config_probe")
+
+config_probe(name = "library_probe")
+config_probe(name = "binary_probe")
+config_probe(name = "test_probe")
+
+py_library(
+    name = "lib",
+    srcs = ["lib.py"],
+    data = [":library_probe"],
+)
+
+py_binary(
+    name = "binary",
+    srcs = ["main.py"],
+    main = "main.py",
+    data = [":binary_probe"],
+    deps = [":lib"],
+    python_version = "3.11",
+    venv = "reset-data-edges",
+)
+
+py_test(
+    name = "binary_smoke_test",
+    srcs = ["binary_smoke_test.py"],
+    main = "binary_smoke_test.py",
+    data = [":binary"],
+)
+
+py_test(
+    name = "test",
+    srcs = ["test_main.py"],
+    main = "test_main.py",
+    data = [":test_probe"],
+    deps = [":lib"],
+    python_version = "3.11",
+    venv = "reset-data-edges",
+)
+
+test_suite(
+    name = "smoke",
+    tests = [":binary_smoke_test", ":test"],
+)

--- a/py/tests/reset-data-edges/binary_smoke_test.py
+++ b/py/tests/reset-data-edges/binary_smoke_test.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import subprocess
+
+def main() -> None:
+    binary = Path(__file__).with_name("binary")
+    result = subprocess.run([str(binary)], check = True, capture_output = True, text = True)
+    assert result.stdout.strip() == "reset ok", result.stdout
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tests/reset-data-edges/lib.py
+++ b/py/tests/reset-data-edges/lib.py
@@ -1,0 +1,1 @@
+MESSAGE = "library loaded"

--- a/py/tests/reset-data-edges/main.py
+++ b/py/tests/reset-data-edges/main.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+EXPECTED = """python_version=3.11
+rules_python_version=3.11
+venv=bazel-pypi-lock
+freethreaded=False
+"""
+
+
+def assert_probe(name: str) -> None:
+    actual = Path(__file__).with_name(name).read_text()
+    assert actual == EXPECTED, "{} had unexpected contents: {!r}".format(name, actual)
+
+
+def main() -> None:
+    assert_probe("binary_probe.txt")
+    assert_probe("library_probe.txt")
+    print("reset ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tests/reset-data-edges/probe.bzl
+++ b/py/tests/reset-data-edges/probe.bzl
@@ -1,0 +1,33 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+def _config_probe_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.write(
+        output = out,
+        content = "\n".join([
+            "python_version={}".format(ctx.attr._python_version[BuildSettingInfo].value),
+            "rules_python_version={}".format(ctx.attr._rules_python_version[BuildSettingInfo].value),
+            "venv={}".format(ctx.attr._venv[BuildSettingInfo].value),
+            "freethreaded={}".format(ctx.attr._freethreaded[BuildSettingInfo].value),
+            "",
+        ]),
+    )
+    return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles(files = [out]))]
+
+config_probe = rule(
+    implementation = _config_probe_impl,
+    attrs = {
+        "_python_version": attr.label(
+            default = "@aspect_rules_py//py/private/interpreter:python_version",
+        ),
+        "_rules_python_version": attr.label(
+            default = "@rules_python//python/config_settings:python_version",
+        ),
+        "_venv": attr.label(
+            default = "@aspect_rules_py//uv/private/constraints/venv:venv",
+        ),
+        "_freethreaded": attr.label(
+            default = "@aspect_rules_py//py/private/interpreter:freethreaded",
+        ),
+    },
+)

--- a/py/tests/reset-data-edges/test_main.py
+++ b/py/tests/reset-data-edges/test_main.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+EXPECTED = """python_version=3.11
+rules_python_version=3.11
+venv=bazel-pypi-lock
+freethreaded=False
+"""
+
+
+def assert_probe(name: str) -> None:
+    actual = Path(__file__).with_name(name).read_text()
+    assert actual == EXPECTED, "{} had unexpected contents: {!r}".format(name, actual)
+
+
+def main() -> None:
+    assert_probe("library_probe.txt")
+    assert_probe("test_probe.txt")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -5,6 +5,22 @@ load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN", "UNPACK_TOOLCHAIN")
 
+_DEP_GROUP_FLAG = "@aspect_rules_py//uv/private/constraints/dep_group:dep_group"
+
+# Wheel installation is dep_group-agnostic: which set of wheels a venv pulls
+# in is the consumer's concern, but the install itself unpacks the same files
+# regardless of which dep_group named this wheel. Canonicalise DEP_GROUP_FLAG
+# on the way in so every consumer reaches the same configured target and the
+# install action runs once per hub repo.
+def _reset_dep_group_impl(_settings, _attr):
+    return {_DEP_GROUP_FLAG: ""}
+
+_reset_dep_group = transition(
+    implementation = _reset_dep_group_impl,
+    inputs = [],
+    outputs = [_DEP_GROUP_FLAG],
+)
+
 def _whl_install(ctx):
     py_toolchain = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
     install_dir = ctx.actions.declare_directory(
@@ -128,6 +144,7 @@ def _whl_install(ctx):
 
 whl_install = rule(
     implementation = _whl_install,
+    cfg = _reset_dep_group,
     doc = """
 Private implementation detail of aspect_rules_py//uv.
 
@@ -139,6 +156,9 @@ to bypass some of the platform checks that UV does to enable crossbuilds, and is
 lighter weight since the toolchain's files aren't inputs.
 """,
     attrs = {
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
         "src": attr.label(
             allow_single_file = True,
             doc = "The wheel to install, or a tree artifact containing exactly one wheel at its root.",


### PR DESCRIPTION
Runfiles `data` deps are packaged artifacts, not part of the parent's resolved venv — they should not inherit the parent binary's `dep_group`. Reset it on `data` edges; new tests verify probes in runfiles see the default lock venv.

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
