### PR TITLE
test(e2e): reproduce py_binary execve failure under bazel run (runfiles discovery)

### DIFF
--- a/e2e/cases/run-runfiles-discovery/BUILD.bazel
+++ b/e2e/cases/run-runfiles-discovery/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+py_binary(
+    name = "hello",
+    srcs = ["hello.py"],
+    main = "hello.py",
+)
+
+# Reproduces a py_binary launcher (hermetic_launcher 0.0.9) failing under
+# `bazel run` / direct exec when RUNFILES_DIR is not pre-set: the launcher
+# cannot self-locate its `.runfiles` dir and aborts with
+# "execve failed with errno 2". `bazel test` masks this by setting RUNFILES_DIR.
+#
+# Tagged `manual` so it stays out of the default `//...` gate until the launcher
+# fix lands; run explicitly with `bazel test //cases/run-runfiles-discovery:runs_via_bazel_run`.
+sh_test(
+    name = "runs_via_bazel_run",
+    srcs = ["run_it.sh"],
+    args = ["$(rootpath :hello)"],
+    data = [":hello"],
+    tags = ["manual"],
+)

--- a/e2e/cases/run-runfiles-discovery/hello.py
+++ b/e2e/cases/run-runfiles-discovery/hello.py
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/e2e/cases/run-runfiles-discovery/run_it.sh
+++ b/e2e/cases/run-runfiles-discovery/run_it.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Regression test: a py_binary must be runnable via `bazel run` (and directly),
+# where the launcher discovers its own `.runfiles` dir from argv[0] rather than
+# relying on a pre-set RUNFILES_DIR.
+#
+# `bazel test` sets RUNFILES_DIR for the test, which masks the bug. We reproduce
+# the `bazel run` / direct-exec path by UNSETTING the runfiles env vars before
+# invoking the binary, forcing the launcher to self-locate its runfiles.
+#
+# BUG (hermetic_launcher 0.0.9): without RUNFILES_DIR/RUNFILES_MANIFEST_FILE set,
+# the launcher fails to resolve the embedded venv-python rlocation and aborts
+# with "execve failed with errno 2". Works when RUNFILES_DIR is pre-set.
+set -euo pipefail
+
+bin="$1"
+unset RUNFILES_DIR RUNFILES_MANIFEST_FILE JAVA_RUNFILES || true
+output="$("$bin")"
+if [[ "$output" != *"Hello, world!"* ]]; then
+  echo "FAIL: expected 'Hello, world!', got: $output" >&2
+  exit 1
+fi
+echo "PASS: py_binary ran via self-located runfiles"


### PR DESCRIPTION
## Summary

A `py_binary` cannot be run via `bazel run` (or as a deployed/direct-exec binary) when `RUNFILES_DIR` is not already set: it aborts with

```
ERROR: execve failed with errno 2 (return code 1)
```

`bazel test` masks it (it sets `RUNFILES_DIR`), so existing e2e coverage doesn't catch it; `bazel run` and deployed binaries do.

## Root cause (in the launcher, not this repo)

`bazel run` execs the binary with a **relative `argv[0]`** (`bazel-bin/<name>`), cwd set **inside** the runfiles tree (`<x>.runfiles/_main`), and **no `RUNFILES_DIR`**. The `hermetic_launcher` stub then computes `<argv[0]>.runfiles` relative to cwd — which points nowhere — so runfiles discovery fails, the embedded venv-python rlocation is left unresolved, and `execve` fails with errno 2.

Verified this reproduces on `hermetic_launcher` **main** (not just the pinned 0.0.9), and that bumping to the latest release **0.0.10 does not fix it**. The launcher fix is here: **hermeticbuild/hermetic-launcher#44** (resolve the real executable path via `_NSGetExecutablePath` / `readlinkat(/proc/self/exe)` when `argv[0]` is relative).

## What changed in this PR

Adds an e2e regression case `cases/run-runfiles-discovery`:
- a trivial `py_binary`,
- an `sh_test` that **unsets** `RUNFILES_DIR` / `RUNFILES_MANIFEST_FILE` / `JAVA_RUNFILES` before invoking the binary, forcing the launcher's self-location path.

Tagged `manual` so it stays out of the default `//...` gate until the launcher fix is released and bumped here.

## Remedy / follow-up

1. Land + release hermeticbuild/hermetic-launcher#44 (new `hermetic_launcher` version).
2. Bump `bazel_dep(name = "hermetic_launcher", ...)` in `MODULE.bazel` to that version.
3. Drop the `manual` tag on `cases/run-runfiles-discovery` so it gates `bazel run`.

(Bumping to 0.0.10 was tried and verified NOT to fix it, so no bump is included here yet — it would need the released fix from #44.)

## Test plan

- New case fails on `main` with `execve errno 2`; the same binary succeeds when `RUNFILES_DIR` is exported, isolating the cause to launcher runfiles resolution.
- hermeticbuild/hermetic-launcher#44 carries the launcher fix + a matching launcher-level regression test (fails before, passes after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
