### PR TITLE
fix: evaluate extra == markers per-extra with OR semantics

### DIFF
--- a/uv/private/markers/BUILD.bazel
+++ b/uv/private/markers/BUILD.bazel
@@ -170,6 +170,27 @@ decide_marker(
 
 # { name = "psutil", marker = "sys_platform != 'cygwin'" },
 
+decide_marker(
+    name = "test_extra_single_match",
+    extras = ["dev"],
+    marker = "extra == 'dev'",
+)
+
+decide_marker(
+    name = "test_extra_multi_match",
+    extras = [
+        "dev",
+        "other",
+    ],
+    marker = "extra == 'dev'",
+)
+
+decide_marker(
+    name = "test_extra_no_match",
+    extras = ["other"],
+    marker = "extra == 'dev'",
+)
+
 # { name = "gpustat", marker = "extra == 'dev'" },
 
 # { name = "ipython", marker = "extra == 'dev'" },

--- a/uv/private/markers/defs.bzl
+++ b/uv/private/markers/defs.bzl
@@ -74,7 +74,6 @@ def _decide_marker_impl(ctx):
     FeatureFlagInfo = config_common.FeatureFlagInfo
 
     extras = sorted(ctx.attr.extras)
-    extra = ",".join(extras)
     dependency_groups = sorted(ctx.attr.dependency_groups)
 
     # Hide the differences between string flags and our custom build settings so
@@ -87,32 +86,40 @@ def _decide_marker_impl(ctx):
         else:
             fail("Unable to deref %r" % it)
 
-    res = _evaluate_marker(
-        marker = ctx.attr.marker,
-        env = {
-            # FIXME: Technically these aren't always defined... but this
-            # implementation will have them present. [1]
-            #
-            # [1] https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers
-            #
-            # {{{
-            "extra": extra,
-            "extras": extras,
-            "dependency_groups": dependency_groups,
-            # }}}
-            "python_version": _value(ctx.attr.python_version),
-            "python_full_version": _value(ctx.attr.python_full_version),
-            "os_name": _value(ctx.attr.os_name),
-            "sys_platform": _value(ctx.attr.sys_platform),
-            "os_release": _value(ctx.attr.os_release),
-            "platform_machine": _value(ctx.attr.platform_machine),
-            "platform_system": _value(ctx.attr.platform_system),
-            "platform_version": _value(ctx.attr.platform_version),
-            "platform_python_implementation": _value(ctx.attr.platform_python_implementation),
-            "implementation_name": _value(ctx.attr.implementation_name),
-            "implementation_version": _value(ctx.attr.implementation_version),
-        },
-    )
+    venv_name = _value(ctx.attr._venv)
+    if not extras and venv_name and "extra" in ctx.attr.marker:
+        venv_name_normalized = venv_name.replace("_", "-")
+        seen = {}
+        for token in ctx.attr.marker.replace("(", " ").replace(")", " ").split("'"):
+            if token.endswith(venv_name_normalized) and token not in seen:
+                seen[token] = True
+        extras = sorted(seen.keys())
+
+    eval_extras = extras if extras else [""]
+
+    res = False
+    for extra in eval_extras:
+        if _evaluate_marker(
+            marker = ctx.attr.marker,
+            env = {
+                "extra": extra,
+                "extras": extras,
+                "dependency_groups": dependency_groups,
+                "python_version": _value(ctx.attr.python_version),
+                "python_full_version": _value(ctx.attr.python_full_version),
+                "os_name": _value(ctx.attr.os_name),
+                "sys_platform": _value(ctx.attr.sys_platform),
+                "os_release": _value(ctx.attr.os_release),
+                "platform_machine": _value(ctx.attr.platform_machine),
+                "platform_system": _value(ctx.attr.platform_system),
+                "platform_version": _value(ctx.attr.platform_version),
+                "platform_python_implementation": _value(ctx.attr.platform_python_implementation),
+                "implementation_name": _value(ctx.attr.implementation_name),
+                "implementation_version": _value(ctx.attr.implementation_version),
+            },
+        ):
+            res = True
+            break
 
     # print(ctx.label, ctx.attr.marker, "->", res)
 
@@ -126,6 +133,7 @@ _decide_marker = rule(
         "marker": attr.string(),
         "extras": attr.string_list(default = []),
         "dependency_groups": attr.string_list(default = []),
+        "_venv": attr.label(default = Label("@aspect_rules_py//uv/private/constraints/venv:venv")),
         "python_version": attr.label(default = Label(":python_version")),
         "python_full_version": attr.label(default = Label(":python_full_version")),
         "os_name": attr.label(default = Label(":os_name")),

--- a/uv/private/markers/pep508_evaluate_test.bzl
+++ b/uv/private/markers/pep508_evaluate_test.bzl
@@ -59,6 +59,11 @@ def _evaluate_test_impl(ctx):
     asserts.true(env, evaluate("((sys_platform == 'linux'))", env = _LINUX_ENV))
     asserts.true(env, evaluate("((sys_platform == 'linux') and (platform_machine == 'x86_64')) or sys_platform == 'win32'", env = _LINUX_ENV))
 
+    asserts.true(env, evaluate("extra == 'dev'", env = dict(_LINUX_ENV, extra = "dev")))
+    asserts.false(env, evaluate("extra == 'dev'", env = dict(_LINUX_ENV, extra = "other")))
+    asserts.false(env, evaluate("extra == 'dev'", env = dict(_LINUX_ENV, extra = "")))
+    asserts.false(env, evaluate("extra == 'dev'", env = dict(_LINUX_ENV, extra = "dev,other")))
+
     return unittest.end(env)
 
 evaluate_test = unittest.make(


### PR DESCRIPTION
`_decide_marker_impl` was joining multiple extras into a single comma-separated string before passing it to the PEP-508 evaluator, so `extras = ["dev", "other"]` became `extra = "dev,other"` which never matched a marker like `extra == 'dev'`, causing optional dependencies gated by extras to be silently excluded. 
This PR fixes that by evaluating the marker once per extra and ORing the results, so a dependency is included if any of the active extras matches. It also adds venv-derived extras inference: since generated decide_marker calls never pass extras explicitly, the fix now reads the active venv name from the `_venv` flag and extracts matching extra values from the marker string, which handles conflict group markers of the form `extra == 'group-N-project-venvname'`. 
Tests added to `pep508_evaluate_test.bzl` cover positive/negative extra == cases including the comma-join regression, and new decide_marker targets in BUILD.bazel exercise the OR evaluation path directly.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
