### PR TITLE
feat(py): expose_venv_link convenience attr for py_binary / py_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,23 +311,20 @@ In v2.0 the venv targets that the v1.x docs auto-emitted alongside every
 `py_binary` are opt-in — declare them on the targets you actually want your
 IDE to follow.
 
+The recommended one-liner:
+
 ```starlark
-load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_venv_link")
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(
     name = "my_app",
     srcs = ["main.py"],
     main = "main.py",
-    expose_venv = True,        # publishes :my_app.venv
-)
-
-py_venv_link(
-    name = "my_app.venv_link",
-    venv = ":my_app.venv",
+    expose_venv_link = True,   # publishes :my_app.venv + :my_app.venv_link
 )
 ```
 
-Two distinct targets, two distinct purposes:
+`expose_venv_link = True` emits two sibling targets:
 
 - `bazel run //:my_app.venv` — drops you into the hermetic interpreter REPL
   with the venv activated. Useful for ad-hoc Python sessions matching your
@@ -342,10 +339,32 @@ Then point your IDE to the symlinked virtualenv:
 - **PyCharm**: Add the symlinked venv as a Python interpreter
 - **Neovim/LSP**: Configure `python-lsp-server` or `pyright` to use the virtualenv
 
+### Underlying mechanism
+
+`expose_venv_link = True` is sugar for the explicit two-target shape:
+
+```starlark
+py_binary(
+    name = "my_app",
+    srcs = ["main.py"],
+    main = "main.py",
+    expose_venv = True,
+)
+
+py_venv_link(
+    name = "my_app.venv_link",
+    venv = ":my_app.venv",
+)
+```
+
+Reach for the explicit form when you want to customise `py_venv_link`'s
+`link_name`, point it at a standalone `py_venv` (declared independently
+of any binary, useful for an IDE-only environment), or selectively skip
+the link target on a subset of binaries.
+
 > **Migrating from v1.x?** `py_binary` no longer auto-emits a `.venv` sibling.
-> The runnable-symlink behavior of v1.x's `bazel run //:my_app.venv` is now
-> split into `expose_venv = True` (publish the venv target) + a separate
-> `py_venv_link` (publish the symlink-creation runnable).
+> Add `expose_venv_link = True` for the equivalent IDE-symlink behavior,
+> or use the explicit two-target form when you want fine-grained control.
 
 ### Debugger Support (VSCode/PyCharm)
 

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -83,7 +83,9 @@ def py_binary(name, srcs = [], main = None, **kwargs):
     rule that exec's that venv's interpreter. Set `expose_venv = True`
     to make the sibling a first-class `:{name}.venv` target — runnable
     (`bazel run :{name}.venv` drops into the hermetic interpreter) and
-    pairable with `py_venv_link` for IDE integration.
+    pairable with `py_venv_link` for IDE integration. For the common
+    case where you want both the venv target *and* an IDE-pointable
+    workspace symlink in one step, set `expose_venv_link = True`.
 
     Args:
         name: Name of the rule.
@@ -100,7 +102,7 @@ def py_binary(name, srcs = [], main = None, **kwargs):
             output happens to be `<name>.py`), the macro can't see that
             and you must pass `main =` explicitly.
         **kwargs: additional named parameters forwarded to the
-            underlying rule and the sibling py_venv. One extra is
+            underlying rule and the sibling py_venv. Two extras are
             handled by this macro:
 
             * `expose_venv` (bool, default `False`) — when `True`, emit
@@ -108,10 +110,17 @@ def py_binary(name, srcs = [], main = None, **kwargs):
               attrs (deps, imports, package_collisions,
               include_*_site_packages, interpreter_options). The `.venv`
               target is runnable (`bazel run :{name}.venv` drops into
-              the hermetic interpreter). To also materialise the venv as
-              a workspace-local symlink for IDE integration, declare an
-              explicit `py_venv_link(name = "...", venv = ":{name}.venv")`
-              target.
+              the hermetic interpreter).
+            * `expose_venv_link` (bool, default `False`) — when `True`,
+              additionally emit a `:{name}.venv_link` py_venv_link.
+              `bazel run :{name}.venv_link` materialises a
+              workspace-local symlink to the venv tree, suitable for an
+              IDE's interpreter setting. Implies `expose_venv = True`;
+              passing `expose_venv = False, expose_venv_link = True`
+              explicitly is rejected with a clear error. Equivalent to
+              declaring an explicit
+              `py_venv_link(name = "{name}.venv_link", venv = ":{name}.venv")`
+              alongside the binary.
     """
 
     # For a clearer DX when updating resolutions, the resolutions dict is "string" -> "label",

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -313,7 +313,7 @@ def _split_kwargs_for_venv(kwargs):
             venv_kwargs[name] = kwargs[name]
     return venv_kwargs
 
-def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], imports = [], tags = None, testonly = None, visibility = None, isolated = True, expose_venv = False, **kwargs):
+def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], imports = [], tags = None, testonly = None, visibility = None, isolated = True, expose_venv = None, expose_venv_link = False, **kwargs):
     """Split `py_rule(name, ...)` into a sibling py_venv target + a
     `py_rule` call routed at it via the internal `venv` rule
     attribute. Called for every `py_binary` / `py_test` macro invocation.
@@ -321,12 +321,28 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], im
     `expose_venv = True` emits a public `:{name}.venv` py_venv:
     runnable (`bazel run :{name}.venv` drops into the hermetic
     interpreter) and pairable with `py_venv_link` for IDE integration.
-    The venv inherits the binary's visibility.
+    The venv inherits the binary's visibility. Default `None` (unset);
+    treated as `False` unless `expose_venv_link = True` promotes it.
+
+    `expose_venv_link = True` additionally emits a public
+    `:{name}.venv_link` py_venv_link. `bazel run :{name}.venv_link`
+    materialises a workspace-local symlink at the venv's tree under
+    `bazel-bin`, suitable for pointing an IDE at. Implies
+    `expose_venv = True` — the link target needs a public venv to point
+    at. Passing `expose_venv = False, expose_venv_link = True`
+    explicitly is contradictory and fails.
 
     All venv-shaping attrs (`deps`, `imports`, `package_collisions`,
     `include_*_site_packages`, `interpreter_options`) land on the
     sibling venv.
     """
+    if expose_venv_link:
+        if expose_venv == False:
+            fail("py_binary/py_test {!r}: expose_venv_link = True requires a public venv to link, but expose_venv = False was passed explicitly. Drop expose_venv = False, or set expose_venv_link = False.".format(name))
+        expose_venv = True
+    else:
+        expose_venv = bool(expose_venv)
+
     venv_kwargs = _split_kwargs_for_venv(kwargs)
     venv_kwargs["srcs"] = srcs
     venv_kwargs["deps"] = deps
@@ -352,6 +368,15 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], im
         tags = venv_tags,
         **venv_kwargs
     )
+
+    if expose_venv_link:
+        py_venv_link(
+            name = "{}.venv_link".format(name),
+            venv = ":" + venv_label,
+            tags = tags,
+            testonly = testonly,
+            visibility = visibility,
+        )
 
     py_rule(
         name = name,

--- a/py/tests/expose-venv-api/BUILD.bazel
+++ b/py/tests/expose-venv-api/BUILD.bazel
@@ -51,6 +51,22 @@ py_binary(
     ],
 )
 
+# `expose_venv_link = True` implies `expose_venv = True` and additionally
+# emits a `:{name}.venv_link` py_venv_link.
+py_binary(
+    name = "link_bin",
+    srcs = ["main.py"],
+    expose_venv_link = True,
+    main = "main.py",
+)
+
+py_test(
+    name = "link_test",
+    srcs = ["main.py"],
+    expose_venv_link = True,
+    main = "main.py",
+)
+
 build_test(
     name = "expose_venv_api_build_test",
     targets = [
@@ -62,5 +78,11 @@ build_test(
         ":legacy_shape_bin.venv",
         ":venv_shaping_bin",
         ":venv_shaping_bin.venv",
+        ":link_bin",
+        ":link_bin.venv",
+        ":link_bin.venv_link",
+        ":link_test",
+        ":link_test.venv",
+        ":link_test.venv_link",
     ],
 )


### PR DESCRIPTION
**Stacked on #1052** (the README v2.0 IDE Integration rewrite). Review #1052 first.

Adds an `expose_venv_link = True` attr to `py_binary` / `py_test` as a convenience for the common IDE-integration shape. Equivalent to writing:

```starlark
py_binary(name = "app", srcs = [...], expose_venv = True)
py_venv_link(name = "app.venv_link", venv = ":app.venv")
```

…but on one rule. `expose_venv_link = True` implies `expose_venv = True` — the link target needs a public venv to point at.

### Why

In v2.0 the runnable-symlink behavior moved from automatic to opt-in across two separate declarations. The two-target shape is fine when you want fine control (custom `link_name`, standalone IDE-only venv, selective opt-out per binary), but it's boilerplate for the dominant case: "I have one binary, I want my IDE to follow its venv."

`expose_venv_link = True` collapses that to one attr. The two-target form stays available unchanged.

### What changed

- [py/private/py_venv/py_venv.bzl](https://github.com/aspect-build/rules_py/blob/feat/py-binary-expose-venv-link/py/private/py_venv/py_venv.bzl) — `py_binary_with_venv` accepts `expose_venv_link`, fans it out into a `py_venv_link` sibling.
- [py/defs.bzl](https://github.com/aspect-build/rules_py/blob/feat/py-binary-expose-venv-link/py/defs.bzl) — docstring on `py_binary` documents the new attr; `py_test` inherits via the same macro path.
- [py/tests/expose-venv-api/BUILD.bazel](https://github.com/aspect-build/rules_py/blob/feat/py-binary-expose-venv-link/py/tests/expose-venv-api/BUILD.bazel) — adds `link_bin` and `link_test` cases exercising the new attr; `build_test` asserts the `:_.venv` + `:_.venv_link` sibling targets analyze.
- [README.md](https://github.com/aspect-build/rules_py/blob/feat/py-binary-expose-venv-link/README.md) — updates the IDE Integration section (which #1052 introduces) to lead with the one-liner and explain the two-target form as the underlying mechanism + escape hatch.

### Behavior on `expose_venv = False, expose_venv_link = True`

The macro's `expose_venv` parameter defaults to `None` (not `False`), which lets the implementation distinguish "user didn't pass it" from "user explicitly said False":

- `expose_venv` unset (defaulted to `None`), `expose_venv_link = True` → promotes `expose_venv` to `True`. Publishes both `:_.venv` and `:_.venv_link`.
- `expose_venv = True, expose_venv_link = True` → publishes both.
- `expose_venv = False, expose_venv_link = True` → `fail()` at macro-evaluation time with a clear error pointing at the contradiction. The user gets to fix the typo immediately rather than wondering why `False` was ignored.
- Both unset or `False` → just emits the existing internal `_:<name>.venv` (no public targets).

### Naming

Picked `expose_venv_link` over alternatives (`link_venv`, `venv_link`, `expose_venv = "link"`) for visual parallelism with the existing `expose_venv`. The two attrs are clearly related and the relationship is in the name.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- (`py`): `py_binary` / `py_test` accept a new `expose_venv_link = True` attr that emits both `:<name>.venv` (runnable hermetic interpreter) AND `:<name>.venv_link` (`bazel run` materialises a workspace-local symlink for IDE integration). Convenience for the common shape; the underlying two-target form (`expose_venv = True` + a separate `py_venv_link`) remains available unchanged.

### Test plan

- `bazel test //...` in main repo: 185 pass (3 new cases in `py/tests/expose-venv-api/` cover the new attr).
- Manual: `bazel run //py/tests/expose-venv-api:link_bin.venv_link` materialises the workspace symlink.
