### PR TITLE
fix: point pyvenv.cfg home= directly at PBS bin/ to fix sys.base_prefix on Python 3.11/3.12

### DIFF
--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
@@ -69,10 +69,10 @@ files:
   - -rwxr-xr-x  0 0      0        4342 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info
-  - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1274 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_bin.venv
-  - -rwxr-xr-x  0 0      0        5759 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
+  - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3-3.11
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/idle3 -> idle3.11

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
@@ -61,12 +61,12 @@ files:
   - -rwxr-xr-x  0 0      0        4342 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info
-  - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1274 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_bin.venv
   - -rwxr-xr-x  0 0      0          42 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/__init__.py
   - -rwxr-xr-x  0 0      0          31 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/palette.txt
-  - -rwxr-xr-x  0 0      0        5759 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
+  - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3-3.11
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/idle3 -> idle3.11

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
@@ -85,7 +85,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks -> ../../../_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info -> ../../../_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info
-  - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1280 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_multi_bin.venv
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
@@ -63,9 +63,9 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/7d3c346c/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         327 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
-  - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        5759 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
+  - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3-3.11
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/idle3 -> idle3.11

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
@@ -63,9 +63,9 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/7d3c346c/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         327 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
-  - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         247 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        5759 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
+  - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_aarch64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_aarch64_unknown_linux_gnu/bin/2to3-3.11
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_aarch64_unknown_linux_gnu/bin/idle3 -> idle3.11

--- a/e2e/cases/pbs-symlink-prefix-1048/BUILD.bazel
+++ b/e2e/cases/pbs-symlink-prefix-1048/BUILD.bazel
@@ -1,0 +1,22 @@
+"""Regression tests for issue #1048.
+
+Verify that sys.base_prefix correctly resolves to the PBS installation
+directory in the runfiles tree, not the PBS compile-time /install sentinel.
+Affected: Python 3.11 and 3.12 with python-build-standalone.
+"""
+
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+[
+    py_test(
+        name = "test_{}".format(version.replace(".", "")),
+        srcs = ["test_pbs_prefix.py"],
+        main = "test_pbs_prefix.py",
+        python_version = version,
+        deps = ["//tools/verify_venv"],
+    )
+    for version in [
+        "3.11",
+        "3.12",
+    ]
+]

--- a/e2e/cases/pbs-symlink-prefix-1048/test_pbs_prefix.py
+++ b/e2e/cases/pbs-symlink-prefix-1048/test_pbs_prefix.py
@@ -1,0 +1,48 @@
+"""Regression test for issue #1048: PBS symlink chain breaks sys.base_prefix.
+
+Python 3.11/3.12 reimplemented prefix discovery in pure Python (getpath.py).
+Its resolvedpath() has a bug with multi-hop relative symlinks that traverse
+.. components across repo boundaries — the exact shape of the venv's
+bin/python → ../../../../interpreter_repo/bin/python3.11 chain.
+
+When resolution fails, Python falls back to the compiled-in /install prefix
+(absent at runtime), causing:
+    ModuleNotFoundError: No module named 'encodings'
+
+The fix: pyvenv.cfg's home= key now points directly to the PBS bin/ directory,
+so Python only resolves the local python → python3.11 symlink (one hop).
+"""
+
+import os
+import sys
+
+from verify_venv import verify_all, verify_base_prefix, verify_in_venv
+
+
+def test_base_prefix_not_install():
+    assert sys.base_prefix != "/install", (
+        f"sys.base_prefix is '/install' (the PBS compile-time prefix). "
+        f"Python {sys.version_info.major}.{sys.version_info.minor} failed to "
+        f"resolve the pyvenv.cfg home= symlink chain."
+    )
+
+
+def test_base_prefix_has_stdlib():
+    stdlib = os.path.join(
+        sys.base_prefix,
+        "lib",
+        f"python{sys.version_info.major}.{sys.version_info.minor}",
+    )
+    assert os.path.isdir(stdlib), (
+        f"stdlib missing: {stdlib!r} (sys.base_prefix={sys.base_prefix!r})"
+    )
+
+
+if __name__ == "__main__":
+    verify_all()
+    test_base_prefix_not_install()
+    test_base_prefix_has_stdlib()
+    print(
+        f"OK: sys.base_prefix={sys.base_prefix!r}, "
+        f"Python {sys.version_info.major}.{sys.version_info.minor}"
+    )

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
@@ -88,7 +88,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2 -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs
-  - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0          66 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/_app_bin.venv
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.12

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
@@ -88,7 +88,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2 -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs
-  - -rwxr-xr-x  0 0      0         160 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         247 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0          66 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/_app_bin.venv
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_aarch64_unknown_linux_gnu/bin/2to3 -> 2to3-3.12

--- a/e2e/tools/verify_venv/verify_venv.py
+++ b/e2e/tools/verify_venv/verify_venv.py
@@ -108,6 +108,26 @@ def verify_in_venv():
     )
 
 
+def verify_base_prefix():
+    """sys.base_prefix must not be the PBS compile-time /install sentinel."""
+    assert sys.base_prefix != "/install", (
+        f"sys.base_prefix is '/install' (the PBS compile-time prefix) instead of "
+        f"the real interpreter installation. Python {sys.version} failed to resolve "
+        f"the runfiles symlink chain in pyvenv.cfg's home= key."
+    )
+    assert os.path.isdir(sys.base_prefix), (
+        f"sys.base_prefix={sys.base_prefix!r} does not exist on disk"
+    )
+    stdlib_dir = os.path.join(
+        sys.base_prefix,
+        "lib",
+        f"python{sys.version_info.major}.{sys.version_info.minor}",
+    )
+    assert os.path.isdir(stdlib_dir), (
+        f"stdlib not found at {stdlib_dir!r} (sys.base_prefix={sys.base_prefix!r})"
+    )
+
+
 def verify_sys_path():
     missing = []
     for p in sys.path:
@@ -139,6 +159,7 @@ def verify_all(imports=()):
     verify_interpreter_symlinks()
     verify_no_dangling_symlinks()
     verify_in_venv()
+    verify_base_prefix()
     verify_sys_path()
     verify_imports(imports)
 

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -420,19 +420,29 @@ def assemble_venv(
     )
     declared.append(site_packages_pth_file)
 
-    # pyvenv.cfg. `home = ./bin/` points at the venv's own bin dir
-    # (relative to pyvenv.cfg's location), so Python finds our bin/python
-    # symlink there and follows it to locate the real interpreter and
-    # derive sys.base_prefix.
+    # pyvenv.cfg. For hermetic interpreters, point `home` directly at the PBS
+    # bin/ directory rather than ./bin/ (the venv's own deep runfiles symlink).
+    # Python 3.11/3.12's pure-Python resolvedpath() in getpath.py fails on
+    # multi-hop relative symlinks across repo boundaries, falling back to the
+    # compile-time /install prefix → ModuleNotFoundError: No module named
+    # 'encodings'. One local hop (python → python3.11 within PBS bin/) works.
+    if py_toolchain.runfiles_interpreter:
+        pbs_rlocation = to_rlocation_path(ctx, py_toolchain.python)
+        pbs_bin_dir = "/".join(pbs_rlocation.split("/")[:-1])
+        pyvenv_home = "{}/{}".format(venv_to_runfiles_escape, pbs_bin_dir)
+    else:
+        pyvenv_home = "./bin"
+
     pyvenv_cfg = ctx.actions.declare_file("{}/pyvenv.cfg".format(venv_name))
     ctx.actions.write(
         output = pyvenv_cfg,
-        content = ("home = ./bin/\n" +
+        content = ("home = {home}\n" +
                    "implementation = CPython\n" +
                    "version_info = {major}.{minor}.{micro}\n" +
                    "include-system-site-packages = {include_system}\n" +
                    "aspect-include-user-site-packages = {include_user}\n" +
                    "relocatable = true\n").format(
+            home = pyvenv_home,
             major = py_toolchain.interpreter_version_info.major,
             minor = py_toolchain.interpreter_version_info.minor,
             micro = py_toolchain.interpreter_version_info.micro,


### PR DESCRIPTION
Fix #1048

## Problem: [#1048 ](https://github.com/aspect-build/rules_py/issues/1048)

  Python 3.11/3.12 reimplemented prefix discovery as pure Python (`Modules/getpath.py`).
  Its `resolvedpath()` correctly handles one-level local symlinks but has a bug with
  multi-hop relative symlinks that traverse `..` components across repository boundaries —
  exactly the shape that `venv/bin/python` produces:

  venv/bin/python → ../../../../interpreter_repo/bin/python3.11

  When resolution fails, Python falls back to the PBS compile-time prefix `/install`,
  which does not exist at runtime:

  ModuleNotFoundError: No module named 'encodings'

  Python 3.9/3.10 used C code (correct). Python 3.13 fixed the bug. Only 3.11 and 3.12
  are affected.

  ## Fix

  Change `pyvenv.cfg`'s `home =` key for hermetic (runfiles-based) interpreters from
  `./bin/` to a relative path that points **directly** at the PBS `bin/` directory:

  home = ../../../../aspect_rules_py++python_interpreters+.../bin

  This means `getpath.py` only needs to resolve `bin/python → python3.11` — a single
  local hop within the PBS package — which works correctly in all Python versions.

  System (non-hermetic) interpreters keep `home = ./bin` unchanged.

  ## Changes

  - `py/private/py_venv/venv.bzl` — compute `pyvenv_home` from the interpreter's
    rlocation path for hermetic toolchains; fall back to `./bin` for system interpreters
  - `e2e/tools/verify_venv/verify_venv.py` — add `verify_base_prefix()` asserting
    `sys.base_prefix != "/install"` and that the stdlib dir exists; call it from
    `verify_all()`
  - `e2e/cases/pbs-symlink-prefix-1048/` — regression tests for Python 3.11 and 3.12
  - OCI layer snapshots updated to reflect the new `pyvenv.cfg` and `verify_venv.py` sizes
