### PR TITLE
test: bazel_env integration with the current Python toolchain

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -92,6 +92,7 @@ uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
 # Per-case MODULE fragments. Each redeclares its own use_extension(...) proxies.
 include("//cases/arch-alias-marker:setup.MODULE.bazel")
 include("//cases/cross-repo-610:setup.MODULE.bazel")
+include("//cases/current-py-toolchain-bazel-env-896:setup.MODULE.bazel")
 include("//cases/firebase-admin-import:setup.MODULE.bazel")
 include("//cases/freethreaded-805:setup.MODULE.bazel")
 include("//cases/multi-project-hub:setup.MODULE.bazel")

--- a/e2e/cases/current-py-toolchain-bazel-env-896/BUILD.bazel
+++ b/e2e/cases/current-py-toolchain-bazel-env-896/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@bazel_env.bzl", "bazel_env")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+bazel_env(
+    name = "python_env",
+    toolchains = {
+        "python": "@python_interpreters//:current_py_toolchain",
+    },
+    tools = {
+        "python3": "$(PYTHON3)",
+    },
+)
+
+exports_files(["test.sh"])
+
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+    data = [
+        ":python_env",
+        ":python_env/toolchains/python",
+    ],
+    tags = [
+        "local",
+        "no-sandbox",
+    ],
+)

--- a/e2e/cases/current-py-toolchain-bazel-env-896/setup.MODULE.bazel
+++ b/e2e/cases/current-py-toolchain-bazel-env-896/setup.MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "bazel_env.bzl", version = "0.7.2", dev_dependency = True)

--- a/e2e/cases/current-py-toolchain-bazel-env-896/test.sh
+++ b/e2e/cases/current-py-toolchain-bazel-env-896/test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+execroot="${TEST_SRCDIR%/bazel-out/*}"
+
+status_script="${execroot}/bazel-out/bazel_env-opt/bin/cases/current-py-toolchain-bazel-env-896/python_env.sh"
+if [[ ! -f "${status_script}" ]]; then
+    echo "ERROR: status script not found at ${status_script}"
+    exit 1
+fi
+echo "OK: status script exists at ${status_script}"
+
+if grep -q "python" "${status_script}"; then
+    echo "OK: status script mentions python toolchain"
+else
+    echo "ERROR: status script does not mention python toolchain"
+    exit 1
+fi
+
+toolchain_symlink="${execroot}/bazel-out/bazel_env-opt/bin/cases/current-py-toolchain-bazel-env-896/python_env/toolchains/python"
+if [[ ! -L "${toolchain_symlink}" ]]; then
+    echo "ERROR: toolchain symlink not found at ${toolchain_symlink}"
+    exit 1
+fi
+echo "OK: toolchain symlink exists at ${toolchain_symlink}"
+
+toolchain_python="${toolchain_symlink}/bin/python3"
+if [[ ! -f "${toolchain_python}" ]]; then
+    echo "ERROR: interpreter not found at ${toolchain_python}"
+    exit 1
+fi
+echo "OK: interpreter exists at ${toolchain_python}"
+
+if "${toolchain_python}" -c 'import sys; print(sys.version)'; then
+    echo "OK: interpreter executed successfully"
+else
+    echo "ERROR: interpreter failed to execute"
+    exit 1
+fi
+
+echo "PASS"
+exit 0


### PR DESCRIPTION
Verifies that bazel_env can consume @python_interpreters//:current_py_toolchain and correctly generates the expected tool launchers and toolchain symlinks.