### PR TITLE
fix: Use get_tool_for_action and absolutize sysroot path

### DIFF
--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -48,11 +48,21 @@ if opts.patches:
 # Get a path to the outdir which will be valid after we cd
 outdir = path.abspath(opts.outdir)
 
-# Resolve CC/CXX to absolute paths so they remain valid after cwd changes
-# into the extracted source tree (Bazel sets these as exec-root-relative).
-for _cc_var in ("CC", "CXX"):
+# Resolve compiler variables to absolute paths so they remain valid after cwd
+# changes into the extracted source tree (Bazel sets these as
+# exec-root-relative).
+for _cc_var in ("CC", "CXX", "SYSROOT"):
     if _cc_var in os.environ and not path.isabs(os.environ[_cc_var]):
         os.environ[_cc_var] = path.abspath(os.environ[_cc_var])
+
+if "SYSROOT" in os.environ:
+    _sysroot = os.environ["SYSROOT"]
+    _sysroot_cflag = f'--sysroot="{_sysroot}"'
+    if "CFLAGS" in os.environ:
+        _cflags = os.environ["CFLAGS"]
+        os.environ["CFLAGS"] = f"{_cflags} {_sysroot_cflag}"
+    else:
+        os.environ["CFLAGS"] = _sysroot_cflag
 
 # Preserve PATH so native sdist builds can find compilers (clang, gcc).
 build_env = dict(os.environ)

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -6,8 +6,8 @@ build backend the sdist declares in its `[build-system]` table.
 """
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_cc_toolchain = "find_cpp_toolchain")
-load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
 
 CC_TOOLCHAIN = "@bazel_tools//tools/cpp:toolchain_type"
@@ -80,11 +80,13 @@ def _pep517_native_whl(ctx):
             feature_configuration = feature_configuration,
             action_name = C_COMPILE_ACTION_NAME,
         )
+
         # Note that these paths are relative to the bazel exec root,
         # and they need to be absolutized if they're to be invoked from any
         # other working directory. (e.g. in build_helper.py for sdist builds.)
         env["CC"] = c_compiler_path
         extra_inputs.append(cc_toolchain.all_files)
+
         # We can extract the relative path to the @llvm-provided sysroot from
         # the list of include directories.
         # It still needs to be absolutized, so we can't add it directly to

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -6,6 +6,8 @@ build backend the sdist declares in its `[build-system]` table.
 """
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_cc_toolchain = "find_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
 
 CC_TOOLCHAIN = "@bazel_tools//tools/cpp:toolchain_type"
@@ -70,8 +72,27 @@ def _pep517_native_whl(ctx):
     # rather than falling back to whatever is on the system PATH.
     cc_toolchain = find_cc_toolchain(ctx, mandatory = False)
     if cc_toolchain:
-        env["CC"] = cc_toolchain.compiler_executable
+        feature_configuration = cc_common.configure_features(
+            ctx = ctx,
+            cc_toolchain = cc_toolchain,
+        )
+        c_compiler_path = cc_common.get_tool_for_action(
+            feature_configuration = feature_configuration,
+            action_name = C_COMPILE_ACTION_NAME,
+        )
+        # Note that these paths are relative to the bazel exec root,
+        # and they need to be absolutized if they're to be invoked from any
+        # other working directory. (e.g. in build_helper.py for sdist builds.)
+        env["CC"] = c_compiler_path
         extra_inputs.append(cc_toolchain.all_files)
+        # We can extract the relative path to the @llvm-provided sysroot from
+        # the list of include directories.
+        # It still needs to be absolutized, so we can't add it directly to
+        # CFLAGS here.
+        for c in cc_toolchain.built_in_include_directories:
+            if c.endswith("sysroot"):
+                env["SYSROOT"] = c
+                break
 
     ctx.actions.run(
         mnemonic = "PySdistNativeBuild",


### PR DESCRIPTION
The compiler executable path provided by `cc_toolchain.compiler_executable` does not necessarily point to the _actual_ compiler path. For example, on MacOS it is `external/llvm+/toolchain/gcc`, which does not actually exist.
Instead, the real compiler needs to be discovered via [`cc_common.get_tool_for_action`](https://bazel.build/versions/8.7.0/rules/lib/toplevel/cc_common#get_tool_for_action). This gives the real compiler path `external/llvm++_repo_rules+llvm-toolchain-minimal-22.1.3-darwin-arm64/bin/clang`.

Additionally, the `--sysroot` flag needs to be passed in to the compiler so that it can find system headers. Like the `CC` and `CXX` env vars, the given sysroot path is relative to the Bazel workspace root, so it needs to be absolutized before it can be added to `CFLAGS`.
This should be perfectly safe, because the sysroot directory is included in the toolchain's `all_files` list, so it will be present in the Bazel workspace.

This is a follow-on from https://github.com/aspect-build/rules_py/pull/1108.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

I am unsure how to test this, because it seems to require MacOS and its weird C++ setup.
