### PR TITLE
fix: quotes in RECORD entries

### DIFF
--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -14,6 +14,43 @@ load("//uv/private/constraints/platform:defs.bzl", "supported_platform")
 load("//uv/private/constraints/python:defs.bzl", "supported_python")
 load("//uv/private/pprint:defs.bzl", "pprint")
 
+def parse_record_path(line):
+    """Return the path field from one CSV-encoded wheel RECORD row.
+
+    RECORD is a CSV file in Python's default `csv` reader dialect: `,`
+    delimiter, `"` quote char, `""` -> `"` escaping. A path is quoted only
+    when it contains a comma (or quote). See:
+    https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-record-file
+
+    NOTE: the caller splits RECORD on line boundaries before calling this, so
+    a path containing an embedded newline inside a quoted field (legal on
+    POSIX, vanishingly rare) is not handled.
+    """
+    line = line.strip()
+    if not line:
+        return ""
+    if not line.startswith("\""):
+        return line.split(",", 1)[0]
+
+    path = []
+    skip_quote = False
+    for index in range(1, len(line)):
+        if skip_quote:
+            skip_quote = False
+            continue
+        char = line[index]
+        if char != "\"":
+            path.append(char)
+        elif index + 1 < len(line) and line[index + 1] == "\"":
+            path.append("\"")
+            skip_quote = True
+        else:
+            if index + 1 < len(line) and line[index + 1] != ",":
+                fail("invalid wheel RECORD row: unexpected text after quoted path")
+            return "".join(path)
+
+    fail("invalid wheel RECORD row: unterminated quoted path")
+
 def _find_whl_file(repository_ctx, whl_label):
     """Resolve an http_file-style wheel label to the actual .whl path on disk.
 
@@ -139,10 +176,7 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
     init_dirs = {}
     if record:
         for line in record.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            path = line.split(",", 1)[0]
+            path = parse_record_path(line)
             if not path:
                 continue
             segments = path.split("/")

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -17,39 +17,58 @@ load("//uv/private/pprint:defs.bzl", "pprint")
 def parse_record_path(line):
     """Return the path field from one CSV-encoded wheel RECORD row.
 
-    RECORD is a CSV file in Python's default `csv` reader dialect: `,`
-    delimiter, `"` quote char, `""` -> `"` escaping. A path is quoted only
-    when it contains a comma (or quote). See:
+    RECORD is a CSV file in Python's default `csv` reader dialect (`,`
+    delimiter, `"` quote char, `""` -> `"` escaping, no whitespace trimming):
     https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-record-file
+    https://docs.python.org/3/library/csv.html#csv.reader
 
-    NOTE: the caller splits RECORD on line boundaries before calling this, so
-    a path containing an embedded newline inside a quoted field (legal on
-    POSIX, vanishingly rare) is not handled.
+    Parses the first field of one row the way `csv.reader` would, matching
+    CPython's RECORD reader `importlib.metadata.Distribution.files` (which also
+    does `read_text("RECORD").splitlines()` then `csv.reader` per line):
+    https://github.com/python/cpython/blob/main/Lib/importlib/metadata/__init__.py
+
+    NOTE: because RECORD is split per line before this is called, a quoted path
+    containing an embedded newline (legal but vanishingly rare) is not handled
+    -- the same limitation `importlib.metadata` has.
     """
-    line = line.strip()
-    if not line:
-        return ""
-    if not line.startswith("\""):
-        return line.split(",", 1)[0]
-
     path = []
-    skip_quote = False
-    for index in range(1, len(line)):
-        if skip_quote:
-            skip_quote = False
-            continue
-        char = line[index]
-        if char != "\"":
-            path.append(char)
-        elif index + 1 < len(line) and line[index + 1] == "\"":
-            path.append("\"")
-            skip_quote = True
-        else:
-            if index + 1 < len(line) and line[index + 1] != ",":
-                fail("invalid wheel RECORD row: unexpected text after quoted path")
-            return "".join(path)
 
-    fail("invalid wheel RECORD row: unterminated quoted path")
+    # States mirror csv.reader's field parser:
+    #   start       - at the field boundary, before any character
+    #   unquoted    - inside an unquoted field; `"` is a literal character
+    #   quoted      - inside a quoted field; `,` is a literal character
+    #   after_quote - just saw a `"` while quoted; decide escape vs. close
+    state = "start"
+    for index in range(len(line)):
+        char = line[index]
+        if state == "start":
+            if char == ",":
+                return ""
+            elif char == "\"":
+                state = "quoted"
+            else:
+                path.append(char)
+                state = "unquoted"
+        elif state == "unquoted":
+            if char == ",":
+                return "".join(path)
+            path.append(char)
+        elif state == "quoted":
+            if char == "\"":
+                state = "after_quote"
+            else:
+                path.append(char)
+        else:  # after_quote
+            if char == "\"":
+                path.append("\"")  # doubled quote -> literal `"`
+                state = "quoted"
+            elif char == ",":
+                return "".join(path)
+            else:
+                path.append(char)  # text after a closing quote
+                state = "unquoted"
+
+    return "".join(path)
 
 def _find_whl_file(repository_ctx, whl_label):
     """Resolve an http_file-style wheel label to the actual .whl path on disk.

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -3,7 +3,7 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//py/private:providers.bzl", "PyWheelsInfo")
-load(":repository.bzl", "compatible_python_tags", "select_key", "sort_select_arms", "source_specificity")
+load(":repository.bzl", "compatible_python_tags", "parse_record_path", "select_key", "sort_select_arms", "source_specificity")
 load(":rule.bzl", "whl_install")
 
 def _whl_sorting_test_impl(ctx):
@@ -82,6 +82,34 @@ def _source_specificity_test_impl(ctx):
 source_specificity_test = unittest.make(
     _source_specificity_test_impl,
 )
+
+def _record_path_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Unquoted: the common case.
+    asserts.equals(env, "plain.py", parse_record_path("plain.py,sha256=abc,1"))
+
+    # Quoted because the path contains a comma (the reason a real wheel
+    # quotes a RECORD path at all).
+    asserts.equals(
+        env,
+        "pkg/data/sample,1.csv",
+        parse_record_path("\"pkg/data/sample,1.csv\",sha256=abc,1"),
+    )
+
+    # Quoted with both an embedded comma and a doubled-quote escape ("" -> ").
+    asserts.equals(
+        env,
+        "package/a,b\"c.py",
+        parse_record_path("\"package/a,b\"\"c.py\",,"),
+    )
+
+    # Blank / whitespace-only lines yield no path (caller skips them).
+    asserts.equals(env, "", parse_record_path("   "))
+
+    return unittest.end(env)
+
+record_path_test = unittest.make(_record_path_test_impl)
 
 # --- whl_install metadata selection ---------------------------------------
 #
@@ -252,4 +280,8 @@ def whl_install_suite():
     unittest.suite(
         "source_specificity_tests",
         source_specificity_test,
+    )
+    unittest.suite(
+        "record_path_tests",
+        record_path_test,
     )

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -114,10 +114,13 @@ def _record_path_test_impl(ctx):
     #
     #   text after a closing quote concatenates literally,
     asserts.equals(env, "abcdef", parse_record_path("\"abc\"def,1"))
+
     #   with quotes in that trailing text staying literal,
     asserts.equals(env, "abcdef\"ghi\"", parse_record_path("\"abc\"def\"ghi\",1"))
+
     #   a `"` that does not open the field is a literal character,
     asserts.equals(env, "a\"b\"c", parse_record_path("a\"b\"c,1"))
+
     #   and an unterminated quote consumes the rest of the row.
     asserts.equals(env, "unterminated,1", parse_record_path("\"unterminated,1"))
 

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -104,8 +104,22 @@ def _record_path_test_impl(ctx):
         parse_record_path("\"package/a,b\"\"c.py\",,"),
     )
 
-    # Blank / whitespace-only lines yield no path (caller skips them).
-    asserts.equals(env, "", parse_record_path("   "))
+    # Empty first field (blank line, or a leading comma) yields no path; the
+    # caller skips falsy paths.
+    asserts.equals(env, "", parse_record_path(""))
+    asserts.equals(env, "", parse_record_path(",sha256=abc,1"))
+
+    # Byte-faithful to csv.reader on malformed-but-parseable rows (these don't
+    # occur in valid RECORD files, but we match the reader rather than guess):
+    #
+    #   text after a closing quote concatenates literally,
+    asserts.equals(env, "abcdef", parse_record_path("\"abc\"def,1"))
+    #   with quotes in that trailing text staying literal,
+    asserts.equals(env, "abcdef\"ghi\"", parse_record_path("\"abc\"def\"ghi\",1"))
+    #   a `"` that does not open the field is a literal character,
+    asserts.equals(env, "a\"b\"c", parse_record_path("a\"b\"c,1"))
+    #   and an unterminated quote consumes the rest of the row.
+    asserts.equals(env, "unterminated,1", parse_record_path("\"unterminated,1"))
 
     return unittest.end(env)
 


### PR DESCRIPTION
RECORD docs: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-record-file

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
