### PR TITLE
fix(platform detection): detect Gentoo glibc

### DIFF
--- a/uv/private/host/repository.bzl
+++ b/uv/private/host/repository.bzl
@@ -34,20 +34,21 @@ def _platform(rctx):
 
         out = res.stdout.lower()
 
-        # - Alpine: "musl libc\nversion <ver>\n ..."
+        # - Alpine: "musl libc ...\nversion <ver>\n ..."
         if "musl" in out:
             ver = res.stdout.split("\n")[1].split(" ")[-1].split(".")
             return "musl", "{}.{}".format(ver[0], ver[1])
 
             # - Amazon Linux: "ldd (gnu libc ...) <ver>\n..."
             # - Arch Linux: "ldd (gnu libc ...) <ver>\n..."
-            # - Debian: "ldd (debian glibc ...) <ver>\n..."
+            # - Debian: "ldd (debian glibc <ver><platformver>) <ver>\n..."
             # - Fedora: "ldd (gnu libc ...) <ver>\n..."
+            # - Gentoo: "ldd (gentoo <ver><platformver>) <ver>\n..."
             # - Oracle Linux: "ldd (gnu libc ...) <ver>\n..."
-            # - Ubuntu: "ldd (ubuntu glibc ...) <ver>\n..."
+            # - Ubuntu: "ldd (ubuntu glibc <ver><platformver>) <ver>\n..."
 
-        elif "glibc" in out or "gnu libc" in out:
-            ver = res.stdout.split("\n")[0].split(")")[1].strip().split(".")
+        elif "glibc" in out or "gnu libc" in out or "gentoo" in out:
+            ver = res.stdout.split("\n")[0].split(")")[-1].strip().split(".")
             major = ver[0]
             minor = ver[1]
             return "glibc", "{}.{}".format(major, minor)


### PR DESCRIPTION
Gentoo's glibc / ldd output doesn't match the pattern that the rest does. In particular, it includes parenthesis in its platform-defined version string, and does not call out that it is glibc at all.

Fixes this hole in libc detection.

Also updates the comments to be more accurate.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; use the uv ruleset in a Gentoo, glibc environment (or run `ldd --version` in a bunch of docker images)
  In particular the coworker that reported this uses a [Gentoo Prefix](https://wiki.gentoo.org/wiki/Project:Prefix), but this matches.
  I have not verified (or fixed if it is broken) the output on nixos because it is too annoying for me to try (couldn't find a true container image, only VMs).
  I have also verified that in a musl-based Gentoo, the output for musl is still correctly detected.