### PR TITLE
chore: add benchmark to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,3 +2,4 @@ e2e/
 examples/dev_deps/
 examples/debugger/
 examples/uv_pip_compile/
+benchmark/


### PR DESCRIPTION
Add beanchmark to .bazelignore

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
