### PR TITLE
chore: remove dead pre-commit comments and document adder fixture

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,10 +42,3 @@ repos:
         entry: /bin/sh -c '/usr/bin/env bazel run //:requirements.update'
         language: script
         require_serial: true
-
-      # - id: check-gazelle-manifest
-      #   name: Update gazelle manifest
-      #   # Note that we use a nested shell to discard $@, which is the file list
-      #   entry: /bin/sh -c '/usr/bin/env bazel run //:gazelle_python_manifest.update'
-      #   language: script
-      #   require_serial: true

--- a/py/tests/internal-deps/adder/BUILD.bazel
+++ b/py/tests/internal-deps/adder/BUILD.bazel
@@ -1,3 +1,8 @@
+"""Deliberate e2e fixture: a py_library from the @aspect_rules_py module consumed by the
+OCI e2e cases (//cases/oci/py_image_layer) to verify that py_image_layer correctly
+includes cross-module first-party deps. Do not inline into the e2e folder — the point
+is to exercise the external-module runfiles path (aspect_rules_py+/...)."""
+
 load("//py:defs.bzl", "py_library")
 
 py_library(
@@ -7,8 +12,5 @@ py_library(
         "add.py",
     ],
     imports = [".."],
-    # This library contributes to the container test, testing we can pull in and use a library from another
-    # package in the repo. Public so the e2e harness's OCI cases (which live in
-    # a different module under //cases/oci/...) can consume it.
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Two small clean-ups split out from the upcoming `py_image_layer` rewrite so they can land independently.

1. **`.pre-commit-config.yaml`** — Removes the commented-out `check-gazelle-manifest` hook. It has been disabled for a while and is no longer planned, so the commented block is just noise.

2. **`py/tests/internal-deps/adder/BUILD.bazel`** — Promotes the inline comments to a module-level docstring that explicitly explains why this target lives in the main repo rather than under `//e2e`. The OCI image-layer tests consume it across module boundaries to exercise the external-module runfiles path (`aspect_rules_py+/...`). Making the intent obvious prevents future refactorings from accidentally inlining it into the e2e folder.

No functional changes.