### PR TITLE
fix(uv): skip virtual workspace installs

### DIFF
--- a/e2e/cases/uv-workspace-789/BUILD.bazel
+++ b/e2e/cases/uv-workspace-789/BUILD.bazel
@@ -8,6 +8,7 @@ py_test(
     dep_group = "workspace",
     main = "__test__.py",
     deps = [
+        "@pypi_uv_workspace_789//dependency_bag",
         "@pypi_uv_workspace_789//foo",  # Firstparty package
         "@pypi_uv_workspace_789//pi",  # Firstparty package
     ],
@@ -23,6 +24,7 @@ py_test(
     isolated = False,
     main = "__test__.py",
     deps = [
+        "@pypi_uv_workspace_789//dependency_bag",
         "@pypi_uv_workspace_789//foo",  # Firstparty package
         "@pypi_uv_workspace_789//pi",  # Firstparty package
     ],

--- a/e2e/cases/uv-workspace-789/README.md
+++ b/e2e/cases/uv-workspace-789/README.md
@@ -1,6 +1,10 @@
-# Editable internal dependencies; #789
+# Workspace dependencies; #789
 
-UV workspaces allow for packages within the workspace to depend on each other.
-The UV extension needs to force the user to provide an override target mapping
-for each such target, and dependencies BETWEEN these projects' Bazel targets
-need to work. Dependencies taken via the UV hub need to work as well.
+The `foo` and `pi` workspace members contain installable code, so their
+`uv.override_package()` annotations map them to Bazel targets. The generated
+dependency graph must preserve dependencies between those targets and packages
+from the uv hub.
+
+The `dependency-bag` member has `package = false`, so uv records it as virtual.
+It contributes `humanize` to the dependency graph without requiring an override
+target of its own.

--- a/e2e/cases/uv-workspace-789/__test__.py
+++ b/e2e/cases/uv-workspace-789/__test__.py
@@ -6,5 +6,8 @@ assert "uv-workspace-789" in pi.__file__
 import foo
 assert "uv-workspace-789" in foo.__file__
 
+import humanize
+assert ".runfiles" in humanize.__file__
+
 import requests
 assert ".runfiles" in requests.__file__

--- a/e2e/cases/uv-workspace-789/packages/dependency-bag/pyproject.toml
+++ b/e2e/cases/uv-workspace-789/packages/dependency-bag/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "dependency-bag"
+version = "0.0.0"
+dependencies = ["humanize"]
+
+[tool.uv]
+package = false

--- a/e2e/cases/uv-workspace-789/pyproject.toml
+++ b/e2e/cases/uv-workspace-789/pyproject.toml
@@ -1,10 +1,12 @@
 [project]
 name = "workspace"
 version = "0.0.0"
-dependencies = []
+requires-python = ">=3.11"
+dependencies = ["dependency-bag"]
 
 [tool.uv.sources]
 workspace = { workspace = true }
+dependency-bag = { workspace = true }
 foo = { workspace = true }
 pi = { workspace = true }
 

--- a/e2e/cases/uv-workspace-789/uv.lock
+++ b/e2e/cases/uv-workspace-789/uv.lock
@@ -4,6 +4,7 @@ requires-python = ">=3.11"
 
 [manifest]
 members = [
+    "dependency-bag",
     "foo",
     "pi",
     "workspace",
@@ -92,6 +93,17 @@ wheels = [
 ]
 
 [[package]]
+name = "dependency-bag"
+version = "0.0.0"
+source = { virtual = "packages/dependency-bag" }
+dependencies = [
+    { name = "humanize" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "humanize" }]
+
+[[package]]
 name = "foo"
 version = "0.0.0"
 source = { editable = "packages/foo" }
@@ -101,6 +113,15 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pi", editable = "packages/pi" }]
+
+[[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
 
 [[package]]
 name = "idna"
@@ -150,3 +171,9 @@ wheels = [
 name = "workspace"
 version = "0.0.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "dependency-bag" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "dependency-bag", virtual = "packages/dependency-bag" }]

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -341,13 +341,17 @@ def _parse_projects(module_ctx, hub_specs):
                 if existing_target != None and existing_target != install_target:
                     # Case of an overridden package
                     continue
-                elif "editable" in package["source"] or "virtual" in package["source"]:
+                elif "virtual" in package["source"]:
+                    override_key = (normalize_name(package["name"]), package["version"])
+                    if override_key in package_overrides:
+                        fail("Virtual package {} in lockfile {} cannot use a modification-only `uv.override_package()` annotation because it is not installed.".format(package["name"], project.lock))
+                    continue
+                elif "editable" in package["source"]:
                     # Case of the workspace self-package
-                    # FIXME: Workspace packages can have srcs? It's a bit weird
                     if normalize_name(package["name"]) == normalize_name(project_name):
                         continue
                     else:
-                        fail("Virtual package {} in lockfile {} doesn't have a mandatory `uv.override_package()` annotation!".format(package["name"], project.lock))
+                        fail("Editable package {} in lockfile {} doesn't have a mandatory `uv.override_package(target = ...)` annotation!".format(package["name"], project.lock))
 
                 install_table[install_key] = install_target
                 sbuild_id = "sdist_build__{}__{}__{}".format(project_stamp, package["name"], normalize_version(package["version"]))


### PR DESCRIPTION
uv workspace members with `package = false` contribute dependencies but
do not produce installable packages. The uv extension currently treats
them as editable members and requires
`uv.override_package(target = ...)`, so these workspaces need a fake
Bazel target.

Do not create an install repository for an unoverridden virtual member.
Keep its package alias and dependency edges, preserve explicit target
overrides, and reject modification-only overrides that would otherwise
be ignored. The `uv-workspace-789` fixture now covers both editable and
virtual workspace members.