### PR TITLE
fix(uv): evaluate version prefix markers

### DIFF
--- a/uv/private/markers/BUILD.bazel
+++ b/uv/private/markers/BUILD.bazel
@@ -253,6 +253,7 @@ bzl_library(
     visibility = ["//uv:__subpackages__"],
     deps = [
         ":semver",
+        "//uv/private/versions",
     ],
 )
 

--- a/uv/private/markers/pep508_evaluate.bzl
+++ b/uv/private/markers/pep508_evaluate.bzl
@@ -20,6 +20,7 @@ Vendored and used here with thanks.
 """
 
 load("@rules_python//python/private:enum.bzl", "enum")
+load("//uv/private/versions:versions.bzl", "version_satisfies")
 load(":semver.bzl", "semver")
 
 # The expression parsing and resolution for the PEP508 is below
@@ -348,6 +349,9 @@ def _env_expr(left, op, right):
 
 def _version_expr(left, op, right):
     """Evaluate a version comparison expression"""
+    if op in ["==", "!="] and right.endswith(".*"):
+        return version_satisfies(left, op + right)
+
     left = semver(left)
     right = semver(right)
     _left = left.key()

--- a/uv/private/markers/pep508_evaluate_test.bzl
+++ b/uv/private/markers/pep508_evaluate_test.bzl
@@ -5,6 +5,7 @@ load(":defs.bzl", "MARKER_ENV_ALIASES")
 load(":pep508_evaluate.bzl", "evaluate")
 
 _LINUX_ENV = {
+    "implementation_version": "3.12.12",
     "platform_machine": "x86_64",
     "python_full_version": "3.11.0",
     "python_version": "3.11",
@@ -58,6 +59,10 @@ def _evaluate_test_impl(ctx):
     asserts.false(env, evaluate("python_version >= '3.12'", env = _LINUX_ENV))
     asserts.true(env, evaluate("python_full_version < '3.12.0'", env = _LINUX_ENV))
     asserts.false(env, evaluate("python_full_version < '3.10.0'", env = _LINUX_ENV))
+    asserts.true(env, evaluate("implementation_version == '3.12.*'", env = _LINUX_ENV))
+    asserts.false(env, evaluate("implementation_version != '3.12.*'", env = _LINUX_ENV))
+    asserts.false(env, evaluate("implementation_version == '3.1.*'", env = _LINUX_ENV))
+    asserts.true(env, evaluate("implementation_version != '3.11.*'", env = _LINUX_ENV))
 
     # 'and' / 'or' combinations
     asserts.true(env, evaluate("sys_platform == 'linux' and python_version >= '3.10'", env = _LINUX_ENV))


### PR DESCRIPTION
uv emits version marker clauses such as
`implementation_version == '3.12.*'` when a lock supports an entire
Python minor release. The marker evaluator currently parses `*` as an
absent patch component, effectively comparing with `3.12.0`, so later
patch releases do not select dependencies guarded by the marker.

Delegate wildcard equality and inequality to the existing PEP 440
version matcher. This keeps marker-specific parsing unchanged and uses
the same [version matching semantics](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-matching)
already used for dependency specifiers.