### PR TITLE
fix: absolutize CC/CXX paths before chdir into extracted sdist source tree

### DIFF
--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -44,6 +44,12 @@ if opts.patches:
 # Get a path to the outdir which will be valid after we cd
 outdir = path.abspath(opts.outdir)
 
+# Resolve CC/CXX to absolute paths so they remain valid after cwd changes
+# into the extracted source tree (Bazel sets these as exec-root-relative).
+for _cc_var in ("CC", "CXX"):
+    if _cc_var in os.environ and not path.isabs(os.environ[_cc_var]):
+        os.environ[_cc_var] = path.abspath(os.environ[_cc_var])
+
 # Preserve PATH so native sdist builds can find compilers (clang, gcc).
 build_env = dict(os.environ)
 build_env.update({


### PR DESCRIPTION
Bazel provides the C/C++ compiler path in CC/CXX as a path relative to the exec root. After unpacking the sdist archive, build_helper.py changes the working directory into the extracted source tree so the build backend can find pyproject.toml and run its build hooks. Any relative CC/CXX value becomes invalid the moment cwd changes, causing native extension builds to fail with a "compiler not found" error that is otherwise hard to diagnose. 

The fix resolves both variables to absolute paths immediately after computing outdir (which is itself absolutized for the same reason) and before any chdir occur

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
