### PR TITLE
fix: allow shared/re-used deps lists across py_test targets

### DIFF
--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -41,8 +41,10 @@ py_image_layer = _py_image_layer
 resolutions = _resolutions
 
 def _resolve_main(name, srcs, main):
-    """Macro-time fallback for `main`. Mirrors `_determine_main` in
-    py_semantics.bzl, except it operates on label strings instead of
+    """Macro-time fallback for `main`.
+
+    Mirrors `_determine_main` in py_semantics.bzl,
+    except it operates on label strings instead of
     files because srcs no longer reaches the underlying rule. Order:
 
     1. Use `main` if set.
@@ -145,7 +147,7 @@ def py_test(name, srcs = [], main = None, pytest_main = False, **kwargs):
     if resolutions:
         resolutions = resolutions.to_label_keyed_dict()
 
-    deps = kwargs.pop("deps", [])
+    deps = list(kwargs.pop("deps", []))
     if pytest_main:
         if main:
             fail("When pytest_main is set, the main attribute should not be set.")

--- a/py/tests/py-test/BUILD.bazel
+++ b/py/tests/py-test/BUILD.bazel
@@ -1,5 +1,7 @@
 load("//py:defs.bzl", "py_test")
 
+COMMON_TEST_DEPS = ["@pypi//pytest"]
+
 py_test(
     name = "test_env_vars",
     srcs = ["test_env_vars.py"],
@@ -13,4 +15,18 @@ py_test(
         "LOCATION": "$(location :test_env_vars.py)",
         "DEFINE": "$(SOME_VAR)",
     },
+)
+
+py_test(
+    name = "test_pytest_main_shared_deps_a",
+    srcs = ["test_pytest_main_shared_deps.py"],
+    pytest_main = True,
+    deps = COMMON_TEST_DEPS,
+)
+
+py_test(
+    name = "test_pytest_main_shared_deps_b",
+    srcs = ["test_pytest_main_shared_deps.py"],
+    pytest_main = True,
+    deps = COMMON_TEST_DEPS,
 )

--- a/py/tests/py-test/test_pytest_main_shared_deps.py
+++ b/py/tests/py-test/test_pytest_main_shared_deps.py
@@ -1,0 +1,3 @@
+def test_pytest_main_shared_deps():
+    """Test that py_test deps can be shared/re-used across py_test targets."""
+    assert True


### PR DESCRIPTION
If there is a common list of dependencies which are shared across multiple `py_test` targets and `pytest_main` is set to `True` on both of them there is a build issue because the `deps` list is mutated and `//py/private:default_pytest_main` is included twice/multiple times.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
  - Added two tests to demonstrate the behavior. Both must be built together to demonstrate the build issue:
    1. `//py/tests/py-test:test_pytest_main_shared_deps_a`
    2. `//py/tests/py-test:test_pytest_main_shared_deps_b`

    `bazel test //py/tests/py-test:test_pytest_main_shared_deps_a //py/tests/py-test:test_pytest_main_shared_deps_b`