### PR TITLE
fix(uv): consolidate per-wheel metadata + namespace/regular-span venv merge

### DIFF
--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -82,11 +82,33 @@ write_source_files(
         # one constraint string.
         "snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel": "@whl_install__uv_bare_linux_wheels__grpcio__1_80_0//:BUILD.bazel",
 
+        # whl_install for the azure-core / azure-core-tracing-opentelemetry
+        # pair (cases/azure-core-tracing-overlap). Pins the namespace_dirs /
+        # regular_roots metadata emission for both sides of a regular
+        # package spanning wheels: azure-core's `regular_roots =
+        # ["azure/core"]` vs the tracing wheel's 4-dir namespace skeleton
+        # reaching down to `azure/core/tracing/ext`. A regression that
+        # stops emitting either attr silently degrades the venv's
+        # PySiteMerge trigger back to the broken `.pth`-only behaviour —
+        # the runtime test would catch that too, but the snapshot shows
+        # WHICH side of the metadata went missing.
+        "snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel": "@whl_install__azure_core_tracing_import__azure_core__1_38_0//:BUILD.bazel",
+        "snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel": "@whl_install__azure_core_tracing_import__azure_core_tracing_opentelemetry__1_0_0b11//:BUILD.bazel",
+
         # whl_install for cryptography 46.0.5, which ships BOTH cp311-abi3
         # AND cp38-abi3 wheels for the same platforms. Pins the select_chain
         # arm mapping so a regression that drops source-specificity
         # disambiguation flips ~150 arms to the cp38 wheel in the diff.
         "snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel": "@whl_install__abi3_compat__cryptography__46_0_5//:BUILD.bazel",
+
+        # whl_install for cffi 2.0.0, whose platform wheels each install a
+        # DIFFERENT C-extension top-level (`_cffi_backend.cpython-312-
+        # darwin.so` vs `...-x86_64-linux-gnu.so` vs win `.pyd`). Pins that
+        # top-level / console-script metadata is keyed per wheel file, so a
+        # regression back to unioning across platform wheels (which leaks an
+        # inactive wheel's package surface into the active configuration)
+        # shows up as the per-wheel dicts collapsing into one merged list.
+        "snapshots/abi3_compat.whl_install.cffi.BUILD.bazel": "@whl_install__abi3_compat__cffi__2_0_0//:BUILD.bazel",
 
         # @sdist_build for jpype1 with uv.override_package toolchains/env
         # ----------------------------------------------------------------
@@ -106,11 +128,14 @@ write_source_files(
         # install_tree.short_path — stable across unrelated lockfile
         # churn; only added/removed/version-bumped wheels rotate them.
         #
-        # * pth_namespace_547 — keyed branch, minimal 2-contributor
-        #   namespace case (jaraco-*).
-        # * firebase_admin — keyed branch at scale (~8 google-*
-        #   namespace contributors); catches ordering / scale-only
-        #   regressions that the 2-line minimum can't.
+        # * pth_namespace_547 — minimal 2-contributor namespace case
+        #   (jaraco-*). The concrete per-entry namespace merge fully
+        #   covers both wheels, so the snapshot pins that neither
+        #   appears in the .pth fallback.
+        # * firebase_admin — namespace merge at scale (~8 google-*
+        #   contributors, nested google/cloud namespace); catches
+        #   ordering / scale-only regressions that the 2-wheel
+        #   minimum can't.
         # * wheel_root_pth — non-keyed branch via `py_unpacked_wheel`
         #   without `top_levels`; pins the `site.addsitedir(...)`
         #   shape so wheel-root `.pth` shims keep running.

--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -92,6 +92,7 @@ uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
 # Per-case MODULE fragments. Each redeclares its own use_extension(...) proxies.
 include("//cases/arch-alias-marker:setup.MODULE.bazel")
 include("//cases/azure-core-tracing-overlap:setup.MODULE.bazel")
+include("//cases/azure-namespace-sibling:setup.MODULE.bazel")
 include("//cases/cross-repo-610:setup.MODULE.bazel")
 include("//cases/current-py-toolchain-bazel-env-896:setup.MODULE.bazel")
 include("//cases/firebase-admin-import:setup.MODULE.bazel")

--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -91,6 +91,7 @@ uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
 
 # Per-case MODULE fragments. Each redeclares its own use_extension(...) proxies.
 include("//cases/arch-alias-marker:setup.MODULE.bazel")
+include("//cases/azure-core-tracing-overlap:setup.MODULE.bazel")
 include("//cases/cross-repo-610:setup.MODULE.bazel")
 include("//cases/current-py-toolchain-bazel-env-896:setup.MODULE.bazel")
 include("//cases/firebase-admin-import:setup.MODULE.bazel")

--- a/e2e/cases/azure-core-tracing-overlap/BUILD.bazel
+++ b/e2e/cases/azure-core-tracing-overlap/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+# Regression test: overlapping regular-package trees across wheels.
+#
+# azure-core owns `azure/core/` and `azure/core/tracing/` as regular
+# packages (both ship an `__init__.py`); azure-core-tracing-opentelemetry
+# installs `azure/core/tracing/ext/` into that same tree from a separate
+# wheel. Unlike the PEP 420 namespace cases (pth-namespace-547,
+# firebase-admin-import), regular packages don't merge `__path__` across
+# sys.path entries — venv assembly has to physically merge the
+# overlapping directories or `azure.core.tracing.ext` is unreachable.
+#
+# Reported by OpenAI: their `oai_otel_init` package hit
+#   ModuleNotFoundError: No module named 'azure.core.tracing.ext.opentelemetry_span'
+# under rules_py while the same pair works in any flat site-packages
+# install.
+#
+# Variants:
+#   :test       — py_test default (.pth strategy)
+#   :test_tool  — py_venv_test variant (symlink-forest venv)
+
+py_test(
+    name = "test",
+    srcs = ["test.py"],
+    dep_group = "azure-core-tracing-import",
+    main = "test.py",
+    deps = [
+        "@pypi_azure_core_tracing//azure_core",
+        "@pypi_azure_core_tracing//azure_core_tracing_opentelemetry",
+    ],
+)
+
+# Naming: `test_tool` (not `test_venv`) to avoid the tree-artifact /
+# internal-venv-dir prefix collision described in
+# cases/firebase-admin-import/BUILD.bazel.
+py_test(
+    name = "test_tool",
+    srcs = ["test.py"],
+    dep_group = "azure-core-tracing-import",
+    expose_venv = True,
+    isolated = False,
+    main = "test.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi_azure_core_tracing//azure_core",
+        "@pypi_azure_core_tracing//azure_core_tracing_opentelemetry",
+    ],
+)

--- a/e2e/cases/azure-core-tracing-overlap/pyproject.toml
+++ b/e2e/cases/azure-core-tracing-overlap/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "azure-core-tracing-import"
+version = "0.0.0"
+# azure-core ships `azure/core/` as a REGULAR package (it has an
+# `__init__.py`, only the `azure/` top level is a PEP 420 namespace).
+# azure-core-tracing-opentelemetry contributes `azure/core/tracing/ext/`
+# INSIDE that regular package from a separate wheel. Regular packages
+# don't merge `__path__` across sys.path entries, so this pair only
+# works if venv assembly physically merges the overlapping directory
+# trees — the namespace `.pth` machinery cannot help here.
+requires-python = ">=3.11"
+dependencies = [
+    # `build` + `setuptools` match the hub's default_build_dependencies
+    # declared in //MODULE.bazel. The uv extension expects every project
+    # lockfile to be able to resolve them.
+    "build",
+    "setuptools",
+    "azure-core==1.38.0",
+    "azure-core-tracing-opentelemetry==1.0.0b11",
+]

--- a/e2e/cases/azure-core-tracing-overlap/setup.MODULE.bazel
+++ b/e2e/cases/azure-core-tracing-overlap/setup.MODULE.bazel
@@ -1,0 +1,20 @@
+"""Regression: overlapping regular-package trees across wheels.
+
+azure-core owns the regular package `azure/core/` (and
+`azure/core/tracing/`); azure-core-tracing-opentelemetry installs
+`azure/core/tracing/ext/` into that same tree from a separate wheel.
+"""
+
+uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
+uv.declare_hub(hub_name = "pypi_azure_core_tracing")
+uv.project(
+    hub_name = "pypi_azure_core_tracing",
+    lock = "//cases/azure-core-tracing-overlap:uv.lock",
+    pyproject = "//cases/azure-core-tracing-overlap:pyproject.toml",
+)
+use_repo(uv, "pypi_azure_core_tracing")
+
+# Exposed so e2e/BUILD.bazel can snapshot the namespace_dirs / regular_roots
+# metadata the whl_install repo rule emits for this overlapping pair.
+use_repo(uv, "whl_install__azure_core_tracing_import__azure_core__1_38_0")
+use_repo(uv, "whl_install__azure_core_tracing_import__azure_core_tracing_opentelemetry__1_0_0b11")

--- a/e2e/cases/azure-core-tracing-overlap/test.py
+++ b/e2e/cases/azure-core-tracing-overlap/test.py
@@ -1,0 +1,65 @@
+"""Regression: overlapping regular-package trees across wheels.
+
+azure-core 1.38.0 ships `azure/core/` and `azure/core/tracing/` as
+REGULAR packages (each has an `__init__.py`); only the `azure/` top
+level is a PEP 420 namespace. azure-core-tracing-opentelemetry
+1.0.0b11 ships `azure/core/tracing/ext/opentelemetry_span.py` — a
+subpackage nested inside a regular package owned by a *different*
+wheel.
+
+Regular packages do not merge `__path__` across sys.path entries, so
+the namespace `.pth` + addsitedir machinery (see
+cases/firebase-admin-import, cases/pth-namespace-547) cannot make
+`azure.core.tracing.ext` reachable: once Python resolves
+`azure.core.tracing` to azure-core's directory, the `ext/` directory
+contributed by the other wheel is invisible unless venv assembly
+physically merges the two trees the way a flat `pip install` into one
+site-packages would.
+
+Reported by OpenAI from their `oai_otel_init` package, which uses this
+exact Azure package pair.
+"""
+
+import sys
+
+
+def test_azure_core_tracing_ext_import():
+    # The failing import from the report: requires `ext/` (from
+    # azure-core-tracing-opentelemetry) to be visible inside the
+    # `azure.core.tracing` regular package (from azure-core).
+    from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+
+    assert OpenTelemetrySpan is not None
+
+
+def test_azure_core_still_intact():
+    # The merge must not break azure-core's own modules next to the
+    # grafted `ext/` directory.
+    from azure.core.settings import settings
+    from azure.core.tracing import SpanKind
+
+    assert settings is not None
+    assert SpanKind is not None
+
+
+def test_azure_core_tracing_is_regular_package():
+    """Guard the premise of this test case.
+
+    If a future azure-core converts `azure.core.tracing` into a
+    namespace package, this case would silently degrade into a
+    duplicate of the pth-namespace-547 coverage. Fail loudly so the
+    fixture gets re-pointed at another overlapping pair.
+    """
+    import azure.core.tracing
+
+    assert azure.core.tracing.__file__ is not None, (
+        "azure.core.tracing should be a regular package with __init__.py"
+    )
+
+
+if __name__ == "__main__":
+    test_azure_core_tracing_ext_import()
+    test_azure_core_still_intact()
+    test_azure_core_tracing_is_regular_package()
+    print("PASS: azure.core.tracing.ext imports correctly")
+    sys.exit(0)

--- a/e2e/cases/azure-core-tracing-overlap/uv.lock
+++ b/e2e/cases/azure-core-tracing-overlap/uv.lock
@@ -1,0 +1,253 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[options]
+exclude-newer = "2026-05-28T23:42:32Z"
+
+[[package]]
+name = "azure-core"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", size = 363033, upload-time = "2026-01-12T17:03:05.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/d8/b8fcba9464f02b121f39de2db2bf57f0b216fe11d014513d666e8634380d/azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335", size = 217825, upload-time = "2026-01-12T17:03:07.291Z" },
+]
+
+[[package]]
+name = "azure-core-tracing-import"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-core-tracing-opentelemetry" },
+    { name = "build" },
+    { name = "setuptools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-core", specifier = "==1.38.0" },
+    { name = "azure-core-tracing-opentelemetry", specifier = "==1.0.0b11" },
+    { name = "build" },
+    { name = "setuptools" },
+]
+
+[[package]]
+name = "azure-core-tracing-opentelemetry"
+version = "1.0.0b11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/f2/2ede1654987b82f45dffe0e82d0d77b13940bb88d044138090c8b7baa439/azure-core-tracing-opentelemetry-1.0.0b11.tar.gz", hash = "sha256:a230d1555838b5d07b7594221cd639ea7bc24e29c881e5675e311c6067bad4f5", size = 19097, upload-time = "2023-09-07T19:49:25.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/6e/3ef6dfba8e0faa4692caa6d103c721ccba6ac37a24744848a3a10bb3fe89/azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl", hash = "sha256:016cefcaff2900fb5cdb7a8a7abd03e9c266622c06e26b3fe6dafa54c4b48bf5", size = 10710, upload-time = "2023-09-07T19:49:26.492Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/e2e/cases/azure-namespace-sibling/BUILD.bazel
+++ b/e2e/cases/azure-namespace-sibling/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+# Regression: azure-core + azure-core-tracing-opentelemetry create a
+# regular-span conflict under the `azure` PEP 420 namespace (tl_conflicted).
+# azure-identity contributes a sibling entry `azure/identity/` that must still
+# receive a concrete per-entry symlink — without the fix, the whole `azure`
+# top-level falls back to .pth and mypy/pyright cannot see azure.identity.
+#
+# test     — .pth strategy (verifies runtime imports)
+# test_venv — symlink-forest venv (verifies concrete site-packages/azure/identity/)
+
+py_test(
+    name = "test",
+    srcs = ["test.py"],
+    dep_group = "azure-namespace-sibling",
+    main = "test.py",
+    deps = [
+        "@pypi_azure_namespace_sibling//azure_core",
+        "@pypi_azure_namespace_sibling//azure_core_tracing_opentelemetry",
+        "@pypi_azure_namespace_sibling//azure_identity",
+    ],
+)
+
+py_test(
+    name = "test_venv",
+    srcs = ["test.py"],
+    dep_group = "azure-namespace-sibling",
+    expose_venv = True,
+    isolated = False,
+    main = "test.py",
+    package_collisions = "warning",
+    python_version = "3.11",
+    deps = [
+        "@pypi_azure_namespace_sibling//azure_core",
+        "@pypi_azure_namespace_sibling//azure_core_tracing_opentelemetry",
+        "@pypi_azure_namespace_sibling//azure_identity",
+    ],
+)

--- a/e2e/cases/azure-namespace-sibling/pyproject.toml
+++ b/e2e/cases/azure-namespace-sibling/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "azure-namespace-sibling"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "build",
+    "setuptools",
+    "azure-core==1.38.0",
+    "azure-core-tracing-opentelemetry==1.0.0b11",
+    "azure-identity==1.21.0",
+]

--- a/e2e/cases/azure-namespace-sibling/setup.MODULE.bazel
+++ b/e2e/cases/azure-namespace-sibling/setup.MODULE.bazel
@@ -1,0 +1,8 @@
+uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
+uv.declare_hub(hub_name = "pypi_azure_namespace_sibling")
+uv.project(
+    hub_name = "pypi_azure_namespace_sibling",
+    lock = "//cases/azure-namespace-sibling:uv.lock",
+    pyproject = "//cases/azure-namespace-sibling:pyproject.toml",
+)
+use_repo(uv, "pypi_azure_namespace_sibling")

--- a/e2e/cases/azure-namespace-sibling/test.py
+++ b/e2e/cases/azure-namespace-sibling/test.py
@@ -1,0 +1,56 @@
+import os
+import sysconfig
+
+
+def test_runtime_imports():
+    import azure.core
+    import azure.identity
+    import azure.core.tracing.ext.opentelemetry_span
+
+    assert azure.core.__file__ is not None
+    assert azure.identity.__file__ is not None
+
+
+def test_sibling_entry_is_concrete_in_site_packages():
+    site_packages = sysconfig.get_paths()["purelib"]
+
+    azure_dir = os.path.join(site_packages, "azure")
+    assert os.path.isdir(azure_dir), (
+        f"site-packages has no concrete azure/ directory at {azure_dir}"
+    )
+    assert not os.path.exists(os.path.join(azure_dir, "__init__.py")), (
+        "azure/ must stay a PEP 420 namespace: no __init__.py"
+    )
+
+    identity_dir = os.path.join(azure_dir, "identity")
+    assert os.path.isdir(identity_dir), (
+        f"site-packages/azure/identity/ is missing — sibling namespace entry "
+        f"lost its concrete symlink due to tl_conflicted. "
+        f"azure/ holds: {sorted(os.listdir(azure_dir))}"
+    )
+    assert os.path.isfile(os.path.join(identity_dir, "__init__.py")), (
+        f"azure/identity/__init__.py not found; "
+        f"identity/ holds: {sorted(os.listdir(identity_dir))}"
+    )
+
+
+def test_conflicted_root_is_physically_merged():
+    site_packages = sysconfig.get_paths()["purelib"]
+    core_dir = os.path.join(site_packages, "azure", "core")
+    assert os.path.isdir(core_dir), (
+        f"site-packages/azure/core/ missing"
+    )
+
+    ext_dir = os.path.join(core_dir, "tracing", "ext", "opentelemetry_span")
+    assert os.path.isdir(ext_dir), (
+        f"azure/core/tracing/ext/opentelemetry_span/ not found — "
+        f"PySiteMerge may not have run. "
+        f"tracing/ holds: {sorted(os.listdir(os.path.join(core_dir, 'tracing')))}"
+    )
+
+
+if __name__ == "__main__":
+    test_runtime_imports()
+    test_sibling_entry_is_concrete_in_site_packages()
+    test_conflicted_root_is_physically_merged()
+    print("PASS")

--- a/e2e/cases/azure-namespace-sibling/uv.lock
+++ b/e2e/cases/azure-namespace-sibling/uv.lock
@@ -1,0 +1,443 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "azure-core"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", size = 363033, upload-time = "2026-01-12T17:03:05.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/d8/b8fcba9464f02b121f39de2db2bf57f0b216fe11d014513d666e8634380d/azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335", size = 217825, upload-time = "2026-01-12T17:03:07.291Z" },
+]
+
+[[package]]
+name = "azure-core-tracing-opentelemetry"
+version = "1.0.0b11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/f2/2ede1654987b82f45dffe0e82d0d77b13940bb88d044138090c8b7baa439/azure-core-tracing-opentelemetry-1.0.0b11.tar.gz", hash = "sha256:a230d1555838b5d07b7594221cd639ea7bc24e29c881e5675e311c6067bad4f5", size = 19097, upload-time = "2023-09-07T19:49:25.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/6e/3ef6dfba8e0faa4692caa6d103c721ccba6ac37a24744848a3a10bb3fe89/azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl", hash = "sha256:016cefcaff2900fb5cdb7a8a7abd03e9c266622c06e26b3fe6dafa54c4b48bf5", size = 10710, upload-time = "2023-09-07T19:49:26.492Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a1/f1a683672e7a88ea0e3119f57b6c7843ed52650fdcac8bfa66ed84e86e40/azure_identity-1.21.0.tar.gz", hash = "sha256:ea22ce6e6b0f429bc1b8d9212d5b9f9877bd4c82f1724bfa910760612c07a9a6", size = 266445, upload-time = "2025-03-11T20:53:07.463Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9f/1f9f3ef4f49729ee207a712a5971a9ca747f2ca47d9cbf13cf6953e3478a/azure_identity-1.21.0-py3-none-any.whl", hash = "sha256:258ea6325537352440f71b35c3dffe9d240eae4a5126c1b7ce5efd5766bd9fd9", size = 189190, upload-time = "2025-03-11T20:53:09.197Z" },
+]
+
+[[package]]
+name = "azure-namespace-sibling"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-core-tracing-opentelemetry" },
+    { name = "azure-identity" },
+    { name = "build" },
+    { name = "setuptools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "azure-core", specifier = "==1.38.0" },
+    { name = "azure-core-tracing-opentelemetry", specifier = "==1.0.0b11" },
+    { name = "azure-identity", specifier = "==1.21.0" },
+    { name = "build" },
+    { name = "setuptools" },
+]
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/e2e/cases/oci/py_image_layer/py_image_content_test.yaml
+++ b/e2e/cases/oci/py_image_layer/py_image_content_test.yaml
@@ -5,7 +5,7 @@ fileExistenceTests:
     path: /app.runfiles/_main/cases/oci/py_image_layer/__main__.py
 
   - name: runfiles dependencies are present
-    path: /app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/__init__.py
+    path: /app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
 
   - name: launcher is present at the entrypoint
     path: /app

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
@@ -6,60 +6,60 @@ files:
 ---
 layer: 1
 files:
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/winterm.py
 ---
 layer: 2
 files:
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
 ---
 layer: 3
 files:
   - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
-  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
-  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0         625 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        4623 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       16269 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        3986 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7974 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        9200 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0         256 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        5901 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       21568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       14195 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        6760 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2935 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7288 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
+  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0         640 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4638 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       16284 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4001 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7989 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        9215 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0         271 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        5916 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       21583 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       14210 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        6775 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2950 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7303 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/winterm.py
   - -rwxr-xr-x  0 0      0        2490 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/bin/activate
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/bin/python -> ../../../../../../aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/python3
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/bin/python3 -> python
@@ -67,8 +67,8 @@ files:
   - -rwxr-xr-x  0 0      0         322 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/3b1f634a/lib/python3.11/site-packages/colorama
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1274 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_bin.venv

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
@@ -1,57 +1,57 @@
 ---
 layer: 0
 files:
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/winterm.py
 ---
 layer: 1
 files:
   - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
-  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
-  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0         625 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        4623 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       16269 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        3986 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7974 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        9200 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0         256 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        5901 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       21568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       14195 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        6760 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2935 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7288 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
+  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0         640 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4638 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       16284 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4001 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7989 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        9215 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0         271 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        5916 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       21583 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       14210 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        6775 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2950 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7303 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/winterm.py
   - -rwxr-xr-x  0 0      0        2490 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/bin/activate
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/bin/python -> ../../../../../../aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/python3
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/bin/python3 -> python
@@ -59,8 +59,8 @@ files:
   - -rwxr-xr-x  0 0      0         322 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/3b1f634a/lib/python3.11/site-packages/colorama
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1274 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_bin.venv

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
@@ -1,79 +1,79 @@
 ---
 layer: 0
 files:
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/winterm.py
-  - -rwxr-xr-x  0 0      0        1081 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/LICENSE
-  - -rwxr-xr-x  0 0      0        1288 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0         691 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/install/lib/python3.11/site-packages/pyproject_hooks/__init__.py
-  - -rwxr-xr-x  0 0      0       14936 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/install/lib/python3.11/site-packages/pyproject_hooks/_impl.py
-  - -rwxr-xr-x  0 0      0         557 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/install/lib/python3.11/site-packages/pyproject_hooks/_in_process/__init__.py
-  - -rwxr-xr-x  0 0      0       12216 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/install/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/install/lib/python3.11/site-packages/pyproject_hooks/py.typed
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0        1081 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/LICENSE
+  - -rwxr-xr-x  0 0      0        1288 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0         691 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/__init__.py
+  - -rwxr-xr-x  0 0      0       14936 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/_impl.py
+  - -rwxr-xr-x  0 0      0         557 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/_in_process/__init__.py
+  - -rwxr-xr-x  0 0      0       12216 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/py.typed
 ---
 layer: 1
 files:
   - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
-  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
-  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0         625 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        4623 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       16269 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        3986 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7974 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        9200 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0         256 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        5901 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       21568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       14195 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        6760 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2935 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7288 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/89fe6648/lib/python3.11/site-packages/colorama/winterm.py
-  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/INSTALLER
-  - -rwxr-xr-x  0 0      0        1081 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/LICENSE
-  - -rwxr-xr-x  0 0      0        1288 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0         966 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/RECORD
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/REQUESTED
-  - -rwxr-xr-x  0 0      0          81 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/WHEEL
-  - -rwxr-xr-x  0 0      0         691 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/__init__.py
-  - -rwxr-xr-x  0 0      0         934 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       20500 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/__pycache__/_impl.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       14936 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/_impl.py
-  - -rwxr-xr-x  0 0      0         557 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/_in_process/__init__.py
-  - -rwxr-xr-x  0 0      0        1214 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/_in_process/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       17528 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/_in_process/__pycache__/_in_process.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       12216 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks/py.typed
+  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
+  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0         640 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4638 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       16284 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4001 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7989 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        9215 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0         271 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        5916 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       21583 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       14210 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        6775 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2950 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7303 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/INSTALLER
+  - -rwxr-xr-x  0 0      0        1081 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/LICENSE
+  - -rwxr-xr-x  0 0      0        1288 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0         966 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/RECORD
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/REQUESTED
+  - -rwxr-xr-x  0 0      0          81 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/WHEEL
+  - -rwxr-xr-x  0 0      0         691 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/__init__.py
+  - -rwxr-xr-x  0 0      0         949 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       20515 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/__pycache__/_impl.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       14936 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/_impl.py
+  - -rwxr-xr-x  0 0      0         557 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/_in_process/__init__.py
+  - -rwxr-xr-x  0 0      0        1229 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/_in_process/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       17543 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/_in_process/__pycache__/_in_process.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       12216 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks/py.typed
   - -rwxr-xr-x  0 0      0        2502 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/bin/activate
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/bin/python -> ../../../../../../aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/python3
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/bin/python3 -> python
@@ -81,10 +81,10 @@ files:
   - -rwxr-xr-x  0 0      0         114 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/_my_app_multi_bin.venv.pth
   - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/_virtualenv.py
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/89fe6648/lib/python3.11/site-packages/colorama-0.4.6.dist-info
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks -> ../../../_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info -> ../../../_wheels/d940a30e/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/3b1f634a/lib/python3.11/site-packages/colorama
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks -> ../../../_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info -> ../../../_wheels/e66f41c4/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1280 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/_my_app_multi_bin.venv

--- a/e2e/cases/oci/py_venv_image_layer/py_amd64_image_content_test.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/py_amd64_image_content_test.yaml
@@ -8,7 +8,7 @@ fileExistenceTests:
     path: /app
 
   - name: runfiles dependencies are present
-    path: /app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__init__.py
+    path: /app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__init__.py
 
   - name: Interpreter executable is present
     path: /app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/python3

--- a/e2e/cases/oci/py_venv_image_layer/py_arm64_image_content_test.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/py_arm64_image_content_test.yaml
@@ -8,7 +8,7 @@ fileExistenceTests:
     path: /app
 
   - name: runfiles dependencies are present
-    path: /app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__init__.py
+    path: /app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__init__.py
 
   - name: Interpreter executable is present
     path: /app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/python3

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
@@ -1,67 +1,67 @@
 ---
 layer: 0
 files:
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/winterm.py
 ---
 layer: 1
 files:
   - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0          42 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/__init__.py
   - -rwxr-xr-x  0 0      0          31 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/palette.txt
-  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
-  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0         630 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        4628 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       16274 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        3991 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7979 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        9205 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0         261 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        5906 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       21573 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       14200 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        6765 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2940 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7293 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
+  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0         645 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4643 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       16289 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4006 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7994 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        9220 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        5921 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       21588 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       14215 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        6780 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2955 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7308 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/winterm.py
   - -rwxr-xr-x  0 0      0        2493 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/activate
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/python -> ../../../../../../aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/python3
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/python3 -> python
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/python3.11 -> python
   - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/7d3c346c/lib/python3.11/site-packages/colorama
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/df4f08a6/lib/python3.11/site-packages/colorama
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         327 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
@@ -1,67 +1,67 @@
 ---
 layer: 0
 files:
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/install/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/winterm.py
 ---
 layer: 1
 files:
   - -rwxr-xr-x  0 0      0       17888 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0          42 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/__init__.py
   - -rwxr-xr-x  0 0      0          31 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/palette.txt
-  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
-  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0         630 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        4628 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       16274 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        3991 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7979 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        9205 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0         261 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        5906 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       21573 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0       14200 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        6765 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2940 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        7293 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/7d3c346c/lib/python3.11/site-packages/colorama/winterm.py
+  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/REQUESTED
+  - -rwxr-xr-x  0 0      0         105 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/WHEEL
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0         645 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4643 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/ansi.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       16289 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/ansitowin32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        4006 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/initialise.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7994 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/win32.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        9220 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/__pycache__/winterm.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/__init__.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        5921 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/ansi_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       21588 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/ansitowin32_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0       14215 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/initialise_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        6780 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/isatty_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2955 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/utils.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        7308 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/__pycache__/winterm_test.cpython-311.pyc
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama/winterm.py
   - -rwxr-xr-x  0 0      0        2493 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/activate
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/python -> ../../../../../../aspect_rules_py++python_interpreters+python_3_11_aarch64_unknown_linux_gnu/bin/python3
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/python3 -> python
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/bin/python3.11 -> python
   - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/7d3c346c/lib/python3.11/site-packages/colorama
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/7d3c346c/lib/python3.11/site-packages/colorama-0.4.6.dist-info
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../_wheels/df4f08a6/lib/python3.11/site-packages/colorama
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         327 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0         247 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test", "py_unpacked_wheel")
 load("//tools:pth_snapshot.bzl", "extract_venv_pth")
 
 # Test namespace package resolution with the symlink-forest venv.
@@ -17,6 +17,34 @@ py_test(
     ],
 )
 
+# Gap-1 fixture: hand-written `py_unpacked_wheel` contributing to the
+# `jaraco` namespace WITHOUT `namespace_entries` (metadata we can't
+# synthesise for an arbitrary wheel). It must not poison the entried
+# `jaraco.classes` contributor's concrete merge.
+py_unpacked_wheel(
+    name = "jaraco_functools_no_entries",
+    src = "@pypi_pth_namespace_547//jaraco_functools:whl",
+    namespace_top_levels = ["jaraco"],
+    top_levels = ["jaraco"],
+)
+
+py_test(
+    name = "test_partial_merge",
+    srcs = ["partial_merge_test.py"],
+    dep_group = "pth-namespace-547",
+    expose_venv = True,
+    isolated = False,
+    main = "partial_merge_test.py",
+    package_collisions = "warning",
+    python_version = "3.11",
+    deps = [
+        # entried (uv whl_install, carries namespace_entries)
+        "@pypi_pth_namespace_547//jaraco_classes",
+        # entryless (hand-written, no namespace_entries)
+        ":jaraco_functools_no_entries",
+    ],
+)
+
 # Test namespace packages with the legacy py_test (.pth strategy).
 py_test(
     name = "test_legacy",
@@ -30,8 +58,9 @@ py_test(
 )
 
 # Snapshot fixture: minimal 2-contributor case (jaraco-classes +
-# jaraco-functools, both PEP 420 under `jaraco/`) for the
-# .pth / addsitedir branch of venv.bzl.
+# jaraco-functools, both PEP 420 under `jaraco/`). Both wheels are
+# fully covered by the concrete per-entry namespace merge, so the
+# snapshot pins that NEITHER appears in the .pth fallback.
 extract_venv_pth(
     name = "test.venv.pth",
     venv = ":test.venv",

--- a/e2e/cases/pth-namespace-547/__test__.py
+++ b/e2e/cases/pth-namespace-547/__test__.py
@@ -4,10 +4,17 @@ The jaraco.functools and jaraco.classes packages both contribute to the
 `jaraco` implicit namespace package. Importing from both must succeed,
 verifying that the venv correctly supports packages that share a
 top-level namespace.
+
+Also asserts the namespace is merged CONCRETELY into site-packages:
+static tools (mypy, pyright) inspect `site-packages/` directly and never
+execute `.pth` files, so a namespace that only resolves through the
+`.pth` fallback is invisible to them — along with the subpackages'
+`py.typed` markers.
 """
 
 import os
 import sys
+import sysconfig
 
 
 def test_namespace_imports():
@@ -37,7 +44,42 @@ def test_jaraco_is_namespace_package():
     )
 
 
+def test_concrete_namespace_entries_in_site_packages():
+    """The merged namespace must exist concretely in site-packages.
+
+    Mimics how mypy/pyright discover packages: plain directory traversal
+    of site-packages, without importing and without executing `.pth`
+    files. Both wheels' subpackages — and their `py.typed` markers —
+    must be reachable that way, and `jaraco/` must NOT gain an
+    `__init__.py` (that would demote it from a PEP 420 namespace).
+    """
+    site_packages = sysconfig.get_paths()["purelib"]
+    assert os.path.isdir(site_packages), f"no site-packages at {site_packages}"
+
+    jaraco_dir = os.path.join(site_packages, "jaraco")
+    assert os.path.isdir(jaraco_dir), (
+        f"site-packages has no concrete jaraco/ entry at {jaraco_dir}; "
+        "static tools (mypy/pyright) cannot see the namespace package "
+        f"(site-packages holds: {sorted(os.listdir(site_packages))})"
+    )
+    assert not os.path.exists(os.path.join(jaraco_dir, "__init__.py")), (
+        "jaraco/ must stay a PEP 420 namespace: no __init__.py"
+    )
+
+    for subpkg in ("functools", "classes"):
+        pkg_dir = os.path.join(jaraco_dir, subpkg)
+        assert os.path.isfile(os.path.join(pkg_dir, "__init__.py")), (
+            f"jaraco/{subpkg}/__init__.py not reachable via site-packages "
+            f"(jaraco/ holds: {sorted(os.listdir(jaraco_dir))})"
+        )
+        assert os.path.isfile(os.path.join(pkg_dir, "py.typed")), (
+            f"jaraco/{subpkg}/py.typed not reachable via site-packages; "
+            "type checkers would treat the package as untyped"
+        )
+
+
 if __name__ == "__main__":
     test_namespace_imports()
     test_jaraco_is_namespace_package()
+    test_concrete_namespace_entries_in_site_packages()
     print("PASS: namespace package resolution works correctly")

--- a/e2e/cases/pth-namespace-547/partial_merge_test.py
+++ b/e2e/cases/pth-namespace-547/partial_merge_test.py
@@ -1,0 +1,60 @@
+"""Gap-1 regression: a namespace with a mix of entried and entryless wheels.
+
+`jaraco.classes` arrives via a uv `whl_install` (carries `namespace_entries`,
+so it merges concretely into site-packages). `jaraco.functools` arrives via a
+hand-written `py_unpacked_wheel` that deliberately omits `namespace_entries`
+(simulating metadata we can't synthesise). Both claim the `jaraco` PEP 420
+namespace.
+
+The entryless contributor must NOT poison the well-formed one: `jaraco.classes`
+has to stay concretely visible in site-packages (the mypy/pyright view), while
+`jaraco.functools` still resolves at import time through the `.pth` fallback.
+A concrete namespace portion and a `.pth`/addsitedir portion merge into one
+`jaraco.__path__` at runtime.
+"""
+
+import os
+import sys
+import sysconfig
+
+
+def test_both_contributors_import():
+    import jaraco.classes
+    import jaraco.functools
+
+    assert jaraco.classes.__file__ is not None
+    assert jaraco.functools.__file__ is not None
+    # jaraco must remain a namespace package, not be promoted to regular.
+    import jaraco
+
+    assert not hasattr(jaraco, "__file__") or jaraco.__file__ is None, (
+        f"jaraco should stay a namespace package, got __file__={jaraco.__file__}"
+    )
+    # Both contributions are present in the merged __path__.
+    assert len(jaraco.__path__) >= 2, (
+        f"expected jaraco.__path__ to merge >=2 portions, got {list(jaraco.__path__)}"
+    )
+
+
+def test_entried_contributor_is_concrete():
+    """The uv (entried) wheel's subpackage must be reachable by plain
+    directory traversal of site-packages — the way mypy/pyright see it —
+    even though it shares the namespace with an entryless wheel."""
+    site_packages = sysconfig.get_paths()["purelib"]
+    classes_init = os.path.join(site_packages, "jaraco", "classes", "__init__.py")
+    assert os.path.isfile(classes_init), (
+        f"jaraco/classes/__init__.py not concrete at {classes_init}; the "
+        "entryless functools contributor poisoned the well-formed classes "
+        "wheel (gap-1 regression)"
+    )
+    assert os.path.isfile(
+        os.path.join(site_packages, "jaraco", "classes", "py.typed")
+    ), "jaraco/classes/py.typed not reachable via site-packages"
+    # jaraco/ itself must stay init-less so PEP 420 merges the .pth portion.
+    assert not os.path.exists(os.path.join(site_packages, "jaraco", "__init__.py"))
+
+
+if __name__ == "__main__":
+    test_both_contributors_import()
+    test_entried_contributor_is_concrete()
+    print("PASS: entried contributor stays concrete; entryless merges via .pth")

--- a/e2e/cases/uv-abi3-compat-853/setup.MODULE.bazel
+++ b/e2e/cases/uv-abi3-compat-853/setup.MODULE.bazel
@@ -14,5 +14,10 @@ uv.project(
 use_repo(
     uv,
     "pypi_uv_abi3_compat_853",
+    # cffi ships per-platform C-extension top-levels
+    # (`_cffi_backend.cpython-312-*.so`/`.pyd`), so its whl_install BUILD
+    # pins that wheel metadata stays keyed per wheel instead of leaking
+    # across platform configurations — see e2e/BUILD.bazel snapshots.
+    "whl_install__abi3_compat__cffi__2_0_0",
     "whl_install__abi3_compat__cryptography__46_0_5",
 )

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
@@ -1,83 +1,83 @@
 ---
 layer: 0
 files:
-  - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/__init__.py
-  - -rwxr-xr-x  0 0      0        2922 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/_ipaddress.py
-  - -rwxr-xr-x  0 0      0        7153 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/_json.py
-  - -rwxr-xr-x  0 0      0      339185 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/_psycopg.cpython-312-x86_64-linux-gnu.so
-  - -rwxr-xr-x  0 0      0       18494 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/_range.py
-  - -rwxr-xr-x  0 0      0       14512 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/errorcodes.py
-  - -rwxr-xr-x  0 0      0        1425 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/errors.py
-  - -rwxr-xr-x  0 0      0        6797 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/extensions.py
-  - -rwxr-xr-x  0 0      0       44215 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/extras.py
-  - -rwxr-xr-x  0 0      0        6316 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/pool.py
-  - -rwxr-xr-x  0 0      0       14779 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/sql.py
-  - -rwxr-xr-x  0 0      0        4870 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/tz.py
-  - -rwxr-xr-x  0 0      0        4936 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        2238 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/licenses/LICENSE
-  - -rwxr-xr-x  0 0      0           9 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/top_level.txt
-  - -rwxr-xr-x  0 0      0       17497 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libcom_err-2abe824b.so.2.1
-  - -rwxr-xr-x  0 0      0     6489873 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libcrypto-81d66ed9.so.3
-  - -rwxr-xr-x  0 0      0      345209 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libgssapi_krb5-497db0c6.so.2.2
-  - -rwxr-xr-x  0 0      0      219953 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libk5crypto-b1f99d5c.so.3.1
-  - -rwxr-xr-x  0 0      0       17913 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libkeyutils-dfe70bd6.so.1.5
-  - -rwxr-xr-x  0 0      0     1018953 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5-fcafa220.so.3.3
-  - -rwxr-xr-x  0 0      0       76873 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5support-d0bcff84.so.0.1
-  - -rwxr-xr-x  0 0      0       60977 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/liblber-568fe118.so.2.0.200
-  - -rwxr-xr-x  0 0      0      451425 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libldap-1accf1ee.so.2.0.200
-  - -rwxr-xr-x  0 0      0      406817 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libpcre-9513aab5.so.1.2.0
-  - -rwxr-xr-x  0 0      0      387497 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libpq-9b38f5e3.so.5.17
-  - -rwxr-xr-x  0 0      0      119217 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libsasl2-883649fd.so.3.0.0
-  - -rwxr-xr-x  0 0      0      178337 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libselinux-0922c95c.so.1
-  - -rwxr-xr-x  0 0      0     1139041 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libssl-81ffa89e.so.3
+  - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/__init__.py
+  - -rwxr-xr-x  0 0      0        2922 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/_ipaddress.py
+  - -rwxr-xr-x  0 0      0        7153 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/_json.py
+  - -rwxr-xr-x  0 0      0      339185 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/_psycopg.cpython-312-x86_64-linux-gnu.so
+  - -rwxr-xr-x  0 0      0       18494 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/_range.py
+  - -rwxr-xr-x  0 0      0       14512 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/errorcodes.py
+  - -rwxr-xr-x  0 0      0        1425 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/errors.py
+  - -rwxr-xr-x  0 0      0        6797 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/extensions.py
+  - -rwxr-xr-x  0 0      0       44215 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/extras.py
+  - -rwxr-xr-x  0 0      0        6316 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/pool.py
+  - -rwxr-xr-x  0 0      0       14779 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/sql.py
+  - -rwxr-xr-x  0 0      0        4870 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/tz.py
+  - -rwxr-xr-x  0 0      0        4936 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        2238 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/licenses/LICENSE
+  - -rwxr-xr-x  0 0      0           9 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/top_level.txt
+  - -rwxr-xr-x  0 0      0       17497 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libcom_err-2abe824b.so.2.1
+  - -rwxr-xr-x  0 0      0     6489873 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libcrypto-81d66ed9.so.3
+  - -rwxr-xr-x  0 0      0      345209 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libgssapi_krb5-497db0c6.so.2.2
+  - -rwxr-xr-x  0 0      0      219953 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libk5crypto-b1f99d5c.so.3.1
+  - -rwxr-xr-x  0 0      0       17913 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libkeyutils-dfe70bd6.so.1.5
+  - -rwxr-xr-x  0 0      0     1018953 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5-fcafa220.so.3.3
+  - -rwxr-xr-x  0 0      0       76873 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5support-d0bcff84.so.0.1
+  - -rwxr-xr-x  0 0      0       60977 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/liblber-568fe118.so.2.0.200
+  - -rwxr-xr-x  0 0      0      451425 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libldap-1accf1ee.so.2.0.200
+  - -rwxr-xr-x  0 0      0      406817 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libpcre-9513aab5.so.1.2.0
+  - -rwxr-xr-x  0 0      0      387497 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libpq-9b38f5e3.so.5.17
+  - -rwxr-xr-x  0 0      0      119217 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libsasl2-883649fd.so.3.0.0
+  - -rwxr-xr-x  0 0      0      178337 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libselinux-0922c95c.so.1
+  - -rwxr-xr-x  0 0      0     1139041 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libssl-81ffa89e.so.3
 ---
 layer: 1
 files:
   - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
-  - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__init__.py
-  - -rwxr-xr-x  0 0      0        3818 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/__init__.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        2684 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/_ipaddress.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        7543 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/_json.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0       21109 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/_range.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0       14633 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/errorcodes.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0         602 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/errors.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        7526 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/extensions.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0       60580 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/extras.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        7888 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/pool.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0       18977 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/sql.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        6264 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/tz.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        2922 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/_ipaddress.py
-  - -rwxr-xr-x  0 0      0        7153 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/_json.py
-  - -rwxr-xr-x  0 0      0      339185 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/_psycopg.cpython-312-x86_64-linux-gnu.so
-  - -rwxr-xr-x  0 0      0       18494 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/_range.py
-  - -rwxr-xr-x  0 0      0       14512 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/errorcodes.py
-  - -rwxr-xr-x  0 0      0        1425 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/errors.py
-  - -rwxr-xr-x  0 0      0        6797 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/extensions.py
-  - -rwxr-xr-x  0 0      0       44215 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/extras.py
-  - -rwxr-xr-x  0 0      0        6316 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/pool.py
-  - -rwxr-xr-x  0 0      0       14779 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/sql.py
-  - -rwxr-xr-x  0 0      0        4870 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/tz.py
-  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/INSTALLER
-  - -rwxr-xr-x  0 0      0        4936 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        3083 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/RECORD
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/REQUESTED
-  - -rwxr-xr-x  0 0      0         151 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/WHEEL
-  - -rwxr-xr-x  0 0      0        2238 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/licenses/LICENSE
-  - -rwxr-xr-x  0 0      0           9 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/top_level.txt
-  - -rwxr-xr-x  0 0      0       17497 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libcom_err-2abe824b.so.2.1
-  - -rwxr-xr-x  0 0      0     6489873 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libcrypto-81d66ed9.so.3
-  - -rwxr-xr-x  0 0      0      345209 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libgssapi_krb5-497db0c6.so.2.2
-  - -rwxr-xr-x  0 0      0      219953 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libk5crypto-b1f99d5c.so.3.1
-  - -rwxr-xr-x  0 0      0       17913 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libkeyutils-dfe70bd6.so.1.5
-  - -rwxr-xr-x  0 0      0     1018953 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5-fcafa220.so.3.3
-  - -rwxr-xr-x  0 0      0       76873 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5support-d0bcff84.so.0.1
-  - -rwxr-xr-x  0 0      0       60977 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/liblber-568fe118.so.2.0.200
-  - -rwxr-xr-x  0 0      0      451425 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libldap-1accf1ee.so.2.0.200
-  - -rwxr-xr-x  0 0      0      406817 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libpcre-9513aab5.so.1.2.0
-  - -rwxr-xr-x  0 0      0      387497 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libpq-9b38f5e3.so.5.17
-  - -rwxr-xr-x  0 0      0      119217 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libsasl2-883649fd.so.3.0.0
-  - -rwxr-xr-x  0 0      0      178337 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libselinux-0922c95c.so.1
-  - -rwxr-xr-x  0 0      0     1139041 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libssl-81ffa89e.so.3
+  - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__init__.py
+  - -rwxr-xr-x  0 0      0        3833 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/__init__.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        2699 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/_ipaddress.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        7558 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/_json.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0       21124 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/_range.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0       14648 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/errorcodes.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0         617 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/errors.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        7541 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/extensions.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0       60595 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/extras.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        7903 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/pool.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0       18992 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/sql.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        6279 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/tz.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        2922 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/_ipaddress.py
+  - -rwxr-xr-x  0 0      0        7153 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/_json.py
+  - -rwxr-xr-x  0 0      0      339185 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/_psycopg.cpython-312-x86_64-linux-gnu.so
+  - -rwxr-xr-x  0 0      0       18494 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/_range.py
+  - -rwxr-xr-x  0 0      0       14512 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/errorcodes.py
+  - -rwxr-xr-x  0 0      0        1425 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/errors.py
+  - -rwxr-xr-x  0 0      0        6797 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/extensions.py
+  - -rwxr-xr-x  0 0      0       44215 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/extras.py
+  - -rwxr-xr-x  0 0      0        6316 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/pool.py
+  - -rwxr-xr-x  0 0      0       14779 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/sql.py
+  - -rwxr-xr-x  0 0      0        4870 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/tz.py
+  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/INSTALLER
+  - -rwxr-xr-x  0 0      0        4936 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        3083 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/RECORD
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/REQUESTED
+  - -rwxr-xr-x  0 0      0         151 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/WHEEL
+  - -rwxr-xr-x  0 0      0        2238 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/licenses/LICENSE
+  - -rwxr-xr-x  0 0      0           9 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/top_level.txt
+  - -rwxr-xr-x  0 0      0       17497 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libcom_err-2abe824b.so.2.1
+  - -rwxr-xr-x  0 0      0     6489873 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libcrypto-81d66ed9.so.3
+  - -rwxr-xr-x  0 0      0      345209 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libgssapi_krb5-497db0c6.so.2.2
+  - -rwxr-xr-x  0 0      0      219953 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libk5crypto-b1f99d5c.so.3.1
+  - -rwxr-xr-x  0 0      0       17913 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libkeyutils-dfe70bd6.so.1.5
+  - -rwxr-xr-x  0 0      0     1018953 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5-fcafa220.so.3.3
+  - -rwxr-xr-x  0 0      0       76873 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5support-d0bcff84.so.0.1
+  - -rwxr-xr-x  0 0      0       60977 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/liblber-568fe118.so.2.0.200
+  - -rwxr-xr-x  0 0      0      451425 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libldap-1accf1ee.so.2.0.200
+  - -rwxr-xr-x  0 0      0      406817 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libpcre-9513aab5.so.1.2.0
+  - -rwxr-xr-x  0 0      0      387497 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libpq-9b38f5e3.so.5.17
+  - -rwxr-xr-x  0 0      0      119217 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libsasl2-883649fd.so.3.0.0
+  - -rwxr-xr-x  0 0      0      178337 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libselinux-0922c95c.so.1
+  - -rwxr-xr-x  0 0      0     1139041 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libssl-81ffa89e.so.3
   - -rwxr-xr-x  0 0      0        2488 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/bin/activate
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/bin/python -> ../../../../../../aspect_rules_py++python_interpreters+python_3_12_x86_64_unknown_linux_gnu/bin/python3
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/bin/python3 -> python
@@ -85,9 +85,9 @@ files:
   - -rwxr-xr-x  0 0      0         118 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/_virtualenv.pth
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/_virtualenv.py
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2 -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2 -> ../../../_wheels/4c143330/lib/python3.12/site-packages/psycopg2
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info -> ../../../_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0          66 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/_app_bin.venv

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
@@ -1,83 +1,83 @@
 ---
 layer: 0
 files:
-  - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/__init__.py
-  - -rwxr-xr-x  0 0      0        2922 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/_ipaddress.py
-  - -rwxr-xr-x  0 0      0        7153 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/_json.py
-  - -rwxr-xr-x  0 0      0      470249 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/_psycopg.cpython-312-aarch64-linux-gnu.so
-  - -rwxr-xr-x  0 0      0       18494 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/_range.py
-  - -rwxr-xr-x  0 0      0       14512 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/errorcodes.py
-  - -rwxr-xr-x  0 0      0        1425 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/errors.py
-  - -rwxr-xr-x  0 0      0        6797 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/extensions.py
-  - -rwxr-xr-x  0 0      0       44215 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/extras.py
-  - -rwxr-xr-x  0 0      0        6316 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/pool.py
-  - -rwxr-xr-x  0 0      0       14779 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/sql.py
-  - -rwxr-xr-x  0 0      0        4870 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2/tz.py
-  - -rwxr-xr-x  0 0      0        4936 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        2238 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/licenses/LICENSE
-  - -rwxr-xr-x  0 0      0           9 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/top_level.txt
-  - -rwxr-xr-x  0 0      0      132193 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libcom_err-057ba42b.so.2.1
-  - -rwxr-xr-x  0 0      0     6067905 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libcrypto-88e3da85.so.3
-  - -rwxr-xr-x  0 0      0      468081 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libgssapi_krb5-fec99a71.so.2.2
-  - -rwxr-xr-x  0 0      0      396073 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libk5crypto-47ac5e52.so.3.1
-  - -rwxr-xr-x  0 0      0       67145 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libkeyutils-19c64d08.so.1.5
-  - -rwxr-xr-x  0 0      0     1133617 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5-90a0ef7c.so.3.3
-  - -rwxr-xr-x  0 0      0      199737 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5support-73f3f43d.so.0.1
-  - -rwxr-xr-x  0 0      0      134681 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/liblber-33741b08.so.2.0.200
-  - -rwxr-xr-x  0 0      0      607017 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libldap-e13ca69f.so.2.0.200
-  - -rwxr-xr-x  0 0      0      329017 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libpcre-6b975b27.so.1.2.0
-  - -rwxr-xr-x  0 0      0      596369 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libpq-320873a1.so.5.17
-  - -rwxr-xr-x  0 0      0      201129 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libsasl2-68c9cb0a.so.3.0.0
-  - -rwxr-xr-x  0 0      0      333953 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libselinux-ae24b712.so.1
-  - -rwxr-xr-x  0 0      0     1204537 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/install/lib/python3.12/site-packages/psycopg2_binary.libs/libssl-92369ee6.so.3
+  - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/__init__.py
+  - -rwxr-xr-x  0 0      0        2922 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/_ipaddress.py
+  - -rwxr-xr-x  0 0      0        7153 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/_json.py
+  - -rwxr-xr-x  0 0      0      470249 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/_psycopg.cpython-312-aarch64-linux-gnu.so
+  - -rwxr-xr-x  0 0      0       18494 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/_range.py
+  - -rwxr-xr-x  0 0      0       14512 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/errorcodes.py
+  - -rwxr-xr-x  0 0      0        1425 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/errors.py
+  - -rwxr-xr-x  0 0      0        6797 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/extensions.py
+  - -rwxr-xr-x  0 0      0       44215 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/extras.py
+  - -rwxr-xr-x  0 0      0        6316 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/pool.py
+  - -rwxr-xr-x  0 0      0       14779 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/sql.py
+  - -rwxr-xr-x  0 0      0        4870 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2/tz.py
+  - -rwxr-xr-x  0 0      0        4936 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        2238 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/licenses/LICENSE
+  - -rwxr-xr-x  0 0      0           9 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/top_level.txt
+  - -rwxr-xr-x  0 0      0      132193 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libcom_err-057ba42b.so.2.1
+  - -rwxr-xr-x  0 0      0     6067905 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libcrypto-88e3da85.so.3
+  - -rwxr-xr-x  0 0      0      468081 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libgssapi_krb5-fec99a71.so.2.2
+  - -rwxr-xr-x  0 0      0      396073 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libk5crypto-47ac5e52.so.3.1
+  - -rwxr-xr-x  0 0      0       67145 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libkeyutils-19c64d08.so.1.5
+  - -rwxr-xr-x  0 0      0     1133617 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5-90a0ef7c.so.3.3
+  - -rwxr-xr-x  0 0      0      199737 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5support-73f3f43d.so.0.1
+  - -rwxr-xr-x  0 0      0      134681 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/liblber-33741b08.so.2.0.200
+  - -rwxr-xr-x  0 0      0      607017 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libldap-e13ca69f.so.2.0.200
+  - -rwxr-xr-x  0 0      0      329017 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libpcre-6b975b27.so.1.2.0
+  - -rwxr-xr-x  0 0      0      596369 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libpq-320873a1.so.5.17
+  - -rwxr-xr-x  0 0      0      201129 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libsasl2-68c9cb0a.so.3.0.0
+  - -rwxr-xr-x  0 0      0      333953 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libselinux-ae24b712.so.1
+  - -rwxr-xr-x  0 0      0     1204537 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs/libssl-92369ee6.so.3
 ---
 layer: 1
 files:
   - -rwxr-xr-x  0 0      0       17888 Jan  1  2023 ./app
-  - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__init__.py
-  - -rwxr-xr-x  0 0      0        3818 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/__init__.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        2684 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/_ipaddress.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        7543 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/_json.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0       21109 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/_range.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0       14633 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/errorcodes.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0         602 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/errors.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        7526 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/extensions.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0       60580 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/extras.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        7888 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/pool.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0       18977 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/sql.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        6264 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/__pycache__/tz.cpython-312.pyc
-  - -rwxr-xr-x  0 0      0        2922 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/_ipaddress.py
-  - -rwxr-xr-x  0 0      0        7153 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/_json.py
-  - -rwxr-xr-x  0 0      0      470249 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/_psycopg.cpython-312-aarch64-linux-gnu.so
-  - -rwxr-xr-x  0 0      0       18494 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/_range.py
-  - -rwxr-xr-x  0 0      0       14512 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/errorcodes.py
-  - -rwxr-xr-x  0 0      0        1425 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/errors.py
-  - -rwxr-xr-x  0 0      0        6797 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/extensions.py
-  - -rwxr-xr-x  0 0      0       44215 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/extras.py
-  - -rwxr-xr-x  0 0      0        6316 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/pool.py
-  - -rwxr-xr-x  0 0      0       14779 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/sql.py
-  - -rwxr-xr-x  0 0      0        4870 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2/tz.py
-  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/INSTALLER
-  - -rwxr-xr-x  0 0      0        4936 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        3087 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/RECORD
-  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/REQUESTED
-  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/WHEEL
-  - -rwxr-xr-x  0 0      0        2238 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/licenses/LICENSE
-  - -rwxr-xr-x  0 0      0           9 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/top_level.txt
-  - -rwxr-xr-x  0 0      0      132193 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libcom_err-057ba42b.so.2.1
-  - -rwxr-xr-x  0 0      0     6067905 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libcrypto-88e3da85.so.3
-  - -rwxr-xr-x  0 0      0      468081 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libgssapi_krb5-fec99a71.so.2.2
-  - -rwxr-xr-x  0 0      0      396073 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libk5crypto-47ac5e52.so.3.1
-  - -rwxr-xr-x  0 0      0       67145 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libkeyutils-19c64d08.so.1.5
-  - -rwxr-xr-x  0 0      0     1133617 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5-90a0ef7c.so.3.3
-  - -rwxr-xr-x  0 0      0      199737 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5support-73f3f43d.so.0.1
-  - -rwxr-xr-x  0 0      0      134681 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/liblber-33741b08.so.2.0.200
-  - -rwxr-xr-x  0 0      0      607017 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libldap-e13ca69f.so.2.0.200
-  - -rwxr-xr-x  0 0      0      329017 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libpcre-6b975b27.so.1.2.0
-  - -rwxr-xr-x  0 0      0      596369 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libpq-320873a1.so.5.17
-  - -rwxr-xr-x  0 0      0      201129 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libsasl2-68c9cb0a.so.3.0.0
-  - -rwxr-xr-x  0 0      0      333953 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libselinux-ae24b712.so.1
-  - -rwxr-xr-x  0 0      0     1204537 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs/libssl-92369ee6.so.3
+  - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__init__.py
+  - -rwxr-xr-x  0 0      0        3833 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/__init__.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        2699 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/_ipaddress.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        7558 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/_json.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0       21124 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/_range.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0       14648 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/errorcodes.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0         617 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/errors.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        7541 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/extensions.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0       60595 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/extras.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        7903 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/pool.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0       18992 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/sql.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        6279 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/tz.cpython-312.pyc
+  - -rwxr-xr-x  0 0      0        2922 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/_ipaddress.py
+  - -rwxr-xr-x  0 0      0        7153 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/_json.py
+  - -rwxr-xr-x  0 0      0      470249 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/_psycopg.cpython-312-aarch64-linux-gnu.so
+  - -rwxr-xr-x  0 0      0       18494 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/_range.py
+  - -rwxr-xr-x  0 0      0       14512 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/errorcodes.py
+  - -rwxr-xr-x  0 0      0        1425 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/errors.py
+  - -rwxr-xr-x  0 0      0        6797 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/extensions.py
+  - -rwxr-xr-x  0 0      0       44215 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/extras.py
+  - -rwxr-xr-x  0 0      0        6316 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/pool.py
+  - -rwxr-xr-x  0 0      0       14779 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/sql.py
+  - -rwxr-xr-x  0 0      0        4870 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/tz.py
+  - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/INSTALLER
+  - -rwxr-xr-x  0 0      0        4936 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        3087 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/RECORD
+  - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/REQUESTED
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/WHEEL
+  - -rwxr-xr-x  0 0      0        2238 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/licenses/LICENSE
+  - -rwxr-xr-x  0 0      0           9 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info/top_level.txt
+  - -rwxr-xr-x  0 0      0      132193 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libcom_err-057ba42b.so.2.1
+  - -rwxr-xr-x  0 0      0     6067905 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libcrypto-88e3da85.so.3
+  - -rwxr-xr-x  0 0      0      468081 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libgssapi_krb5-fec99a71.so.2.2
+  - -rwxr-xr-x  0 0      0      396073 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libk5crypto-47ac5e52.so.3.1
+  - -rwxr-xr-x  0 0      0       67145 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libkeyutils-19c64d08.so.1.5
+  - -rwxr-xr-x  0 0      0     1133617 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5-90a0ef7c.so.3.3
+  - -rwxr-xr-x  0 0      0      199737 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libkrb5support-73f3f43d.so.0.1
+  - -rwxr-xr-x  0 0      0      134681 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/liblber-33741b08.so.2.0.200
+  - -rwxr-xr-x  0 0      0      607017 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libldap-e13ca69f.so.2.0.200
+  - -rwxr-xr-x  0 0      0      329017 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libpcre-6b975b27.so.1.2.0
+  - -rwxr-xr-x  0 0      0      596369 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libpq-320873a1.so.5.17
+  - -rwxr-xr-x  0 0      0      201129 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libsasl2-68c9cb0a.so.3.0.0
+  - -rwxr-xr-x  0 0      0      333953 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libselinux-ae24b712.so.1
+  - -rwxr-xr-x  0 0      0     1204537 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs/libssl-92369ee6.so.3
   - -rwxr-xr-x  0 0      0        2488 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/bin/activate
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/bin/python -> ../../../../../../aspect_rules_py++python_interpreters+python_3_12_aarch64_unknown_linux_gnu/bin/python3
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/bin/python3 -> python
@@ -85,9 +85,9 @@ files:
   - -rwxr-xr-x  0 0      0         118 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/_virtualenv.pth
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/_virtualenv.py
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2 -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../_wheels/e73c8722/lib/python3.12/site-packages/psycopg2_binary.libs
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2 -> ../../../_wheels/4c143330/lib/python3.12/site-packages/psycopg2
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info -> ../../../_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../_wheels/4c143330/lib/python3.12/site-packages/psycopg2_binary.libs
   - -rwxr-xr-x  0 0      0         247 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0          66 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/__main__.py
   - -rwxr-xr-x  0 0      0        1275 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/_app_bin.venv

--- a/e2e/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
+++ b/e2e/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
@@ -1,0 +1,125 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+select_chain(
+   name = "whl",
+   arms = {
+        "@aspect_rules_py_pip_configurations//:cp312-macosx_11_0_arm64-cp312": "@whl__cffi__8eca2a813c1cb7ad//file",
+        "@aspect_rules_py_pip_configurations//:cp312-macosx_10_13_x86_64-cp312": "@whl__cffi__6d02d6655b0e54f5//file",
+        "@aspect_rules_py_pip_configurations//:cp312-manylinux_2_17_i686-cp312": "@whl__cffi__21d1152871b01940//file",
+        "@aspect_rules_py_pip_configurations//:cp312-manylinux_2_17_aarch64-cp312": "@whl__cffi__b21e08af67b8a103//file",
+        "@aspect_rules_py_pip_configurations//:cp312-manylinux_2_17_ppc64le-cp312": "@whl__cffi__1e3a615586f05fc4//file",
+        "@aspect_rules_py_pip_configurations//:cp312-manylinux_2_17_s390x-cp312": "@whl__cffi__81afed14892743bb//file",
+        "@aspect_rules_py_pip_configurations//:cp312-manylinux_2_17_x86_64-cp312": "@whl__cffi__3e17ed538242334b//file",
+        "@aspect_rules_py_pip_configurations//:cp312-manylinux_2_5_i686-cp312": "@whl__cffi__21d1152871b01940//file",
+        "@aspect_rules_py_pip_configurations//:cp312-musllinux_1_2_aarch64-cp312": "@whl__cffi__3925dd22fa2b7699//file",
+        "@aspect_rules_py_pip_configurations//:cp312-musllinux_1_2_x86_64-cp312": "@whl__cffi__2c8f814d84194c9e//file",
+        "@aspect_rules_py_pip_configurations//:cp312-win32-cp312": "@whl__cffi__da902562c3e9c550//file",
+        "@aspect_rules_py_pip_configurations//:cp312-win_amd64-cp312": "@whl__cffi__da68248800ad6320//file",
+        "@aspect_rules_py_pip_configurations//:cp312-win_arm64-cp312": "@whl__cffi__4671d9dd5ec934cb//file"
+   },
+   default_target = "@@aspect_rules_py++uv+sdist_build__abi3_compat__cffi__2_0_0//:whl",
+   visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "gazelle_index_whl",
+    srcs = [
+        "@whl__cffi__6d02d6655b0e54f5//file",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+whl_install(
+    name = "actual_install",
+    src = ":whl",
+    compile_pyc = select({
+        "@aspect_rules_py//uv/private/pyc:is_precompile": True,
+        "//conditions:default": False,
+    }),
+    pyc_invalidation_mode = select({
+        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
+        "//conditions:default": "checked-hash",
+    }),
+    top_levels = {
+        "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl": [
+            "_cffi_backend.cpython-312-darwin.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl": [
+            "_cffi_backend.cpython-312-darwin.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl": [
+            "_cffi_backend.cpython-312-i386-linux-gnu.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "_cffi_backend.cpython-312-aarch64-linux-gnu.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl": [
+            "_cffi_backend.cpython-312-powerpc64le-linux-gnu.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl": [
+            "_cffi_backend.cpython-312-s390x-linux-gnu.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "_cffi_backend.cpython-312-x86_64-linux-gnu.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl": [
+            "_cffi_backend.cpython-312-aarch64-linux-musl.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl": [
+            "_cffi_backend.cpython-312-x86_64-linux-musl.so",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-win32.whl": [
+            "_cffi_backend.cp312-win32.pyd",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-win_amd64.whl": [
+            "_cffi_backend.cp312-win_amd64.pyd",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-win_arm64.whl": [
+            "_cffi_backend.cp312-win_arm64.pyd",
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+    },
+    namespace_top_levels = {},
+    console_scripts = {},
+    visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "install",
+    actual = ":actual_install",
+    visibility = ["//visibility:public"],
+)
+
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
+++ b/e2e/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
@@ -214,9 +214,153 @@ whl_install(
         "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
         "//conditions:default": "checked-hash",
     }),
-    top_levels = ["cryptography", "cryptography-46.0.5.dist-info", "cryptography.libs"],
-    namespace_top_levels = ["cryptography.libs"],
-    console_scripts = [],
+    top_levels = {
+        "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp311-abi3-win32.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-win_amd64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp38-abi3-win32.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-win_amd64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+    },
+    namespace_top_levels = {
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography.libs",
+        ],
+    },
+    console_scripts = {},
+    namespace_entries = {
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography.libs/libgcc_s-2d945d6c.so.1",
+        ],
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography.libs/libgcc_s-0cd532bd.so.1",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography.libs/libgcc_s-2d945d6c.so.1",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography.libs/libgcc_s-0cd532bd.so.1",
+        ],
+    },
     visibility = ["//visibility:private"],
 )
 

--- a/e2e/snapshots/firebase_admin.test_tool.venv.pth
+++ b/e2e/snapshots/firebase_admin.test_tool.venv.pth
@@ -1,11 +1,3 @@
 ../../../../../../..
 ../../../../../../../_main
 ../../../../../../../aspect_rules_py++uv+project__firebase_admin_import
-../../../_wheels/9d59437d/lib/python3.11/site-packages
-../../../_wheels/7f3e1928/lib/python3.11/site-packages
-../../../_wheels/6a0cbaf1/lib/python3.11/site-packages
-../../../_wheels/656bae2e/lib/python3.11/site-packages
-../../../_wheels/0ad20c61/lib/python3.11/site-packages
-../../../_wheels/5048576e/lib/python3.11/site-packages
-../../../_wheels/40a5b82b/lib/python3.11/site-packages
-../../../_wheels/e371a4a2/lib/python3.11/site-packages

--- a/e2e/snapshots/pth_namespace_547.test.venv.pth
+++ b/e2e/snapshots/pth_namespace_547.test.venv.pth
@@ -1,5 +1,3 @@
 ../../../../../../..
-../../../_wheels/c8dc2569/lib/python3.11/site-packages
 ../../../../../../../_main
 ../../../../../../../aspect_rules_py++uv+project__pth_namespace_547
-../../../_wheels/189ba7d9/lib/python3.11/site-packages

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
@@ -6,16 +6,16 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 select_chain(
    name = "whl",
    arms = {
-        "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__attrs__99b87a485a5820b2//file"
+        "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__azure_core__ab0c9b2cd71fecb1//file"
    },
-   default_target = "@@+uv+sdist_build__aspect_rules_py__attrs__23_2_0//:whl",
+   default_target = "@@aspect_rules_py++uv+sdist_build__azure_core_tracing_import__azure_core__1_38_0//:whl",
    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "gazelle_index_whl",
     srcs = [
-        "@whl__attrs__99b87a485a5820b2//file",
+        "@whl__azure_core__ab0c9b2cd71fecb1//file",
     ],
     visibility = ["//visibility:public"],
 )
@@ -34,14 +34,28 @@ whl_install(
         "//conditions:default": "checked-hash",
     }),
     top_levels = {
-        "attrs-23.2.0-py3-none-any.whl": [
-            "attr",
-            "attrs",
-            "attrs-23.2.0.dist-info",
+        "azure_core-1.38.0-py3-none-any.whl": [
+            "azure",
+            "azure_core-1.38.0.dist-info",
         ],
     },
-    namespace_top_levels = {},
+    namespace_top_levels = {
+        "azure_core-1.38.0-py3-none-any.whl": [
+            "azure",
+        ],
+    },
     console_scripts = {},
+    namespace_entries = {
+        "azure_core-1.38.0-py3-none-any.whl": [
+            "azure/core",
+        ],
+    },
+    namespace_dirs = {},
+    regular_roots = {
+        "azure_core-1.38.0-py3-none-any.whl": [
+            "azure/core",
+        ],
+    },
     visibility = ["//visibility:private"],
 )
 

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
@@ -6,16 +6,16 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 select_chain(
    name = "whl",
    arms = {
-        "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__attrs__99b87a485a5820b2//file"
+        "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__azure_core_tracing_opentelemetry__016cefcaff2900fb//file"
    },
-   default_target = "@@+uv+sdist_build__aspect_rules_py__attrs__23_2_0//:whl",
+   default_target = "@@aspect_rules_py++uv+sdist_build__azure_core_tracing_import__azure_core_tracing_opentelemetry__1_0_0b11//:whl",
    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "gazelle_index_whl",
     srcs = [
-        "@whl__attrs__99b87a485a5820b2//file",
+        "@whl__azure_core_tracing_opentelemetry__016cefcaff2900fb//file",
     ],
     visibility = ["//visibility:public"],
 )
@@ -34,14 +34,34 @@ whl_install(
         "//conditions:default": "checked-hash",
     }),
     top_levels = {
-        "attrs-23.2.0-py3-none-any.whl": [
-            "attr",
-            "attrs",
-            "attrs-23.2.0.dist-info",
+        "azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl": [
+            "azure",
+            "azure_core_tracing_opentelemetry-1.0.0b11.dist-info",
         ],
     },
-    namespace_top_levels = {},
+    namespace_top_levels = {
+        "azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl": [
+            "azure",
+        ],
+    },
     console_scripts = {},
+    namespace_entries = {
+        "azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl": [
+            "azure/core/tracing/ext/opentelemetry_span",
+        ],
+    },
+    namespace_dirs = {
+        "azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl": [
+            "azure/core",
+            "azure/core/tracing",
+            "azure/core/tracing/ext",
+        ],
+    },
+    regular_roots = {
+        "azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl": [
+            "azure/core/tracing/ext/opentelemetry_span",
+        ],
+    },
     visibility = ["//visibility:private"],
 )
 

--- a/e2e/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
+++ b/e2e/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
@@ -72,9 +72,170 @@ whl_install(
         "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
         "//conditions:default": "checked-hash",
     }),
-    top_levels = ["grpc", "grpcio-1.80.0.dist-info"],
-    namespace_top_levels = [],
-    console_scripts = [],
+    top_levels = {
+        "grpcio-1.80.0-cp311-cp311-linux_armv7l.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-win32.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-win_amd64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-linux_armv7l.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-win32.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-win_amd64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-linux_armv7l.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-win32.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-win_amd64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-linux_armv7l.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-win32.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-win_amd64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+    },
+    namespace_top_levels = {},
+    console_scripts = {},
     visibility = ["//visibility:private"],
 )
 

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -15,10 +15,22 @@ Downstream rules (notably `py_binary`) use this to create one
 executable wrappers under `<venv>/bin/<name>` for console scripts.
 """,
     fields = {
-        "wheels": """Depset of `struct(top_levels, namespace_top_levels, site_packages_rfpath, console_scripts)`
+        "wheels": """Depset of `struct(top_levels, namespace_top_levels, namespace_entries, site_packages_rfpath, console_scripts)`
 — one per wheel in the transitive closure. Fields:
   * `top_levels`: tuple[str] — top-level names the wheel installs into site-packages.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
+  * `namespace_entries`: tuple[str] — `/`-joined paths of the concrete entries beneath
+    the namespace top-levels (e.g. `jaraco/functools`), used to materialise a merged
+    namespace directory out of per-entry symlinks. May be absent on structs from
+    older producers; consumers use `getattr` with a `()` default.
+  * `namespace_dirs`: tuple[str] — implicit-namespace directory skeleton under the
+    namespace top-levels (site-packages-relative `/`-joined paths). May be absent
+    on structs from older producers; consumers use `getattr` with a `()` default.
+  * `regular_roots`: tuple[str] — minimal directories under the namespace
+    top-levels carrying an `__init__.py`. Cross-referencing a wheel's
+    `regular_roots` with another wheel's `namespace_dirs` detects regular
+    packages spanning wheels, which venv assembly must physically merge.
+    May be absent on structs from older producers.
   * `site_packages_rfpath`: str — runfiles-root-relative path to the wheel's site-packages.
   * `console_scripts`: tuple[str] — entry points encoded as `"name=module:func"`.
 """,

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -84,6 +84,7 @@ def _py_unpacked_wheel_impl(ctx):
             wheels = depset(direct = [struct(
                 top_levels = tuple(ctx.attr.top_levels),
                 namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
+                namespace_entries = tuple(ctx.attr.namespace_entries),
                 site_packages_rfpath = site_packages_rfpath,
                 console_scripts = tuple(ctx.attr.console_scripts),
                 # See whl_install rule for the rationale.
@@ -134,6 +135,18 @@ See the equivalent attribute on the `whl_install` rule for the full
 story; short version: names listed here suppress collision errors when
 multiple wheels claim the same top-level, because Python's namespace
 machinery is meant to merge their contributions.
+""",
+        default = [],
+    ),
+    "namespace_entries": attr.string_list(
+        doc = """Concrete entries this wheel installs beneath its `namespace_top_levels`.
+
+See the equivalent attribute on the `whl_install` rule for the full
+story; short version: `/`-joined paths like `jaraco/functools` that
+let venv assembly materialise a merged namespace directory out of
+per-entry symlinks, so static tools that inspect `site-packages/`
+directly see the package. When empty, namespace merging falls back to
+`.pth`-based resolution (runtime-only).
 """,
         default = [],
     ),

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -29,7 +29,7 @@ load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path"
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_version_transition")
-load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
+load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
 load(":py_venv_exec.bzl", _py_venv_exec = "py_venv_exec")
 load(":types.bzl", "VirtualenvInfo")
 load(":venv.bzl", "assemble_venv")
@@ -80,6 +80,7 @@ def _assemble_shared(ctx):
         default_env = default_env,
         venv_activate_tmpl = ctx.file._venv_activate_tmpl,
         virtualenv_shim_py = ctx.file._virtualenv_shim,
+        site_merge_script_py = ctx.file._site_merge_script,
         venv_name = ".{}".format(safe_name),
     )
 
@@ -251,6 +252,13 @@ environment. Forwarded to the sibling py_binary/py_test consumer
         allow_single_file = True,
         default = ":_virtualenv.py",
     ),
+    # Tool for physically merging a regular package that spans wheels
+    # (e.g. azure-core + azure-core-tracing-opentelemetry both
+    # installing into `azure/core/tracing/`) — see assemble_venv.
+    "_site_merge_script": attr.label(
+        allow_single_file = True,
+        default = "//py/tools/site_merge:site_merge.py",
+    ),
 })
 
 _attrs.update(**_py_library.attrs)
@@ -259,7 +267,14 @@ _py_venv = rule(
     doc = """Build a Python virtual environment and execute its interpreter.""",
     implementation = _py_venv_rule_impl,
     attrs = _attrs,
-    toolchains = [PY_TOOLCHAIN],
+    toolchains = [
+        PY_TOOLCHAIN,
+        # Optional: only consulted when a regular package spans wheels
+        # and assemble_venv needs an exec-config interpreter to run the
+        # site_merge action. Optional so venvs keep analyzing in setups
+        # that never registered rules_py's exec-tools toolchain.
+        config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
+    ],
     executable = True,
     cfg = python_version_transition,
 )

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -23,6 +23,9 @@ distutils, etc.) treat it as a real venv:
         _virtualenv.py                          distutils-compat shim
         _virtualenv.pth                         loads the shim at site init
         <top_level>                             symlink to a wheel's subdir
+        <ns_pkg>/<entry>                        merged PEP 420 namespace: real
+                                                <ns_pkg>/ dir, per-entry symlinks
+                                                into each contributing wheel
         <dist>-<ver>.dist-info                  symlink to a wheel's dist-info
 
 The whole tree is declared at analysis time as individual
@@ -33,6 +36,7 @@ Bazel's action cache treats each piece independently (no tree-artifact
 
 load("@bazel_lib//lib:paths.bzl", "to_rlocation_path")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
+load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
 
 # Template for console-script wrappers under <venv>/bin/<name>. A tiny shell
 # script that execs the venv's own bin/python with an inline `-c` to import
@@ -57,21 +61,48 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     * **Top-level in site-packages.** Multiple wheels claiming the same
       top-level name. When ALL contributing wheels flag the name as a
       PEP 420 namespace package (no `__init__.py` at that level), the
-      collision is benign — skip the per-top-level symlink and let each
-      wheel's site-packages fall through to `.pth` + `addsitedir`, where
-      Python's namespace machinery merges contributions natively.
-      Otherwise apply `package_collisions` policy.
+      collision is benign — merge the namespace CONCRETELY: a real
+      `site-packages/<tl>/` directory whose members are per-entry
+      symlinks into each contributing wheel (from the wheels'
+      `namespace_entries` metadata). Runtime imports would also work via
+      `.pth` + `addsitedir` alone, but tools that inspect site-packages
+      directly — mypy, pyright — never execute `.pth` files, so without
+      a concrete entry they miss the package and its `py.typed` markers
+      entirely. Wheels lacking entry metadata (hand-written
+      `py_unpacked_wheel`) keep the historical `.pth`-only fallback,
+      where Python's namespace machinery merges contributions at
+      runtime. Otherwise apply `package_collisions` policy.
+
+      Within an all-namespace top-level there's one shape `.pth` +
+      `addsitedir` cannot handle: a REGULAR package spanning wheels.
+      E.g. azure-core owns `azure/core/` (has `__init__.py`) while
+      azure-core-tracing-opentelemetry installs
+      `azure/core/tracing/ext/opentelemetry_span/` into that same tree.
+      Python locks a regular package's `__path__` to the first
+      directory found, so the second wheel's graft is unreachable. We
+      detect this by cross-referencing each wheel's `regular_roots`
+      against the other claimants' `namespace_dirs` skeletons, and
+      return the minimal conflicted roots as `merge_groups` — the
+      caller physically merges those subtrees (what a flat
+      `pip install` would have produced).
 
     * **Console-script name in bin/.** Apply `package_collisions` directly
       — no namespace equivalent.
 
     Returns:
-      top_level_to_site_pkgs: dict {top_level_name: site_packages_rfpath}
+      top_level_to_site_pkgs: dict {site_packages_relative_path: site_packages_rfpath}
+          — keys are top-level names, plus `/`-joined deeper paths (e.g.
+          `jaraco/functools`) for merged namespace packages.
       fully_covered_site_pkgs: dict[str, True] — site-packages paths whose
-          declared top-levels ALL ended up claimed by them — safe to drop
-          from the .pth fallback.
+          declared top-levels ALL ended up claimed by them (directly or
+          via a complete namespace merge) — safe to drop from the .pth
+          fallback.
       console_scripts_map: dict {script_name: struct(module, func)} after
           collision resolution.
+      merge_groups: list of struct(root, site_packages_list) — regular
+          package dirs (site-packages-relative paths) that span wheels
+          and need a physical merge, with the contributing wheels'
+          site-packages paths in first-wins priority order.
     """
 
     def _complain(what, name, a, b):
@@ -89,14 +120,20 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             print(msg)
 
     # Pass 1: bucket claimants per top-level / per console-script name.
-    tl_claimants = {}  # tl -> list of struct(site_packages, is_ns)
+    tl_claimants = {}  # tl -> list of struct(site_packages, is_ns, ns_entries)
     cs_claimants = {}  # name -> list of struct(site_packages, module, func)
+    wheel_by_sp = {}  # site_packages_rfpath -> wheel struct
     for w in wheels:
+        wheel_by_sp[w.site_packages_rfpath] = w
         ns_set = {tl: True for tl in getattr(w, "namespace_top_levels", ())}
+        ns_entries_by_tl = {}
+        for entry in getattr(w, "namespace_entries", ()):
+            ns_entries_by_tl.setdefault(entry.split("/")[0], []).append(entry)
         for tl in w.top_levels:
             tl_claimants.setdefault(tl, []).append(struct(
                 site_packages = w.site_packages_rfpath,
                 is_ns = tl in ns_set,
+                ns_entries = tuple(ns_entries_by_tl.get(tl, [])),
             ))
         for entry in getattr(w, "console_scripts", ()):
             # Entry encoding from the repo rule: "name=module:func".
@@ -118,9 +155,14 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             ))
 
     # Pass 2: resolve top-levels. Track which (site_packages, tl) pairs
-    # we SKIPPED so pass 3 can decide which wheels are fully covered.
+    # we SKIPPED (left to the .pth fallback) and which namespace claims
+    # were fully COVERED by per-entry symlinks, so pass 3 can decide
+    # which wheels are fully covered.
     top_level_to_site_pkgs = {}
     skipped_per_wheel = {}
+    ns_covered_per_wheel = {}
+    conflicted_roots = {}  # root path -> True (regular package spanning wheels)
+    ns_claimant_sps = {}  # sp -> True, wheels in any all-namespace collision
     for tl, claimants in tl_claimants.items():
         distinct_sp = {c.site_packages: c for c in claimants}
         if len(distinct_sp) == 1:
@@ -129,8 +171,127 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
 
         all_namespace = all([c.is_ns for c in claimants])
         if all_namespace:
-            for c in claimants:
-                skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+            # Deep-overlap scan first: a regular root of one claimant
+            # appearing in another claimant's namespace skeleton (B
+            # installs files below it) or as another's own regular root
+            # marks a REGULAR package spanning wheels (azure-core +
+            # azure-core-tracing-opentelemetry). Python locks a regular
+            # package's __path__ to one directory, so neither .pth nor a
+            # per-entry symlink can merge it — collect the roots for the
+            # physical merge in pass 2a, and record every all-namespace
+            # claimant sp.
+            tl_prefix = tl + "/"
+            tl_conflicted = False
+            for sp_a in distinct_sp.keys():
+                ns_claimant_sps[sp_a] = True
+                w_a = wheel_by_sp[sp_a]
+                for root in getattr(w_a, "regular_roots", ()):
+                    if not root.startswith(tl_prefix):
+                        continue
+                    for sp_b in distinct_sp.keys():
+                        if sp_b == sp_a:
+                            continue
+                        w_b = wheel_by_sp[sp_b]
+                        if (root in getattr(w_b, "namespace_dirs", ()) or
+                            root in getattr(w_b, "regular_roots", ())):
+                            conflicted_roots[root] = True
+                            tl_conflicted = True
+
+            unique_claimants = distinct_sp.values()
+
+            # When a regular package spans wheels under this top-level the
+            # physical merge (pass 2a -> merge_groups) owns the conflicted
+            # subtree and the remaining namespace portions fall through to
+            # .pth. Don't ALSO lay per-entry symlinks for this top-level:
+            # they'd collide with the merged directory and can't represent
+            # a regular package anyway.
+            if tl_conflicted:
+                for c in unique_claimants:
+                    skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+                continue
+
+            # Pure PEP 420 namespace (no regular package spanning wheels).
+            # Entry metadata is optional (a hand-written py_unpacked_wheel
+            # may omit it). Merge the claimants that HAVE entries
+            # concretely, and route the entryless ones to the .pth
+            # fallback: a concrete `site-packages/<tl>/` directory (no
+            # `__init__.py`) and a .pth/addsitedir portion both contribute
+            # to the same PEP 420 namespace at runtime, so the well-formed
+            # wheels stay visible to static tools (mypy, pyright) while the
+            # entryless wheel still resolves at import time. Only when NO
+            # claimant has entries do we keep the historical .pth-only
+            # fallback for the whole group.
+            entried = [c for c in unique_claimants if c.ns_entries]
+            for c in unique_claimants:
+                if not c.ns_entries:
+                    skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+            if not entried:
+                continue
+
+            # Per-entry merge over the entries-bearing claimants: first
+            # wheel to claim an entry wins. A later distinct wheel shipping
+            # the same entry is a genuine collision (same subpackage twice)
+            # — complain per policy and leave the loser on the .pth path.
+            # (An entryless claimant shipping the same subpackage can't be
+            # detected here; the concrete symlink wins deterministically
+            # over its .pth portion — the same first-on-path resolution the
+            # old all-.pth path gave, only now order-independent.)
+            entry_owner = {}
+            for c in entried:
+                for entry in c.ns_entries:
+                    prior = entry_owner.get(entry)
+                    if prior == None:
+                        entry_owner[entry] = c
+                    elif prior.site_packages != c.site_packages:
+                        _complain("namespace entry", entry, prior.site_packages, c.site_packages)
+                        skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+
+            # A nested-namespace mismatch (wheel A ships
+            # `google/cloud/__init__.py` while wheel B treats
+            # `google/cloud` as a namespace and ships
+            # `google/cloud/bigquery`) yields an entry that is a
+            # path-prefix of another — two declared outputs at
+            # conflicting paths. Keep the shallower entry (its symlink
+            # subsumes the deeper region) and leave the deeper wheel on
+            # the .pth path.
+            #
+            # KNOWN LIMITATION: this is a heuristic, not a full merge.
+            # When the shallower entry is a REGULAR package (A's
+            # `google/cloud/__init__.py`), `google.cloud` is not a
+            # namespace at runtime, so B's `.pth`-routed
+            # `google/cloud/bigquery` is shadowed and won't import — a flat
+            # `pip install` would instead overlay both into one
+            # `google/cloud/` directory. Correctly handling that needs a
+            # recursive merge at the conflict depth (symlink A's
+            # `__init__.py` + members AND B's subpackages into a concrete
+            # `google/cloud/`), which in turn needs per-member metadata we
+            # don't currently emit. We surface the conflict via
+            # `package_collisions` rather than silently mis-merging. No
+            # wheel set in our fixtures hits this (every google-* wheel
+            # treats `google/cloud` as a namespace); it's defensive.
+            for entry in entry_owner.keys():
+                segments = entry.split("/")
+                for depth in range(2, len(segments)):
+                    shallower = entry_owner.get("/".join(segments[:depth]))
+                    if shallower == None:
+                        continue
+                    loser = entry_owner.pop(entry)
+                    if shallower.site_packages != loser.site_packages:
+                        _complain("namespace entry", entry, shallower.site_packages, loser.site_packages)
+                        skipped_per_wheel.setdefault(loser.site_packages, {})[tl] = True
+                    break
+
+            for entry, c in entry_owner.items():
+                top_level_to_site_pkgs[entry] = c.site_packages
+
+            # Entries-bearing claimants that kept every one of their
+            # entries are fully represented by the merged directory; record
+            # per-wheel coverage so pass 3 can drop them from the .pth
+            # fallback. Entryless claimants stay in skipped_per_wheel
+            # (routed to .pth above) and are intentionally excluded.
+            for c in entried:
+                if tl not in skipped_per_wheel.get(c.site_packages, {}):
+                    ns_covered_per_wheel.setdefault(c.site_packages, {})[tl] = True
             continue
 
         first = claimants[0]
@@ -142,6 +303,35 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             _complain("top-level", tl, first.site_packages, c.site_packages)
             seen_losers[c.site_packages] = True
             skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+
+    # Pass 2a: fold conflicted roots into merge groups. Keep only the
+    # minimal (shallowest) roots — a conflicted root nested inside
+    # another conflicted root is covered by merging the outer one. For
+    # each root, the contributors are every namespace-claimant wheel
+    # that has the root in its skeleton (content below it) or as its
+    # own regular root, in wheel order (= first-wins priority).
+    merge_groups = []
+    minimal_roots = []
+    for root in sorted(conflicted_roots.keys()):
+        nested = False
+        for outer in minimal_roots:
+            if root == outer or root.startswith(outer + "/"):
+                nested = True
+                break
+        if not nested:
+            minimal_roots.append(root)
+    for root in minimal_roots:
+        group_sps = []
+        for sp in ns_claimant_sps.keys():
+            w = wheel_by_sp[sp]
+            if (root in getattr(w, "regular_roots", ()) or
+                root in getattr(w, "namespace_dirs", ())):
+                group_sps.append(sp)
+        if len(group_sps) >= 2:
+            merge_groups.append(struct(
+                root = root,
+                site_packages_list = group_sps,
+            ))
 
     # Pass 2b: console scripts.
     console_scripts_map = {}
@@ -160,19 +350,24 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             _complain("console script", name, first.site_packages, c.site_packages)
             seen_losers[c.site_packages] = True
 
-    # Pass 3: wheels fully covered by direct symlinks.
+    # Pass 3: wheels fully covered by direct (or complete per-entry
+    # namespace) symlinks.
     fully_covered = {}
     for w in wheels:
         skipped = skipped_per_wheel.get(w.site_packages_rfpath, {})
+        ns_covered = ns_covered_per_wheel.get(w.site_packages_rfpath, {})
         covered = True
         for tl in w.top_levels:
-            if tl in skipped or top_level_to_site_pkgs.get(tl) != w.site_packages_rfpath:
+            if tl in skipped:
+                covered = False
+                break
+            if top_level_to_site_pkgs.get(tl) != w.site_packages_rfpath and tl not in ns_covered:
                 covered = False
                 break
         if covered:
             fully_covered[w.site_packages_rfpath] = True
 
-    return top_level_to_site_pkgs, fully_covered, console_scripts_map
+    return top_level_to_site_pkgs, fully_covered, console_scripts_map, merge_groups
 
 def _wheel_key(wheel):
     """8-hex key derived from the wheel's install_tree.short_path (globally
@@ -194,6 +389,7 @@ def assemble_venv(
         default_env = {},
         venv_activate_tmpl,
         virtualenv_shim_py,
+        site_merge_script_py = None,
         venv_name = None):
     """Declare every file + symlink that makes up a venv for a target.
 
@@ -217,6 +413,11 @@ def assemble_venv(
         `ctx.file._venv_activate_tmpl`).
       virtualenv_shim_py: File — the `_virtualenv.py` distutils shim
         source (usually `ctx.file._virtualenv_shim`).
+      site_merge_script_py: File — the site_merge.py tool source
+        (usually `ctx.file._site_merge_script`). Only needed when the
+        wheel graph contains a regular package spanning wheels; the
+        merge action also requires the rule to declare the (optional)
+        EXEC_TOOLS_TOOLCHAIN for an exec-configuration interpreter.
       venv_name: Optional str — explicit venv dir basename. Defaults to
         "." + safe_name + ".venv" when unset.
 
@@ -234,7 +435,7 @@ def assemble_venv(
 
     wheels_depset = _py_library.make_wheels_depset(ctx)
     wheels = wheels_depset.to_list()
-    top_level_to_site_pkgs, fully_covered_site_pkgs, console_scripts_map = _resolve_wheel_collisions(
+    top_level_to_site_pkgs, fully_covered_site_pkgs, console_scripts_map, merge_groups = _resolve_wheel_collisions(
         ctx,
         wheels,
         package_collisions,
@@ -355,13 +556,18 @@ def assemble_venv(
     # symlinks. If the owning wheel has a `_wheels/<key>/` entry, we
     # route through it with an intra-venv relative path; otherwise fall
     # back to the historical runfiles-root-escape unresolved symlink.
+    # Keys may be `/`-joined paths below the site-packages root (merged
+    # namespace packages, e.g. `jaraco/functools`); each extra path
+    # segment needs one more `..` to escape back up.
     for tl, wheel_site_pkgs in top_level_to_site_pkgs.items():
         out = ctx.actions.declare_symlink("{}/{}".format(site_packages_rel, tl))
+        extra_up = "../" * tl.count("/")
         key = wheel_key_by_sp.get(wheel_site_pkgs)
         if key != None:
             ctx.actions.symlink(
                 output = out,
-                target_path = "{}/{}/lib/{}/site-packages/{}".format(
+                target_path = "{}{}/{}/lib/{}/site-packages/{}".format(
+                    extra_up,
                     site_packages_to_wheels_root,
                     key,
                     wheel_py_ver,
@@ -371,9 +577,82 @@ def assemble_venv(
         else:
             ctx.actions.symlink(
                 output = out,
-                target_path = "{}/{}/{}".format(escape, wheel_site_pkgs, tl),
+                target_path = "{}{}/{}/{}".format(extra_up, escape, wheel_site_pkgs, tl),
             )
         declared.append(out)
+
+    # Physical merges for regular packages that span wheels (see
+    # _resolve_wheel_collisions). Each group's subtree is copied from
+    # every contributing wheel into a real directory inside our
+    # site-packages — the layout a flat `pip install` produces. The
+    # venv's own site-packages precedes the per-wheel `.pth` entries on
+    # sys.path, so the merged copy is the one Python binds the regular
+    # package's `__path__` to; the per-wheel originals are shadowed.
+    #
+    # The merge runs as a build action under the exec-configuration
+    # interpreter (same shape as WhlInstall's unpack action). Wheels
+    # without an install_tree (legacy py_unpacked_wheel) can't
+    # contribute — they also never carry the metadata that forms a
+    # merge group, so they can't appear here.
+    for group in merge_groups:
+        if site_merge_script_py == None:
+            fail(("{}: wheels {} all contribute to the regular package `{}` — merging it " +
+                  "requires the venv rule to supply the site_merge tool.").format(
+                ctx.label,
+                group.site_packages_list,
+                group.root,
+            ))
+        exec_toolchain = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN]
+        exec_runtime = exec_toolchain.exec_tools.exec_runtime if exec_toolchain else None
+        if exec_runtime == None:
+            fail(("{}: wheels {} all contribute to the regular package `{}` — merging it " +
+                  "requires an exec-configuration Python interpreter, but no `{}` toolchain " +
+                  "was registered.").format(
+                ctx.label,
+                group.site_packages_list,
+                group.root,
+                EXEC_TOOLS_TOOLCHAIN,
+            ))
+
+        merged_dir = ctx.actions.declare_directory(
+            "{}/{}".format(site_packages_rel, group.root),
+        )
+        arguments = ctx.actions.args()
+        arguments.add(site_merge_script_py)
+        arguments.add_all([merged_dir], expand_directories = False, before_each = "--into")
+        arguments.add("--collision-policy", package_collisions)
+        trees = []
+        for sp in group.site_packages_list:
+            key = wheel_key_by_sp.get(sp)
+            if key == None:
+                fail("{}: wheel at {} contributes to merged package `{}` but has no install_tree.".format(
+                    ctx.label,
+                    sp,
+                    group.root,
+                ))
+            tree = wheel_by_key[key].install_tree
+            trees.append(tree)
+            arguments.add_all(
+                [tree],
+                expand_directories = False,
+                before_each = "--src",
+                format_each = "%s/lib/{}/site-packages/{}".format(wheel_py_ver, group.root),
+            )
+        ctx.actions.run(
+            mnemonic = "PySiteMerge",
+            executable = exec_runtime.interpreter,
+            toolchain = EXEC_TOOLS_TOOLCHAIN,
+            arguments = [arguments],
+            inputs = depset(
+                direct = [site_merge_script_py] + trees,
+                transitive = [exec_runtime.files],
+            ),
+            outputs = [merged_dir],
+            execution_requirements = {
+                "supports-path-mapping": "1",
+            },
+        )
+        declared.append(merged_dir)
 
     # Keyed wheels (have `_wheels/<key>/`) emit a plain relative path:
     # site.py joins it with the .pth's directory and appends to

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -199,15 +199,34 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
 
             unique_claimants = distinct_sp.values()
 
-            # When a regular package spans wheels under this top-level the
-            # physical merge (pass 2a -> merge_groups) owns the conflicted
-            # subtree and the remaining namespace portions fall through to
-            # .pth. Don't ALSO lay per-entry symlinks for this top-level:
-            # they'd collide with the merged directory and can't represent
-            # a regular package anyway.
+            # Regular-span conflict: PySiteMerge owns the conflicted roots;
+            # all claimants fall back to .pth. Sibling namespace entries
+            # outside the conflict still get concrete per-entry symlinks.
             if tl_conflicted:
                 for c in unique_claimants:
                     skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+
+                entried = [c for c in unique_claimants if c.ns_entries]
+                if entried:
+                    entry_owner = {}
+                    for c in entried:
+                        for entry in c.ns_entries:
+                            # Skip entries inside a conflicted root —
+                            # the physical merge owns those.
+                            under_conflict = False
+                            for root in conflicted_roots:
+                                if entry == root or entry.startswith(root + "/"):
+                                    under_conflict = True
+                                    break
+                            if under_conflict:
+                                continue
+                            prior = entry_owner.get(entry)
+                            if prior == None:
+                                entry_owner[entry] = c
+                            elif prior.site_packages != c.site_packages:
+                                _complain("namespace entry", entry, prior.site_packages, c.site_packages)
+                    for entry, c in entry_owner.items():
+                        top_level_to_site_pkgs[entry] = c.site_packages
                 continue
 
             # Pure PEP 420 namespace (no regular package spanning wheels).

--- a/py/tools/site_merge/BUILD.bazel
+++ b/py/tools/site_merge/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(
+    ["site_merge.py"],
+    visibility = ["//visibility:public"],
+)

--- a/py/tools/site_merge/site_merge.py
+++ b/py/tools/site_merge/site_merge.py
@@ -1,0 +1,90 @@
+"""Site-packages subtree merger for aspect_rules_py venv assembly.
+
+Physically merges one package directory contributed by multiple wheels
+into a single output directory — the shape a flat `pip install` into one
+site-packages would produce.
+
+Needed when a *regular* package (one with an `__init__.py`) spans
+wheels: e.g. azure-core owns `azure/core/` while
+azure-core-tracing-opentelemetry installs
+`azure/core/tracing/ext/opentelemetry_span/` into that same tree.
+Python locks a regular package's `__path__` to the first directory
+found on `sys.path`, so unlike PEP 420 namespace portions the
+contributions cannot be merged at import time — they have to be merged
+on disk.
+
+Invoked by Bazel as::
+
+    <exec_python> site_merge.py --into <dir> [--collision-policy P] --src <dir> [--src <dir> ...]
+
+Each ``--src`` is one wheel's copy of the package directory, in
+priority order: on file-level conflicts the first wheel providing a
+path wins. Sources that don't exist are skipped (platform wheels for
+other architectures may not ship the directory).
+"""
+
+import argparse
+import filecmp
+import os
+import shutil
+from pathlib import Path
+
+
+def merge(into, sources, collision_policy):
+    into.mkdir(parents=True, exist_ok=True)
+    owners = {}
+    conflicts = []
+
+    for src in sources:
+        if not src.is_dir():
+            continue
+        for root, dirs, files in os.walk(src):
+            rel_root = Path(root).relative_to(src)
+            for d in sorted(dirs):
+                (into / rel_root / d).mkdir(parents=True, exist_ok=True)
+            for f in sorted(files):
+                rel = rel_root / f
+                dest = into / rel
+                src_file = Path(root) / f
+                prior = owners.get(rel)
+                if prior is not None:
+                    # First wheel wins; byte-identical duplicates (e.g.
+                    # an empty __init__.py or py.typed shipped by both
+                    # wheels) are benign and not reported.
+                    if not filecmp.cmp(str(src_file), str(dest), shallow=False):
+                        conflicts.append((rel, prior, src))
+                    continue
+                shutil.copy(str(src_file), str(dest))
+                owners[rel] = src
+
+    return conflicts
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--into", required=True, type=Path)
+    ap.add_argument("--src", dest="sources", action="append", default=[], type=Path)
+    ap.add_argument(
+        "--collision-policy",
+        default="warning",
+        choices=["error", "warning", "ignore"],
+    )
+    args = ap.parse_args()
+
+    conflicts = merge(args.into, args.sources, args.collision_policy)
+
+    if conflicts and args.collision_policy != "ignore":
+        for rel, winner, loser in conflicts:
+            print(
+                "Package collision while merging {}: `{}` is provided by both {} and {}.".format(
+                    args.into, rel, winner, loser
+                )
+            )
+        if args.collision_policy == "error":
+            raise SystemExit(
+                'Set `package_collisions = "warning"` or "ignore" to downgrade.'
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tools/site_merge/site_merge.py
+++ b/py/tools/site_merge/site_merge.py
@@ -30,7 +30,7 @@ import shutil
 from pathlib import Path
 
 
-def merge(into, sources, collision_policy):
+def merge(into, sources):
     into.mkdir(parents=True, exist_ok=True)
     owners = {}
     conflicts = []
@@ -41,11 +41,24 @@ def merge(into, sources, collision_policy):
         for root, dirs, files in os.walk(src):
             rel_root = Path(root).relative_to(src)
             for d in sorted(dirs):
-                (into / rel_root / d).mkdir(parents=True, exist_ok=True)
+                dest_dir = into / rel_root / d
+                if dest_dir.exists() and not dest_dir.is_dir():
+                    raise ValueError(
+                        "Type conflict at {}: was a file (from {}), now a directory (from {}).".format(
+                            rel_root / d, owners.get(rel_root / d, "unknown"), src
+                        )
+                    )
+                dest_dir.mkdir(parents=True, exist_ok=True)
             for f in sorted(files):
                 rel = rel_root / f
                 dest = into / rel
                 src_file = Path(root) / f
+                if dest.is_dir():
+                    raise ValueError(
+                        "Type conflict at {}: was a directory, now a file (from {}).".format(
+                            rel, src
+                        )
+                    )
                 prior = owners.get(rel)
                 if prior is not None:
                     # First wheel wins; byte-identical duplicates (e.g.
@@ -71,7 +84,13 @@ def main():
     )
     args = ap.parse_args()
 
-    conflicts = merge(args.into, args.sources, args.collision_policy)
+    try:
+        conflicts = merge(args.into, args.sources)
+    except ValueError as exc:
+        if args.collision_policy == "error":
+            raise SystemExit(str(exc))
+        print(str(exc))
+        conflicts = []
 
     if conflicts and args.collision_policy != "ignore":
         for rel, winner, loser in conflicts:

--- a/uv/private/whl_install/BUILD.bazel
+++ b/uv/private/whl_install/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
-load(":test.bzl", "whl_install_suite")
+load(":test.bzl", "metadata_selection_test_suite", "whl_install_suite")
 
 package(default_visibility = [
     "//docs:__pkg__",
@@ -32,11 +32,15 @@ bzl_library(
 
 whl_install_suite()
 
+metadata_selection_test_suite(name = "metadata_selection")
+
 bzl_library(
     name = "test",
     srcs = ["test.bzl"],
     deps = [
         ":repository",
+        ":rule",
         "@bazel_skylib//lib:unittest",
+        "@bazel_skylib//rules:write_file",
     ],
 )

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -551,6 +551,9 @@ filegroup(
     # wheel repos to our visibility so `rctx.path(Label(...))` can
     # resolve. `whl_files` mirrors the truthy `whls` values in order, so
     # pair them up by index to recover the filename ↔ label association.
+    # Both lists are generated together by the hub rule from the same
+    # source data, so the ordering invariant is maintained at the point
+    # of production and does not depend on runtime dict iteration order.
     whl_file_labels = {}
     whl_file_index = 0
     for target in prebuilds.values():

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -51,25 +51,37 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
                  label_list attr so Bazel wires up repo visibility.
 
     Returns:
-      Tuple (top_levels_set, regular_top_levels_set, console_scripts_set):
+      Tuple (top_levels_set, regular_top_levels_set, console_scripts_set,
+             namespace_entries_set, dirs_set, init_dirs_set):
         * top_levels_set: dict[name → True] — all first-path-segment
           names in RECORD (excluding `*.data/` staging entries).
         * regular_top_levels_set: subset that had an `__init__.py` at
           depth 1, i.e. regular packages. Its complement (within
           top_levels_set, minus `.dist-info/`) is the PEP 420 namespace
-          set. Returned separately so callers can union regular/top sets
-          across multiple platform wheels before deriving namespaces —
-          a top-level is a namespace only if NO wheel has it as regular.
+          set for this wheel.
         * console_scripts_set: dict[script_name → "name=module:func"].
+        * namespace_entries_set: dict[path → True] — for each top-level
+          that looks like a PEP 420 namespace in THIS wheel, the
+          `/`-joined paths of the concrete entries beneath it: the
+          shallowest directory holding a direct `__init__.py` (recursing
+          through nested namespace dirs like `google/cloud/`), or the
+          file itself for plain modules / data files. Lets venv assembly
+          materialise a merged namespace dir out of per-entry symlinks.
+        * dirs_set: dict[path → True] — every directory implied by a
+          RECORD entry, as a `/`-joined relative path.
+        * init_dirs_set: dict[path → True] — subset of dirs_set that
+          directly contain an `__init__.py` (regular packages). Powers
+          the per-wheel namespace_dirs / regular_roots derivation, which
+          venv assembly uses to detect regular packages spanning wheels.
       All empty on any failure — callers tolerate empty and fall back.
     """
     unzip = repository_ctx.which("unzip")
     if not unzip:
-        return {}, {}, {}
+        return {}, {}, {}, {}, {}, {}
 
     whl_path = _find_whl_file(repository_ctx, whl_label)
     if whl_path == None:
-        return {}, {}, {}
+        return {}, {}, {}, {}, {}, {}
 
     # RECORD: authoritative list of every installed file. First path segment
     # = top-level name, excluding the wheel's `*.data/` staging area.
@@ -81,6 +93,13 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
     # appear with an `__init__.py` at depth 1) are PEP 420 namespace
     # packages that expect to be merged across wheels.
     regular_top_levels = {}
+
+    # Raw material for the namespace derivations below: every kept RECORD
+    # path (as segment lists) plus the full directory skeleton and the set
+    # of directories that hold a direct `__init__.py` at any depth.
+    record_segments = []
+    dirs_set = {}
+    init_dirs = {}
     if record.return_code == 0 and record.stdout:
         for line in record.stdout.splitlines():
             line = line.strip()
@@ -92,9 +111,20 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
             segments = path.split("/")
             first_segment = segments[0]
 
-            # `*.data/` files (PEP 427) aren't installed to site-packages;
-            # they're routed to data/scripts/headers/purelib/etc. under
-            # sys.prefix. Exclude from site-packages top-level list.
+            # `*.data/` files (PEP 427) are routed to
+            # data/scripts/headers/purelib/platlib under sys.prefix at
+            # install time. Exclude from the site-packages top-level list.
+            #
+            # KNOWN LIMITATION: `*.data/purelib/` and `*.data/platlib/`
+            # ARE overlaid into site-packages on a real install, so a wheel
+            # that ships a namespace contribution there (e.g.
+            # `foo.data/purelib/ns/sub/`) won't have `ns` discovered as a
+            # top-level or `ns/sub` as a namespace entry — that
+            # contribution stays invisible to the concrete merge (and to
+            # static tools). Rare in practice (wheels overwhelmingly ship
+            # packages at the archive root); handling it would mean
+            # rewriting the `*.data/{purelib,platlib}/` prefix to
+            # site-packages-relative before deriving top-levels/entries.
             if first_segment.endswith(".data"):
                 continue
 
@@ -117,6 +147,35 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
             # namespace packages — treat them as regular.
             if len(segments) == 1 or (len(segments) >= 2 and segments[1] == "__init__.py"):
                 regular_top_levels[first_segment] = True
+
+            record_segments.append(segments)
+
+            # Record every directory along the path, and which of them
+            # directly contain an `__init__.py`.
+            for i in range(1, len(segments)):
+                dirs_set["/".join(segments[:i])] = True
+            if len(segments) >= 2 and segments[-1] == "__init__.py":
+                init_dirs["/".join(segments[:-1])] = True
+
+    # Namespace entries: for each path under a (per-this-wheel) namespace
+    # top-level, descend until hitting the shallowest concrete prefix — a
+    # directory with a direct `__init__.py`, or the file itself when no
+    # such directory exists on the way down (plain modules like
+    # `jaraco/context.py`, or bare data files). Nested namespaces
+    # (`google/cloud/storage/…`) recurse naturally: `google/cloud` has no
+    # `__init__.py`, so the walk continues to `google/cloud/storage`.
+    # Entries for top-levels that turn out regular are filtered out here.
+    namespace_entries = {}
+    for segments in record_segments:
+        if segments[0] in regular_top_levels or segments[0].endswith(".dist-info"):
+            continue
+        if len(segments) < 2:
+            continue
+        for depth in range(2, len(segments) + 1):
+            prefix = "/".join(segments[:depth])
+            if depth == len(segments) or prefix in init_dirs:
+                namespace_entries[prefix] = True
+                break
 
     # entry_points.txt: INI-style file. Only `[console_scripts]` interests
     # us — pip/uv synthesize executables under `bin/<name>` from those at
@@ -146,10 +205,53 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
             # Normalise to "name=module:func" so downstream parsing is trivial.
             console_scripts[name] = "{}={}".format(name, target)
 
-    # Return raw sets (not the final namespace derivation) so callers can
-    # union across multiple platform wheels before deciding namespace
-    # status — see the caller in `_whl_install_repo_impl`.
-    return top_levels_set, regular_top_levels, console_scripts
+    return top_levels_set, regular_top_levels, console_scripts, namespace_entries, dirs_set, init_dirs
+
+def _namespace_dirs_and_roots(dirs_set, init_dirs, namespace_top_levels_set):
+    """Split a wheel's directory skeleton into the implicit-namespace dirs
+    and the minimal regular-package roots, restricted to the wheel's
+    namespace top-levels.
+
+    Walking from the top, content is an implicit-namespace portion until
+    the first directory carrying an `__init__.py` — that directory is a
+    "regular root" and everything below it is interior to a regular
+    package.
+
+      * namespace_dirs: the implicit-namespace skeleton, minus the depth-1
+        entries already covered by namespace_top_levels
+        (azure-core → []; azure-core-tracing-opentelemetry →
+        ["azure/core", "azure/core/tracing", "azure/core/tracing/ext"]).
+      * regular_roots: the minimal regular-package dirs (azure-core →
+        ["azure/core"]).
+
+    venv assembly cross-references these across wheels: a regular root
+    appearing in another wheel's namespace skeleton means a regular
+    package SPANS wheels — Python's namespace machinery cannot merge that,
+    so the subtree must be physically merged. Dirs under regular
+    top-levels are skipped (handled by the top-level first-wins policy).
+    """
+    namespace_dirs = []
+    regular_roots = []
+    for d in sorted(dirs_set.keys()):
+        segments = d.split("/")
+        if segments[0] not in namespace_top_levels_set:
+            continue
+        boundary = None
+        for i in range(len(segments)):
+            prefix = "/".join(segments[:i + 1])
+            if prefix in init_dirs:
+                boundary = prefix
+                break
+        if boundary == None:
+            # Depth-1 entries are redundant with namespace_top_levels
+            # (regular roots are always depth >= 2, so the cross-wheel
+            # scan never consults them) — dropping them keeps wheels with
+            # only a `<pkg>.libs/` shared-library dir attr-free.
+            if len(segments) >= 2:
+                namespace_dirs.append(d)
+        elif boundary == d:
+            regular_roots.append(d)
+    return namespace_dirs, regular_roots
 
 def indent(text, space = " "):
     return "\n".join(["{}{}".format(space, l) for l in text.splitlines()])
@@ -318,6 +420,11 @@ def _whl_install_impl(repository_ctx):
     # Strip the bookkeeping specificity score; downstream only needs the target.
     select_arms = {k: v[1] for k, v in select_arms.items()}
 
+    # Wheel targets that survived platform/interpreter filtering — the only
+    # wheels the select chain below can ever resolve to. Used to limit
+    # metadata extraction to selectable wheels.
+    arm_targets = {v: True for v in select_arms.values()}
+
     # Unfortunately the way that Bazel decides ambiguous selects is explicitly
     # NOT designed to allow for the implementation of ranges. Because that would
     # be too easy. The disambiguation criteria is based on the number of
@@ -415,46 +522,92 @@ filegroup(
         "//conditions:default": "checked-hash",
     })"""
 
-    # Peek into each wheel to extract the top-level names it installs AND
-    # its `[console_scripts]` entry points. This powers PyWheelsInfo,
-    # which py_binary uses to build a merged site-packages tree via
-    # ctx.actions.symlink and to wrap console scripts into <venv>/bin/.
-    # Falls back gracefully to [] if extraction fails; consumers tolerate it.
+    # Peek into each selectable wheel to extract the top-level names it
+    # installs AND its `[console_scripts]` entry points, keyed by the
+    # wheel's file basename. This powers PyWheelsInfo, which py_binary
+    # uses to build a merged site-packages tree via ctx.actions.symlink
+    # and to wrap console scripts into <venv>/bin/.
+    #
+    # Metadata is kept per wheel rather than unioned across the platform
+    # wheels: the `whl_install` build rule looks up the entry whose key
+    # matches the basename of the wheel the select chain resolved to for
+    # the active configuration. A union would leak an inactive wheel's
+    # package surface into the active one — e.g. cffi's macOS
+    # `_cffi_backend.cpython-312-darwin.so` top-level showing up (as a
+    # dangling site-packages symlink) in a Linux build, or a console
+    # script shipped only by the win32 wheel getting a `<venv>/bin/`
+    # wrapper pointing at a module that doesn't exist on Linux.
+    #
+    # Wheels that didn't make it into the select chain (unsupported
+    # platform/interpreter) are skipped — they can never be the active
+    # wheel, and peeking at them would force a useless download.
+    #
+    # Falls back gracefully: a wheel without an entry (extraction failed,
+    # or the sbuild fallback whose contents are unknowable until build
+    # time) emits no PyWheelsInfo and consumers use .pth-based resolution.
     #
     # We read from `whl_files` (a real label_list) rather than `whls` (a
     # JSON-encoded string of labels) because only the former adds the
-    # wheel repos to our visibility so `rctx.path(Label(...))` can resolve.
-    #
-    # Union across all platform wheels — same-python-version wheels for
-    # a given package share their pure-Python top-levels but have
-    # DIFFERENT C-extension filenames (e.g. cffi's `_cffi_backend` ships
-    # as `_cffi_backend.cpython-311-darwin.so` on macOS and
-    # `_cffi_backend.cpython-311-x86_64-linux-gnu.so` on Linux). Picking
-    # only one wheel bakes in that wheel's suffix; at build time on a
-    # different platform, the venv's top-level symlink points at a file
-    # that doesn't exist in the actually-installed wheel. Unioning lets
-    # every platform see its own suffix in top_levels — the dangling
-    # symlinks for other platforms' suffixes are invisible to Python's
-    # importer (it matches by the current interpreter's exact suffix).
-    top_levels_set = {}
-    regular_top_levels_set = {}
-    console_scripts_set = {}
-    for whl_file in repository_ctx.attr.whl_files:
-        tls, reg, css = _extract_wheel_metadata(repository_ctx, whl_file)
-        top_levels_set.update(tls)
-        regular_top_levels_set.update(reg)
-        console_scripts_set.update(css)
+    # wheel repos to our visibility so `rctx.path(Label(...))` can
+    # resolve. `whl_files` mirrors the truthy `whls` values in order, so
+    # pair them up by index to recover the filename ↔ label association.
+    whl_file_labels = {}
+    whl_file_index = 0
+    for target in prebuilds.values():
+        if not target:
+            continue
+        whl_file_labels[target] = repository_ctx.attr.whl_files[whl_file_index]
+        whl_file_index += 1
 
-    # Namespace derivation happens AFTER the union: a top-level counts as
-    # a PEP 420 namespace only if NO extracted wheel had `__init__.py` at
-    # depth 1 for it. If any wheel flagged it regular, it's regular.
-    top_levels = sorted(top_levels_set.keys())
-    namespace_top_levels = sorted([
-        tl
-        for tl in top_levels_set
-        if tl not in regular_top_levels_set and not tl.endswith(".dist-info")
-    ])
-    console_scripts = sorted(console_scripts_set.values())
+    top_levels_by_whl = {}
+    namespace_top_levels_by_whl = {}
+    namespace_entries_by_whl = {}
+    namespace_dirs_by_whl = {}
+    regular_roots_by_whl = {}
+    console_scripts_by_whl = {}
+    for whl_name, target in prebuilds.items():
+        if not target or target not in arm_targets:
+            continue
+        tls, regular, css, ns_entries, dirs_set, init_dirs = _extract_wheel_metadata(
+            repository_ctx,
+            whl_file_labels[target],
+        )
+        if tls:
+            top_levels_by_whl[whl_name] = sorted(tls.keys())
+
+            # A top-level counts as a PEP 420 namespace for this wheel if
+            # its RECORD shows no `<toplevel>/__init__.py` at depth 1.
+            namespaces = sorted([
+                tl
+                for tl in tls
+                if tl not in regular and not tl.endswith(".dist-info")
+            ])
+            if namespaces:
+                namespace_top_levels_by_whl[whl_name] = namespaces
+                namespace_set = {tl: True for tl in namespaces}
+
+                # Concrete entries beneath this wheel's namespace
+                # top-levels (`jaraco/functools`) — for the per-entry
+                # symlink merge that makes the namespace mypy/pyright
+                # visible.
+                entries = sorted([
+                    entry
+                    for entry in ns_entries
+                    if entry.split("/")[0] in namespace_set
+                ])
+                if entries:
+                    namespace_entries_by_whl[whl_name] = entries
+
+                # Implicit-namespace dir skeleton + minimal regular roots
+                # under this wheel's namespace top-levels — for detecting
+                # a regular package that spans wheels (azure-core case).
+                ndirs, rroots = _namespace_dirs_and_roots(dirs_set, init_dirs, namespace_set)
+                if ndirs:
+                    namespace_dirs_by_whl[whl_name] = ndirs
+                if rroots:
+                    regular_roots_by_whl[whl_name] = rroots
+        if css:
+            console_scripts_by_whl[whl_name] = sorted(css.values())
 
     install_attrs = """
     src = ":whl",
@@ -465,10 +618,26 @@ filegroup(
     console_scripts = {console_scripts},""".format(
         compile_pyc = compile_pyc_select,
         pyc_invalidation_mode = pyc_invalidation_mode_select,
-        top_levels = repr(top_levels),
-        namespace_top_levels = repr(namespace_top_levels),
-        console_scripts = repr(console_scripts),
+        top_levels = indent(pprint(top_levels_by_whl), " " * 4).lstrip(),
+        namespace_top_levels = indent(pprint(namespace_top_levels_by_whl), " " * 4).lstrip(),
+        console_scripts = indent(pprint(console_scripts_by_whl), " " * 4).lstrip(),
     )
+
+    # Only emitted for wheels that contribute to a namespace — keeps the
+    # generated BUILD files (and their e2e snapshots) unchanged for the
+    # common regular-top-level-only case.
+    if namespace_entries_by_whl:
+        install_attrs += """
+    namespace_entries = {namespace_entries},""".format(
+            namespace_entries = indent(pprint(namespace_entries_by_whl), " " * 4).lstrip(),
+        )
+    if namespace_dirs_by_whl or regular_roots_by_whl:
+        install_attrs += """
+    namespace_dirs = {namespace_dirs},
+    regular_roots = {regular_roots},""".format(
+            namespace_dirs = indent(pprint(namespace_dirs_by_whl), " " * 4).lstrip(),
+            regular_roots = indent(pprint(regular_roots_by_whl), " " * 4).lstrip(),
+        )
 
     if post_install_patches:
         install_attrs += """
@@ -534,7 +703,7 @@ whl_install = repository_rule(
         # label_list so Bazel adds those repos to this repo's visibility
         # mapping. Needed so that `repository_ctx.path(Label(...))` can
         # resolve any one of them at repo-rule time to peek at the wheel's
-        # `*.dist-info/RECORD` — see `_extract_top_levels` above.
+        # `*.dist-info/RECORD` — see `_extract_wheel_metadata` above.
         "whl_files": attr.label_list(allow_files = [".whl"]),
         "sbuild": attr.label(),
         "post_install_patches": attr.string(default = ""),

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -8,8 +8,12 @@ load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
 def _whl_install(ctx):
     py_toolchain = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
     exec_runtime = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN].exec_tools.exec_runtime
+
+    # Name the install tree after the target rather than a fixed "install"
+    # so several whl_install targets can coexist in one package without
+    # declaring conflicting outputs.
     install_dir = ctx.actions.declare_directory(
-        "install",
+        ctx.label.name + ".install",
     )
 
     archive = ctx.file.src
@@ -57,10 +61,17 @@ def _whl_install(ctx):
         },
     )
 
-    site_packages_rfpath = ctx.label.repo_name + "/install/lib/python{}.{}/site-packages".format(
+    # Runfiles-root-relative path to the install tree's site-packages.
+    # Derived from the same label components as `install_dir` above so the
+    # two can never drift apart.
+    site_packages_rfpath = "/".join([
+        segment
+        for segment in [ctx.label.repo_name, ctx.label.package, ctx.label.name + ".install"]
+        if segment
+    ] + ["lib/python{}.{}/site-packages".format(
         py_toolchain.interpreter_version_info.major,
         py_toolchain.interpreter_version_info.minor,
-    )
+    )])
 
     providers = [
         DefaultInfo(
@@ -89,21 +100,57 @@ def _whl_install(ctx):
         ),
     ]
 
-    if ctx.attr.top_levels or ctx.attr.console_scripts:
+    # Per-configuration metadata selection: `src` resolves (through the
+    # repo rule's select_chain) to exactly one wheel for the active
+    # configuration, and the metadata attrs are dicts keyed by wheel file
+    # basename. Looking up the resolved wheel at analysis time limits the
+    # advertised package surface (top-levels, console scripts) to the
+    # wheel that is actually installed — metadata from inactive platform
+    # wheels must not leak in (e.g. another platform's C-extension
+    # suffix, or a console script shipped only by the win32 wheel).
+    # A lookup miss (sbuild fallback, failed extraction at repo-fetch
+    # time) emits no PyWheelsInfo and consumers fall back to .pth-based
+    # resolution.
+    whl_basename = ctx.file.src.basename
+    top_levels = ctx.attr.top_levels.get(whl_basename, [])
+    namespace_top_levels = ctx.attr.namespace_top_levels.get(whl_basename, [])
+    namespace_entries = ctx.attr.namespace_entries.get(whl_basename, [])
+    namespace_dirs = ctx.attr.namespace_dirs.get(whl_basename, [])
+    regular_roots = ctx.attr.regular_roots.get(whl_basename, [])
+    console_scripts = ctx.attr.console_scripts.get(whl_basename, [])
+
+    if top_levels or console_scripts:
         providers.append(PyWheelsInfo(
             wheels = depset(direct = [struct(
-                top_levels = tuple(ctx.attr.top_levels),
+                top_levels = tuple(top_levels),
                 # PEP 420 namespace packages this wheel contributes to.
                 # When multiple wheels claim the same top-level and ALL of
-                # them flag it as namespace, py_binary treats the
-                # collision as benign and falls back to .pth-based
-                # resolution so Python's namespace-package machinery
-                # merges contributions across wheels.
-                namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
+                # them flag it as namespace, py_binary merges the namespace
+                # CONCRETELY from `namespace_entries` per-entry symlinks
+                # (so tools that inspect site-packages directly — mypy,
+                # pyright — see the packages and their py.typed markers),
+                # unless a regular package spans the wheels (detected via
+                # `regular_roots` × `namespace_dirs`), which needs a
+                # physical merge instead. Falls back to .pth-based
+                # resolution when entry metadata is missing.
+                namespace_top_levels = tuple(namespace_top_levels),
+                # Concrete per-wheel paths beneath namespace top-levels
+                # (e.g. `jaraco/functools`) that venv assembly symlinks
+                # individually to materialise a merged namespace directory.
+                namespace_entries = tuple(namespace_entries),
+                # Directory skeleton under namespace top-levels: which dirs
+                # are implicit-namespace portions (`namespace_dirs`) and
+                # which are the minimal regular-package roots
+                # (`regular_roots`). venv assembly cross-references these
+                # across wheels to detect a regular package spanning wheels
+                # (Python can't merge a regular package's __path__ at
+                # runtime, so the subtree is physically merged).
+                namespace_dirs = tuple(namespace_dirs),
+                regular_roots = tuple(regular_roots),
                 site_packages_rfpath = site_packages_rfpath,
                 # Each entry is "name=module:func"; py_binary parses into
                 # wrapper scripts at <venv>/bin/<name> at analysis time.
-                console_scripts = tuple(ctx.attr.console_scripts),
+                console_scripts = tuple(console_scripts),
                 # Tree artifact holding this wheel's installed file tree
                 # (`install/`, whose internal shape is
                 # `lib/python<M>.<m>/site-packages/...`). Downstream
@@ -156,31 +203,38 @@ lighter weight since the toolchain's files aren't inputs.
             values = ["checked-hash", "unchecked-hash", "timestamp"],
             doc = "PEP 552 invalidation mode for pre-compiled .pyc files.",
         ),
-        "top_levels": attr.string_list(
-            doc = """Names of the top-level packages / modules / *.dist-info directories this wheel installs into its site-packages.
+        "top_levels": attr.string_list_dict(
+            doc = """Per-wheel top-level names, keyed by wheel file basename.
 
-When set, the target emits a `PyWheelsInfo` provider describing this wheel.
-Downstream rules (such as `py_binary`) can consume this to assemble a merged
-`site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth`
-entries. Empty default preserves existing `.pth`-based behavior.
+Each value lists the top-level packages / modules / *.dist-info directories
+that wheel installs into its site-packages. At analysis time the entry whose
+key matches the basename of the wheel `src` resolved to (the selected wheel
+for the active configuration) is used; entries for other platform wheels are
+ignored so their package surface cannot leak into this configuration.
 
-Typically populated automatically by the `whl_install` repo rule from the
-wheel's `*.dist-info/top_level.txt` or `RECORD` at repo-fetch time.
+When the lookup hits, the target emits a `PyWheelsInfo` provider describing
+the selected wheel. Downstream rules (such as `py_binary`) consume this to
+assemble a merged `site-packages/` tree via `ctx.actions.symlink` instead of
+relying on `.pth` entries. A miss preserves the `.pth`-based behavior.
+
+Typically populated automatically by the `whl_install` repo rule from each
+wheel's `*.dist-info/RECORD` at repo-fetch time.
 """,
-            default = [],
+            default = {},
         ),
-        "console_scripts": attr.string_list(
-            doc = """Console-script entry points declared by this wheel, in the form `"name=module:func"`.
+        "console_scripts": attr.string_list_dict(
+            doc = """Per-wheel console-script entry points (`"name=module:func"`), keyed by wheel file basename.
 
-Populated from the wheel's `*.dist-info/entry_points.txt` `[console_scripts]`
-section by the `whl_install` repo rule at repo-fetch time. `py_binary`
-consumes these via `PyWheelsInfo` to generate executable wrappers under
-`<venv>/bin/<name>` so `subprocess.run(["<name>", ...])` works.
+Populated from each wheel's `*.dist-info/entry_points.txt`
+`[console_scripts]` section by the `whl_install` repo rule at repo-fetch
+time. Only the entry matching the selected wheel (see `top_levels`) is used.
+`py_binary` consumes these via `PyWheelsInfo` to generate executable wrappers
+under `<venv>/bin/<name>` so `subprocess.run(["<name>", ...])` works.
 """,
-            default = [],
+            default = {},
         ),
-        "namespace_top_levels": attr.string_list(
-            doc = """Subset of `top_levels` that are PEP 420 namespace packages.
+        "namespace_top_levels": attr.string_list_dict(
+            doc = """Per-wheel subset of `top_levels` that are PEP 420 namespace packages, keyed by wheel file basename.
 
 A top-level is a namespace if the wheel's RECORD shows no
 `<toplevel>/__init__.py`. When multiple wheels contribute to the same
@@ -189,7 +243,45 @@ namespace (e.g. `jaraco-classes` and `jaraco-functools` both claim
 benign and falls back to `.pth`-based resolution so Python's namespace
 machinery merges the contributions at runtime.
 """,
-            default = [],
+            default = {},
+        ),
+        "namespace_entries": attr.string_list_dict(
+            doc = """Per-wheel concrete entries beneath the wheel's `namespace_top_levels`, keyed by wheel file basename.
+
+Each entry is a `/`-joined site-packages-relative path to the shallowest
+non-namespace member: a package directory holding a direct `__init__.py`
+(`jaraco/functools`, `google/cloud/storage` — nested namespaces are
+recursed through), or a plain module / data file (`jaraco/context.py`).
+venv assembly symlinks each entry individually, materialising a merged
+namespace directory in `site-packages/` so tools that inspect it directly
+(mypy, pyright) see every contribution — and its `py.typed` markers —
+without executing `.pth` files. Only the entry matching the selected wheel
+(see `top_levels`) is used.
+""",
+            default = {},
+        ),
+        "namespace_dirs": attr.string_list_dict(
+            doc = """Per-wheel implicit-namespace directory skeleton under the wheel's namespace top-levels, keyed by wheel file basename.
+
+Every directory (as a `/`-joined path relative to site-packages) the wheel
+installs files under without an `__init__.py` anywhere on the path. E.g.
+azure-core-tracing-opentelemetry: `["azure/core", "azure/core/tracing",
+"azure/core/tracing/ext"]`. venv assembly cross-references this with other
+wheels' `regular_roots` to find regular packages that span wheels.
+""",
+            default = {},
+        ),
+        "regular_roots": attr.string_list_dict(
+            doc = """Per-wheel minimal regular-package directories under the wheel's namespace top-levels, keyed by wheel file basename.
+
+The shallowest directories (as `/`-joined paths relative to site-packages)
+carrying an `__init__.py`. E.g. azure-core: `["azure/core"]`. When such a
+root shows up in another wheel's `namespace_dirs`, that other wheel grafts
+content inside this regular package — venv assembly must physically merge
+the subtree since Python locks a regular package's `__path__` to one
+directory.
+""",
+            default = {},
         ),
     },
     toolchains = [

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -1,5 +1,10 @@
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+"""Unit + analysis tests for whl_install wheel selection and metadata."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//py/private:providers.bzl", "PyWheelsInfo")
 load(":repository.bzl", "compatible_python_tags", "select_key", "sort_select_arms", "source_specificity")
+load(":rule.bzl", "whl_install")
 
 def _whl_sorting_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -77,6 +82,163 @@ def _source_specificity_test_impl(ctx):
 source_specificity_test = unittest.make(
     _source_specificity_test_impl,
 )
+
+# --- whl_install metadata selection ---------------------------------------
+#
+# Regression: the package surface advertised via PyWheelsInfo (top-levels,
+# console scripts) must be limited to the wheel selected for the active
+# configuration. The metadata attrs carry entries for EVERY platform wheel,
+# keyed by wheel file basename; the rule must use only the entry matching
+# the wheel `src` resolved to. Historically the repo rule unioned the
+# metadata across all platform wheels, leaking e.g. the macOS C-extension
+# suffix (a dangling site-packages symlink) and macOS-only console scripts
+# into Linux builds.
+
+_LINUX_WHL = "demo-1.0.0-cp311-cp311-manylinux_2_17_x86_64.whl"
+_MACOS_WHL = "demo-1.0.0-cp311-cp311-macosx_11_0_arm64.whl"
+
+# Built-from-source fallback: contents are unknowable at repo-fetch time, so
+# no metadata entry exists for it.
+_SBUILD_WHL = "demo-1.0.0-py3-none-any.whl"
+
+_TOP_LEVELS = {
+    _LINUX_WHL: [
+        "_demo_backend.cpython-311-x86_64-linux-gnu.so",
+        "demo",
+        "demo-1.0.0.dist-info",
+    ],
+    _MACOS_WHL: [
+        "_demo_backend.cpython-311-darwin.so",
+        "demo",
+        "demo-1.0.0.dist-info",
+        "demo_ns",
+    ],
+}
+
+_NAMESPACE_TOP_LEVELS = {
+    _MACOS_WHL: ["demo_ns"],
+}
+
+_CONSOLE_SCRIPTS = {
+    _LINUX_WHL: ["demo=demo.cli:main"],
+    _MACOS_WHL: [
+        "demo-mac=demo.cli:mac_main",
+        "demo=demo.cli:main",
+    ],
+}
+
+def _metadata_selection_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    wheels = target[PyWheelsInfo].wheels.to_list()
+    asserts.equals(env, 1, len(wheels), "expected exactly one wheel struct in PyWheelsInfo")
+
+    wheel = wheels[0]
+    asserts.equals(env, tuple(ctx.attr.expected_top_levels), wheel.top_levels)
+    asserts.equals(env, tuple(ctx.attr.expected_namespace_top_levels), wheel.namespace_top_levels)
+    asserts.equals(env, tuple(ctx.attr.expected_console_scripts), wheel.console_scripts)
+
+    # Explicit leak checks: surface belonging to the OTHER (inactive)
+    # platform wheel must not appear for this configuration's wheel.
+    for leaked in ctx.attr.leaked_top_levels:
+        asserts.false(
+            env,
+            leaked in wheel.top_levels,
+            "top-level '{}' from an inactive platform wheel leaked into the selected wheel's surface".format(leaked),
+        )
+    for leaked in ctx.attr.leaked_console_scripts:
+        asserts.false(
+            env,
+            leaked in wheel.console_scripts,
+            "console script '{}' from an inactive platform wheel leaked into the selected wheel's surface".format(leaked),
+        )
+
+    return analysistest.end(env)
+
+_metadata_selection_test = analysistest.make(
+    _metadata_selection_test_impl,
+    attrs = {
+        "expected_top_levels": attr.string_list(),
+        "expected_namespace_top_levels": attr.string_list(),
+        "expected_console_scripts": attr.string_list(),
+        "leaked_top_levels": attr.string_list(),
+        "leaked_console_scripts": attr.string_list(),
+    },
+)
+
+def _metadata_miss_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    asserts.false(
+        env,
+        PyWheelsInfo in target,
+        "a wheel without a metadata entry (sbuild fallback) must not emit PyWheelsInfo",
+    )
+
+    return analysistest.end(env)
+
+_metadata_miss_test = analysistest.make(_metadata_miss_test_impl)
+
+def metadata_selection_test_suite(name):
+    """Fixtures + analysis tests for per-configuration metadata selection.
+
+    Args:
+        name: prefix for the generated test targets.
+    """
+
+    for basename in [_LINUX_WHL, _MACOS_WHL, _SBUILD_WHL]:
+        # The wheel is never unpacked at analysis time; an empty stub file
+        # with the right basename is enough to drive the metadata lookup.
+        write_file(
+            name = "__stub_" + basename,
+            out = basename,
+            content = [""],
+            tags = ["manual"],
+        )
+
+    for fixture_name, src in [
+        ("__metadata_linux_fixture", _LINUX_WHL),
+        ("__metadata_macos_fixture", _MACOS_WHL),
+        ("__metadata_sbuild_fixture", _SBUILD_WHL),
+    ]:
+        whl_install(
+            name = fixture_name,
+            src = src,
+            top_levels = _TOP_LEVELS,
+            namespace_top_levels = _NAMESPACE_TOP_LEVELS,
+            console_scripts = _CONSOLE_SCRIPTS,
+            tags = ["manual"],
+        )
+
+    _metadata_selection_test(
+        name = name + "_linux_test",
+        target_under_test = ":__metadata_linux_fixture",
+        expected_top_levels = _TOP_LEVELS[_LINUX_WHL],
+        expected_namespace_top_levels = [],
+        expected_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
+        leaked_top_levels = [
+            "_demo_backend.cpython-311-darwin.so",
+            "demo_ns",
+        ],
+        leaked_console_scripts = ["demo-mac=demo.cli:mac_main"],
+    )
+
+    _metadata_selection_test(
+        name = name + "_macos_test",
+        target_under_test = ":__metadata_macos_fixture",
+        expected_top_levels = _TOP_LEVELS[_MACOS_WHL],
+        expected_namespace_top_levels = _NAMESPACE_TOP_LEVELS[_MACOS_WHL],
+        expected_console_scripts = _CONSOLE_SCRIPTS[_MACOS_WHL],
+        leaked_top_levels = ["_demo_backend.cpython-311-x86_64-linux-gnu.so"],
+        leaked_console_scripts = [],
+    )
+
+    _metadata_miss_test(
+        name = name + "_sbuild_fallback_test",
+        target_under_test = ":__metadata_sbuild_fixture",
+    )
 
 def whl_install_suite():
     unittest.suite(


### PR DESCRIPTION
Schema foundation: wheel metadata (top_levels, namespace_top_levels, console_scripts) is keyed per wheel by file basename instead of unioned across platform wheels, and the whl_install build rule selects the entry for the wheel the select chain resolved to for the active config. A union leaked an inactive wheel's surface into the active one (another platform's C-extension suffix as a dangling symlink, a win32-only console script wrapper everywhere). A lookup miss (sbuild fallback, failed extraction) emits no PyWheelsInfo and consumers fall back to .pth resolution.

Namespace packages: PEP 420 namespace packages are now materialised CONCRETELY in site-packages via per-entry symlinks under a real namespace directory, from the new per-wheel `namespace_entries` metadata, so tools that inspect site-packages directly (mypy, pyright) see the packages and their py.typed markers — runtime .pth resolution alone left them invisible. Wheels lacking entry metadata (hand-written py_unpacked_wheel) keep the historical .pth-only fallback.

Regular packages spanning wheels: a regular package split across wheels (azure-core owns `azure/core/` while azure-core-tracing-opentelemetry grafts `azure/core/tracing/ext/...` into it) can't be merged by symlinks or .pth — Python locks a regular package's __path__ to one directory. The new per-wheel `namespace_dirs` / `regular_roots` metadata is cross-referenced across wheels to detect the overlap, and the conflicted subtree is physically merged by a new site_merge tool run under the (optional) exec-tools toolchain.

The two assembly mechanisms coexist in _resolve_wheel_collisions: an all-namespace top-level with a spanning regular package goes to the physical merge + .pth (azure); a pure PEP 420 namespace goes to the per-entry concrete symlinks. They never declare conflicting outputs for the same path.

All metadata fields are now `attr.string_list_dict` keyed by wheel basename. e2e: pth-namespace-547 (concrete namespace, mypy-visible), azure-core-tracing-overlap (regular package spanning wheels), and the cffi abi3 snapshot (per-wheel surface) all pass; snapshots regenerated.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
