### PR TITLE
 fix: set SOURCE_DATE_EPOCH and skip dependency check in sdist wheel builds

### DIFF
--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -50,6 +50,9 @@ build_env.update({
     "TMP": tmp_root,
     "TEMP": tmp_root,
     "TEMPDIR": tmp_root,
+    # Bazel sets file timestamps to epoch 0 for reproducibility. wheel < 0.38
+    # fails when creating ZIP files with timestamps before 1980-01-01.
+    "SOURCE_DATE_EPOCH": "315532800",
 })
 
 if path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "setup.py")):
@@ -62,6 +65,7 @@ if path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "setu
         "-m", "build",
         "--wheel",
         "--no-isolation",
+        "--skip-dependency-check",
         "--outdir", outdir,
     ]
 


### PR DESCRIPTION


---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
