### PR TITLE
fix(py): normalize wheel tree permissions

### DIFF
--- a/py/tools/unpack/BUILD.bazel
+++ b/py/tools/unpack/BUILD.bazel
@@ -1,4 +1,18 @@
+load("//py:defs.bzl", "py_test")
+
 exports_files(
     ["unpack.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "unpack_test",
+    srcs = ["unpack_test.py"],
+    args = ["$(rootpath :unpack.py)"],
+    data = [":unpack.py"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -157,6 +157,8 @@ def install_wheel(version_major, version_minor, into, wheel_path):
 
 
 def main():
+    os.umask(0o022)
+
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--into", required=True, type=Path)
     ap.add_argument("--wheel", required=True, type=Path)

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -1,0 +1,102 @@
+import stat
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def _write_member(archive: zipfile.ZipFile, name: str, data: bytes, mode: int) -> None:
+    info = zipfile.ZipInfo(name)
+    info.external_attr = mode << 16
+    archive.writestr(info, data)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def main() -> None:
+    unpack = Path(sys.argv[1])
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        wheel = root / "fixture-1.0-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as archive:
+            _write_member(archive, "fixture/__init__.py", b"VALUE = 1\n", 0o600)
+            _write_member(archive, "fixture/executable", b"payload\n", 0o700)
+            _write_member(
+                archive,
+                "fixture-1.0.data/scripts/wheel-tool",
+                b"#!/usr/bin/python\nprint('tool')\n",
+                0o600,
+            )
+            _write_member(
+                archive,
+                "fixture-1.0.dist-info/entry_points.txt",
+                b"[console_scripts]\nfixture-cli = fixture:main\n",
+                0o600,
+            )
+            _write_member(archive, "fixture-1.0.dist-info/RECORD", b"", 0o600)
+
+        for inherited_umask in (0o077, 0o000):
+            output = root / f"install-{inherited_umask:o}"
+            output.mkdir(mode=0o700)
+            wrapper = (
+                "import os, runpy, sys; "
+                f"os.umask({inherited_umask}); "
+                "script = sys.argv[1]; "
+                "sys.argv = sys.argv[1:]; "
+                "runpy.run_path(script, run_name='__main__')"
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    wrapper,
+                    str(unpack),
+                    "--into",
+                    str(output),
+                    "--wheel",
+                    str(wheel),
+                    "--python-version-major",
+                    str(sys.version_info.major),
+                    "--python-version-minor",
+                    str(sys.version_info.minor),
+                    "--compile-pyc",
+                    "--python",
+                    sys.executable,
+                ],
+                check=True,
+            )
+
+            site_packages = (
+                output
+                / "lib"
+                / f"python{sys.version_info.major}.{sys.version_info.minor}"
+                / "site-packages"
+            )
+            dist_info = site_packages / "fixture-1.0.dist-info"
+            pyc = next((site_packages / "fixture" / "__pycache__").glob("*.pyc"))
+
+            for directory in (
+                output / "lib",
+                site_packages.parent,
+                site_packages,
+                site_packages / "fixture",
+                dist_info,
+                pyc.parent,
+                output / "bin",
+            ):
+                assert _mode(directory) == 0o755
+            assert _mode(site_packages / "fixture" / "__init__.py") == 0o644
+            assert _mode(site_packages / "fixture" / "executable") == 0o755
+            assert _mode(output / "bin" / "wheel-tool") == 0o755
+            assert _mode(output / "bin" / "fixture-cli") == 0o755
+            assert _mode(dist_info / "INSTALLER") == 0o644
+            assert _mode(dist_info / "REQUESTED") == 0o644
+            assert _mode(dist_info / "RECORD") == 0o644
+            assert _mode(pyc) == 0o644
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -15,9 +15,9 @@ def _write_member(archive: zipfile.ZipFile, name: str, data: bytes, mode: int) -
 def _build_wheel(path: Path, *, broken: bool) -> None:
     body = b"def f(\n" if broken else b"def f():\n    return 1\n"
     with zipfile.ZipFile(path, "w") as archive:
-        _write_member(archive, "fixture/__init__.py", b"VALUE = 1\n")
-        _write_member(archive, "fixture/mod.py", body)
-        _write_member(archive, "fixture-1.0.dist-info/RECORD", b"")
+        _write_member(archive, "fixture/__init__.py", b"VALUE = 1\n", 0o644)
+        _write_member(archive, "fixture/mod.py", body, 0o644)
+        _write_member(archive, "fixture-1.0.dist-info/RECORD", b"", 0o644)
 
 def _mode(path: Path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
@@ -69,6 +69,7 @@ def main() -> None:
         assert bad.returncode != 0, "expected non-zero exit on compile failure"
         assert "compileall failed" in bad.stderr, bad.stderr
 
+        wheel = root / "fixture-1.0-py3-none-any.whl"
         with zipfile.ZipFile(wheel, "w") as archive:
             _write_member(archive, "fixture/__init__.py", b"VALUE = 1\n", 0o600)
             _write_member(archive, "fixture/executable", b"payload\n", 0o700)


### PR DESCRIPTION
Set a conventional umask before unpacking wheels so installed tree modes do not inherit the caller action environment. Stable permissions keep wheel TreeArtifacts reproducible across local and remote executors.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
