### PR TITLE
test: add verify_venv test util to run in venvs such as py_test or containers

### DIFF
--- a/e2e/cases/interpreter-exec-under-glibc-target/BUILD.bazel
+++ b/e2e/cases/interpreter-exec-under-glibc-target/BUILD.bazel
@@ -40,6 +40,7 @@ platform(
 py_binary(
     name = "tool",
     srcs = ["tool.py"],
+    deps = ["//tools/verify_venv"],
 )
 
 genrule(

--- a/e2e/cases/interpreter-exec-under-glibc-target/tool.py
+++ b/e2e/cases/interpreter-exec-under-glibc-target/tool.py
@@ -1,10 +1,18 @@
 """Trivial cfg=exec py_binary stand-in. The body doesn't matter; the test
 asserts that the interpreter under which this runs can find its stdlib.
 If Python's bootstrap can't import `encodings`, the action fails before
-reaching this script — regression mode."""
+reaching this script — regression mode.
+
+Also runs `verify_venv.verify_all()` so a venv-layout regression in the
+exec-config interpreter shows up as a genrule failure with a precise
+assertion message."""
 
 import argparse
 import sys
+
+from verify_venv import verify_all
+
+verify_all()
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--output", required=True)

--- a/e2e/cases/interpreter-features-836/BUILD.bazel
+++ b/e2e/cases/interpreter-features-836/BUILD.bazel
@@ -21,6 +21,7 @@ py_binary(
     srcs = ["__main__.py"],
     main = "__main__.py",
     tags = ["manual"],
+    deps = ["//tools/verify_venv"],
 )
 
 py_image_layer(
@@ -52,7 +53,16 @@ container_structure_test(
     configs = ["test.yaml"],
     image = ":amd64_image",
     platform = "linux/amd64",
-    tags = ["requires-docker"],
+    # `skip-on-bazel9`: `__main__` calls `verify_venv.verify_all()`, which
+    # asserts the interpreter's `bin/` has python3.<x> + python + python3
+    # as 1 real binary + 2 symlinks. Bazel 9 materialises tree-artifact
+    # internal symlinks as copies when packing OCI layers, so all three
+    # land as full binaries and the assertion fires. Re-enable once
+    # Bazel 9 preserves tree-artifact symlinks.
+    tags = [
+        "requires-docker",
+        "skip-on-bazel9",
+    ],
     target_compatible_with = [
         "@platforms//cpu:x86_64",
     ],

--- a/e2e/cases/interpreter-features-836/__main__.py
+++ b/e2e/cases/interpreter-features-836/__main__.py
@@ -1,7 +1,11 @@
 import importlib.util
 import sys
 
+from verify_venv import verify_all
+
 if __name__ == "__main__":
+    verify_all()
+
     turtle_spec = importlib.util.find_spec("turtle")
     turtledemo_spec = importlib.util.find_spec("turtledemo")
 

--- a/e2e/cases/interpreter-provisioning/BUILD.bazel
+++ b/e2e/cases/interpreter-provisioning/BUILD.bazel
@@ -7,6 +7,7 @@ py_test(
     srcs = ["test_interpreter.py"],
     main = "test_interpreter.py",
     python_version = "3.11",
+    deps = ["//tools/verify_venv"],
 )
 
 py_test(
@@ -16,4 +17,5 @@ py_test(
     isolated = False,
     main = "test_interpreter.py",
     python_version = "3.11",
+    deps = ["//tools/verify_venv"],
 )

--- a/e2e/cases/interpreter-provisioning/test_interpreter.py
+++ b/e2e/cases/interpreter-provisioning/test_interpreter.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+from verify_venv import verify_all
+
 
 def test_not_rules_python():
     # In a py_venv_test, sys.executable points to the venv bin/python symlink.
@@ -13,7 +15,12 @@ def test_not_rules_python():
     )
 
 
+def test_venv_layout():
+    verify_all()
+
+
 if __name__ == "__main__":
     test_not_rules_python()
+    test_venv_layout()
     real_exe = os.path.realpath(sys.executable)
     print("OK: interpreter is", real_exe)

--- a/e2e/cases/interpreter-version-541/BUILD.bazel
+++ b/e2e/cases/interpreter-version-541/BUILD.bazel
@@ -23,6 +23,7 @@ load("@bazel_lib//lib:expand_template.bzl", "expand_template")
             isolated = False,
             main = "expanded_test_{}.py".format(ver.replace(".", "_")),
             python_version = ver,
+            deps = ["//tools/verify_venv"],
         ),
         py_test(
             name = "test_{}_classic".format(ver.replace(".", "_")),
@@ -34,6 +35,7 @@ load("@bazel_lib//lib:expand_template.bzl", "expand_template")
             ],
             main = "expanded_test_{}.py".format(ver.replace(".", "_")),
             python_version = ver,
+            deps = ["//tools/verify_venv"],
         ),
     ]
     for ver in [

--- a/e2e/cases/interpreter-version-541/test.py
+++ b/e2e/cases/interpreter-version-541/test.py
@@ -3,6 +3,10 @@
 import sys
 import site
 
+from verify_venv import verify_all
+
+verify_all()
+
 print("---")
 print("__file__:", __file__)
 print("sys.prefix:", sys.prefix)

--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -40,6 +40,7 @@ py_binary(
     dep_group = "images",
     deps = [
         "//cases/oci/py_image_layer/branding",
+        "//tools/verify_venv",
         "@aspect_rules_py//py/tests/internal-deps/adder",
         "@pypi_oci_py_image_layer//colorama",
     ],

--- a/e2e/cases/oci/py_image_layer/__main__.py
+++ b/e2e/cases/oci/py_image_layer/__main__.py
@@ -2,6 +2,8 @@ from colorama import Fore, Style
 
 from branding import get_branding
 from adder.add import add
+from verify_venv import verify_all
 
 if __name__ == "__main__":
+    verify_all(imports=["colorama"])
     print(f"{Fore.GREEN}Hello {get_branding()} - {add(3, .14)}{Style.RESET_ALL}")

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
@@ -2571,7 +2571,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/0/lib/python3.11/site-packages/colorama/win32.py -> external/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/win32.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/0/lib/python3.11/site-packages/colorama/winterm.py -> external/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/winterm.py
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/
-  - -rwxr-xr-x  0 0      0         274 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_my_app_bin.venv.pth
+  - -rwxr-xr-x  0 0      0         322 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
   - -rwxr-xr-x  0 0      0        4342 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/0/lib/python3.11/site-packages/colorama
@@ -2621,7 +2621,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/
-  - -rwxr-xr-x  0 0      0         204 Jan  1  2023 ./cases/oci/py_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./cases/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1624 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/
@@ -2641,11 +2641,14 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/
   - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
-  - -rwxr-xr-x  0 0      0         204 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1274 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/_my_app_bin.venv
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/branding/
   - -rwxr-xr-x  0 0      0          42 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/branding/__init__.py
   - -rwxr-xr-x  0 0      0        1624 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/cases/oci/py_image_layer/my_app_bin
+  - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/tools/
+  - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/tools/verify_venv/
+  - -rwxr-xr-x  0 0      0        5759 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/_main/tools/verify_venv/verify_venv.py
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/

--- a/e2e/cases/oci/py_venv_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_venv_image_layer/BUILD.bazel
@@ -50,6 +50,7 @@ py_binary(
     tags = ["manual"],
     deps = [
         "//cases/oci/py_image_layer/branding",
+        "//tools/verify_venv",
         "@aspect_rules_py//py/tests/internal-deps/adder",
         "@pypi_oci_py_venv_image_layer//colorama",
     ],

--- a/e2e/cases/oci/py_venv_image_layer/__main__.py
+++ b/e2e/cases/oci/py_venv_image_layer/__main__.py
@@ -9,7 +9,10 @@ from branding import get_branding
 
 from adder.add import add
 
+from verify_venv import verify_all
+
 if __name__ == "__main__":
+    verify_all(imports=["colorama"])
     print(sys.executable)
     print(sys.prefix)
     print(sys.version)

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
@@ -2575,7 +2575,7 @@ files:
   - -rwxr-xr-x  0 0      0        4342 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/0/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/0/lib/python3.11/site-packages/colorama-0.4.6.dist-info
-  - -rwxr-xr-x  0 0      0         279 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
+  - -rwxr-xr-x  0 0      0         327 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER -> external/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
@@ -2621,7 +2621,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/
-  - -rwxr-xr-x  0 0      0         390 Jan  1  2023 ./cases/oci/py_venv_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./cases/oci/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1635 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/
@@ -2644,9 +2644,12 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/
   - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
-  - -rwxr-xr-x  0 0      0         390 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1635 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/my_app_bin
   - -rwxr-xr-x  0 0      0        1278 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/my_app_bin.venv
+  - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/tools/
+  - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/tools/verify_venv/
+  - -rwxr-xr-x  0 0      0        5759 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/tools/verify_venv/verify_venv.py
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
@@ -2575,7 +2575,7 @@ files:
   - -rwxr-xr-x  0 0      0        4342 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/0/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/0/lib/python3.11/site-packages/colorama-0.4.6.dist-info
-  - -rwxr-xr-x  0 0      0         279 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
+  - -rwxr-xr-x  0 0      0         327 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER -> external/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
@@ -2621,7 +2621,7 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/
-  - -rwxr-xr-x  0 0      0         390 Jan  1  2023 ./cases/oci/py_venv_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./cases/oci/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1635 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/
@@ -2644,9 +2644,12 @@ files:
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/
   - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
-  - -rwxr-xr-x  0 0      0         390 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1635 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/my_app_bin
   - -rwxr-xr-x  0 0      0        1278 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/cases/oci/py_venv_image_layer/my_app_bin.venv
+  - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/tools/
+  - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/tools/verify_venv/
+  - -rwxr-xr-x  0 0      0        5759 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/_main/tools/verify_venv/verify_venv.py
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/
   - drwxr-xr-x  0 0      0           0 Jan  1  2023 ./cases/oci/py_venv_image_layer/my_app_bin.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/

--- a/e2e/tools/verify_venv/BUILD.bazel
+++ b/e2e/tools/verify_venv/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library", "py_test")
+
+# Shared helpers for asserting venv / interpreter layout properties from
+# inside a py_binary or py_test. Consumers add this to their py_binary
+# `deps` and call `verify_venv.<check>()`. The colocated py_test
+# exercises the helpers against the default toolchain.
+#
+# Current checks:
+#   * `verify()` — interpreter's `bin/` reachable from `sys.executable`
+#     has exactly one real `python3.<minor>` binary and two symlinks
+#     (`python`, `python3`) resolving to it.
+py_library(
+    name = "verify_venv",
+    srcs = ["verify_venv.py"],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "verify_venv_test",
+    srcs = ["verify_venv.py"],
+    main = "verify_venv.py",
+)

--- a/e2e/tools/verify_venv/verify_venv.py
+++ b/e2e/tools/verify_venv/verify_venv.py
@@ -1,0 +1,150 @@
+"""Venv / interpreter layout assertions for e2e tests.
+
+Add `//tools/verify_venv` to a `py_binary`'s `deps`, then call the
+relevant check (or `verify_all()`) inside the entry script. Each
+assertion raises AssertionError with enough detail to localise a
+regression.
+
+Checks exposed:
+
+  * verify_interpreter_symlinks()      — the interpreter's `bin/` reached
+                                          via `sys.executable` has exactly
+                                          one real `python3.<minor>` binary,
+                                          with `python` and `python3` as
+                                          symlinks resolving to it.
+
+  * verify_no_dangling_symlinks(root)  — every symlink under `root`
+                                          (default: `sys.prefix`) resolves
+                                          to an existing path. Catches the
+                                          class of regression where layer
+                                          packaging emits literal symlink
+                                          targets that don't exist inside
+                                          the container.
+
+  * verify_in_venv()                   — `sys.base_prefix != sys.prefix`.
+                                          The binary is actually running
+                                          in its own venv, not the base
+                                          Python install.
+
+  * verify_sys_path()                  — every non-empty entry on
+                                          `sys.path` exists (tolerating
+                                          the speculative `python<x>.zip`
+                                          stubs Python adds without
+                                          guaranteeing them).
+
+  * verify_imports(packages)           — each named package imports and
+                                          exposes a non-None `__file__`.
+                                          A package falling back to the
+                                          namespace-package shape (e.g.
+                                          because its `__init__.py`
+                                          dangles) has `__file__ is None`
+                                          — exactly the symptom of the
+                                          original wheel-symlink bug.
+
+  * verify_all(imports=())             — runs every check above, with
+                                          `imports` passed through to
+                                          `verify_imports`.
+
+Designed to run two ways:
+
+  * Directly as a py_test on the host (`bazel test :verify_venv_test`) —
+    exercises the runfiles-tree layout the default toolchain ships.
+  * Inlined into a py_binary's `__main__.py` so the same assertion runs
+    inside the OCI container under `container_structure_test`.
+"""
+
+import glob
+import importlib
+import os
+import sys
+
+
+def verify_interpreter_symlinks():
+    bin_dir = os.path.dirname(os.path.realpath(sys.executable))
+    candidates = []
+    for name in ("python", "python3"):
+        p = os.path.join(bin_dir, name)
+        if os.path.lexists(p):
+            candidates.append(p)
+    candidates.extend(glob.glob(os.path.join(bin_dir, "python3.*[0-9]")))
+
+    real = [p for p in candidates if not os.path.islink(p)]
+    links = [p for p in candidates if os.path.islink(p)]
+
+    assert len(real) == 1, (
+        f"want exactly 1 real interpreter binary in {bin_dir}, "
+        f"got {len(real)}: {real}"
+    )
+    assert len(links) >= 2, (
+        f"want >=2 python* symlinks in {bin_dir}, "
+        f"got {len(links)}: {links}"
+    )
+    for s in links:
+        target = os.path.realpath(s)
+        assert target == real[0], (
+            f"symlink {s} resolves to {target}, expected {real[0]}"
+        )
+
+
+def verify_no_dangling_symlinks(root=None):
+    if root is None:
+        root = sys.prefix
+    dangling = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        for name in filenames + dirnames:
+            p = os.path.join(dirpath, name)
+            if os.path.islink(p) and not os.path.exists(p):
+                dangling.append((p, os.readlink(p)))
+    assert not dangling, (
+        f"{len(dangling)} dangling symlink(s) under {root}:\n"
+        + "\n".join(f"  {p} -> {t}" for p, t in dangling[:10])
+        + ("\n  ..." if len(dangling) > 10 else "")
+    )
+
+
+def verify_in_venv():
+    assert sys.base_prefix != sys.prefix, (
+        f"not running in a venv: sys.base_prefix == sys.prefix == {sys.prefix}"
+    )
+
+
+def verify_sys_path():
+    missing = []
+    for p in sys.path:
+        if not p:
+            continue  # The empty entry means "current working directory".
+        if os.path.exists(p):
+            continue
+        # Python prepends `pythonX.Y.zip` to sys.path speculatively; the
+        # file doesn't have to exist on disk for stdlib lookups to work.
+        if p.endswith(".zip"):
+            continue
+        missing.append(p)
+    assert not missing, (
+        "missing sys.path entries:\n" + "\n".join(f"  {p}" for p in missing)
+    )
+
+
+def verify_imports(packages):
+    for name in packages:
+        mod = importlib.import_module(name)
+        path = getattr(mod, "__file__", None)
+        assert path is not None, (
+            f"{name} imported as a namespace package (likely __init__.py "
+            f"is unreadable or missing — chase the underlying symlinks)"
+        )
+
+
+def verify_all(imports=()):
+    verify_interpreter_symlinks()
+    verify_no_dangling_symlinks()
+    verify_in_venv()
+    verify_sys_path()
+    verify_imports(imports)
+
+
+if __name__ == "__main__":
+    verify_all()
+    print(
+        f"verify_venv: ok bin_dir={os.path.dirname(os.path.realpath(sys.executable))}"
+    )


### PR DESCRIPTION
This is a basic "verify venv is good" util that can be run in any venv, including within containers. This should catch errors such as the `py_image_layer` bug in #960 that converts symlinks (2/3 of the python binaries) into non-symlinks.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
