### PR TITLE
fix(uv): restore Bazel 7 compatibility by replacing set() with a bazel_features-aware compat shim

### DIFF
--- a/uv/private/BUILD.bazel
+++ b/uv/private/BUILD.bazel
@@ -15,6 +15,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "compat",
+    srcs = ["compat.bzl"],
+    deps = ["@bazel_features//:features"],
+)
+
+bzl_library(
     name = "normalize_name",
     srcs = ["normalize_name.bzl"],
     deps = [],

--- a/uv/private/compat.bzl
+++ b/uv/private/compat.bzl
@@ -1,0 +1,19 @@
+load("@bazel_features//:features.bzl", features = "bazel_features")
+
+# bazel_features generates globals.bzl at repository evaluation time:
+# - Bazel 8+: _native_set is the built-in set() constructor (O(1) membership)
+# - Bazel 7:  _native_set is None (dict-backed fallback below)
+_native_set = features.globals.set
+
+def new_set():
+    """Returns an empty set, using native set() on Bazel 8+ or a dict on Bazel 7."""
+    if _native_set != None:
+        return _native_set()
+    return {}
+
+def set_add(s, item):
+    """Inserts item into a set produced by new_set()."""
+    if _native_set != None:
+        s.add(item)
+    else:
+        s[item] = None

--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -37,6 +37,7 @@ bzl_library(
     srcs = ["graph_utils.bzl"],
     visibility = ["//uv:__subpackages__"],
     deps = [
+        "//uv/private:compat",
         "//uv/private:sha1",
         "//uv/private/graph:sccs",
     ],

--- a/uv/private/extension/graph_utils.bzl
+++ b/uv/private/extension/graph_utils.bzl
@@ -1,3 +1,4 @@
+load("//uv/private:compat.bzl", "new_set", "set_add")
 load("//uv/private:sha1.bzl", "sha1")
 load("//uv/private/graph:sccs.bzl", "sccs")
 
@@ -22,11 +23,11 @@ def collect_sccs(marker_graph):
           dependencies.
     """
 
-    all_nodes = set()
+    all_nodes = new_set()
     for pkg, deps in marker_graph.items():
-        all_nodes.add(pkg)
+        set_add(all_nodes, pkg)
         for dep in deps.keys():
-            all_nodes.add(dep)
+            set_add(all_nodes, dep)
 
     simplified_graph = {node: [] for node in all_nodes}
     for pkg, deps in marker_graph.items():

--- a/uv/private/uv_project/BUILD.bazel
+++ b/uv/private/uv_project/BUILD.bazel
@@ -9,6 +9,7 @@ bzl_library(
     name = "repository",
     srcs = ["repository.bzl"],
     deps = [
+        "//uv/private:compat",
         "//uv/private:sha1",
         "//uv/private/pprint:defs",
         "@bazel_features//:features",

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -3,6 +3,7 @@
 """
 
 load("@bazel_features//:features.bzl", features = "bazel_features")
+load("//uv/private:compat.bzl", "new_set", "set_add")
 load("//uv/private:sha1.bzl", "sha1")
 load("//uv/private/pprint:defs.bzl", "pprint")
 
@@ -90,10 +91,10 @@ alias(
     venv_content = []
 
     # Collect all unique cfgs first
-    all_cfgs = set()
+    all_cfgs = new_set()
     for dep, cfgs in dep_to_scc.items():
         for cfg in cfgs.keys():
-            all_cfgs.add(cfg)
+            set_add(all_cfgs, cfg)
 
     for cfg_name in all_cfgs:
         venv_content.append(


### PR DESCRIPTION
## Problem

  Users on Bazel 7 hit a load-time error in `graph_utils.bzl` and
  `uv_project/repository.bzl` because `set()` is a Starlark built-in
  that was only introduced in Bazel 8. Any workspace still on Bazel 7
  fails immediately with:

      name 'set' is not defined

  ## Solution

  Adds `uv/private/compat.bzl`, a thin shim that uses `bazel_features`
  (already a project dependency) to select the right implementation at
  repository evaluation time:

  - **Bazel 8+**: delegates to the native `set()` constructor — O(1)
    membership, zero overhead.
  - **Bazel 7**: falls back to a plain dict used as a set, which is the
    standard Starlark idiom and fully compatible.

  Iteration (`for x in s`) and membership (`x in s`) work identically on
  both a native set and a dict, so call-site ergonomics are unchanged.

  ## Affected files

  - `uv/private/compat.bzl` — new shim (new_set / set_add)
  - `uv/private/extension/graph_utils.bzl` — was line 25
  - `uv/private/uv_project/repository.bzl` — was line 93


---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
