### PR TITLE
fix: add setuptools and wheel to default sdist build dependencies

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -442,10 +442,6 @@ uv.project(
 # python-geohash is sdist-only and contains a C++ extension (_geohash).
 # {{{
 uv.project(
-    default_build_dependencies = [
-        "build",
-        "setuptools",
-    ],
     hub_name = "pypi",
     lock = "//cases/uv-sdist-native-build:uv.lock",
     pyproject = "//cases/uv-sdist-native-build:pyproject.toml",

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -628,6 +628,8 @@ _project_tag = tag_class(
             mandatory = False,
             default = [
                 "build",
+                "setuptools",
+                "wheel",
             ],
         ),
         "unstable_configure_command": attr.string_list(


### PR DESCRIPTION
Projects using setuptools.build_meta as their sdist build backend require both setuptools and wheel to be available during the PEP 517 build, but the default_build_dependencies list only shipped build, causing silent failures for any project that didn't explicitly override the list. This adds setuptools and wheel to the default, covering the overwhelmingly common case; the existing uv-sdist-native-build e2e test (python-geohash, a C-extension sdist built with setuptools) now relies on this default instead of an explicit override, so any future regression against these defaults will fail CI directly.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
