### PR TITLE
fix(ci): use 9.x not 9.* for the Bazel 9 test matrix version

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -60,7 +60,7 @@ jobs:
                 - { path: "examples/uv_pip_compile", slug: "examples-uv_pip_compile", runner: "ubuntu-latest" }
                 bazel:
                 - { id: "bazel-8", version: "8.x", flags: "--bazel-flag=--test_tag_filters=-skip-on-bazel8" }
-                - { id: "bazel-9", version: "9.*", flags: "--bazel-flag=--test_tag_filters=-skip-on-bazel9" }
+                - { id: "bazel-9", version: "9.x", flags: "--bazel-flag=--test_tag_filters=-skip-on-bazel9" }
                 exclude:
                 - { workspace: { slug: "examples-uv_pip_compile" }, bazel: { id: "bazel-9" } }
         env:


### PR DESCRIPTION
`9.*` is not valid Bazelisk wildcard syntax — Bazelisk uses `X.x` / `X.Y.x`. The `bazel-8` row in this same matrix already uses `8.x`, and every sibling ruleset (rules_ts, rules_jest, rules_esbuild, rules_rollup, …) pins `9.x`.
---


### Changes are visible to end-users: no

### Test plan

- CI (the bazel-9 test matrix jobs should now resolve a real release and pass)