### PR TITLE
fix: handle variable tokens immediately followed by brackets in tokeizer

### DIFF
--- a/uv/private/markers/pep508_evaluate.bzl
+++ b/uv/private/markers/pep508_evaluate.bzl
@@ -95,6 +95,9 @@ def tokenize(marker):
 
         char = marker[0]
         if char in _BRACKETS:
+            if state in [_STATE.VAR, _STATE.OP]:
+                state = _STATE.NONE
+                continue
             state = _STATE.NONE
             token = char
         elif state == _STATE.STRING and char in _QUOTES:

--- a/uv/private/markers/pep508_evaluate_test.bzl
+++ b/uv/private/markers/pep508_evaluate_test.bzl
@@ -59,6 +59,10 @@ def _evaluate_test_impl(ctx):
     asserts.true(env, evaluate("((sys_platform == 'linux'))", env = _LINUX_ENV))
     asserts.true(env, evaluate("((sys_platform == 'linux') and (platform_machine == 'x86_64')) or sys_platform == 'win32'", env = _LINUX_ENV))
 
+    asserts.true(env, evaluate("('linux' in sys_platform)", env = _LINUX_ENV))
+    asserts.false(env, evaluate("('win32' in sys_platform)", env = _LINUX_ENV))
+    asserts.true(env, evaluate("(sys_platform == 'linux') and ('x86_64' in platform_machine)", env = _LINUX_ENV))
+
     return unittest.end(env)
 
 evaluate_test = unittest.make(


### PR DESCRIPTION
The PEP-508 marker tokenizer would lose a variable token when a bracket character appeared immediately after it without whitespace. For example, in `'linux' in sys_platform)` the `)` branch would overwrite the accumulated `sys_platform` token, causing the evaluator to receive `)` as a variable name and fail with `key ")" not found in dictionary`.

The fix checks whether the tokenizer is mid-token (VAR or OP state) when a bracket is encountered. If so, it emits the current token first by transitioning to NONE and re-processing the bracket on the next iteration, matching the same emit-then-reprocess pattern already used for whitespace-terminated tokens.

---

### Changes are visible to end-users: no

- New test cases added
