### PR TITLE
fix: regular package spanning two wheels (azure-core + azure-core-tracing-opentelemetry) is importable

### DIFF
--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -82,6 +82,19 @@ write_source_files(
         # one constraint string.
         "snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel": "@whl_install__uv_bare_linux_wheels__grpcio__1_80_0//:BUILD.bazel",
 
+        # whl_install for the azure-core / azure-core-tracing-opentelemetry
+        # pair (cases/azure-core-tracing-overlap). Pins the namespace_dirs /
+        # regular_roots metadata emission for both sides of a regular
+        # package spanning wheels: azure-core's `regular_roots =
+        # ["azure/core"]` vs the tracing wheel's 4-dir namespace skeleton
+        # reaching down to `azure/core/tracing/ext`. A regression that
+        # stops emitting either attr silently degrades the venv's
+        # PySiteMerge trigger back to the broken `.pth`-only behaviour —
+        # the runtime test would catch that too, but the snapshot shows
+        # WHICH side of the metadata went missing.
+        "snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel": "@whl_install__azure_core_tracing_import__azure_core__1_38_0//:BUILD.bazel",
+        "snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel": "@whl_install__azure_core_tracing_import__azure_core_tracing_opentelemetry__1_0_0b11//:BUILD.bazel",
+
         # whl_install for cryptography 46.0.5, which ships BOTH cp311-abi3
         # AND cp38-abi3 wheels for the same platforms. Pins the select_chain
         # arm mapping so a regression that drops source-specificity

--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -91,6 +91,7 @@ uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
 
 # Per-case MODULE fragments. Each redeclares its own use_extension(...) proxies.
 include("//cases/arch-alias-marker:setup.MODULE.bazel")
+include("//cases/azure-core-tracing-overlap:setup.MODULE.bazel")
 include("//cases/cross-repo-610:setup.MODULE.bazel")
 include("//cases/current-py-toolchain-bazel-env-896:setup.MODULE.bazel")
 include("//cases/firebase-admin-import:setup.MODULE.bazel")

--- a/e2e/cases/azure-core-tracing-overlap/BUILD.bazel
+++ b/e2e/cases/azure-core-tracing-overlap/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+# Regression test: overlapping regular-package trees across wheels.
+#
+# azure-core owns `azure/core/` and `azure/core/tracing/` as regular
+# packages (both ship an `__init__.py`); azure-core-tracing-opentelemetry
+# installs `azure/core/tracing/ext/` into that same tree from a separate
+# wheel. Unlike the PEP 420 namespace cases (pth-namespace-547,
+# firebase-admin-import), regular packages don't merge `__path__` across
+# sys.path entries — venv assembly has to physically merge the
+# overlapping directories or `azure.core.tracing.ext` is unreachable.
+#
+# Reported by OpenAI: their `oai_otel_init` package hit
+#   ModuleNotFoundError: No module named 'azure.core.tracing.ext.opentelemetry_span'
+# under rules_py while the same pair works in any flat site-packages
+# install.
+#
+# Variants:
+#   :test       — py_test default (.pth strategy)
+#   :test_tool  — py_venv_test variant (symlink-forest venv)
+
+py_test(
+    name = "test",
+    srcs = ["test.py"],
+    dep_group = "azure-core-tracing-import",
+    main = "test.py",
+    deps = [
+        "@pypi_azure_core_tracing//azure_core",
+        "@pypi_azure_core_tracing//azure_core_tracing_opentelemetry",
+    ],
+)
+
+# Naming: `test_tool` (not `test_venv`) to avoid the tree-artifact /
+# internal-venv-dir prefix collision described in
+# cases/firebase-admin-import/BUILD.bazel.
+py_test(
+    name = "test_tool",
+    srcs = ["test.py"],
+    dep_group = "azure-core-tracing-import",
+    expose_venv = True,
+    isolated = False,
+    main = "test.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi_azure_core_tracing//azure_core",
+        "@pypi_azure_core_tracing//azure_core_tracing_opentelemetry",
+    ],
+)

--- a/e2e/cases/azure-core-tracing-overlap/pyproject.toml
+++ b/e2e/cases/azure-core-tracing-overlap/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "azure-core-tracing-import"
+version = "0.0.0"
+# azure-core ships `azure/core/` as a REGULAR package (it has an
+# `__init__.py`, only the `azure/` top level is a PEP 420 namespace).
+# azure-core-tracing-opentelemetry contributes `azure/core/tracing/ext/`
+# INSIDE that regular package from a separate wheel. Regular packages
+# don't merge `__path__` across sys.path entries, so this pair only
+# works if venv assembly physically merges the overlapping directory
+# trees — the namespace `.pth` machinery cannot help here.
+requires-python = ">=3.11"
+dependencies = [
+    # `build` + `setuptools` match the hub's default_build_dependencies
+    # declared in //MODULE.bazel. The uv extension expects every project
+    # lockfile to be able to resolve them.
+    "build",
+    "setuptools",
+    "azure-core==1.38.0",
+    "azure-core-tracing-opentelemetry==1.0.0b11",
+]

--- a/e2e/cases/azure-core-tracing-overlap/setup.MODULE.bazel
+++ b/e2e/cases/azure-core-tracing-overlap/setup.MODULE.bazel
@@ -1,0 +1,20 @@
+"""Regression: overlapping regular-package trees across wheels.
+
+azure-core owns the regular package `azure/core/` (and
+`azure/core/tracing/`); azure-core-tracing-opentelemetry installs
+`azure/core/tracing/ext/` into that same tree from a separate wheel.
+"""
+
+uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
+uv.declare_hub(hub_name = "pypi_azure_core_tracing")
+uv.project(
+    hub_name = "pypi_azure_core_tracing",
+    lock = "//cases/azure-core-tracing-overlap:uv.lock",
+    pyproject = "//cases/azure-core-tracing-overlap:pyproject.toml",
+)
+use_repo(uv, "pypi_azure_core_tracing")
+
+# Exposed so e2e/BUILD.bazel can snapshot the namespace_dirs / regular_roots
+# metadata the whl_install repo rule emits for this overlapping pair.
+use_repo(uv, "whl_install__azure_core_tracing_import__azure_core__1_38_0")
+use_repo(uv, "whl_install__azure_core_tracing_import__azure_core_tracing_opentelemetry__1_0_0b11")

--- a/e2e/cases/azure-core-tracing-overlap/test.py
+++ b/e2e/cases/azure-core-tracing-overlap/test.py
@@ -1,0 +1,65 @@
+"""Regression: overlapping regular-package trees across wheels.
+
+azure-core 1.38.0 ships `azure/core/` and `azure/core/tracing/` as
+REGULAR packages (each has an `__init__.py`); only the `azure/` top
+level is a PEP 420 namespace. azure-core-tracing-opentelemetry
+1.0.0b11 ships `azure/core/tracing/ext/opentelemetry_span.py` — a
+subpackage nested inside a regular package owned by a *different*
+wheel.
+
+Regular packages do not merge `__path__` across sys.path entries, so
+the namespace `.pth` + addsitedir machinery (see
+cases/firebase-admin-import, cases/pth-namespace-547) cannot make
+`azure.core.tracing.ext` reachable: once Python resolves
+`azure.core.tracing` to azure-core's directory, the `ext/` directory
+contributed by the other wheel is invisible unless venv assembly
+physically merges the two trees the way a flat `pip install` into one
+site-packages would.
+
+Reported by OpenAI from their `oai_otel_init` package, which uses this
+exact Azure package pair.
+"""
+
+import sys
+
+
+def test_azure_core_tracing_ext_import():
+    # The failing import from the report: requires `ext/` (from
+    # azure-core-tracing-opentelemetry) to be visible inside the
+    # `azure.core.tracing` regular package (from azure-core).
+    from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+
+    assert OpenTelemetrySpan is not None
+
+
+def test_azure_core_still_intact():
+    # The merge must not break azure-core's own modules next to the
+    # grafted `ext/` directory.
+    from azure.core.settings import settings
+    from azure.core.tracing import SpanKind
+
+    assert settings is not None
+    assert SpanKind is not None
+
+
+def test_azure_core_tracing_is_regular_package():
+    """Guard the premise of this test case.
+
+    If a future azure-core converts `azure.core.tracing` into a
+    namespace package, this case would silently degrade into a
+    duplicate of the pth-namespace-547 coverage. Fail loudly so the
+    fixture gets re-pointed at another overlapping pair.
+    """
+    import azure.core.tracing
+
+    assert azure.core.tracing.__file__ is not None, (
+        "azure.core.tracing should be a regular package with __init__.py"
+    )
+
+
+if __name__ == "__main__":
+    test_azure_core_tracing_ext_import()
+    test_azure_core_still_intact()
+    test_azure_core_tracing_is_regular_package()
+    print("PASS: azure.core.tracing.ext imports correctly")
+    sys.exit(0)

--- a/e2e/cases/azure-core-tracing-overlap/uv.lock
+++ b/e2e/cases/azure-core-tracing-overlap/uv.lock
@@ -1,0 +1,253 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[options]
+exclude-newer = "2026-05-28T23:42:32Z"
+
+[[package]]
+name = "azure-core"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", size = 363033, upload-time = "2026-01-12T17:03:05.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/d8/b8fcba9464f02b121f39de2db2bf57f0b216fe11d014513d666e8634380d/azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335", size = 217825, upload-time = "2026-01-12T17:03:07.291Z" },
+]
+
+[[package]]
+name = "azure-core-tracing-import"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-core-tracing-opentelemetry" },
+    { name = "build" },
+    { name = "setuptools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-core", specifier = "==1.38.0" },
+    { name = "azure-core-tracing-opentelemetry", specifier = "==1.0.0b11" },
+    { name = "build" },
+    { name = "setuptools" },
+]
+
+[[package]]
+name = "azure-core-tracing-opentelemetry"
+version = "1.0.0b11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/f2/2ede1654987b82f45dffe0e82d0d77b13940bb88d044138090c8b7baa439/azure-core-tracing-opentelemetry-1.0.0b11.tar.gz", hash = "sha256:a230d1555838b5d07b7594221cd639ea7bc24e29c881e5675e311c6067bad4f5", size = 19097, upload-time = "2023-09-07T19:49:25.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/6e/3ef6dfba8e0faa4692caa6d103c721ccba6ac37a24744848a3a10bb3fe89/azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl", hash = "sha256:016cefcaff2900fb5cdb7a8a7abd03e9c266622c06e26b3fe6dafa54c4b48bf5", size = 10710, upload-time = "2023-09-07T19:49:26.492Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
@@ -1,0 +1,54 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+select_chain(
+   name = "whl",
+   arms = {
+        "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__azure_core__ab0c9b2cd71fecb1//file"
+   },
+   default_target = "@@aspect_rules_py++uv+sdist_build__azure_core_tracing_import__azure_core__1_38_0//:whl",
+   visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "gazelle_index_whl",
+    srcs = [
+        "@whl__azure_core__ab0c9b2cd71fecb1//file",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+whl_install(
+    name = "actual_install",
+    src = ":whl",
+    compile_pyc = select({
+        "@aspect_rules_py//uv/private/pyc:is_precompile": True,
+        "//conditions:default": False,
+    }),
+    pyc_invalidation_mode = select({
+        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
+        "//conditions:default": "checked-hash",
+    }),
+    top_levels = ["azure", "azure_core-1.38.0.dist-info"],
+    namespace_top_levels = ["azure"],
+    console_scripts = [],
+    namespace_dirs = [],
+    regular_roots = ["azure/core"],
+    visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "install",
+    actual = ":actual_install",
+    visibility = ["//visibility:public"],
+)
+
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
@@ -1,0 +1,54 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+select_chain(
+   name = "whl",
+   arms = {
+        "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__azure_core_tracing_opentelemetry__016cefcaff2900fb//file"
+   },
+   default_target = "@@aspect_rules_py++uv+sdist_build__azure_core_tracing_import__azure_core_tracing_opentelemetry__1_0_0b11//:whl",
+   visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "gazelle_index_whl",
+    srcs = [
+        "@whl__azure_core_tracing_opentelemetry__016cefcaff2900fb//file",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+whl_install(
+    name = "actual_install",
+    src = ":whl",
+    compile_pyc = select({
+        "@aspect_rules_py//uv/private/pyc:is_precompile": True,
+        "//conditions:default": False,
+    }),
+    pyc_invalidation_mode = select({
+        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
+        "//conditions:default": "checked-hash",
+    }),
+    top_levels = ["azure", "azure_core_tracing_opentelemetry-1.0.0b11.dist-info"],
+    namespace_top_levels = ["azure"],
+    console_scripts = [],
+    namespace_dirs = ["azure/core", "azure/core/tracing", "azure/core/tracing/ext"],
+    regular_roots = ["azure/core/tracing/ext/opentelemetry_span"],
+    visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "install",
+    actual = ":actual_install",
+    visibility = ["//visibility:public"],
+)
+
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -19,6 +19,14 @@ executable wrappers under `<venv>/bin/<name>` for console scripts.
 — one per wheel in the transitive closure. Fields:
   * `top_levels`: tuple[str] — top-level names the wheel installs into site-packages.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
+  * `namespace_dirs`: tuple[str] — implicit-namespace directory skeleton under the
+    namespace top-levels (site-packages-relative `/`-joined paths). May be absent
+    on structs from older producers; consumers use `getattr` with a `()` default.
+  * `regular_roots`: tuple[str] — minimal directories under the namespace
+    top-levels carrying an `__init__.py`. Cross-referencing a wheel's
+    `regular_roots` with another wheel's `namespace_dirs` detects regular
+    packages spanning wheels, which venv assembly must physically merge.
+    May be absent on structs from older producers.
   * `site_packages_rfpath`: str — runfiles-root-relative path to the wheel's site-packages.
   * `console_scripts`: tuple[str] — entry points encoded as `"name=module:func"`.
 """,

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -29,7 +29,7 @@ load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path"
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_version_transition")
-load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
+load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
 load(":py_venv_exec.bzl", _py_venv_exec = "py_venv_exec")
 load(":types.bzl", "VirtualenvInfo")
 load(":venv.bzl", "assemble_venv")
@@ -80,6 +80,7 @@ def _assemble_shared(ctx):
         default_env = default_env,
         venv_activate_tmpl = ctx.file._venv_activate_tmpl,
         virtualenv_shim_py = ctx.file._virtualenv_shim,
+        site_merge_script_py = ctx.file._site_merge_script,
         venv_name = ".{}".format(safe_name),
     )
 
@@ -251,6 +252,13 @@ environment. Forwarded to the sibling py_binary/py_test consumer
         allow_single_file = True,
         default = ":_virtualenv.py",
     ),
+    # Tool for physically merging a regular package that spans wheels
+    # (e.g. azure-core + azure-core-tracing-opentelemetry both
+    # installing into `azure/core/tracing/`) — see assemble_venv.
+    "_site_merge_script": attr.label(
+        allow_single_file = True,
+        default = "//py/tools/site_merge:site_merge.py",
+    ),
 })
 
 _attrs.update(**_py_library.attrs)
@@ -259,7 +267,14 @@ _py_venv = rule(
     doc = """Build a Python virtual environment and execute its interpreter.""",
     implementation = _py_venv_rule_impl,
     attrs = _attrs,
-    toolchains = [PY_TOOLCHAIN],
+    toolchains = [
+        PY_TOOLCHAIN,
+        # Optional: only consulted when a regular package spans wheels
+        # and assemble_venv needs an exec-config interpreter to run the
+        # site_merge action. Optional so venvs keep analyzing in setups
+        # that never registered rules_py's exec-tools toolchain.
+        config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
+    ],
     executable = True,
     cfg = python_version_transition,
 )

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -33,6 +33,7 @@ Bazel's action cache treats each piece independently (no tree-artifact
 
 load("@bazel_lib//lib:paths.bzl", "to_rlocation_path")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
+load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
 
 # Template for console-script wrappers under <venv>/bin/<name>. A tiny shell
 # script that execs the venv's own bin/python with an inline `-c` to import
@@ -62,6 +63,19 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
       Python's namespace machinery merges contributions natively.
       Otherwise apply `package_collisions` policy.
 
+      Within an all-namespace top-level there's one shape `.pth` +
+      `addsitedir` cannot handle: a REGULAR package spanning wheels.
+      E.g. azure-core owns `azure/core/` (has `__init__.py`) while
+      azure-core-tracing-opentelemetry installs
+      `azure/core/tracing/ext/opentelemetry_span/` into that same tree.
+      Python locks a regular package's `__path__` to the first
+      directory found, so the second wheel's graft is unreachable. We
+      detect this by cross-referencing each wheel's `regular_roots`
+      against the other claimants' `namespace_dirs` skeletons, and
+      return the minimal conflicted roots as `merge_groups` — the
+      caller physically merges those subtrees (what a flat
+      `pip install` would have produced).
+
     * **Console-script name in bin/.** Apply `package_collisions` directly
       — no namespace equivalent.
 
@@ -72,6 +86,10 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
           from the .pth fallback.
       console_scripts_map: dict {script_name: struct(module, func)} after
           collision resolution.
+      merge_groups: list of struct(root, site_packages_list) — regular
+          package dirs (site-packages-relative paths) that span wheels
+          and need a physical merge, with the contributing wheels'
+          site-packages paths in first-wins priority order.
     """
 
     def _complain(what, name, a, b):
@@ -91,7 +109,9 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     # Pass 1: bucket claimants per top-level / per console-script name.
     tl_claimants = {}  # tl -> list of struct(site_packages, is_ns)
     cs_claimants = {}  # name -> list of struct(site_packages, module, func)
+    wheel_by_sp = {}  # site_packages_rfpath -> wheel struct
     for w in wheels:
+        wheel_by_sp[w.site_packages_rfpath] = w
         ns_set = {tl: True for tl in getattr(w, "namespace_top_levels", ())}
         for tl in w.top_levels:
             tl_claimants.setdefault(tl, []).append(struct(
@@ -121,6 +141,8 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     # we SKIPPED so pass 3 can decide which wheels are fully covered.
     top_level_to_site_pkgs = {}
     skipped_per_wheel = {}
+    conflicted_roots = {}  # root path -> True (deep regular-package overlaps)
+    ns_claimant_sps = {}  # sp -> True, wheels in any all-namespace collision
     for tl, claimants in tl_claimants.items():
         distinct_sp = {c.site_packages: c for c in claimants}
         if len(distinct_sp) == 1:
@@ -131,6 +153,25 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
         if all_namespace:
             for c in claimants:
                 skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+
+            # Deep-overlap scan: a regular root of wheel A appearing in
+            # wheel B's namespace skeleton (B installs files below it)
+            # or in B's own regular roots (both own it) marks a regular
+            # package spanning wheels.
+            tl_prefix = tl + "/"
+            for sp_a in distinct_sp.keys():
+                ns_claimant_sps[sp_a] = True
+                w_a = wheel_by_sp[sp_a]
+                for root in getattr(w_a, "regular_roots", ()):
+                    if not root.startswith(tl_prefix):
+                        continue
+                    for sp_b in distinct_sp.keys():
+                        if sp_b == sp_a:
+                            continue
+                        w_b = wheel_by_sp[sp_b]
+                        if (root in getattr(w_b, "namespace_dirs", ()) or
+                            root in getattr(w_b, "regular_roots", ())):
+                            conflicted_roots[root] = True
             continue
 
         first = claimants[0]
@@ -142,6 +183,35 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             _complain("top-level", tl, first.site_packages, c.site_packages)
             seen_losers[c.site_packages] = True
             skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+
+    # Pass 2a: fold conflicted roots into merge groups. Keep only the
+    # minimal (shallowest) roots — a conflicted root nested inside
+    # another conflicted root is covered by merging the outer one. For
+    # each root, the contributors are every namespace-claimant wheel
+    # that has the root in its skeleton (content below it) or as its
+    # own regular root, in wheel order (= first-wins priority).
+    merge_groups = []
+    minimal_roots = []
+    for root in sorted(conflicted_roots.keys()):
+        nested = False
+        for outer in minimal_roots:
+            if root == outer or root.startswith(outer + "/"):
+                nested = True
+                break
+        if not nested:
+            minimal_roots.append(root)
+    for root in minimal_roots:
+        group_sps = []
+        for sp in ns_claimant_sps.keys():
+            w = wheel_by_sp[sp]
+            if (root in getattr(w, "regular_roots", ()) or
+                root in getattr(w, "namespace_dirs", ())):
+                group_sps.append(sp)
+        if len(group_sps) >= 2:
+            merge_groups.append(struct(
+                root = root,
+                site_packages_list = group_sps,
+            ))
 
     # Pass 2b: console scripts.
     console_scripts_map = {}
@@ -172,7 +242,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
         if covered:
             fully_covered[w.site_packages_rfpath] = True
 
-    return top_level_to_site_pkgs, fully_covered, console_scripts_map
+    return top_level_to_site_pkgs, fully_covered, console_scripts_map, merge_groups
 
 def _wheel_key(wheel):
     """8-hex key derived from the wheel's install_tree.short_path (globally
@@ -194,6 +264,7 @@ def assemble_venv(
         default_env = {},
         venv_activate_tmpl,
         virtualenv_shim_py,
+        site_merge_script_py = None,
         venv_name = None):
     """Declare every file + symlink that makes up a venv for a target.
 
@@ -217,6 +288,11 @@ def assemble_venv(
         `ctx.file._venv_activate_tmpl`).
       virtualenv_shim_py: File — the `_virtualenv.py` distutils shim
         source (usually `ctx.file._virtualenv_shim`).
+      site_merge_script_py: File — the site_merge.py tool source
+        (usually `ctx.file._site_merge_script`). Only needed when the
+        wheel graph contains a regular package spanning wheels; the
+        merge action also requires the rule to declare the (optional)
+        EXEC_TOOLS_TOOLCHAIN for an exec-configuration interpreter.
       venv_name: Optional str — explicit venv dir basename. Defaults to
         "." + safe_name + ".venv" when unset.
 
@@ -234,7 +310,7 @@ def assemble_venv(
 
     wheels_depset = _py_library.make_wheels_depset(ctx)
     wheels = wheels_depset.to_list()
-    top_level_to_site_pkgs, fully_covered_site_pkgs, console_scripts_map = _resolve_wheel_collisions(
+    top_level_to_site_pkgs, fully_covered_site_pkgs, console_scripts_map, merge_groups = _resolve_wheel_collisions(
         ctx,
         wheels,
         package_collisions,
@@ -374,6 +450,79 @@ def assemble_venv(
                 target_path = "{}/{}/{}".format(escape, wheel_site_pkgs, tl),
             )
         declared.append(out)
+
+    # Physical merges for regular packages that span wheels (see
+    # _resolve_wheel_collisions). Each group's subtree is copied from
+    # every contributing wheel into a real directory inside our
+    # site-packages — the layout a flat `pip install` produces. The
+    # venv's own site-packages precedes the per-wheel `.pth` entries on
+    # sys.path, so the merged copy is the one Python binds the regular
+    # package's `__path__` to; the per-wheel originals are shadowed.
+    #
+    # The merge runs as a build action under the exec-configuration
+    # interpreter (same shape as WhlInstall's unpack action). Wheels
+    # without an install_tree (legacy py_unpacked_wheel) can't
+    # contribute — they also never carry the metadata that forms a
+    # merge group, so they can't appear here.
+    for group in merge_groups:
+        if site_merge_script_py == None:
+            fail(("{}: wheels {} all contribute to the regular package `{}` — merging it " +
+                  "requires the venv rule to supply the site_merge tool.").format(
+                ctx.label,
+                group.site_packages_list,
+                group.root,
+            ))
+        exec_toolchain = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN]
+        exec_runtime = exec_toolchain.exec_tools.exec_runtime if exec_toolchain else None
+        if exec_runtime == None:
+            fail(("{}: wheels {} all contribute to the regular package `{}` — merging it " +
+                  "requires an exec-configuration Python interpreter, but no `{}` toolchain " +
+                  "was registered.").format(
+                ctx.label,
+                group.site_packages_list,
+                group.root,
+                EXEC_TOOLS_TOOLCHAIN,
+            ))
+
+        merged_dir = ctx.actions.declare_directory(
+            "{}/{}".format(site_packages_rel, group.root),
+        )
+        arguments = ctx.actions.args()
+        arguments.add(site_merge_script_py)
+        arguments.add_all([merged_dir], expand_directories = False, before_each = "--into")
+        arguments.add("--collision-policy", package_collisions)
+        trees = []
+        for sp in group.site_packages_list:
+            key = wheel_key_by_sp.get(sp)
+            if key == None:
+                fail("{}: wheel at {} contributes to merged package `{}` but has no install_tree.".format(
+                    ctx.label,
+                    sp,
+                    group.root,
+                ))
+            tree = wheel_by_key[key].install_tree
+            trees.append(tree)
+            arguments.add_all(
+                [tree],
+                expand_directories = False,
+                before_each = "--src",
+                format_each = "%s/lib/{}/site-packages/{}".format(wheel_py_ver, group.root),
+            )
+        ctx.actions.run(
+            mnemonic = "PySiteMerge",
+            executable = exec_runtime.interpreter,
+            toolchain = EXEC_TOOLS_TOOLCHAIN,
+            arguments = [arguments],
+            inputs = depset(
+                direct = [site_merge_script_py] + trees,
+                transitive = [exec_runtime.files],
+            ),
+            outputs = [merged_dir],
+            execution_requirements = {
+                "supports-path-mapping": "1",
+            },
+        )
+        declared.append(merged_dir)
 
     # Keyed wheels (have `_wheels/<key>/`) emit a plain relative path:
     # site.py joins it with the .pth's directory and appends to

--- a/py/tools/site_merge/BUILD.bazel
+++ b/py/tools/site_merge/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(
+    ["site_merge.py"],
+    visibility = ["//visibility:public"],
+)

--- a/py/tools/site_merge/site_merge.py
+++ b/py/tools/site_merge/site_merge.py
@@ -1,0 +1,90 @@
+"""Site-packages subtree merger for aspect_rules_py venv assembly.
+
+Physically merges one package directory contributed by multiple wheels
+into a single output directory — the shape a flat `pip install` into one
+site-packages would produce.
+
+Needed when a *regular* package (one with an `__init__.py`) spans
+wheels: e.g. azure-core owns `azure/core/` while
+azure-core-tracing-opentelemetry installs
+`azure/core/tracing/ext/opentelemetry_span/` into that same tree.
+Python locks a regular package's `__path__` to the first directory
+found on `sys.path`, so unlike PEP 420 namespace portions the
+contributions cannot be merged at import time — they have to be merged
+on disk.
+
+Invoked by Bazel as::
+
+    <exec_python> site_merge.py --into <dir> [--collision-policy P] --src <dir> [--src <dir> ...]
+
+Each ``--src`` is one wheel's copy of the package directory, in
+priority order: on file-level conflicts the first wheel providing a
+path wins. Sources that don't exist are skipped (platform wheels for
+other architectures may not ship the directory).
+"""
+
+import argparse
+import filecmp
+import os
+import shutil
+from pathlib import Path
+
+
+def merge(into, sources, collision_policy):
+    into.mkdir(parents=True, exist_ok=True)
+    owners = {}
+    conflicts = []
+
+    for src in sources:
+        if not src.is_dir():
+            continue
+        for root, dirs, files in os.walk(src):
+            rel_root = Path(root).relative_to(src)
+            for d in sorted(dirs):
+                (into / rel_root / d).mkdir(parents=True, exist_ok=True)
+            for f in sorted(files):
+                rel = rel_root / f
+                dest = into / rel
+                src_file = Path(root) / f
+                prior = owners.get(rel)
+                if prior is not None:
+                    # First wheel wins; byte-identical duplicates (e.g.
+                    # an empty __init__.py or py.typed shipped by both
+                    # wheels) are benign and not reported.
+                    if not filecmp.cmp(str(src_file), str(dest), shallow=False):
+                        conflicts.append((rel, prior, src))
+                    continue
+                shutil.copy(str(src_file), str(dest))
+                owners[rel] = src
+
+    return conflicts
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--into", required=True, type=Path)
+    ap.add_argument("--src", dest="sources", action="append", default=[], type=Path)
+    ap.add_argument(
+        "--collision-policy",
+        default="warning",
+        choices=["error", "warning", "ignore"],
+    )
+    args = ap.parse_args()
+
+    conflicts = merge(args.into, args.sources, args.collision_policy)
+
+    if conflicts and args.collision_policy != "ignore":
+        for rel, winner, loser in conflicts:
+            print(
+                "Package collision while merging {}: `{}` is provided by both {} and {}.".format(
+                    args.into, rel, winner, loser
+                )
+            )
+        if args.collision_policy == "error":
+            raise SystemExit(
+                'Set `package_collisions = "warning"` or "ignore" to downgrade.'
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -51,7 +51,8 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
                  label_list attr so Bazel wires up repo visibility.
 
     Returns:
-      Tuple (top_levels_set, regular_top_levels_set, console_scripts_set):
+      Tuple (top_levels_set, regular_top_levels_set, console_scripts_set,
+             dirs_set, init_dirs_set):
         * top_levels_set: dict[name → True] — all first-path-segment
           names in RECORD (excluding `*.data/` staging entries).
         * regular_top_levels_set: subset that had an `__init__.py` at
@@ -61,15 +62,19 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
           across multiple platform wheels before deriving namespaces —
           a top-level is a namespace only if NO wheel has it as regular.
         * console_scripts_set: dict[script_name → "name=module:func"].
+        * dirs_set: dict[path → True] — every directory implied by a
+          RECORD entry, as a `/`-joined relative path.
+        * init_dirs_set: dict[path → True] — subset of dirs_set that
+          directly contain an `__init__.py` (regular packages).
       All empty on any failure — callers tolerate empty and fall back.
     """
     unzip = repository_ctx.which("unzip")
     if not unzip:
-        return {}, {}, {}
+        return {}, {}, {}, {}, {}
 
     whl_path = _find_whl_file(repository_ctx, whl_label)
     if whl_path == None:
-        return {}, {}, {}
+        return {}, {}, {}, {}, {}
 
     # RECORD: authoritative list of every installed file. First path segment
     # = top-level name, excluding the wheel's `*.data/` staging area.
@@ -81,6 +86,14 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
     # appear with an `__init__.py` at depth 1) are PEP 420 namespace
     # packages that expect to be merged across wheels.
     regular_top_levels = {}
+
+    # Full directory skeleton + which directories hold an `__init__.py`.
+    # Powers the namespace_dirs / regular_roots derivation in the caller,
+    # which venv assembly uses to detect regular packages spanning wheels
+    # (e.g. azure-core-tracing-opentelemetry grafting into azure-core's
+    # `azure/core/tracing/` tree).
+    dirs_set = {}
+    init_dirs_set = {}
     if record.return_code == 0 and record.stdout:
         for line in record.stdout.splitlines():
             line = line.strip()
@@ -118,6 +131,13 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
             if len(segments) == 1 or (len(segments) >= 2 and segments[1] == "__init__.py"):
                 regular_top_levels[first_segment] = True
 
+            # Record every directory along the path, and which of them
+            # directly contain an `__init__.py`.
+            for i in range(1, len(segments)):
+                dirs_set["/".join(segments[:i])] = True
+            if segments[-1] == "__init__.py" and len(segments) >= 2:
+                init_dirs_set["/".join(segments[:-1])] = True
+
     # entry_points.txt: INI-style file. Only `[console_scripts]` interests
     # us — pip/uv synthesize executables under `bin/<name>` from those at
     # install time. Missing file is normal (lots of libs have no scripts).
@@ -149,7 +169,7 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
     # Return raw sets (not the final namespace derivation) so callers can
     # union across multiple platform wheels before deciding namespace
     # status — see the caller in `_whl_install_repo_impl`.
-    return top_levels_set, regular_top_levels, console_scripts
+    return top_levels_set, regular_top_levels, console_scripts, dirs_set, init_dirs_set
 
 def indent(text, space = " "):
     return "\n".join(["{}{}".format(space, l) for l in text.splitlines()])
@@ -439,11 +459,15 @@ filegroup(
     top_levels_set = {}
     regular_top_levels_set = {}
     console_scripts_set = {}
+    dirs_set = {}
+    init_dirs_set = {}
     for whl_file in repository_ctx.attr.whl_files:
-        tls, reg, css = _extract_wheel_metadata(repository_ctx, whl_file)
+        tls, reg, css, dirs, init_dirs = _extract_wheel_metadata(repository_ctx, whl_file)
         top_levels_set.update(tls)
         regular_top_levels_set.update(reg)
         console_scripts_set.update(css)
+        dirs_set.update(dirs)
+        init_dirs_set.update(init_dirs)
 
     # Namespace derivation happens AFTER the union: a top-level counts as
     # a PEP 420 namespace only if NO extracted wheel had `__init__.py` at
@@ -455,6 +479,47 @@ filegroup(
         if tl not in regular_top_levels_set and not tl.endswith(".dist-info")
     ])
     console_scripts = sorted(console_scripts_set.values())
+
+    # Classify every directory under a namespace top-level. Walking from
+    # the top, content is an implicit-namespace portion until the first
+    # directory carrying an `__init__.py` — that directory is a "regular
+    # root" and everything below it is interior to a regular package.
+    #
+    #   * namespace_dirs: the implicit-namespace skeleton, minus the
+    #     depth-1 entries already covered by namespace_top_levels
+    #     (azure-core → []; azure-core-tracing-opentelemetry →
+    #     ["azure/core", "azure/core/tracing", "azure/core/tracing/ext"]).
+    #   * regular_roots: the minimal regular-package dirs (azure-core →
+    #     ["azure/core"]).
+    #
+    # venv assembly cross-references these across wheels: a regular root
+    # appearing in another wheel's namespace skeleton means a regular
+    # package SPANS wheels — Python's namespace machinery cannot merge
+    # that, so the subtree must be physically merged. Dirs under regular
+    # top-levels are skipped: those collisions are already handled by the
+    # top-level first-wins policy.
+    namespace_top_levels_set = {tl: True for tl in namespace_top_levels}
+    namespace_dirs = []
+    regular_roots = []
+    for d in sorted(dirs_set.keys()):
+        segments = d.split("/")
+        if segments[0] not in namespace_top_levels_set:
+            continue
+        boundary = None
+        for i in range(len(segments)):
+            prefix = "/".join(segments[:i + 1])
+            if prefix in init_dirs_set:
+                boundary = prefix
+                break
+        if boundary == None:
+            # Depth-1 entries are redundant with namespace_top_levels
+            # (regular roots are always depth >= 2, so the cross-wheel
+            # scan never consults them) — dropping them keeps wheels
+            # with only a `<pkg>.libs/` shared-library dir attr-free.
+            if len(segments) >= 2:
+                namespace_dirs.append(d)
+        elif boundary == d:
+            regular_roots.append(d)
 
     install_attrs = """
     src = ":whl",
@@ -469,6 +534,17 @@ filegroup(
         namespace_top_levels = repr(namespace_top_levels),
         console_scripts = repr(console_scripts),
     )
+
+    # Only emitted for wheels that contribute to a namespace — keeps the
+    # generated BUILD files (and their e2e snapshots) unchanged for the
+    # common regular-top-level case.
+    if namespace_dirs or regular_roots:
+        install_attrs += """
+    namespace_dirs = {namespace_dirs},
+    regular_roots = {regular_roots},""".format(
+            namespace_dirs = repr(namespace_dirs),
+            regular_roots = repr(regular_roots),
+        )
 
     if post_install_patches:
         install_attrs += """

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -100,6 +100,14 @@ def _whl_install(ctx):
                 # resolution so Python's namespace-package machinery
                 # merges contributions across wheels.
                 namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
+                # Directory skeleton under namespace top-levels: which
+                # dirs are implicit-namespace portions and which are the
+                # minimal regular-package roots. venv assembly uses the
+                # cross-wheel combination to detect regular packages
+                # spanning wheels (which need a physical merge — Python
+                # can't merge a regular package's __path__ at runtime).
+                namespace_dirs = tuple(ctx.attr.namespace_dirs),
+                regular_roots = tuple(ctx.attr.regular_roots),
                 site_packages_rfpath = site_packages_rfpath,
                 # Each entry is "name=module:func"; py_binary parses into
                 # wrapper scripts at <venv>/bin/<name> at analysis time.
@@ -188,6 +196,32 @@ namespace (e.g. `jaraco-classes` and `jaraco-functools` both claim
 `jaraco`), `py_binary`'s collision detector treats the overlap as
 benign and falls back to `.pth`-based resolution so Python's namespace
 machinery merges the contributions at runtime.
+""",
+            default = [],
+        ),
+        "namespace_dirs": attr.string_list(
+            doc = """Implicit-namespace directory skeleton under the wheel's namespace top-levels.
+
+Every directory (as a `/`-joined path relative to site-packages) that
+the wheel installs files under without an `__init__.py` anywhere on the
+path. E.g. azure-core-tracing-opentelemetry: `["azure", "azure/core",
+"azure/core/tracing", "azure/core/tracing/ext"]`.
+
+Populated from the wheel's RECORD by the `whl_install` repo rule.
+venv assembly cross-references this with other wheels' `regular_roots`
+to find regular packages that span wheels.
+""",
+            default = [],
+        ),
+        "regular_roots": attr.string_list(
+            doc = """Minimal regular-package directories under the wheel's namespace top-levels.
+
+The shallowest directories (as `/`-joined paths relative to
+site-packages) carrying an `__init__.py`. E.g. azure-core:
+`["azure/core"]`. When such a root shows up in another wheel's
+`namespace_dirs`, that other wheel grafts content inside this regular
+package — venv assembly must physically merge the subtree since
+Python locks a regular package's `__path__` to one directory.
 """,
             default = [],
         ),


### PR DESCRIPTION
See https://github.com/aspect-build/rules_py/pull/1092 instead

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
