### PR TITLE
 Fix PBS encodings error by making pyvenv.cfg home absolute at runtime

### DIFF
--- a/e2e/snapshots/project_single.BUILD.bazel
+++ b/e2e/snapshots/project_single.BUILD.bazel
@@ -42,6 +42,7 @@ alias(
     name = "cowsay",
     actual = select({
         "//private/dep_group:single_project_hub": ":_package_cowsay_single_project_hub",
+        "//conditions:default": ":_package_cowsay_single_project_hub",
     }),
     visibility = ["//visibility:public"],
 )
@@ -51,6 +52,7 @@ alias(
     name = "cowsay_whl",
     actual = select({
         "//private/dep_group:single_project_hub": ":_package_cowsay_single_project_hub_whl",
+        "//conditions:default": ":_package_cowsay_single_project_hub_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -88,6 +90,7 @@ alias(
     name = "single_project_hub",
     actual = select({
         "//private/dep_group:single_project_hub": ":_package_single_project_hub_single_project_hub",
+        "//conditions:default": ":_package_single_project_hub_single_project_hub",
     }),
     visibility = ["//visibility:public"],
 )
@@ -97,6 +100,7 @@ alias(
     name = "single_project_hub_whl",
     actual = select({
         "//private/dep_group:single_project_hub": ":_package_single_project_hub_single_project_hub_whl",
+        "//conditions:default": ":_package_single_project_hub_single_project_hub_whl",
     }),
     visibility = ["//visibility:public"],
 )

--- a/e2e/snapshots/pypi_single.cowsay.BUILD.bazel
+++ b/e2e/snapshots/pypi_single.cowsay.BUILD.bazel
@@ -18,6 +18,7 @@ alias(
     name = "whl",
     actual = select({
           "//dep_group:single_project_hub": "@project__single_project_hub//:cowsay_whl",
+          "//conditions:default": "@project__single_project_hub//:cowsay_whl",
       }),
     target_compatible_with = select(compatible_with(["single_project_hub"])),
     visibility = ["//visibility:public"],
@@ -31,6 +32,7 @@ alias(
     name = "cowsay",
     actual = select({
           "//dep_group:single_project_hub": "@project__single_project_hub//:cowsay",
+          "//conditions:default": "@project__single_project_hub//:cowsay",
       },
         no_match_error = "Available only in dep_groups: single_project_hub",
     ),

--- a/e2e/snapshots/pypi_single.defs.bzl
+++ b/e2e/snapshots/pypi_single.defs.bzl
@@ -9,21 +9,33 @@ def compatible_with(venvs, extra_constraints = []):
     if v not in VIRTUALENVS:
       fail("Errant virtualenv reference %r" % v)
 
-  return {
+  result = {
     Label("//dep_group:" + it): extra_constraints
     for it in venvs
-  } | {
-    "//conditions:default": ["@platforms//:incompatible"],
   }
+
+  # When a package is only available in a single virtualenv, allow it to be
+  # used without an explicit dep_group selection for convenience.
+  if len(venvs) == 1:
+    result["//conditions:default"] = extra_constraints
+  else:
+    result["//conditions:default"] = ["@platforms//:incompatible"]
+
+  return result
 
 def incompatible_with(venvs, extra_constraints = []):
   for v in venvs:
     if v not in VIRTUALENVS:
       fail("Errant virtualenv reference %r" % v)
 
-  return {
+  result = {
     Label("//dep_group:" + it): ["@platforms//:incompatible"]
     for it in venvs
-  } | {
-    "//conditions:default": extra_constraints,
   }
+
+  if len(venvs) == 1:
+    result["//conditions:default"] = extra_constraints
+  else:
+    result["//conditions:default"] = ["@platforms//:incompatible"]
+
+  return result

--- a/py/private/py_venv/run.tmpl.sh
+++ b/py/private/py_venv/run.tmpl.sh
@@ -13,4 +13,60 @@ set -o errexit -o nounset -o pipefail
 VENV_PYTHON="$(rlocation {{ARG_VENV_PYTHON}})"
 export PATH="$(dirname "${VENV_PYTHON}"):${PATH-}"
 
+VENV_DIR="$(dirname "$(dirname "${VENV_PYTHON}")")"
+
+# Python 3.11/3.12 PBS: getpath.py fails to resolve multi-hop relative symlinks
+# that cross runfiles boundaries, falling back to the /install prefix.
+# PYTHONHOME is also ignored in that path. Fix: rewrite pyvenv.cfg with an
+# absolute home= so getpath.py discovers the stdlib without following symlinks.
+PYTHONHOME=""
+if [ -L "${VENV_PYTHON}" ]; then
+    # Resolve the symlink chain to the real interpreter.
+    if command -v readlink >/dev/null 2>&1 && readlink -f "${VENV_PYTHON}" >/dev/null 2>&1; then
+        REAL_PYTHON="$(readlink -f "${VENV_PYTHON}")"
+    elif command -v realpath >/dev/null 2>&1; then
+        REAL_PYTHON="$(realpath "${VENV_PYTHON}")"
+    else
+        # Portable fallback: walk symlink chain manually and normalize with cd/pwd
+        REAL_PYTHON="${VENV_PYTHON}"
+        while [ -L "${REAL_PYTHON}" ]; do
+            DIR="$(dirname "${REAL_PYTHON}")"
+            TARGET="$(readlink "${REAL_PYTHON}")"
+            if [ "${TARGET#/}" != "${TARGET}" ]; then
+                REAL_PYTHON="${TARGET}"
+            else
+                REAL_PYTHON="${DIR}/${TARGET}"
+            fi
+            # Normalize .. components
+            REAL_PYTHON="$(cd "$(dirname "${REAL_PYTHON}")" && pwd -P)/$(basename "${REAL_PYTHON}")"
+        done
+    fi
+    PBS_BIN="$(dirname "${REAL_PYTHON}")"
+    PYTHONHOME="$(dirname "${PBS_BIN}")"
+
+    if [ -e "${VENV_DIR}/pyvenv.cfg" ] || [ -L "${VENV_DIR}/pyvenv.cfg" ]; then
+        PYVENV_TMP="${VENV_DIR}/.pyvenv.cfg.$$"
+        if [ -r "${VENV_DIR}/pyvenv.cfg" ]; then
+            while IFS= read -r line || [ -n "$line" ]; do
+                case "$line" in
+                    home\ =*) echo "home = ${PBS_BIN}" ;;
+                    *) echo "$line" ;;
+                esac
+            done < "${VENV_DIR}/pyvenv.cfg" > "${PYVENV_TMP}"
+        else
+            cat > "${PYVENV_TMP}" <<EOF
+home = ${PBS_BIN}
+implementation = CPython
+include-system-site-packages = false
+aspect-include-user-site-packages = false
+relocatable = true
+EOF
+        fi
+        mv -f "${PYVENV_TMP}" "${VENV_DIR}/pyvenv.cfg"
+    fi
+fi
+if [ -n "${PYTHONHOME}" ]; then
+    export PYTHONHOME
+fi
+
 exec "${VENV_PYTHON}" {{INTERPRETER_FLAGS}} "$(rlocation {{ENTRYPOINT}})" "$@"

--- a/py/tests/snapshots/run.launcher.sh
+++ b/py/tests/snapshots/run.launcher.sh
@@ -25,4 +25,60 @@ set -o errexit -o nounset -o pipefail
 VENV_PYTHON="$(rlocation _main/py/tests/.snapshot_venv/bin/python)"
 export PATH="$(dirname "${VENV_PYTHON}"):${PATH-}"
 
+VENV_DIR="$(dirname "$(dirname "${VENV_PYTHON}")")"
+
+# Python 3.11/3.12 PBS: getpath.py fails to resolve multi-hop relative symlinks
+# that cross runfiles boundaries, falling back to the /install prefix.
+# PYTHONHOME is also ignored in that path. Fix: rewrite pyvenv.cfg with an
+# absolute home= so getpath.py discovers the stdlib without following symlinks.
+PYTHONHOME=""
+if [ -L "${VENV_PYTHON}" ]; then
+    # Resolve the symlink chain to the real interpreter.
+    if command -v readlink >/dev/null 2>&1 && readlink -f "${VENV_PYTHON}" >/dev/null 2>&1; then
+        REAL_PYTHON="$(readlink -f "${VENV_PYTHON}")"
+    elif command -v realpath >/dev/null 2>&1; then
+        REAL_PYTHON="$(realpath "${VENV_PYTHON}")"
+    else
+        # Portable fallback: walk symlink chain manually and normalize with cd/pwd
+        REAL_PYTHON="${VENV_PYTHON}"
+        while [ -L "${REAL_PYTHON}" ]; do
+            DIR="$(dirname "${REAL_PYTHON}")"
+            TARGET="$(readlink "${REAL_PYTHON}")"
+            if [ "${TARGET#/}" != "${TARGET}" ]; then
+                REAL_PYTHON="${TARGET}"
+            else
+                REAL_PYTHON="${DIR}/${TARGET}"
+            fi
+            # Normalize .. components
+            REAL_PYTHON="$(cd "$(dirname "${REAL_PYTHON}")" && pwd -P)/$(basename "${REAL_PYTHON}")"
+        done
+    fi
+    PBS_BIN="$(dirname "${REAL_PYTHON}")"
+    PYTHONHOME="$(dirname "${PBS_BIN}")"
+
+    if [ -e "${VENV_DIR}/pyvenv.cfg" ] || [ -L "${VENV_DIR}/pyvenv.cfg" ]; then
+        PYVENV_TMP="${VENV_DIR}/.pyvenv.cfg.$$"
+        if [ -r "${VENV_DIR}/pyvenv.cfg" ]; then
+            while IFS= read -r line || [ -n "$line" ]; do
+                case "$line" in
+                    home\ =*) echo "home = ${PBS_BIN}" ;;
+                    *) echo "$line" ;;
+                esac
+            done < "${VENV_DIR}/pyvenv.cfg" > "${PYVENV_TMP}"
+        else
+            cat > "${PYVENV_TMP}" <<EOF
+home = ${PBS_BIN}
+implementation = CPython
+include-system-site-packages = false
+aspect-include-user-site-packages = false
+relocatable = true
+EOF
+        fi
+        mv -f "${PYVENV_TMP}" "${VENV_DIR}/pyvenv.cfg"
+    fi
+fi
+if [ -n "${PYTHONHOME}" ]; then
+    export PYTHONHOME
+fi
+
 exec "${VENV_PYTHON}" -B -I "$(rlocation _main/py/tests/main.py)" "$@"

--- a/uv/private/uv_hub/repository.bzl
+++ b/uv/private/uv_hub/repository.bzl
@@ -109,6 +109,13 @@ load("//:defs.bzl", "compatible_with")
             for cfg, l in specs.items()
         }
 
+        # When a package is only available in a single virtualenv, allow it to
+        # resolve without an explicit dep_group selection.
+        if len(specs) == 1:
+            single_cfg = list(specs.keys())[0]
+            select_spec["//conditions:default"] = specs[single_cfg]
+            whl_select_spec["//conditions:default"] = specs[single_cfg] + "_whl"
+
         error = "Available only in dep_groups: " + ", ".join(specs.keys())  # Simplified error string
 
         # When the package itself is named "pkg", the `:{name}` alias below already
@@ -181,24 +188,36 @@ def compatible_with(venvs, extra_constraints = []):
     if v not in VIRTUALENVS:
       fail("Errant virtualenv reference %r" % v)
 
-  return {{
+  result = {{
     Label("//dep_group:" + it): extra_constraints
     for it in venvs
-  }} | {{
-    "//conditions:default": ["@platforms//:incompatible"],
   }}
+
+  # When a package is only available in a single virtualenv, allow it to be
+  # used without an explicit dep_group selection for convenience.
+  if len(venvs) == 1:
+    result["//conditions:default"] = extra_constraints
+  else:
+    result["//conditions:default"] = ["@platforms//:incompatible"]
+
+  return result
 
 def incompatible_with(venvs, extra_constraints = []):
   for v in venvs:
     if v not in VIRTUALENVS:
       fail("Errant virtualenv reference %r" % v)
 
-  return {{
+  result = {{
     Label("//dep_group:" + it): ["@platforms//:incompatible"]
     for it in venvs
-  }} | {{
-    "//conditions:default": extra_constraints,
   }}
+
+  if len(venvs) == 1:
+    result["//conditions:default"] = extra_constraints
+  else:
+    result["//conditions:default"] = ["@platforms//:incompatible"]
+
+  return result
 """.format(
             configurations = pprint(repository_ctx.attr.configurations.keys()),
             repo_name = repr(repository_ctx.name),

--- a/uv/private/uv_hub/snapshots/project.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/project.BUILD.bazel
@@ -42,6 +42,7 @@ alias(
     name = "arrow",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_arrow_aspect_rules_py",
+        "//conditions:default": ":_package_arrow_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -51,6 +52,7 @@ alias(
     name = "arrow_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_arrow_aspect_rules_py_whl",
+        "//conditions:default": ":_package_arrow_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -88,6 +90,7 @@ alias(
     name = "asgiref",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_asgiref_aspect_rules_py",
+        "//conditions:default": ":_package_asgiref_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -97,6 +100,7 @@ alias(
     name = "asgiref_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_asgiref_aspect_rules_py_whl",
+        "//conditions:default": ":_package_asgiref_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -134,6 +138,7 @@ alias(
     name = "aspect_rules_py",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_aspect_rules_py_aspect_rules_py",
+        "//conditions:default": ":_package_aspect_rules_py_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -143,6 +148,7 @@ alias(
     name = "aspect_rules_py_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_aspect_rules_py_aspect_rules_py_whl",
+        "//conditions:default": ":_package_aspect_rules_py_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -180,6 +186,7 @@ alias(
     name = "attrs",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_attrs_aspect_rules_py",
+        "//conditions:default": ":_package_attrs_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -189,6 +196,7 @@ alias(
     name = "attrs_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_attrs_aspect_rules_py_whl",
+        "//conditions:default": ":_package_attrs_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -226,6 +234,7 @@ alias(
     name = "bazel_runfiles",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_bazel_runfiles_aspect_rules_py",
+        "//conditions:default": ":_package_bazel_runfiles_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -235,6 +244,7 @@ alias(
     name = "bazel_runfiles_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_bazel_runfiles_aspect_rules_py_whl",
+        "//conditions:default": ":_package_bazel_runfiles_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -272,6 +282,7 @@ alias(
     name = "boto3",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_boto3_aspect_rules_py",
+        "//conditions:default": ":_package_boto3_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -281,6 +292,7 @@ alias(
     name = "boto3_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_boto3_aspect_rules_py_whl",
+        "//conditions:default": ":_package_boto3_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -318,6 +330,7 @@ alias(
     name = "botocore",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_botocore_aspect_rules_py",
+        "//conditions:default": ":_package_botocore_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -327,6 +340,7 @@ alias(
     name = "botocore_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_botocore_aspect_rules_py_whl",
+        "//conditions:default": ":_package_botocore_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -364,6 +378,7 @@ alias(
     name = "bravado",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_bravado_aspect_rules_py",
+        "//conditions:default": ":_package_bravado_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -373,6 +388,7 @@ alias(
     name = "bravado_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_bravado_aspect_rules_py_whl",
+        "//conditions:default": ":_package_bravado_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -410,6 +426,7 @@ alias(
     name = "bravado_core",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_bravado_core_aspect_rules_py",
+        "//conditions:default": ":_package_bravado_core_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -419,6 +436,7 @@ alias(
     name = "bravado_core_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_bravado_core_aspect_rules_py_whl",
+        "//conditions:default": ":_package_bravado_core_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -456,6 +474,7 @@ alias(
     name = "build",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_build_aspect_rules_py",
+        "//conditions:default": ":_package_build_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -465,6 +484,7 @@ alias(
     name = "build_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_build_aspect_rules_py_whl",
+        "//conditions:default": ":_package_build_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -502,6 +522,7 @@ alias(
     name = "certifi",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_certifi_aspect_rules_py",
+        "//conditions:default": ":_package_certifi_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -511,6 +532,7 @@ alias(
     name = "certifi_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_certifi_aspect_rules_py_whl",
+        "//conditions:default": ":_package_certifi_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -548,6 +570,7 @@ alias(
     name = "charset_normalizer",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_charset_normalizer_aspect_rules_py",
+        "//conditions:default": ":_package_charset_normalizer_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -557,6 +580,7 @@ alias(
     name = "charset_normalizer_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_charset_normalizer_aspect_rules_py_whl",
+        "//conditions:default": ":_package_charset_normalizer_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -594,6 +618,7 @@ alias(
     name = "click",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_click_aspect_rules_py",
+        "//conditions:default": ":_package_click_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -603,6 +628,7 @@ alias(
     name = "click_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_click_aspect_rules_py_whl",
+        "//conditions:default": ":_package_click_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -642,6 +668,7 @@ alias(
     name = "colorama",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_colorama_aspect_rules_py",
+        "//conditions:default": ":_package_colorama_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -651,6 +678,7 @@ alias(
     name = "colorama_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_colorama_aspect_rules_py_whl",
+        "//conditions:default": ":_package_colorama_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -688,6 +716,7 @@ alias(
     name = "coverage",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_coverage_aspect_rules_py",
+        "//conditions:default": ":_package_coverage_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -697,6 +726,7 @@ alias(
     name = "coverage_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_coverage_aspect_rules_py_whl",
+        "//conditions:default": ":_package_coverage_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -734,6 +764,7 @@ alias(
     name = "cowsay",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_cowsay_aspect_rules_py",
+        "//conditions:default": ":_package_cowsay_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -743,6 +774,7 @@ alias(
     name = "cowsay_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_cowsay_aspect_rules_py_whl",
+        "//conditions:default": ":_package_cowsay_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -780,6 +812,7 @@ alias(
     name = "django",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_django_aspect_rules_py",
+        "//conditions:default": ":_package_django_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -789,6 +822,7 @@ alias(
     name = "django_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_django_aspect_rules_py_whl",
+        "//conditions:default": ":_package_django_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -826,6 +860,7 @@ alias(
     name = "exceptiongroup",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_exceptiongroup_aspect_rules_py",
+        "//conditions:default": ":_package_exceptiongroup_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -835,6 +870,7 @@ alias(
     name = "exceptiongroup_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_exceptiongroup_aspect_rules_py_whl",
+        "//conditions:default": ":_package_exceptiongroup_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -872,6 +908,7 @@ alias(
     name = "fqdn",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_fqdn_aspect_rules_py",
+        "//conditions:default": ":_package_fqdn_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -881,6 +918,7 @@ alias(
     name = "fqdn_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_fqdn_aspect_rules_py_whl",
+        "//conditions:default": ":_package_fqdn_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -918,6 +956,7 @@ alias(
     name = "ftfy",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_ftfy_aspect_rules_py",
+        "//conditions:default": ":_package_ftfy_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -927,6 +966,7 @@ alias(
     name = "ftfy_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_ftfy_aspect_rules_py_whl",
+        "//conditions:default": ":_package_ftfy_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -964,6 +1004,7 @@ alias(
     name = "future",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_future_aspect_rules_py",
+        "//conditions:default": ":_package_future_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -973,6 +1014,7 @@ alias(
     name = "future_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_future_aspect_rules_py_whl",
+        "//conditions:default": ":_package_future_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1010,6 +1052,7 @@ alias(
     name = "gitdb",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_gitdb_aspect_rules_py",
+        "//conditions:default": ":_package_gitdb_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1019,6 +1062,7 @@ alias(
     name = "gitdb_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_gitdb_aspect_rules_py_whl",
+        "//conditions:default": ":_package_gitdb_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1056,6 +1100,7 @@ alias(
     name = "gitpython",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_gitpython_aspect_rules_py",
+        "//conditions:default": ":_package_gitpython_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1065,6 +1110,7 @@ alias(
     name = "gitpython_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_gitpython_aspect_rules_py_whl",
+        "//conditions:default": ":_package_gitpython_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1102,6 +1148,7 @@ alias(
     name = "idna",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_idna_aspect_rules_py",
+        "//conditions:default": ":_package_idna_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1111,6 +1158,7 @@ alias(
     name = "idna_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_idna_aspect_rules_py_whl",
+        "//conditions:default": ":_package_idna_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1148,6 +1196,7 @@ alias(
     name = "importlib_metadata",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_importlib_metadata_aspect_rules_py",
+        "//conditions:default": ":_package_importlib_metadata_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1157,6 +1206,7 @@ alias(
     name = "importlib_metadata_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_importlib_metadata_aspect_rules_py_whl",
+        "//conditions:default": ":_package_importlib_metadata_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1194,6 +1244,7 @@ alias(
     name = "iniconfig",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_iniconfig_aspect_rules_py",
+        "//conditions:default": ":_package_iniconfig_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1203,6 +1254,7 @@ alias(
     name = "iniconfig_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_iniconfig_aspect_rules_py_whl",
+        "//conditions:default": ":_package_iniconfig_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1240,6 +1292,7 @@ alias(
     name = "isoduration",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_isoduration_aspect_rules_py",
+        "//conditions:default": ":_package_isoduration_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1249,6 +1302,7 @@ alias(
     name = "isoduration_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_isoduration_aspect_rules_py_whl",
+        "//conditions:default": ":_package_isoduration_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1286,6 +1340,7 @@ alias(
     name = "jmespath",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jmespath_aspect_rules_py",
+        "//conditions:default": ":_package_jmespath_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1295,6 +1350,7 @@ alias(
     name = "jmespath_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jmespath_aspect_rules_py_whl",
+        "//conditions:default": ":_package_jmespath_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1332,6 +1388,7 @@ alias(
     name = "jsonpointer",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jsonpointer_aspect_rules_py",
+        "//conditions:default": ":_package_jsonpointer_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1341,6 +1398,7 @@ alias(
     name = "jsonpointer_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jsonpointer_aspect_rules_py_whl",
+        "//conditions:default": ":_package_jsonpointer_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1378,6 +1436,7 @@ alias(
     name = "jsonref",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jsonref_aspect_rules_py",
+        "//conditions:default": ":_package_jsonref_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1387,6 +1446,7 @@ alias(
     name = "jsonref_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jsonref_aspect_rules_py_whl",
+        "//conditions:default": ":_package_jsonref_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1424,6 +1484,7 @@ alias(
     name = "jsonschema",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jsonschema_aspect_rules_py",
+        "//conditions:default": ":_package_jsonschema_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1433,6 +1494,7 @@ alias(
     name = "jsonschema_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jsonschema_aspect_rules_py_whl",
+        "//conditions:default": ":_package_jsonschema_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1470,6 +1532,7 @@ alias(
     name = "jsonschema_specifications",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jsonschema_specifications_aspect_rules_py",
+        "//conditions:default": ":_package_jsonschema_specifications_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1479,6 +1542,7 @@ alias(
     name = "jsonschema_specifications_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_jsonschema_specifications_aspect_rules_py_whl",
+        "//conditions:default": ":_package_jsonschema_specifications_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1516,6 +1580,7 @@ alias(
     name = "maturin",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_maturin_aspect_rules_py",
+        "//conditions:default": ":_package_maturin_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1525,6 +1590,7 @@ alias(
     name = "maturin_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_maturin_aspect_rules_py_whl",
+        "//conditions:default": ":_package_maturin_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1562,6 +1628,7 @@ alias(
     name = "monotonic",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_monotonic_aspect_rules_py",
+        "//conditions:default": ":_package_monotonic_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1571,6 +1638,7 @@ alias(
     name = "monotonic_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_monotonic_aspect_rules_py_whl",
+        "//conditions:default": ":_package_monotonic_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1608,6 +1676,7 @@ alias(
     name = "msgpack",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_msgpack_aspect_rules_py",
+        "//conditions:default": ":_package_msgpack_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1617,6 +1686,7 @@ alias(
     name = "msgpack_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_msgpack_aspect_rules_py_whl",
+        "//conditions:default": ":_package_msgpack_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1654,6 +1724,7 @@ alias(
     name = "neptune",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_neptune_aspect_rules_py",
+        "//conditions:default": ":_package_neptune_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1663,6 +1734,7 @@ alias(
     name = "neptune_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_neptune_aspect_rules_py_whl",
+        "//conditions:default": ":_package_neptune_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1700,6 +1772,7 @@ alias(
     name = "numpy",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_numpy_aspect_rules_py",
+        "//conditions:default": ":_package_numpy_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1709,6 +1782,7 @@ alias(
     name = "numpy_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_numpy_aspect_rules_py_whl",
+        "//conditions:default": ":_package_numpy_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1746,6 +1820,7 @@ alias(
     name = "oauthlib",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_oauthlib_aspect_rules_py",
+        "//conditions:default": ":_package_oauthlib_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1755,6 +1830,7 @@ alias(
     name = "oauthlib_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_oauthlib_aspect_rules_py_whl",
+        "//conditions:default": ":_package_oauthlib_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1792,6 +1868,7 @@ alias(
     name = "packaging",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_packaging_aspect_rules_py",
+        "//conditions:default": ":_package_packaging_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1801,6 +1878,7 @@ alias(
     name = "packaging_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_packaging_aspect_rules_py_whl",
+        "//conditions:default": ":_package_packaging_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1838,6 +1916,7 @@ alias(
     name = "pandas",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pandas_aspect_rules_py",
+        "//conditions:default": ":_package_pandas_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1847,6 +1926,7 @@ alias(
     name = "pandas_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pandas_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pandas_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1884,6 +1964,7 @@ alias(
     name = "pillow",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pillow_aspect_rules_py",
+        "//conditions:default": ":_package_pillow_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1893,6 +1974,7 @@ alias(
     name = "pillow_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pillow_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pillow_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1930,6 +2012,7 @@ alias(
     name = "pkg",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pkg_aspect_rules_py",
+        "//conditions:default": ":_package_pkg_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1939,6 +2022,7 @@ alias(
     name = "pkg_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pkg_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pkg_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1976,6 +2060,7 @@ alias(
     name = "pluggy",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pluggy_aspect_rules_py",
+        "//conditions:default": ":_package_pluggy_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -1985,6 +2070,7 @@ alias(
     name = "pluggy_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pluggy_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pluggy_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2022,6 +2108,7 @@ alias(
     name = "psutil",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_psutil_aspect_rules_py",
+        "//conditions:default": ":_package_psutil_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2031,6 +2118,7 @@ alias(
     name = "psutil_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_psutil_aspect_rules_py_whl",
+        "//conditions:default": ":_package_psutil_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2068,6 +2156,7 @@ alias(
     name = "pyjwt",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pyjwt_aspect_rules_py",
+        "//conditions:default": ":_package_pyjwt_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2077,6 +2166,7 @@ alias(
     name = "pyjwt_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pyjwt_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pyjwt_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2114,6 +2204,7 @@ alias(
     name = "pyproject_hooks",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pyproject_hooks_aspect_rules_py",
+        "//conditions:default": ":_package_pyproject_hooks_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2123,6 +2214,7 @@ alias(
     name = "pyproject_hooks_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pyproject_hooks_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pyproject_hooks_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2160,6 +2252,7 @@ alias(
     name = "pytest",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pytest_aspect_rules_py",
+        "//conditions:default": ":_package_pytest_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2169,6 +2262,7 @@ alias(
     name = "pytest_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pytest_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pytest_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2206,6 +2300,7 @@ alias(
     name = "python_dateutil",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_python_dateutil_aspect_rules_py",
+        "//conditions:default": ":_package_python_dateutil_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2215,6 +2310,7 @@ alias(
     name = "python_dateutil_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_python_dateutil_aspect_rules_py_whl",
+        "//conditions:default": ":_package_python_dateutil_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2252,6 +2348,7 @@ alias(
     name = "pytz",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pytz_aspect_rules_py",
+        "//conditions:default": ":_package_pytz_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2261,6 +2358,7 @@ alias(
     name = "pytz_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pytz_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pytz_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2298,6 +2396,7 @@ alias(
     name = "pyyaml",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pyyaml_aspect_rules_py",
+        "//conditions:default": ":_package_pyyaml_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2307,6 +2406,7 @@ alias(
     name = "pyyaml_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_pyyaml_aspect_rules_py_whl",
+        "//conditions:default": ":_package_pyyaml_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2344,6 +2444,7 @@ alias(
     name = "referencing",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_referencing_aspect_rules_py",
+        "//conditions:default": ":_package_referencing_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2353,6 +2454,7 @@ alias(
     name = "referencing_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_referencing_aspect_rules_py_whl",
+        "//conditions:default": ":_package_referencing_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2390,6 +2492,7 @@ alias(
     name = "requests",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_requests_aspect_rules_py",
+        "//conditions:default": ":_package_requests_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2399,6 +2502,7 @@ alias(
     name = "requests_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_requests_aspect_rules_py_whl",
+        "//conditions:default": ":_package_requests_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2436,6 +2540,7 @@ alias(
     name = "requests_oauthlib",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_requests_oauthlib_aspect_rules_py",
+        "//conditions:default": ":_package_requests_oauthlib_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2445,6 +2550,7 @@ alias(
     name = "requests_oauthlib_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_requests_oauthlib_aspect_rules_py_whl",
+        "//conditions:default": ":_package_requests_oauthlib_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2482,6 +2588,7 @@ alias(
     name = "rfc3339_validator",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_rfc3339_validator_aspect_rules_py",
+        "//conditions:default": ":_package_rfc3339_validator_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2491,6 +2598,7 @@ alias(
     name = "rfc3339_validator_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_rfc3339_validator_aspect_rules_py_whl",
+        "//conditions:default": ":_package_rfc3339_validator_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2528,6 +2636,7 @@ alias(
     name = "rfc3986_validator",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_rfc3986_validator_aspect_rules_py",
+        "//conditions:default": ":_package_rfc3986_validator_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2537,6 +2646,7 @@ alias(
     name = "rfc3986_validator_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_rfc3986_validator_aspect_rules_py_whl",
+        "//conditions:default": ":_package_rfc3986_validator_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2574,6 +2684,7 @@ alias(
     name = "rpds_py",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_rpds_py_aspect_rules_py",
+        "//conditions:default": ":_package_rpds_py_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2583,6 +2694,7 @@ alias(
     name = "rpds_py_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_rpds_py_aspect_rules_py_whl",
+        "//conditions:default": ":_package_rpds_py_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2620,6 +2732,7 @@ alias(
     name = "s3transfer",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_s3transfer_aspect_rules_py",
+        "//conditions:default": ":_package_s3transfer_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2629,6 +2742,7 @@ alias(
     name = "s3transfer_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_s3transfer_aspect_rules_py_whl",
+        "//conditions:default": ":_package_s3transfer_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2666,6 +2780,7 @@ alias(
     name = "setuptools",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_setuptools_aspect_rules_py",
+        "//conditions:default": ":_package_setuptools_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2675,6 +2790,7 @@ alias(
     name = "setuptools_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_setuptools_aspect_rules_py_whl",
+        "//conditions:default": ":_package_setuptools_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2712,6 +2828,7 @@ alias(
     name = "simplejson",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_simplejson_aspect_rules_py",
+        "//conditions:default": ":_package_simplejson_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2721,6 +2838,7 @@ alias(
     name = "simplejson_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_simplejson_aspect_rules_py_whl",
+        "//conditions:default": ":_package_simplejson_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2758,6 +2876,7 @@ alias(
     name = "six",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_six_aspect_rules_py",
+        "//conditions:default": ":_package_six_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2767,6 +2886,7 @@ alias(
     name = "six_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_six_aspect_rules_py_whl",
+        "//conditions:default": ":_package_six_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2804,6 +2924,7 @@ alias(
     name = "smmap",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_smmap_aspect_rules_py",
+        "//conditions:default": ":_package_smmap_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2813,6 +2934,7 @@ alias(
     name = "smmap_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_smmap_aspect_rules_py_whl",
+        "//conditions:default": ":_package_smmap_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2850,6 +2972,7 @@ alias(
     name = "snakesay",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_snakesay_aspect_rules_py",
+        "//conditions:default": ":_package_snakesay_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2859,6 +2982,7 @@ alias(
     name = "snakesay_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_snakesay_aspect_rules_py_whl",
+        "//conditions:default": ":_package_snakesay_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2896,6 +3020,7 @@ alias(
     name = "sqlparse",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_sqlparse_aspect_rules_py",
+        "//conditions:default": ":_package_sqlparse_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2905,6 +3030,7 @@ alias(
     name = "sqlparse_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_sqlparse_aspect_rules_py_whl",
+        "//conditions:default": ":_package_sqlparse_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2942,6 +3068,7 @@ alias(
     name = "swagger_spec_validator",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_swagger_spec_validator_aspect_rules_py",
+        "//conditions:default": ":_package_swagger_spec_validator_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2951,6 +3078,7 @@ alias(
     name = "swagger_spec_validator_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_swagger_spec_validator_aspect_rules_py_whl",
+        "//conditions:default": ":_package_swagger_spec_validator_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2988,6 +3116,7 @@ alias(
     name = "tomli",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_tomli_aspect_rules_py",
+        "//conditions:default": ":_package_tomli_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -2997,6 +3126,7 @@ alias(
     name = "tomli_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_tomli_aspect_rules_py_whl",
+        "//conditions:default": ":_package_tomli_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3034,6 +3164,7 @@ alias(
     name = "types_python_dateutil",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_types_python_dateutil_aspect_rules_py",
+        "//conditions:default": ":_package_types_python_dateutil_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3043,6 +3174,7 @@ alias(
     name = "types_python_dateutil_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_types_python_dateutil_aspect_rules_py_whl",
+        "//conditions:default": ":_package_types_python_dateutil_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3081,6 +3213,7 @@ alias(
     name = "typing_extensions",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_typing_extensions_aspect_rules_py",
+        "//conditions:default": ":_package_typing_extensions_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3090,6 +3223,7 @@ alias(
     name = "typing_extensions_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_typing_extensions_aspect_rules_py_whl",
+        "//conditions:default": ":_package_typing_extensions_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3128,6 +3262,7 @@ alias(
     name = "tzdata",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_tzdata_aspect_rules_py",
+        "//conditions:default": ":_package_tzdata_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3137,6 +3272,7 @@ alias(
     name = "tzdata_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_tzdata_aspect_rules_py_whl",
+        "//conditions:default": ":_package_tzdata_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3174,6 +3310,7 @@ alias(
     name = "uri_template",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_uri_template_aspect_rules_py",
+        "//conditions:default": ":_package_uri_template_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3183,6 +3320,7 @@ alias(
     name = "uri_template_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_uri_template_aspect_rules_py_whl",
+        "//conditions:default": ":_package_uri_template_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3220,6 +3358,7 @@ alias(
     name = "urllib3",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_urllib3_aspect_rules_py",
+        "//conditions:default": ":_package_urllib3_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3229,6 +3368,7 @@ alias(
     name = "urllib3_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_urllib3_aspect_rules_py_whl",
+        "//conditions:default": ":_package_urllib3_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3266,6 +3406,7 @@ alias(
     name = "wcwidth",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_wcwidth_aspect_rules_py",
+        "//conditions:default": ":_package_wcwidth_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3275,6 +3416,7 @@ alias(
     name = "wcwidth_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_wcwidth_aspect_rules_py_whl",
+        "//conditions:default": ":_package_wcwidth_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3312,6 +3454,7 @@ alias(
     name = "webcolors",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_webcolors_aspect_rules_py",
+        "//conditions:default": ":_package_webcolors_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3321,6 +3464,7 @@ alias(
     name = "webcolors_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_webcolors_aspect_rules_py_whl",
+        "//conditions:default": ":_package_webcolors_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3358,6 +3502,7 @@ alias(
     name = "websocket_client",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_websocket_client_aspect_rules_py",
+        "//conditions:default": ":_package_websocket_client_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3367,6 +3512,7 @@ alias(
     name = "websocket_client_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_websocket_client_aspect_rules_py_whl",
+        "//conditions:default": ":_package_websocket_client_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3404,6 +3550,7 @@ alias(
     name = "zipp",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_zipp_aspect_rules_py",
+        "//conditions:default": ":_package_zipp_aspect_rules_py",
     }),
     visibility = ["//visibility:public"],
 )
@@ -3413,6 +3560,7 @@ alias(
     name = "zipp_whl",
     actual = select({
         "//private/dep_group:aspect_rules_py": ":_package_zipp_aspect_rules_py_whl",
+        "//conditions:default": ":_package_zipp_aspect_rules_py_whl",
     }),
     visibility = ["//visibility:public"],
 )

--- a/uv/private/uv_hub/snapshots/pypi.cowsay.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/pypi.cowsay.BUILD.bazel
@@ -18,6 +18,7 @@ alias(
     name = "whl",
     actual = select({
           "//dep_group:aspect_rules_py": "@project__aspect_rules_py//:cowsay_whl",
+          "//conditions:default": "@project__aspect_rules_py//:cowsay_whl",
       }),
     target_compatible_with = select(compatible_with(["aspect_rules_py"])),
     visibility = ["//visibility:public"],
@@ -31,6 +32,7 @@ alias(
     name = "cowsay",
     actual = select({
           "//dep_group:aspect_rules_py": "@project__aspect_rules_py//:cowsay",
+          "//conditions:default": "@project__aspect_rules_py//:cowsay",
       },
         no_match_error = "Available only in dep_groups: aspect_rules_py",
     ),

--- a/uv/private/uv_hub/snapshots/pypi.defs.bzl
+++ b/uv/private/uv_hub/snapshots/pypi.defs.bzl
@@ -9,21 +9,33 @@ def compatible_with(venvs, extra_constraints = []):
     if v not in VIRTUALENVS:
       fail("Errant virtualenv reference %r" % v)
 
-  return {
+  result = {
     Label("//dep_group:" + it): extra_constraints
     for it in venvs
-  } | {
-    "//conditions:default": ["@platforms//:incompatible"],
   }
+
+  # When a package is only available in a single virtualenv, allow it to be
+  # used without an explicit dep_group selection for convenience.
+  if len(venvs) == 1:
+    result["//conditions:default"] = extra_constraints
+  else:
+    result["//conditions:default"] = ["@platforms//:incompatible"]
+
+  return result
 
 def incompatible_with(venvs, extra_constraints = []):
   for v in venvs:
     if v not in VIRTUALENVS:
       fail("Errant virtualenv reference %r" % v)
 
-  return {
+  result = {
     Label("//dep_group:" + it): ["@platforms//:incompatible"]
     for it in venvs
-  } | {
-    "//conditions:default": extra_constraints,
   }
+
+  if len(venvs) == 1:
+    result["//conditions:default"] = extra_constraints
+  else:
+    result["//conditions:default"] = ["@platforms//:incompatible"]
+
+  return result

--- a/uv/private/uv_hub/snapshots/pypi.pkg.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/pypi.pkg.BUILD.bazel
@@ -13,6 +13,7 @@ alias(
     name = "whl",
     actual = select({
           "//dep_group:aspect_rules_py": "@project__aspect_rules_py//:pkg_whl",
+          "//conditions:default": "@project__aspect_rules_py//:pkg_whl",
       }),
     target_compatible_with = select(compatible_with(["aspect_rules_py"])),
     visibility = ["//visibility:public"],
@@ -26,6 +27,7 @@ alias(
     name = "pkg",
     actual = select({
           "//dep_group:aspect_rules_py": "@project__aspect_rules_py//:pkg",
+          "//conditions:default": "@project__aspect_rules_py//:pkg",
       },
         no_match_error = "Available only in dep_groups: aspect_rules_py",
     ),

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -201,6 +201,14 @@ alias(
 )
 """.format(name = whl_cfg_name, arms = indent(pprint(whl_cfg_arms), " " * 4).lstrip()))
 
+        # When a package is only available in a single virtualenv, allow it to
+        # resolve without an explicit dep_group selection.
+        if len(cfgs) == 1:
+            single_cfg = list(cfgs.keys())[0]
+            single_cfg_name = "_package_{}_{}".format(package, single_cfg)
+            main_arms["//conditions:default"] = ":" + single_cfg_name
+            whl_main_arms["//conditions:default"] = ":" + single_cfg_name + "_whl"
+
         # Finally we can render the wrapper over all the component arms
         content.append("""
 alias(


### PR DESCRIPTION
 PBS encodings fix                                                                                                                                                                                                                                                                                                                                                             
 
Python 3.11/3.12 PBS reimplemented prefix discovery in getpath.py. Its  resolvedpath() fails on multi-hop relative symlinks that traverse components across runfiles boundaries. When resolution fails Python  falls back to the /install compile-time prefix.                                                                                                                                        
                                                                                                                                                                                                        
                                                                                                                                                                                                       
The launcher workaround (exporting PYTHONHOME) doesn't help when  nvoked through a venv symlink with -I, because getpath.py reads the  venv's pyvenv.cfg first and ignores PYTHONHOME when the relative home = be  resolved.                                                                                                                                                                                
                                                                                                                                                                                                        
Fix: rewrite pyvenv.cfg at runtime with an absolute home= path so getpath.py discovers the stdlib without following symlinks.                                                                                                                                        
                                                                                                                                                                                                        
Dep group fallback fix:                                                                                                                                                                         
Packages with a single available dep_group or single cfg previously required an explicit dep_group attribute, even though there was no ambiguity. Add //conditions:default fallbacks in uv_hub/repository.bzl and uv_project/repository.bzl so these packages resolve automatically.


### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
