### PR TITLE
fix: sdist build pipeline, pep508 bracket tokenizer, whl visibility, and pytest coverage

### DIFF
--- a/py/private/pytest.py.tmpl
+++ b/py/private/pytest.py.tmpl
@@ -35,13 +35,18 @@ if "COVERAGE_MANIFEST" in os.environ:
     try:
         import coverage
         # The lines are files that matched the --instrumentation_filter flag
-        with open(os.getenv("COVERAGE_MANIFEST"), "r") as mf:
-            manifest_entries = mf.read().splitlines()
-            cov = coverage.Coverage(include = manifest_entries)
-            # coveragepy incorrectly converts our entries by following symlinks
-            # record a mapping of their conversion so we can undo it later in reporting the coverage
-            coveragepy_absfile_mapping = {coverage.files.abs_file(mfe): mfe for mfe in manifest_entries}
-        cov.start()
+
+        existing_cov = coverage.Coverage.current()
+        if existing_cov is not None:
+            cov = existing_cov
+        else:
+            with open(os.getenv("COVERAGE_MANIFEST"), "r") as mf:
+                manifest_entries = mf.read().splitlines()
+                cov = coverage.Coverage(include = manifest_entries)
+                # coveragepy incorrectly converts our entries by following symlinks
+                # record a mapping of their conversion so we can undo it later in reporting the coverage
+                coveragepy_absfile_mapping = {coverage.files.abs_file(mfe): mfe for mfe in manifest_entries}
+            cov.start()
     except ModuleNotFoundError as e:
         print("WARNING: python coverage setup failed. Do you need to include the 'coverage' package as a dependency of py_pytest_main?", e)
         pass
@@ -58,6 +63,8 @@ if __name__ == "__main__":
     args = [
         "--verbose",
         "--ignore=external/",
+        "-p",
+        "no:anyio",
         # Avoid loading of the plugin "cacheprovider".
         "-p",
         "no:cacheprovider",
@@ -108,12 +115,16 @@ if __name__ == "__main__":
         # https://bazel.build/configure/coverage
         coverage_output_file = os.getenv("COVERAGE_OUTPUT_FILE")
 
-        unfixed_dat = coverage_output_file + ".tmp"
+        # postprocessor action writes to COVERAGE_OUTPUT_FILE. Write coverage data to
+        # COVERAGE_DIR so the postprocessor finds it; otherwise write directly.
+        coverage_dir = os.environ.get("COVERAGE_DIR")
+        target_dat = os.path.join(coverage_dir, "python_coverage.dat") if coverage_dir else coverage_output_file
+        unfixed_dat = target_dat + ".tmp"
         cov.lcov_report(outfile = unfixed_dat)
         cov.save()
-        
+
         with open(unfixed_dat, "r") as unfixed:
-          with open(coverage_output_file, "w") as output_file:
+          with open(target_dat, "w") as output_file:
             for line in unfixed:
               # Workaround https://github.com/nedbat/coveragepy/issues/963
               # by mapping SF: records to un-do the symlink-following

--- a/py/tools/py/src/pth.rs
+++ b/py/tools/py/src/pth.rs
@@ -151,6 +151,10 @@ pub fn create_symlinks(
         // `__init__.py` files in the root site-packages directory. The site-packages directory
         // itself is not a regular package and is not supposed to have an `__init__.py` file.
         if path.is_dir() {
+            // Skip __pycache__ directories entirely. .pyc bytecode caches embed
+            if path.file_name().map_or(false, |n| n == "__pycache__") {
+                continue;
+            }
             create_symlinks(&path, root_dir, dst_dir, collision_strategy)?;
         }
         // rules_python runfiles helper needs some special handling when consumed as pip dependency.

--- a/py/tools/py/src/venv.rs
+++ b/py/tools/py/src/venv.rs
@@ -514,7 +514,10 @@ fn walk_skip_venvs(root: &Path) -> impl Iterator<Item = walkdir::DirEntry> {
         .into_iter()
         .filter_entry(|e| {
             if e.file_type().is_dir() {
-                !e.path().join("pyvenv.cfg").exists()
+                let name = e.file_name().to_string_lossy();
+                // Skip virtual environments and __pycache__ directories.
+                // __pycache__ contains .pyc bytecode caches that embed the source
+                !e.path().join("pyvenv.cfg").exists() && name != "__pycache__"
             } else {
                 true
             }

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -360,6 +360,7 @@ def _parse_projects(module_ctx, hub_specs):
                         lock_build_deps = [
                             it[0]
                             for req in project.default_build_dependencies
+                            if normalize_name(req.split(";")[0].split("[")[0].split(">")[0].split("<")[0].split("=")[0].split("!")[0].split("~")[0].split(" ")[0].strip()) in package_versions
                             for it in extract_requirement_marker_pairs(project.lock, project_id, req, default_versions, package_versions)
                         ]
 
@@ -391,6 +392,7 @@ def _parse_projects(module_ctx, hub_specs):
                         pre_build_patch_strip = pre_build_patch_strip,
                         available_deps = project_available_deps,
                         configure_command = project.unstable_configure_command,
+                        subdirectory = package.get("source", {}).get("subdirectory", ""),
                     )
 
                     has_sbuild = True
@@ -574,6 +576,8 @@ def _uv_impl(module_ctx):
         if sbuild_cfg.pre_build_patches:
             sbuild_kwargs["pre_build_patches"] = sbuild_cfg.pre_build_patches
             sbuild_kwargs["pre_build_patch_strip"] = sbuild_cfg.pre_build_patch_strip
+        if sbuild_cfg.subdirectory:
+            sbuild_kwargs["subdirectory"] = sbuild_cfg.subdirectory
         sdist_build(**sbuild_kwargs)
 
     for install_id, install_cfg in cfg.install_cfgs.items():
@@ -628,6 +632,8 @@ _project_tag = tag_class(
             mandatory = False,
             default = [
                 "build",
+                "setuptools",
+                "wheel",
             ],
         ),
         "unstable_configure_command": attr.string_list(

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -189,7 +189,7 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
 
         for spec in resolved_specs:
             for dep, _marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, group_preferences):
-                group_preferences[dep[1]] = (dep[0], dep[1], dep[2], "__base__")
+                group_preferences.setdefault(dep[1], (dep[0], dep[1], dep[2], "__base__"))
 
         all_group_preferences[group_name] = group_preferences
 

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -200,6 +200,63 @@ collect_activated_extras_transitive_remap_test = unittest.make(
     _collect_activated_extras_transitive_remap_test_impl,
 )
 
+def _collect_activated_extras_setdefault_preserves_first_resolution_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    project_data = {
+        "project": {"name": "myapp"},
+        "dependency-groups": {
+            "base": ["requests"],
+            "dev": [
+                {"include-group": "base"},
+                "requests",  # requests appears a second time via direct inclusion
+            ],
+        },
+    }
+    lock_data = {
+        "manifest": {"members": ["myapp"]},
+        "package": [{
+            "name": "myapp",
+            "version": "0.0.0",
+            "source": {"virtual": "."},
+            "dev-dependencies": {
+                # The lockfile pins requests at 2.28.0 for both groups.
+                "base": [{"name": "requests", "version": "2.28.0"}],
+                "dev": [{"name": "requests", "version": "2.28.0"}],
+            },
+        }],
+    }
+    graph = {
+        ("lock", "requests", "2.28.0", "__base__"): {},
+        ("lock", "requests", "2.31.0", "__base__"): {},
+    }
+    package_versions = {
+        "requests": {"2.28.0": 1, "2.31.0": 1},
+    }
+
+    _cfg_names, activated_extras = collect_activated_extras(
+        "//:pyproject.toml",
+        "lock",
+        project_data,
+        lock_data,
+        {},
+        graph,
+        package_versions,
+    )
+
+    req_2280 = ("lock", "requests", "2.28.0", "__base__")
+    req_2310 = ("lock", "requests", "2.31.0", "__base__")
+
+    # requests==2.28.0 (lockfile-pinned) must be activated; 2.31.0 must not.
+    asserts.true(env, req_2280 in activated_extras)
+    asserts.false(env, req_2310 in activated_extras)
+
+    return unittest.end(env)
+
+collect_activated_extras_setdefault_preserves_first_resolution_test = unittest.make(
+    _collect_activated_extras_setdefault_preserves_first_resolution_test_impl,
+)
+
 def projectfile_test_suite():
     unittest.suite(
         "extract_requirement_marker_pairs_tests",
@@ -210,4 +267,5 @@ def projectfile_test_suite():
         extract_requirement_marker_pairs_preferred_overrides_version_map_test,
         extract_requirement_marker_pairs_preferred_overrides_multi_version_test,
         collect_activated_extras_transitive_remap_test,
+        collect_activated_extras_setdefault_preserves_first_resolution_test,
     )

--- a/uv/private/markers/defs.bzl
+++ b/uv/private/markers/defs.bzl
@@ -74,7 +74,6 @@ def _decide_marker_impl(ctx):
     FeatureFlagInfo = config_common.FeatureFlagInfo
 
     extras = sorted(ctx.attr.extras)
-    extra = ",".join(extras)
     dependency_groups = sorted(ctx.attr.dependency_groups)
 
     # Hide the differences between string flags and our custom build settings so
@@ -87,32 +86,47 @@ def _decide_marker_impl(ctx):
         else:
             fail("Unable to deref %r" % it)
 
-    res = _evaluate_marker(
-        marker = ctx.attr.marker,
-        env = {
-            # FIXME: Technically these aren't always defined... but this
-            # implementation will have them present. [1]
-            #
-            # [1] https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers
-            #
-            # {{{
-            "extra": extra,
-            "extras": extras,
-            "dependency_groups": dependency_groups,
-            # }}}
-            "python_version": _value(ctx.attr.python_version),
-            "python_full_version": _value(ctx.attr.python_full_version),
-            "os_name": _value(ctx.attr.os_name),
-            "sys_platform": _value(ctx.attr.sys_platform),
-            "os_release": _value(ctx.attr.os_release),
-            "platform_machine": _value(ctx.attr.platform_machine),
-            "platform_system": _value(ctx.attr.platform_system),
-            "platform_version": _value(ctx.attr.platform_version),
-            "platform_python_implementation": _value(ctx.attr.platform_python_implementation),
-            "implementation_name": _value(ctx.attr.implementation_name),
-            "implementation_version": _value(ctx.attr.implementation_version),
-        },
-    )
+    venv_name = _value(ctx.attr._venv)
+    if not extras and venv_name and "extra" in ctx.attr.marker:
+        venv_name_normalized = venv_name.replace("_", "-")
+        seen = {}
+        for token in ctx.attr.marker.replace("(", " ").replace(")", " ").split("'"):
+            if token.endswith(venv_name_normalized) and token not in seen:
+                seen[token] = True
+        extras = sorted(seen.keys())
+
+    eval_extras = extras if extras else [""]
+
+    res = False
+    for extra in eval_extras:
+        if _evaluate_marker(
+            marker = ctx.attr.marker,
+            env = {
+                # FIXME: Technically these aren't always defined... but this
+                # implementation will have them present. [1]
+                #
+                # [1] https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers
+                #
+                # {{{
+                "extra": extra,
+                "extras": extras,
+                "dependency_groups": dependency_groups,
+                # }}}
+                "python_version": _value(ctx.attr.python_version),
+                "python_full_version": _value(ctx.attr.python_full_version),
+                "os_name": _value(ctx.attr.os_name),
+                "sys_platform": _value(ctx.attr.sys_platform),
+                "os_release": _value(ctx.attr.os_release),
+                "platform_machine": _value(ctx.attr.platform_machine),
+                "platform_system": _value(ctx.attr.platform_system),
+                "platform_version": _value(ctx.attr.platform_version),
+                "platform_python_implementation": _value(ctx.attr.platform_python_implementation),
+                "implementation_name": _value(ctx.attr.implementation_name),
+                "implementation_version": _value(ctx.attr.implementation_version),
+            },
+        ):
+            res = True
+            break
 
     # print(ctx.label, ctx.attr.marker, "->", res)
 
@@ -126,6 +140,7 @@ _decide_marker = rule(
         "marker": attr.string(),
         "extras": attr.string_list(default = []),
         "dependency_groups": attr.string_list(default = []),
+        "_venv": attr.label(default = Label("@aspect_rules_py//uv/private/constraints/venv:venv")),
         "python_version": attr.label(default = Label(":python_version")),
         "python_full_version": attr.label(default = Label(":python_full_version")),
         "os_name": attr.label(default = Label(":os_name")),

--- a/uv/private/markers/pep508_evaluate.bzl
+++ b/uv/private/markers/pep508_evaluate.bzl
@@ -95,6 +95,9 @@ def tokenize(marker):
 
         char = marker[0]
         if char in _BRACKETS:
+            if state in [_STATE.VAR, _STATE.OP]:
+                state = _STATE.NONE
+                continue  # Re-process this char after emitting the token
             state = _STATE.NONE
             token = char
         elif state == _STATE.STRING and char in _QUOTES:

--- a/uv/private/markers/pep508_evaluate_test.bzl
+++ b/uv/private/markers/pep508_evaluate_test.bzl
@@ -59,6 +59,20 @@ def _evaluate_test_impl(ctx):
     asserts.true(env, evaluate("((sys_platform == 'linux'))", env = _LINUX_ENV))
     asserts.true(env, evaluate("((sys_platform == 'linux') and (platform_machine == 'x86_64')) or sys_platform == 'win32'", env = _LINUX_ENV))
 
+    # Bracket immediately following a variable name without whitespace (tokenizer bug fix).
+    # e.g. `'linux' in sys_platform)` would lose `sys_platform` and crash.
+    asserts.true(env, evaluate("('linux' in sys_platform)", env = _LINUX_ENV))
+    asserts.false(env, evaluate("('linux' in sys_platform)", env = _WINDOWS_ENV))
+    asserts.true(env, evaluate("('win32' not in sys_platform)", env = _LINUX_ENV))
+    asserts.false(env, evaluate("('win32' not in sys_platform)", env = _WINDOWS_ENV))
+    asserts.true(env, evaluate("(sys_platform == 'linux')", env = _LINUX_ENV))
+    asserts.false(env, evaluate("(sys_platform == 'linux')", env = _WINDOWS_ENV))
+    asserts.true(env, evaluate("sys_platform == 'linux' and ('linux' in sys_platform)", env = _LINUX_ENV))
+    asserts.false(env, evaluate("sys_platform == 'linux' and ('linux' in sys_platform)", env = _WINDOWS_ENV))
+    asserts.true(env, evaluate("(sys_platform == 'linux' or sys_platform == 'win32')", env = _LINUX_ENV))
+    asserts.true(env, evaluate("(sys_platform == 'linux' or sys_platform == 'win32')", env = _WINDOWS_ENV))
+    asserts.false(env, evaluate("(sys_platform == 'darwin' or sys_platform == 'win32')", env = _LINUX_ENV))
+
     return unittest.end(env)
 
 evaluate_test = unittest.make(

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -6,3 +6,13 @@ exports_files(
     ["build_helper.py"],
     visibility = ["//visibility:public"],
 )
+
+load("//py/unstable:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "build_helper_test",
+    srcs = ["build_helper_test.py"],
+    data = ["build_helper.py"],
+    main = "build_helper_test.py",
+    visibility = ["//visibility:private"],
+)

--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -20,6 +20,7 @@ PARSER.add_argument("outdir")
 PARSER.add_argument("--validate-anyarch", action="store_true")
 PARSER.add_argument("--patch-strip", type=int, default=0, help="Strip count for patch (-p)")
 PARSER.add_argument("--patch", action="append", default=[], dest="patches", help="Patch file to apply (repeatable)")
+PARSER.add_argument("--subdirectory", default="", help="Subdirectory within the archive containing pyproject.toml")
 opts, args = PARSER.parse_known_args()
 
 tmp_root = opts.outdir.lstrip("/") + ".tmp"
@@ -33,6 +34,10 @@ shutil.unpack_archive(opts.srcarchive, t)
 # accordingly. Not worth the eng effort to prevent creating this dir.
 t = path.join(t, listdir(t)[0])
 
+# If a subdirectory is specified (e.g. for monorepo archives), descend into it.
+if opts.subdirectory:
+    t = path.join(t, opts.subdirectory)
+
 if opts.patches:
     for patch_file in opts.patches:
         check_call(
@@ -41,8 +46,133 @@ if opts.patches:
         )
 
 
+def _ensure_build_backend(src_dir):
+    """Patch pyproject.toml and generate setup.cfg if needed for buildability."""
+    import importlib.metadata
+
+    pyproject_path = path.join(src_dir, "pyproject.toml")
+    if not path.exists(pyproject_path):
+        return
+
+    # Minimal TOML parsing
+    lines = []
+    with open(pyproject_path) as f:
+        lines = f.readlines()
+
+    # Parse [project] name, version and [build-system] build-backend
+    name = None
+    version = None
+    build_backend = None
+    in_project = False
+    in_build_system = False
+    in_project_scripts = False
+    has_src_layout = path.isdir(path.join(src_dir, "src"))
+    scripts = {}
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "[project]":
+            in_project = True
+            in_build_system = False
+            in_project_scripts = False
+            continue
+        elif stripped == "[build-system]":
+            in_build_system = True
+            in_project = False
+            in_project_scripts = False
+            continue
+        elif stripped == "[project.scripts]":
+            in_project_scripts = True
+            in_project = False
+            in_build_system = False
+            continue
+        elif stripped.startswith("["):
+            in_project = False
+            in_build_system = False
+            in_project_scripts = False
+            continue
+        if in_project:
+            if stripped.startswith("name"):
+                _, _, val = stripped.partition("=")
+                name = val.strip().strip('"').strip("'")
+            elif stripped.startswith("version"):
+                _, _, val = stripped.partition("=")
+                version = val.strip().strip('"').strip("'")
+        elif in_build_system:
+            if stripped.startswith("build-backend"):
+                _, _, val = stripped.partition("=")
+                build_backend = val.strip().strip('"').strip("'")
+        elif in_project_scripts:
+            if "=" in stripped:
+                script_name, _, script_val = stripped.partition("=")
+                scripts[script_name.strip().strip('"').strip("'")] = script_val.strip().strip('"').strip("'")
+
+    # Check if the declared build backend is importable
+    backend_available = True
+    if build_backend and build_backend != "setuptools.build_meta":
+        backend_module = build_backend.split(":")[0].split(".")[0]
+        try:
+            __import__(backend_module)
+        except ImportError:
+            backend_available = False
+
+    # If backend is unavailable, rewrite pyproject.toml to use setuptools
+    if not backend_available:
+        new_lines = []
+        in_build_system_section = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped == "[build-system]":
+                in_build_system_section = True
+                new_lines.append("[build-system]\n")
+                new_lines.append('requires = ["setuptools", "wheel"]\n')
+                new_lines.append('build-backend = "setuptools.build_meta"\n')
+                continue
+            elif stripped.startswith("[") and in_build_system_section:
+                in_build_system_section = False
+            if in_build_system_section:
+                continue  # skip original build-system lines
+            new_lines.append(line)
+        with open(pyproject_path, "w") as f:
+            f.writelines(new_lines)
+        build_backend = "setuptools.build_meta"
+
+    # For setuptools.build_meta, ensure metadata is available
+    if build_backend == "setuptools.build_meta" or build_backend is None:
+        try:
+            st_ver = tuple(int(x) for x in importlib.metadata.version("setuptools").split(".")[:2])
+        except Exception:
+            st_ver = (0, 0)
+
+        setup_cfg_path = path.join(src_dir, "setup.cfg")
+        need_setup_cfg = st_ver < (61, 0) and name and version
+        if need_setup_cfg and not path.exists(setup_cfg_path):
+            cfg_content = "[metadata]\nname = {}\nversion = {}\n".format(name, version)
+            # Add package discovery for src-layout
+            if has_src_layout:
+                cfg_content += "\n[options]\npackage_dir =\n    = src\npackages = find:\n\n[options.packages.find]\nwhere = src\n"
+            else:
+                cfg_content += "\n[options]\npackages = find:\n"
+            # Include all non-Python data files in packages
+            cfg_content += "\n[options.package_data]\n* = *\n"
+            # Add entry points (console_scripts) from [project.scripts]
+            if scripts:
+                cfg_content += "\n[options.entry_points]\nconsole_scripts =\n"
+                for script_name, script_val in scripts.items():
+                    cfg_content += "    {} = {}\n".format(script_name, script_val)
+            with open(setup_cfg_path, "w") as f:
+                f.write(cfg_content)
+
+_ensure_build_backend(t)
+
 # Get a path to the outdir which will be valid after we cd
 outdir = path.abspath(opts.outdir)
+
+# Resolve CC/CXX to absolute paths so they remain valid after cwd changes
+# into the extracted source tree (Bazel sets these as exec-root-relative).
+for _cc_var in ("CC", "CXX"):
+    if _cc_var in os.environ and not path.isabs(os.environ[_cc_var]):
+        os.environ[_cc_var] = path.abspath(os.environ[_cc_var])
 
 # Preserve PATH so native sdist builds can find compilers (clang, gcc).
 build_env = dict(os.environ)
@@ -50,6 +180,10 @@ build_env.update({
     "TMP": tmp_root,
     "TEMP": tmp_root,
     "TEMPDIR": tmp_root,
+    # Bazel sets file timestamps to epoch 0 for reproducibility. wheel < 0.38
+    # fails when creating ZIP files with timestamps before 1980. Setting
+    # SOURCE_DATE_EPOCH to 1980-01-01 avoids this issue.
+    "SOURCE_DATE_EPOCH": "315532800",
 })
 
 if path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "setup.py")):
@@ -62,6 +196,7 @@ if path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "setu
         "-m", "build",
         "--wheel",
         "--no-isolation",
+        "--skip-dependency-check",
         "--outdir", outdir,
     ]
 

--- a/uv/private/pep517_whl/build_helper_test.py
+++ b/uv/private/pep517_whl/build_helper_test.py
@@ -1,0 +1,297 @@
+"""Tests for build_helper.py's _ensure_build_backend function.
+
+Covers issues reported in the enterprise support ticket:
+ - Non-setuptools backends (hatchling, flit_core) not available in the build
+   sandbox cause ModuleNotFoundError; the fix falls back to setuptools.
+ - Setuptools < 61 does not understand PEP 621 [project] tables; the fix
+   generates a compatible setup.cfg.
+ - setup.cfg must include [options.package_data] so non-Python data files
+   (YAML, models, etc.) are included in the wheel.
+ - Packages with a src/ layout need the correct package_dir / find: config.
+ - [project.scripts] entries should translate to console_scripts entry points.
+"""
+
+import ast
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Extract _ensure_build_backend from the script without executing it.
+# build_helper.py is a runnable script (not a module), so direct import would
+# trigger top-level directory operations.  We pull out only the function we
+# need by parsing the AST and compiling that subtree.
+# ---------------------------------------------------------------------------
+_HELPER_PATH = os.path.join(os.path.dirname(__file__), "build_helper.py")
+
+
+def _load_ensure_build_backend():
+    with open(_HELPER_PATH) as fh:
+        source = fh.read()
+    tree = ast.parse(source, _HELPER_PATH)
+    func_node = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_ensure_build_backend"
+    )
+    mod = ast.Module(body=[func_node], type_ignores=[])
+    code = compile(mod, _HELPER_PATH, "exec")
+    ns = {
+        "path": os.path,
+        "os": os,
+        "__name__": "__extracted__",
+    }
+    exec(code, ns)  # noqa: S102 – intentional extraction, not untrusted input
+    return ns["_ensure_build_backend"]
+
+
+_ensure_build_backend = _load_ensure_build_backend()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write(directory, rel_path, content):
+    full = os.path.join(directory, rel_path)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w") as fh:
+        fh.write(content)
+    return full
+
+
+def _read(directory, rel_path):
+    with open(os.path.join(directory, rel_path)) as fh:
+        return fh.read()
+
+
+def _exists(directory, rel_path):
+    return os.path.exists(os.path.join(directory, rel_path))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestEnsureBuildBackendNoop(unittest.TestCase):
+    """_ensure_build_backend is a no-op when pyproject.toml is absent."""
+
+    def test_no_pyproject_toml(self):
+        with tempfile.TemporaryDirectory() as d:
+            _ensure_build_backend(d)
+            self.assertFalse(_exists(d, "setup.cfg"))
+
+
+class TestBackendFallback(unittest.TestCase):
+    """Non-importable backends (hatchling, flit_core) fall back to setuptools.
+
+    We use a module name that is guaranteed not to exist so that the fallback
+    logic is exercised without any mocking of builtins.__import__.
+    """
+
+    _FAKE_BACKEND = "_aspect_test_nonexistent_backend_xyz"
+
+    def _pyproject(self, backend=None):
+        b = backend or self._FAKE_BACKEND
+        return textwrap.dedent(f"""\
+            [project]
+            name = "mypkg"
+            version = "1.0.0"
+
+            [build-system]
+            requires = ["{b}"]
+            build-backend = "{b}.buildapi"
+        """)
+
+    def test_unavailable_backend_falls_back(self):
+        """An unavailable build backend triggers setuptools fallback."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._pyproject())
+            _ensure_build_backend(d)
+            content = _read(d, "pyproject.toml")
+        self.assertIn("setuptools.build_meta", content)
+        self.assertNotIn(self._FAKE_BACKEND, content)
+
+    def test_fallback_adds_setuptools_requires(self):
+        """Rewritten [build-system] must require setuptools and wheel."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._pyproject())
+            _ensure_build_backend(d)
+            content = _read(d, "pyproject.toml")
+        self.assertIn('requires = ["setuptools", "wheel"]', content)
+
+    def test_setuptools_backend_unchanged(self):
+        """Packages already using setuptools should not be rewritten."""
+        pyproject = textwrap.dedent("""\
+            [project]
+            name = "mypkg"
+            version = "1.0.0"
+
+            [build-system]
+            requires = ["setuptools"]
+            build-backend = "setuptools.build_meta"
+        """)
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", pyproject)
+            _ensure_build_backend(d)
+            content = _read(d, "pyproject.toml")
+        self.assertIn("setuptools.build_meta", content)
+        # requires line should be preserved as-is
+        self.assertIn('requires = ["setuptools"]', content)
+
+    def test_fallback_preserves_project_section(self):
+        """After rewriting [build-system], [project] must be intact."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._pyproject())
+            _ensure_build_backend(d)
+            content = _read(d, "pyproject.toml")
+        self.assertIn('[project]', content)
+        self.assertIn('name = "mypkg"', content)
+        self.assertIn('version = "1.0.0"', content)
+
+
+class TestSetupCfgGeneration(unittest.TestCase):
+    """setup.cfg is generated when setuptools < 61 and pyproject.toml has [project]."""
+
+    _PYPROJECT = textwrap.dedent("""\
+        [project]
+        name = "mypkg"
+        version = "2.3.4"
+
+        [build-system]
+        requires = ["setuptools"]
+        build-backend = "setuptools.build_meta"
+    """)
+
+    def _run(self, tmpdir, st_version="60.0.0"):
+        import importlib.metadata as _meta
+        with patch.object(_meta, "version", return_value=st_version):
+            _ensure_build_backend(tmpdir)
+
+    def test_setup_cfg_generated_for_old_setuptools(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._PYPROJECT)
+            self._run(d, st_version="60.0.0")
+            self.assertTrue(_exists(d, "setup.cfg"))
+            cfg = _read(d, "setup.cfg")
+        self.assertIn("name = mypkg", cfg)
+        self.assertIn("version = 2.3.4", cfg)
+
+    def test_setup_cfg_not_generated_for_new_setuptools(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._PYPROJECT)
+            self._run(d, st_version="61.0.0")
+            self.assertFalse(_exists(d, "setup.cfg"))
+
+    def test_setup_cfg_not_overwritten_if_exists(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._PYPROJECT)
+            _write(d, "setup.cfg", "[metadata]\nname = existing\n")
+            self._run(d, st_version="60.0.0")
+            cfg = _read(d, "setup.cfg")
+        # Original content must be preserved
+        self.assertIn("name = existing", cfg)
+        self.assertNotIn("name = mypkg", cfg)
+
+    def test_setup_cfg_includes_package_data(self):
+        """Package data wildcard must be present so non-Python files are included."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._PYPROJECT)
+            self._run(d, st_version="60.0.0")
+            cfg = _read(d, "setup.cfg")
+        self.assertIn("[options.package_data]", cfg)
+        self.assertIn("* = *", cfg)
+
+    def test_setup_cfg_src_layout(self):
+        """src/ layout generates correct package_dir and find: config."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._PYPROJECT)
+            os.makedirs(os.path.join(d, "src"))
+            self._run(d, st_version="60.0.0")
+            cfg = _read(d, "setup.cfg")
+        self.assertIn("package_dir", cfg)
+        self.assertIn("= src", cfg)
+        self.assertIn("[options.packages.find]", cfg)
+        self.assertIn("where = src", cfg)
+
+    def test_setup_cfg_flat_layout(self):
+        """Flat layout (no src/) generates simpler find: config."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", self._PYPROJECT)
+            self._run(d, st_version="60.0.0")
+            cfg = _read(d, "setup.cfg")
+        self.assertIn("packages = find:", cfg)
+        self.assertNotIn("package_dir", cfg)
+
+
+class TestConsoleScripts(unittest.TestCase):
+    """[project.scripts] entries end up as console_scripts in setup.cfg."""
+
+    def test_scripts_in_entry_points(self):
+        pyproject = textwrap.dedent("""\
+            [project]
+            name = "mytool"
+            version = "0.1.0"
+
+            [project.scripts]
+            mytool = "mytool.cli:main"
+            other-cmd = "mytool.other:run"
+
+            [build-system]
+            requires = ["setuptools"]
+            build-backend = "setuptools.build_meta"
+        """)
+        import importlib.metadata as _meta
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "pyproject.toml", pyproject)
+            with patch.object(_meta, "version", return_value="60.0.0"):
+                _ensure_build_backend(d)
+            cfg = _read(d, "setup.cfg")
+        self.assertIn("[options.entry_points]", cfg)
+        self.assertIn("console_scripts =", cfg)
+        self.assertIn("mytool = mytool.cli:main", cfg)
+        self.assertIn("other-cmd = mytool.other:run", cfg)
+
+
+class TestCCPathResolution(unittest.TestCase):
+    """CC and CXX are converted to absolute paths before the cwd changes."""
+
+    def test_relative_cc_becomes_absolute(self):
+        """A relative CC path must be made absolute (using cwd at that point)."""
+        rel_path = "external/toolchain/bin/cc"
+        abs_path = os.path.abspath(rel_path)
+        env = {"CC": rel_path}
+        with patch.dict(os.environ, env, clear=False):
+            # Simulate what build_helper.py does at the CC/CXX normalization block
+            for var in ("CC", "CXX"):
+                if var in os.environ and not os.path.isabs(os.environ[var]):
+                    os.environ[var] = os.path.abspath(os.environ[var])
+            self.assertTrue(os.path.isabs(os.environ["CC"]))
+            self.assertEqual(os.environ["CC"], abs_path)
+
+    def test_absolute_cc_unchanged(self):
+        """An already-absolute CC path must not be modified."""
+        abs_path = "/usr/bin/gcc"
+        env = {"CC": abs_path}
+        with patch.dict(os.environ, env, clear=False):
+            for var in ("CC", "CXX"):
+                if var in os.environ and not os.path.isabs(os.environ[var]):
+                    os.environ[var] = os.path.abspath(os.environ[var])
+            self.assertEqual(os.environ["CC"], abs_path)
+
+    def test_missing_cc_not_set(self):
+        """If CC is absent from the environment, it must not be injected."""
+        env_without_cc = {k: v for k, v in os.environ.items() if k not in ("CC", "CXX")}
+        with patch.dict(os.environ, env_without_cc, clear=True):
+            for var in ("CC", "CXX"):
+                if var in os.environ and not os.path.isabs(os.environ[var]):
+                    os.environ[var] = os.path.abspath(os.environ[var])
+            self.assertNotIn("CC", os.environ)
+            self.assertNotIn("CXX", os.environ)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -87,10 +87,23 @@ def _resolve_extra_deps(repository_ctx, inspection):
     if repository_ctx.attr.available_deps:
         available_deps = json.decode(repository_ctx.attr.available_deps)
 
+    # Extract package names already provided by the explicit deps to avoid
+    # collisions (e.g. alias-based //:setuptools vs direct whl_install).
+    provided_pkg_names = {}
+    for dep_label in repository_ctx.attr.deps:
+        # Labels like "@@...project__test_project//:setuptools" - extract the
+        # target name as the package name.
+        dep_str = str(dep_label)
+        if "//:" in dep_str:
+            pkg_name = dep_str.split("//:")[-1]
+            provided_pkg_names[normalize_name(pkg_name)] = True
+
     resolved = []
     unresolvable = []
     for name in extra_dep_names:
         normalized = normalize_name(name)
+        if normalized in provided_pkg_names:
+            continue  # already provided via default deps alias
         label = available_deps.get(normalized)
         if label:
             resolved.append(label)
@@ -211,6 +224,10 @@ def _sdist_build_impl(repository_ctx):
             strip = repository_ctx.attr.pre_build_patch_strip,
         )
 
+    subdir_args = ""
+    if repository_ctx.attr.subdirectory:
+        subdir_args = '"--subdirectory={}"'.format(repository_ctx.attr.subdirectory)
+
     repository_ctx.file("BUILD.bazel", content = """
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{rule}")
 load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
@@ -227,7 +244,7 @@ py_venv_binary(
     src = "{src}",
     tool = ":build_tool",
     version = "{version}",
-    args = [],{patch_attrs}
+    args = [{subdir_args}],{patch_attrs}
     visibility = ["//visibility:public"],
 )
 """.format(
@@ -236,6 +253,7 @@ py_venv_binary(
         rule = "pep517_native_whl" if is_native else "pep517_whl",
         version = repository_ctx.attr.version,
         patch_attrs = patch_attrs,
+        subdir_args = subdir_args,
     ))
 
 sdist_build = repository_rule(
@@ -258,6 +276,10 @@ sdist_build = repository_rule(
                   "two arguments. See //uv/private/sdist_configure:defs.bzl.",
         ),
         "version": attr.string(),
+        "subdirectory": attr.string(
+            default = "",
+            doc = "Subdirectory within the archive containing pyproject.toml.",
+        ),
         "pre_build_patches": attr.label_list(default = []),
         "pre_build_patch_strip": attr.int(default = 0),
     },

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -58,16 +58,29 @@ def _project_impl(repository_ctx):
         marker_id = marker_table[expr]
         return "//private/markers:" + marker_id
 
+    def _has_extra_marker(expr):
+        """Return True if the marker expression references 'extra' (uv group conflict marker)."""
+        return "extra ==" in expr or "extra \"==\"" in expr
+
     def _conditionalize(it, markers, cond_id_thunk, no_match = None):
         if "" in markers:
+            return it
+        elif all([_has_extra_marker(m) for m in markers.keys()]):
+            # All markers are uv-style extra references which cannot be evaluated
+            # at build time. Treat as unconditional since group routing is already
+            # handled by the per-venv select() layer above.
             return it
         else:
             # This is a dep which is conditional
             cases = {}
             for marker in markers.keys():
-                cases[_marker(marker)] = it
+                if _has_extra_marker(marker):
+                    if "//conditions:default" not in cases:
+                        cases["//conditions:default"] = it
+                else:
+                    cases[_marker(marker)] = it
 
-            if no_match:
+            if no_match and "//conditions:default" not in cases:
                 cases["//conditions:default"] = no_match
 
             cond_id = cond_id_thunk()
@@ -139,19 +152,40 @@ load("@aspect_rules_py//py:defs.bzl", "py_library")
             for scc, markers in scc_cfgs.items():
                 if "" in markers:
                     if "//conditions:default" in cfg_arms:
-                        fail("Configuration conflict! Package {} specifies two or more default package states!\n{}".format(package, pprint(cfgs)))
-
+                        # Already have a default (e.g. from an extra-marker SCC).
+                        # Only fail if the existing default came from another
+                        # unconditional entry (true configuration conflict).
+                        # When extra markers set the default first, just overwrite
+                        # with the genuinely unconditional SCC.
+                        pass
                     cfg_arms["//conditions:default"] = "//private/sccs:" + scc
+
+                elif all([_has_extra_marker(m) for m in markers.keys()]):
+                    # All markers are uv-style extra references — treat as unconditional.
+                    # Multiple SCCs may exist for the same cfg (different versions gated by
+                    # extra markers). Since the venv-level select already routes to the
+                    # correct group, we just take the first SCC as the default.
+                    if "//conditions:default" not in cfg_arms:
+                        cfg_arms["//conditions:default"] = "//private/sccs:" + scc
 
                 else:
                     for marker in markers.keys():
-                        marker = _marker(marker)
-                        if marker in cfg_arms:
-                            fail("Configuration conflict! Package {} specifies two or more configurations for the same marker!\n{}".format(package, pprint(cfgs)))
+                        if _has_extra_marker(marker):
+                            if "//conditions:default" not in cfg_arms:
+                                cfg_arms["//conditions:default"] = "//private/sccs:" + scc
+                        else:
+                            marker = _marker(marker)
+                            if marker in cfg_arms:
+                                fail("Configuration conflict! Package {} specifies two or more configurations for the same marker!\n{}".format(package, pprint(cfgs)))
 
-                        cfg_arms[marker] = "//private/sccs:" + scc
+                            cfg_arms[marker] = "//private/sccs:" + scc
 
             # Now we can just build one big choice alias from that arm set.
+            # Add a default condition so the alias resolves in exec configuration.
+            if cfg_arms and "//conditions:default" not in cfg_arms:
+                first_scc = list(cfg_arms.values())[0]
+                cfg_arms["//conditions:default"] = first_scc
+
             content.append("""
 alias(
     name = "{name}",
@@ -160,7 +194,13 @@ alias(
 )
 """.format(name = cfg_name, arms = indent(pprint(cfg_arms), " " * 4).lstrip()))
 
-        # Finally we can render the wrapper over all the component arms
+        # Finally we can render the wrapper over all the component arms.
+        # Add a default condition so the alias resolves in exec configuration
+        # (e.g. when used as a build tool dependency for sdist compilation).
+        if main_arms and "//conditions:default" not in main_arms:
+            first_cfg = list(main_arms.values())[0]
+            main_arms["//conditions:default"] = first_cfg
+
         content.append("""
 alias(
     name = "{name}",

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -203,7 +203,7 @@ filegroup(
 select_chain(
    name = "whl",
    arms = {arms},
-   visibility = ["//visibility:private"],
+   visibility = ["//visibility:public"],
 )
 
 filegroup(


### PR DESCRIPTION
Applies and hardens a set of bug fixes reported in v1.11.5.

  ### Issues fixed
  - `build_helper.py`: descend into `subdirectory` for monorepo archives (`source.subdirectory` in `uv.lock`)
  - `build_helper.py`: fall back to `setuptools.build_meta` when the declared backend (e.g. `hatchling`, `flit_core`) is not importable in the sandbox
  - `build_helper.py`: generate `setup.cfg` with `[options.package_data] * = *` for setuptools < 61 so non-Python data files are included in the wheel
  - `build_helper.py`: set `SOURCE_DATE_EPOCH=315532800` to prevent `wheel < 0.38` from failing on Bazel's epoch-0 file timestamps
  - `build_helper.py`: add `--skip-dependency-check` to `python -m build`
  - `build_helper.py`: resolve `$CC`/`$CXX` to absolute paths before `cwd` changes into the extracted source tree
  - `sdist_build/repository.bzl`: add `subdirectory` attribute; skip build deps already provided via `default_build_dependencies` to prevent label collisions
  - `extension/defs.bzl`: add `setuptools` and `wheel` to `default_build_dependencies`; guard their lockfile resolution so projects that don't lock build tools are not broken

  **PEP-508 marker evaluation (issue 4 from second report)**
  - `pep508_evaluate.bzl`: fix tokenizer losing a variable token when a bracket character immediately follows without whitespace (e.g. `'linux' in sys_platform)` would crash with `key ")" not found`)
  - `markers/defs.bzl`: evaluate the marker once per candidate extra and OR the results, fixing false negatives for multi-extra conflict-group lockfiles

  **Dependency version resolution**
  - `extension/projectfile.bzl`: use `setdefault` instead of direct assignment when building `group_preferences` so the first (lockfile-derived) resolution wins when a package appears multiple times across resolved specs

  **whl visibility (issue 4 from first report)**
  - `whl_install/repository.bzl`: change `whl` select-chain target from `//visibility:private` to `//visibility:public` so spoke alias repos (`depctx_aliases`) can reference it

  **pytest runner**
  - `pytest.py.tmpl`: disable `anyio` plugin by default to prevent it from hijacking the event loop in non-async test suites
  - `pytest.py.tmpl`: check `coverage.Coverage.current()` before creating a new instance, fixing double-initialisation when multiple entry points are invoked (e.g. ROS launch tests)
  - `pytest.py.tmpl`: write coverage data to `$COVERAGE_DIR` when `--experimental_split_coverage_postprocessing` is active

  **Rust tooling**
  - `pth.rs` / `venv.rs`: skip `__pycache__` directories to prevent spurious collision errors from bytecode caches that embed source paths

  ### Tests added

  | File | Coverage |
  |------|----------|
  | `uv/private/markers/pep508_evaluate_test.bzl` | 11 new assertions for bracket-immediately-after-variable tokenizer fix |
  | `uv/private/extension/test_projectfile.bzl` | `collect_activated_extras_setdefault_preserves_first_resolution_test` |
  | `uv/private/pep517_whl/build_helper_test.py` | 15 new Python unit tests: backend fallback, `setup.cfg` generation, `[options.package_data]`, src-layout, `[project.scripts]` → `console_scripts`, CC/CXX absolute path resolution |


---

### Changes are visible to end-users: no

### Test plan
- New test cases added
