### PR TITLE
fix(uv): sanitize all chars invalid in Bazel repo names

### DIFF
--- a/e2e/cases/uv-plus-version/BUILD.bazel
+++ b/e2e/cases/uv-plus-version/BUILD.bazel
@@ -8,6 +8,7 @@ py_test(
     python_version = "3.12",
     deps = [
         "@pypi_uv_plus_version//jaxlib",
+        "@pypi_uv_plus_version//metomi_isodatetime",
     ],
 )
 
@@ -21,5 +22,6 @@ py_test(
     python_version = "3.12",
     deps = [
         "@pypi_uv_plus_version//jaxlib",
+        "@pypi_uv_plus_version//metomi_isodatetime",
     ],
 )

--- a/e2e/cases/uv-plus-version/__test__.py
+++ b/e2e/cases/uv-plus-version/__test__.py
@@ -1,8 +1,15 @@
 from importlib.metadata import version
 
-# Verify the package is installed in the venv - regression test for versions containing '+'
-# Previously, a version like "0.4.25+cuda11.cudnn86" would produce an invalid Bazel repo
-# name because '+' is not allowed in repo names.
+# Regression test for PEP 440 versions with characters invalid in Bazel repo
+# names. normalize_version must sanitize any character outside [A-Za-z0-9_-]
+# to '_', otherwise the generated repo name is malformed and the build fails.
+#
+#   jaxlib "0.4.25+cuda11.cudnn86" exercises '+' (local-version segment).
+#   metomi-isodatetime "1!3.1.0"   exercises '!' (PEP 440 epoch).
 jaxlib_version = version("jaxlib")
 assert jaxlib_version == "0.4.25+cuda11.cudnn86", "version is " + jaxlib_version
-print("jaxlib (version 0.4.25+cuda11.cudnn86) found - regression test passed!")
+
+isodatetime_version = version("metomi-isodatetime")
+assert isodatetime_version == "1!3.1.0", "version is " + isodatetime_version
+
+print("odd-version regression test passed!")

--- a/e2e/cases/uv-plus-version/pyproject.toml
+++ b/e2e/cases/uv-plus-version/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.12"
 dependencies = [
     "jaxlib",
+    "metomi-isodatetime",
 ]
 
 [[tool.uv.index]]

--- a/e2e/cases/uv-plus-version/setup.MODULE.bazel
+++ b/e2e/cases/uv-plus-version/setup.MODULE.bazel
@@ -1,4 +1,4 @@
-"""Versions containing '+' must not produce invalid Bazel repo names."""
+"""PEP 440 versions with chars invalid in Bazel repo names (e.g. '+', '!') must be normalized."""
 
 uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
 uv.declare_hub(hub_name = "pypi_uv_plus_version")

--- a/e2e/cases/uv-plus-version/uv.lock
+++ b/e2e/cases/uv-plus-version/uv.lock
@@ -11,12 +11,25 @@ wheels = [
 ]
 
 [[package]]
+name = "metomi-isodatetime"
+version = "1!3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/cc/e910e3e8616807dfb9a526e2887623398fee67c987a2112aee103bd120f5/metomi-isodatetime-1!3.1.0.tar.gz", hash = "sha256:2ec15eb9c323d5debd0678f33af99bc9a91aa0b534ee5f65f3487aed518ebf2d", size = 74350, upload-time = "2023-10-05T12:14:39.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5f/8446ce923b5aa995e5fbd75af4f00cc6666fd16883add8c9644b4f89ef04/metomi_isodatetime-1!3.1.0-py3-none-any.whl", hash = "sha256:837880717817d0325703b9b3ce94093fc92fc7ac18cd14f9fe389f2d21266407", size = 81676, upload-time = "2023-10-05T12:14:37.634Z" },
+]
+
+[[package]]
 name = "plus-version"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jaxlib" },
+    { name = "metomi-isodatetime" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "jaxlib" }]
+requires-dist = [
+    { name = "jaxlib" },
+    { name = "metomi-isodatetime" },
+]

--- a/uv/private/BUILD.bazel
+++ b/uv/private/BUILD.bazel
@@ -1,9 +1,12 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load(":normalize_version_test.bzl", "normalize_version_test_suite")
 
 package(default_visibility = [
     "//docs:__pkg__",
     "//uv/private:__subpackages__",
 ])
+
+normalize_version_test_suite()
 
 bzl_library(
     name = "sha1",

--- a/uv/private/normalize_version.bzl
+++ b/uv/private/normalize_version.bzl
@@ -14,4 +14,10 @@ def normalize_version(version):
     Returns:
         a normalized version as a string.
     """
-    return version.replace(".", "_").replace("+", "_")
+    acc = []
+    for c in version.elems():
+        if c.isalnum() or c == "-" or c == "_":
+            acc.append(c)
+        else:
+            acc.append("_")
+    return "".join(acc)

--- a/uv/private/normalize_version_test.bzl
+++ b/uv/private/normalize_version_test.bzl
@@ -1,0 +1,32 @@
+"""Tests for normalize_version.bzl."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":normalize_version.bzl", "normalize_version")
+
+# Bazel repo-name components may only contain these characters.
+_VALID_REPO_NAME_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_."
+
+def _is_valid_repo_name_component(s):
+    for i in range(len(s)):
+        if s[i] not in _VALID_REPO_NAME_CHARS:
+            return False
+    return True
+
+def _normalize_version_epoch_test_impl(ctx):
+    """PEP 440 epoch versions (e.g. ``1!2.0``) must not leak ``!`` into repo names."""
+    env = unittest.begin(ctx)
+    out = normalize_version("1!2.0")
+    asserts.true(
+        env,
+        _is_valid_repo_name_component(out),
+        "normalize_version(%r) = %r contains characters invalid in a Bazel repo name" % ("1!2.0", out),
+    )
+    return unittest.end(env)
+
+normalize_version_epoch_test = unittest.make(_normalize_version_epoch_test_impl)
+
+def normalize_version_test_suite():
+    unittest.suite(
+        "normalize_version_tests",
+        normalize_version_epoch_test,
+    )


### PR DESCRIPTION
`normalize_version()` previously only replaced '.' and '+'. PEP 440 allows other characters that are invalid in Bazel repo names — most notably '!' in epoch versions like '1!2.0' — which would leak through and produce an invalid repo name (e.g. 'sdist_build__pkg__1!2_0'). Sanitize anything outside [A-Za-z0-9_-] to '_'.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
