### PR TITLE
fix: drop platform_libc from darwin/windows toolchain target_settings…

### DIFF
--- a/e2e/cases/interpreter-exec-under-glibc-target/BUILD.bazel
+++ b/e2e/cases/interpreter-exec-under-glibc-target/BUILD.bazel
@@ -1,0 +1,61 @@
+"""Regression test for exec-config Python toolchain selection when target
+config carries a non-host `platform_libc` value.
+
+Setup:
+  - `:linux_glibc` is a `platform()` whose `flags = [...]` pin
+    `platform_libc=glibc`.
+  - `:invoke_tool` is a genrule that runs `:tool` (a `py_binary`) via
+    `tools =`, which puts `:tool` in exec config.
+  - `:invoke_tool_under_glibc` is a `platform_transition_filegroup` that
+    transitions the genrule's target config to `:linux_glibc`. The exec
+    config Bazel derives for the genrule's `tools` then inherits
+    `platform_libc=glibc`.
+
+On a darwin host this triggered the pre-fix bug: aspect_rules_py's darwin
+interpreter required `target_settings: platform_libc=libsystem` and stopped
+matching against the inherited glibc value, so toolchain resolution fell
+through to rules_python's auto-registered toolchain. Its hermetic
+interpreter doesn't bootstrap through the rules_py launcher
+(`ModuleNotFoundError: No module named 'encodings'`).
+
+The fix in `py/private/interpreter/versions.bzl` drops the unnecessary
+`target_settings: platform_libc=libsystem/msvc` from non-linux toolchains.
+"""
+
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+platform(
+    name = "linux_glibc",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    # This flag is what bleeds into the exec config the py_binary gets
+    # resolved under, disqualifying the host's interpreter toolchain pre-fix.
+    flags = ["--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc"],
+)
+
+py_binary(
+    name = "tool",
+    srcs = ["tool.py"],
+)
+
+genrule(
+    name = "invoke_tool",
+    outs = ["invoke_tool.log"],
+    cmd = "$(execpath :tool) --output $@",
+    tools = [":tool"],
+)
+
+platform_transition_filegroup(
+    name = "invoke_tool_under_glibc",
+    srcs = [":invoke_tool"],
+    target_platform = ":linux_glibc",
+)
+
+build_test(
+    name = "interpreter_exec_under_glibc_target_test",
+    targets = [":invoke_tool_under_glibc"],
+)

--- a/e2e/cases/interpreter-exec-under-glibc-target/tool.py
+++ b/e2e/cases/interpreter-exec-under-glibc-target/tool.py
@@ -1,0 +1,13 @@
+"""Trivial cfg=exec py_binary stand-in. The body doesn't matter; the test
+asserts that the interpreter under which this runs can find its stdlib.
+If Python's bootstrap can't import `encodings`, the action fails before
+reaching this script — regression mode."""
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--output", required=True)
+args = parser.parse_args()
+with open(args.output, "w") as fh:
+    fh.write("python " + sys.version + "\n")

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -85,6 +85,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "versions",
+    srcs = ["versions.bzl"],
+    deps = ["//uv/private/constraints/platform:defs"],
+)
+
+bzl_library(
     name = "resolve",
     srcs = ["resolve.bzl"],
 )
@@ -92,9 +98,4 @@ bzl_library(
 bzl_library(
     name = "version_util",
     srcs = ["version_util.bzl"],
-)
-
-bzl_library(
-    name = "versions",
-    srcs = ["versions.bzl"],
 )

--- a/py/private/interpreter/versions.bzl
+++ b/py/private/interpreter/versions.bzl
@@ -9,6 +9,8 @@ extension evaluation time by downloading the SHA256SUMS file from each release,
 then cached in the MODULE.bazel.lock via the Bazel facts API.
 """
 
+load("//uv/private/constraints/platform:defs.bzl", "PLATFORM_LIBC_FLAG")
+
 DEFAULT_RELEASE_BASE_URL = "https://github.com/astral-sh/python-build-standalone/releases/download"
 
 # Default PBS release dates, ordered newest-first. These are used when the user
@@ -25,8 +27,12 @@ DEFAULT_RELEASE_DATES = [
     "20241002",  # 3.8-3.13
 ]
 
-# The libc flag used to disambiguate glibc vs musl Linux toolchains.
-_PLATFORM_LIBC_FLAG = "@aspect_rules_py//uv/private/constraints/platform:platform_libc"
+# `PLATFORM_LIBC_FLAG` is only applied to linux toolchains below: on
+# darwin/windows there's only one libc (libsystem/msvc), so the constraint
+# disambiguates nothing in target config — and on macOS/Windows hosts it
+# actively breaks cfg=exec toolchain selection when a linux cross-build
+# platform pins `platform_libc=glibc` and that flag inherits into the exec
+# config the host's interpreter is being resolved under.
 
 # Mapping from PBS platform triple to Bazel platform constraints.
 #
@@ -40,9 +46,6 @@ PLATFORMS = {
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
-        "target_settings": {
-            _PLATFORM_LIBC_FLAG: "libsystem",
-        },
     },
     "aarch64-unknown-linux-gnu": {
         "compatible_with": [
@@ -50,7 +53,7 @@ PLATFORMS = {
             "@platforms//cpu:aarch64",
         ],
         "target_settings": {
-            _PLATFORM_LIBC_FLAG: "glibc",
+            PLATFORM_LIBC_FLAG: "glibc",
         },
     },
     "aarch64-unknown-linux-musl": {
@@ -59,7 +62,7 @@ PLATFORMS = {
             "@platforms//cpu:aarch64",
         ],
         "target_settings": {
-            _PLATFORM_LIBC_FLAG: "musl",
+            PLATFORM_LIBC_FLAG: "musl",
         },
     },
     "x86_64-apple-darwin": {
@@ -67,9 +70,6 @@ PLATFORMS = {
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
-        "target_settings": {
-            _PLATFORM_LIBC_FLAG: "libsystem",
-        },
     },
     "x86_64-unknown-linux-gnu": {
         "compatible_with": [
@@ -77,7 +77,7 @@ PLATFORMS = {
             "@platforms//cpu:x86_64",
         ],
         "target_settings": {
-            _PLATFORM_LIBC_FLAG: "glibc",
+            PLATFORM_LIBC_FLAG: "glibc",
         },
     },
     "x86_64-unknown-linux-musl": {
@@ -86,7 +86,7 @@ PLATFORMS = {
             "@platforms//cpu:x86_64",
         ],
         "target_settings": {
-            _PLATFORM_LIBC_FLAG: "musl",
+            PLATFORM_LIBC_FLAG: "musl",
         },
     },
     "x86_64-pc-windows-msvc": {
@@ -94,27 +94,18 @@ PLATFORMS = {
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
-        "target_settings": {
-            _PLATFORM_LIBC_FLAG: "msvc",
-        },
     },
     "aarch64-pc-windows-msvc": {
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:aarch64",
         ],
-        "target_settings": {
-            _PLATFORM_LIBC_FLAG: "msvc",
-        },
     },
     "i686-pc-windows-msvc": {
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_32",
         ],
-        "target_settings": {
-            _PLATFORM_LIBC_FLAG: "msvc",
-        },
     },
 }
 

--- a/uv/private/constraints/platform/BUILD.bazel
+++ b/uv/private/constraints/platform/BUILD.bazel
@@ -10,7 +10,7 @@ package(default_visibility = ["//visibility:public"])
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
-    deps = [],
+    deps = ["@bazel_skylib//rules:common_settings"],
 )
 
 bzl_library(

--- a/uv/private/constraints/platform/defs.bzl
+++ b/uv/private/constraints/platform/defs.bzl
@@ -118,6 +118,9 @@ def supported_platform(platform_tag):
 # Adapted from rules_python's config_settings.bzl
 MAJOR_MINOR_FLAG = Label("//uv/private/constraints/platform:platform_version")
 
+# String label of the platform_libc string_flag (string not Label so it can be a dict key).
+PLATFORM_LIBC_FLAG = "@aspect_rules_py//uv/private/constraints/platform:platform_libc"
+
 def _platform_version_at_least_impl(ctx):
     flag_value = ctx.attr._major_minor[BuildSettingInfo].value
 

--- a/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
@@ -33,12 +33,6 @@ config_setting(
 
 
 config_setting(
-    name = "platform_libc_is_libsystem",
-    flag_values = {"@aspect_rules_py//uv/private/constraints/platform:platform_libc": "libsystem"},
-)
-
-
-config_setting(
     name = "platform_libc_is_glibc",
     flag_values = {"@aspect_rules_py//uv/private/constraints/platform:platform_libc": "glibc"},
 )
@@ -47,12 +41,6 @@ config_setting(
 config_setting(
     name = "platform_libc_is_musl",
     flag_values = {"@aspect_rules_py//uv/private/constraints/platform:platform_libc": "musl"},
-)
-
-
-config_setting(
-    name = "platform_libc_is_msvc",
-    flag_values = {"@aspect_rules_py//uv/private/constraints/platform:platform_libc": "msvc"},
 )
 
 
@@ -66,7 +54,7 @@ config_setting(
 toolchain(
     name = "python_3_13_aarch64_apple_darwin",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_libsystem"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_apple_darwin//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -144,7 +132,7 @@ toolchain(
 toolchain(
     name = "python_3_13_x86_64_apple_darwin",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_libsystem"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_apple_darwin//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -222,7 +210,7 @@ toolchain(
 toolchain(
     name = "python_3_13_x86_64_pc_windows_msvc",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_msvc"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_pc_windows_msvc//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -248,7 +236,7 @@ toolchain(
 toolchain(
     name = "python_3_13_aarch64_pc_windows_msvc",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_msvc"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_pc_windows_msvc//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -274,7 +262,7 @@ toolchain(
 toolchain(
     name = "python_3_13_i686_pc_windows_msvc",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_msvc"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_i686_pc_windows_msvc//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -300,7 +288,7 @@ toolchain(
 toolchain(
     name = "python_3_13_aarch64_apple_darwin_install_only_stripped",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_libsystem"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_apple_darwin_install_only_stripped//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -378,7 +366,7 @@ toolchain(
 toolchain(
     name = "python_3_13_x86_64_apple_darwin_install_only_stripped",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_libsystem"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_apple_darwin_install_only_stripped//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -456,7 +444,7 @@ toolchain(
 toolchain(
     name = "python_3_13_x86_64_pc_windows_msvc_install_only_stripped",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_msvc"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_pc_windows_msvc_install_only_stripped//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -482,7 +470,7 @@ toolchain(
 toolchain(
     name = "python_3_13_aarch64_pc_windows_msvc_install_only_stripped",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_msvc"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_pc_windows_msvc_install_only_stripped//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -508,7 +496,7 @@ toolchain(
 toolchain(
     name = "python_3_13_i686_pc_windows_msvc_install_only_stripped",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_msvc"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_i686_pc_windows_msvc_install_only_stripped//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -534,7 +522,7 @@ toolchain(
 toolchain(
     name = "python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_libsystem"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -586,7 +574,7 @@ toolchain(
 toolchain(
     name = "python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_libsystem"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -638,7 +626,7 @@ toolchain(
 toolchain(
     name = "python_3_13_aarch64_apple_darwin_freethreaded_debug",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_libsystem"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_debug//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
@@ -716,7 +704,7 @@ toolchain(
 toolchain(
     name = "python_3_13_x86_64_apple_darwin_freethreaded_debug",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_libsystem"],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_debug//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )


### PR DESCRIPTION
… to unbreak exec-config py_binary resolution under cross-platform builds

This removes the need for doing this in #960 (see https://github.com/aspect-build/rules_py/pull/960/commits/765594f17c97cd18015cc6a6f2be50f5198bb25e)

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
