### PR TITLE
feat: support packages in git monorepo subdirectories for sdist builds

### DIFF
--- a/docs/uv.md
+++ b/docs/uv.md
@@ -296,6 +296,13 @@ An sdist (if available) will be built into a wheel for installation if no wheels
 are available, or no wheels matching the target configuration are found. Sdist
 builds occur using the configured Python and Cc toolchains.
 
+Packages sourced from git repositories that live in a subdirectory of the
+repository (common in monorepos) are supported. When uv resolves such a
+dependency — e.g. `pkg @ git+https://github.com/org/repo.git#subdirectory=packages/pkg`
+— the `subdirectory` field recorded in `uv.lock` is automatically forwarded to
+the build backend so that `pyproject.toml` is found in the correct location
+within the archive.
+
 ## Best practices
 
 **Consolidate your hubs**. In `rules_python`, environments with multiple depsets

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -391,6 +391,7 @@ def _parse_projects(module_ctx, hub_specs):
                         pre_build_patch_strip = pre_build_patch_strip,
                         available_deps = project_available_deps,
                         configure_command = project.unstable_configure_command,
+                        subdirectory = package.get("source", {}).get("subdirectory", ""),
                     )
 
                     has_sbuild = True
@@ -574,6 +575,8 @@ def _uv_impl(module_ctx):
         if sbuild_cfg.pre_build_patches:
             sbuild_kwargs["pre_build_patches"] = sbuild_cfg.pre_build_patches
             sbuild_kwargs["pre_build_patch_strip"] = sbuild_cfg.pre_build_patch_strip
+        if sbuild_cfg.subdirectory:
+            sbuild_kwargs["subdirectory"] = sbuild_cfg.subdirectory
         sdist_build(**sbuild_kwargs)
 
     for install_id, install_cfg in cfg.install_cfgs.items():

--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -20,6 +20,7 @@ PARSER.add_argument("outdir")
 PARSER.add_argument("--validate-anyarch", action="store_true")
 PARSER.add_argument("--patch-strip", type=int, default=0, help="Strip count for patch (-p)")
 PARSER.add_argument("--patch", action="append", default=[], dest="patches", help="Patch file to apply (repeatable)")
+PARSER.add_argument("--subdirectory", default="", help="Subdirectory within the archive containing pyproject.toml")
 opts, args = PARSER.parse_known_args()
 
 tmp_root = opts.outdir.lstrip("/") + ".tmp"
@@ -32,6 +33,9 @@ shutil.unpack_archive(opts.srcarchive, t)
 # Annoyingly, unpack_archive creates a subdir in the target. Update t
 # accordingly. Not worth the eng effort to prevent creating this dir.
 t = path.join(t, listdir(t)[0])
+
+if opts.subdirectory:
+    t = path.join(t, opts.subdirectory)
 
 if opts.patches:
     for patch_file in opts.patches:

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -211,6 +211,10 @@ def _sdist_build_impl(repository_ctx):
             strip = repository_ctx.attr.pre_build_patch_strip,
         )
 
+    subdir_args = ""
+    if repository_ctx.attr.subdirectory:
+        subdir_args = '"--subdirectory={}"'.format(repository_ctx.attr.subdirectory)
+
     repository_ctx.file("BUILD.bazel", content = """
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{rule}")
 load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
@@ -227,7 +231,7 @@ py_venv_binary(
     src = "{src}",
     tool = ":build_tool",
     version = "{version}",
-    args = [],{patch_attrs}
+    args = [{subdir_args}],{patch_attrs}
     visibility = ["//visibility:public"],
 )
 """.format(
@@ -236,6 +240,7 @@ py_venv_binary(
         rule = "pep517_native_whl" if is_native else "pep517_whl",
         version = repository_ctx.attr.version,
         patch_attrs = patch_attrs,
+        subdir_args = subdir_args,
     ))
 
 sdist_build = repository_rule(
@@ -258,6 +263,10 @@ sdist_build = repository_rule(
                   "two arguments. See //uv/private/sdist_configure:defs.bzl.",
         ),
         "version": attr.string(),
+        "subdirectory": attr.string(
+            default = "",
+            doc = "Subdirectory within the archive containing pyproject.toml.",
+        ),
         "pre_build_patches": attr.label_list(default = []),
         "pre_build_patch_strip": attr.int(default = 0),
     },


### PR DESCRIPTION
When a dependency is pinned from a git monorepo (e.g. pkg @ git+https://github.com/org/repo.git#subdirectory=packages/pkg) uv records a subdirectory field in the lock file source entry. Previously the sdist build pipeline ignored this field entirely, so the wheel build would fail because build_helper.py was trying to run python -m build from the archive root instead of the correct subdirectory where pyproject.toml actually lives. 

This change threads subdirectory from the lock file through the extension layer (defs.bzl), into the sdist_build repository rule as a new attribute, and finally into build_helper.py as a --subdirectory flag that descends into the right directory before invoking the build backend.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes

### Test plan


- Covered by existing test cases
