### PR TITLE
fix: upgrade hermetic_launcher to 0.0.11 to fix py_binary execve failure

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "tar.bzl", version = "0.10.1")
 bazel_dep(name = "with_cfg.bzl", version = "0.14.6")
-bazel_dep(name = "hermetic_launcher", version = "0.0.9")
+bazel_dep(name = "hermetic_launcher", version = "0.0.11")
 
 bazel_lib_toolchains = use_extension("@tar.bzl//tar:extensions.bzl", "toolchains")
 use_repo(bazel_lib_toolchains, "bsd_tar_toolchains")

--- a/e2e/cases/hermetic-launcher-1116/BUILD.bazel
+++ b/e2e/cases/hermetic-launcher-1116/BUILD.bazel
@@ -1,0 +1,24 @@
+# Fixture for the hermetic-launcher `bazel run` regression (driven by ./test.sh).
+#
+# Regression for https://github.com/aspect-build/rules_py/issues/1116: after the
+# move to hermetic-launcher (#1045), `bazel run` on a minimal py_binary failed at
+# runtime with `execve failed with errno 2`. The bug only surfaces when the
+# launcher is the top-level `bazel run` process and must self-locate its runfiles
+# (falling back to the sibling `.runfiles_manifest`, whose venv-python entry is a
+# relative symlink that the 0.0.9 launcher couldn't `execve`). A normal `sh_test`
+# under `//...` inherits a materialized `RUNFILES_DIR` and never hits that path,
+# so this is driven by ./test.sh which runs `bazel run` directly. Fixed in
+# hermetic-launcher 0.0.11.
+#
+# Mirrors the issue's repro (lucidsoftware/rules_py_hermetic_launcher_repro): a
+# single source, no deps. Tagged `manual` so it's a fixture, not part of `//...`.
+#
+# gazelle:ignore
+
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+
+py_binary(
+    name = "hello",
+    srcs = ["hello.py"],
+    tags = ["manual"],
+)

--- a/e2e/cases/hermetic-launcher-1116/hello.py
+++ b/e2e/cases/hermetic-launcher-1116/hello.py
@@ -1,0 +1,1 @@
+print("hello")

--- a/e2e/cases/hermetic-launcher-1116/test.sh
+++ b/e2e/cases/hermetic-launcher-1116/test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Regression test for https://github.com/aspect-build/rules_py/issues/1116:
+# after the move to hermetic-launcher (#1045), `bazel run` on a minimal
+# py_binary failed at runtime with `execve failed with errno 2`. The failure
+# only reproduces under a real `bazel run` (the launcher is the top-level
+# process and must self-locate its runfiles), so it can't be an `sh_test` under
+# //... — CI runs this directly. Fixed in hermetic-launcher 0.0.11.
+#
+# Run from the e2e workspace root; override bazel with $BAZEL.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."  # e2e workspace root
+
+BAZEL="${BAZEL:-bazel}"
+TARGET="//cases/hermetic-launcher-1116:hello"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+echo "== bazel run on a minimal py_binary must succeed and print 'hello' =="
+out_log="$(mktemp)"
+trap 'rm -f "$out_log"' EXIT
+
+# `bazel run` writes program output to stdout; keep bazel's own chatter on
+# stderr out of the captured value by selecting the last line.
+if ! "$BAZEL" run "$TARGET" >"$out_log" 2>&1; then
+    cat "$out_log" >&2
+    if grep -qi "execve failed" "$out_log"; then
+        fail "bazel run regressed: launcher could not execve the venv python (issue #1116)"
+    fi
+    fail "expected 'bazel run $TARGET' to succeed"
+fi
+
+if ! grep -qx "hello" "$out_log"; then
+    cat "$out_log" >&2
+    fail "expected output 'hello' from $TARGET"
+fi
+
+echo "PASS: bazel run launches the py_binary and prints 'hello'"

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
@@ -27,7 +27,7 @@ files:
 ---
 layer: 3
 files:
-  - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0       17400 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
   - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
   - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
@@ -19,7 +19,7 @@ files:
 ---
 layer: 1
 files:
-  - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0       17400 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
   - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
   - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
@@ -26,7 +26,7 @@ files:
 ---
 layer: 1
 files:
-  - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0       17400 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER
   - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
   - -rwxr-xr-x  0 0      0        1568 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/._my_app_multi_bin.venv/_wheels/3b1f634a/lib/python3.11/site-packages/colorama-0.4.6.dist-info/RECORD

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
@@ -19,7 +19,7 @@ files:
 ---
 layer: 1
 files:
-  - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0       17400 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0          42 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/__init__.py
   - -rwxr-xr-x  0 0      0          31 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/palette.txt
   - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
@@ -19,7 +19,7 @@ files:
 ---
 layer: 1
 files:
-  - -rwxr-xr-x  0 0      0       17888 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0       16560 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0          42 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/__init__.py
   - -rwxr-xr-x  0 0      0          31 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_image_layer/branding/palette.txt
   - -rwxr-xr-x  0 0      0          15 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/_wheels/df4f08a6/lib/python3.11/site-packages/colorama-0.4.6.dist-info/INSTALLER

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
@@ -33,7 +33,7 @@ files:
 ---
 layer: 1
 files:
-  - -rwxr-xr-x  0 0      0       18704 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0       17400 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__init__.py
   - -rwxr-xr-x  0 0      0        3833 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/__init__.cpython-312.pyc
   - -rwxr-xr-x  0 0      0        2699 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/_ipaddress.cpython-312.pyc

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
@@ -33,7 +33,7 @@ files:
 ---
 layer: 1
 files:
-  - -rwxr-xr-x  0 0      0       17888 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0       16560 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0        4768 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__init__.py
   - -rwxr-xr-x  0 0      0        3833 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/__init__.cpython-312.pyc
   - -rwxr-xr-x  0 0      0        2699 Jan  1  2023 ./app.runfiles/_main/cases/uv-deps-650/crossbuild/._app_bin.venv/_wheels/4c143330/lib/python3.12/site-packages/psycopg2/__pycache__/_ipaddress.cpython-312.pyc


### PR DESCRIPTION
Fix #1116

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
