### PR TITLE
refactor: remove unnecessary use of itertools cargo dep

### DIFF
--- a/py/tools/unpack/BUILD.bazel
+++ b/py/tools/unpack/BUILD.bazel
@@ -10,7 +10,6 @@ rust_binary(
     visibility = ["//visibility:public"],
     deps = [
         "@aspect_rules_py__crates//:clap",
-        "@aspect_rules_py__crates//:itertools",
         "@aspect_rules_py__crates//:miette",
         "@aspect_rules_py__crates//:percent-encoding-2.3.1",
         "@aspect_rules_py__crates//:tempfile",

--- a/py/tools/unpack/Cargo.toml
+++ b/py/tools/unpack/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-itertools = { workspace = true }
 miette = { workspace = true }
 percent-encoding = "2.3.1"
 tempfile = { workspace = true }

--- a/py/tools/unpack/src/main.rs
+++ b/py/tools/unpack/src/main.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use clap::Parser;
-use itertools::Itertools;
 use miette::{miette, Context, IntoDiagnostic, Result};
 use percent_encoding::percent_decode_str;
 
@@ -33,20 +32,18 @@ fn unpack_wheel(
     let wheel = if wheel.is_file() {
         wheel.to_owned()
     } else {
-        fs::read_dir(wheel)
+        let mut whls = fs::read_dir(wheel)
             .into_diagnostic()?
             .filter_map(|res| res.ok())
             .map(|dir_entry| dir_entry.path())
-            .filter_map(|path| {
-                if path.extension().map_or(false, |ext| ext == "whl") {
-                    Some(path)
-                } else {
-                    None
-                }
-            })
-            .exactly_one()
-            .into_diagnostic()
-            .wrap_err_with(|| "Didn't find exactly one wheel file to install!")?
+            .filter(|path| path.extension().map_or(false, |ext| ext == "whl"));
+        let first = whls
+            .next()
+            .ok_or_else(|| miette!("Didn't find exactly one wheel file to install!"))?;
+        if whls.next().is_some() {
+            return Err(miette!("Didn't find exactly one wheel file to install!"));
+        }
+        first
     };
     let wheel_file_reader = fs::File::open(&wheel).into_diagnostic()?;
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
