### PR TITLE
docs: fix misleading debugger support section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,16 +317,25 @@ Then point your IDE to the generated virtualenv:
 
 ### Debugger Support (VSCode/PyCharm)
 
-Attach debuggers using `debugpy`:
+Attach DAP-compatible debuggers (VSCode, PyCharm, Neovim, etc.) using
+[debugpy](https://github.com/microsoft/debugpy). This requires a wrapper
+entrypoint that starts a debugpy listener before running your application —
+simply adding `debugpy` to `deps` is not enough.
 
-```starlark
-# In debug mode, wraps the binary with debugpy listener
-py_binary(
-    name = "app_debug",
-    srcs = ["main.py"],
-    deps = ["//:lib", "@pypi//debugpy"],
-    env = {"DEBUGPY_WAIT": "1"},  # Wait for IDE attachment
-)
+See the [complete debugger example](examples/debugger/) for a working
+setup, including a `py_debuggable_binary` macro that handles the wrapper
+generation automatically.
+
+Quick overview:
+
+```sh
+cd examples/debugger
+
+# Start with debugpy listener, wait for IDE to attach:
+DEBUGPY_WAIT=1 bazel run //:app
+
+# Release mode — no debugpy, runs directly:
+bazel run //:app --config=release
 ```
 
 VSCode `launch.json`:


### PR DESCRIPTION
## Summary

The README's "Debugger Support" section shows a plain `py_binary` with `debugpy` in `deps` and `DEBUGPY_WAIT` in `env`, implying this works out of the box. It doesn't — `py_binary`'s Bash launcher has no debugpy integration, so the env var is set but nothing reads it. Users need the `py_debuggable_binary` macro from `examples/debugger/` which generates a wrapper entrypoint that actually starts the debugpy listener.

This PR updates the README to:
- Clarify that a wrapper entrypoint is required (not just adding `debugpy` to `deps`)
- Point to the `examples/debugger/` directory for the complete working setup
- Show the correct CLI usage from the example

## Context

We hit this at CTC while setting up debugpy support in our monorepo. After following the README's instructions, `DEBUGPY_WAIT=1 bazelisk run //:app` started the app without any debugger — the env var was silently ignored. We traced it to the launcher template (`py_binary.tmpl.sh`) which has no `DEBUGPY_WAIT` handling, and eventually found the working implementation in `examples/debugger/`.

We ended up porting the `py_debuggable_binary` pattern into our build rules with one improvement: our version is **runtime-gated** — the debugpy listener only activates when `DEBUGPY_WAIT=1` or `DEBUGPY=1` is set, making it safe to use on targets that are also deployed as OCI images (no open debug port in production). Happy to submit a follow-up PR to upstream this improvement, potentially as part of the ruleset itself rather than just an example, if there's interest.