### PR TITLE
refactor: expose the main() function in pytest_main

### DIFF
--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -18,6 +18,7 @@ py_library(
     name = "default_pytest_main",
     testonly = True,
     srcs = ["pytest_main.py"],
+    imports = ["."],
     visibility = ["//visibility:public"],
     deps = ["//py/private/pytest_shard"],
 )

--- a/py/private/pytest_main.py
+++ b/py/private/pytest_main.py
@@ -48,7 +48,7 @@ if "COVERAGE_MANIFEST" in os.environ:
 
 from pytest_shard import ShardPlugin
 
-if __name__ == "__main__":
+def main():
     # This statement will be replaced if the user provides a chdir path
     _ = 0  # no-op
 
@@ -155,4 +155,8 @@ if __name__ == "__main__":
               output_file.write(line)
         os.unlink(unfixed_dat)
 
-    sys.exit(exit_code)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Expose the main() function in pytest_main.py so people can add setup or tear down logic for the test main

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
