### PR TITLE
docs: update IDE Integration section for v2.0 venv model

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,18 +306,46 @@ bazel build //:image --platforms=//platforms:linux_amd64
 
 ## IDE Integration
 
-`aspect_rules_py` generates standard virtualenv structures that IDEs understand:
+`aspect_rules_py` generates standard virtualenv structures that IDEs understand.
+In v2.0 the venv targets that the v1.x docs auto-emitted alongside every
+`py_binary` are opt-in — declare them on the targets you actually want your
+IDE to follow.
 
-```bash
-# Creates a .venv symlink for the target
-bazel run //:my_app.venv
+```starlark
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_venv_link")
+
+py_binary(
+    name = "my_app",
+    srcs = ["main.py"],
+    main = "main.py",
+    expose_venv = True,        # publishes :my_app.venv
+)
+
+py_venv_link(
+    name = "my_app.venv_link",
+    venv = ":my_app.venv",
+)
 ```
 
-Then point your IDE to the generated virtualenv:
+Two distinct targets, two distinct purposes:
 
-- **VSCode**: Set `python.defaultInterpreterPath` to the `.venv` path
-- **PyCharm**: Add the `.venv` as a Python interpreter
+- `bazel run //:my_app.venv` — drops you into the hermetic interpreter REPL
+  with the venv activated. Useful for ad-hoc Python sessions matching your
+  binary's deps.
+- `bazel run //:my_app.venv_link` — materialises a workspace-local symlink
+  pointing at the venv tree under `bazel-bin`. **This is what your IDE should
+  point at.**
+
+Then point your IDE to the symlinked virtualenv:
+
+- **VSCode**: Set `python.defaultInterpreterPath` to the symlinked path
+- **PyCharm**: Add the symlinked venv as a Python interpreter
 - **Neovim/LSP**: Configure `python-lsp-server` or `pyright` to use the virtualenv
+
+> **Migrating from v1.x?** `py_binary` no longer auto-emits a `.venv` sibling.
+> The runnable-symlink behavior of v1.x's `bazel run //:my_app.venv` is now
+> split into `expose_venv = True` (publish the venv target) + a separate
+> `py_venv_link` (publish the symlink-creation runnable).
 
 ### Debugger Support (VSCode/PyCharm)
 


### PR DESCRIPTION
The IDE Integration section in the README still described v1.x behavior where `py_binary` auto-emitted a runnable `.venv` sibling whose `bazel run` created a workspace-local symlink. That behavior was removed in #981 — the venv sibling is now opt-in (`expose_venv = True`), and the symlink-creation step is a separate `py_venv_link` macro.

This is a real source of user confusion: a v2.0.0-alpha1 user followed the README's instructions, ran `bazel run //:my_app.venv`, got a Python REPL instead of a symlink, and asked in Slack whether it was a bug. It's not — the docs just haven't caught up.

Rewrites the section to show the two targets, what each does, and adds a short migration callout for v1.x users.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no (docs-only)

### Test plan

- Covered by existing test cases (the `expose_venv` + `py_venv_link` shapes documented here are exercised by `py/tests/expose-venv-api/` and the runtime symlink behavior is covered elsewhere).