### PR TITLE
fix: providate data to py_venv and py_venv_exec for use in $(location) expansion

### DIFF
--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -382,6 +382,12 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], im
         name = name,
         main = main,
         srcs = srcs,
+        # `data` lands on both targets: the venv merges it into the
+        # runfiles every consumer inherits, while the launcher needs it
+        # directly so `args` / `env` `$(location :data_file)` expansion
+        # and the coverage walk can resolve the label (srcs are kept on
+        # the launcher for the same reason).
+        data = data,
         tags = tags,
         testonly = testonly,
         visibility = visibility,

--- a/py/tests/data-files/BUILD.bazel
+++ b/py/tests/data-files/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//py:defs.bzl", "py_binary", "py_test")
+
+# Regression: `data` on py_binary / py_test must reach the generated
+# launcher rule, not only the sibling py_venv. The launcher needs it for
+# `$(location :data_file)` expansion in `args` (analysis fails without
+# it) and so its own runfiles carry the files. read_data.py asserts the
+# file is present at runtime; the `args` attribute below asserts the
+# expansion resolves at analysis time.
+
+py_test(
+    name = "test_data_on_test",
+    srcs = ["read_data.py"],
+    args = ["$(location :data.txt)"],
+    data = ["data.txt"],
+    env = {
+        "DATA_LOCATION": "$(location :data.txt)",
+    },
+    main = "read_data.py",
+)
+
+py_binary(
+    name = "bin_data",
+    srcs = ["read_data.py"],
+    args = ["$(location :data.txt)"],
+    data = ["data.txt"],
+    main = "read_data.py",
+)
+
+# Run the binary launcher as a test — read_data.py asserts internally.
+sh_test(
+    name = "test_data_on_binary",
+    srcs = ["check_binary.sh"],
+    data = [":bin_data"],
+)

--- a/py/tests/data-files/check_binary.sh
+++ b/py/tests/data-files/check_binary.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run the py_binary launcher, passing the workspace-relative path that
+# `args = ["$(location :data.txt)"]` would expand to under `bazel run`.
+# read_data.py asserts the file is present in runfiles and readable.
+set -euo pipefail
+
+ROOT="$(dirname "$0")"
+"$ROOT"/bin_data py/tests/data-files/data.txt

--- a/py/tests/data-files/data.txt
+++ b/py/tests/data-files/data.txt
@@ -1,0 +1,1 @@
+hello from data file

--- a/py/tests/data-files/read_data.py
+++ b/py/tests/data-files/read_data.py
@@ -1,0 +1,45 @@
+"""Assert `data` files reach the launcher target.
+
+Regression test: the `py_binary` / `py_test` macros must forward `data`
+to the generated launcher rule, not only to the sibling py_venv —
+otherwise `$(location :data_file)` expansion in `args` fails analysis
+and the launcher's own runfiles miss the files.
+
+Checks, in order:
+1. `data.txt` is present in the runfiles tree.
+2. If argv[1] is given (the `args = ["$(location :data.txt)"]`
+   expansion), it resolves to the same file.
+3. If `DATA_LOCATION` is set (the `env` expansion), it resolves too.
+"""
+
+import os
+import sys
+
+EXPECTED = "hello from data file"
+
+
+def read(path):
+    with open(path) as f:
+        return f.read().strip()
+
+
+# 1. Runfiles presence.
+rfdir = os.environ.get("RUNFILES_DIR")
+if not rfdir:
+    sys.exit("RUNFILES_DIR not set")
+workspace = os.environ.get("BAZEL_WORKSPACE", "_main")
+runfiles_path = os.path.join(rfdir, workspace, "py", "tests", "data-files", "data.txt")
+if not os.path.exists(runfiles_path):
+    sys.exit("data file missing from runfiles: " + runfiles_path)
+assert read(runfiles_path) == EXPECTED
+
+# 2. `args` location expansion (workspace-relative, resolved from cwd).
+if len(sys.argv) > 1:
+    assert read(sys.argv[1]) == EXPECTED, sys.argv[1]
+
+# 3. `env` location expansion.
+env_path = os.environ.get("DATA_LOCATION")
+if env_path:
+    assert read(env_path) == EXPECTED, env_path
+
+print("ok")


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
