### PR TITLE
test: register llvm toolchains in e2e test module

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -60,6 +60,9 @@ use_repo(tools, "rules_py_tools")
 
 register_toolchains("@rules_py_tools//:all")
 
+# CC toolchain for native sdist builds (e.g. cdifflib, pyahocorasick).
+register_toolchains("@llvm//toolchain:all")
+
 # For the OCI tests
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(


### PR DESCRIPTION
On BCR when `is_release = True` this gets [marked as dev](https://github.com/aspect-build/rules_py/blob/v2.0.0-alpha.0/MODULE.bazel#L117-L120) in the root MODULE so must be properly declared in tests.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
