### PR TITLE
feat(uv): reserve wheel build resources via uv.override_package(resource_set)

### DIFF
--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -124,6 +124,11 @@ uv.override_package(
 Resource reservations are only honored when Bazel runs with
 `--experimental_action_resource_set`; add it to your `.bazelrc`.
 
+`resource_set` only applies to packages built from an sdist. Setting it on a
+package that resolves to a prebuilt wheel (no source build) fails the build
+rather than silently dropping the reservation — force a source build with
+`[tool.uv] no-binary-package` if you need the reservation to apply.
+
 ### Full replacement
 
 To replace a package entirely with a custom target (existing functionality):

--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -100,6 +100,30 @@ uv.override_package(
 )
 ```
 
+### Reserving wheel build resources
+
+Native sdist builds can be memory-hungry. Without a hint, Bazel assumes the
+default per-action estimate (~1 CPU, 250 MB) and may schedule several heavy
+builds at once, leading to OOM kills on the local machine. Set `resource_set`
+to reserve more RAM (or CPU) for a package's wheel build so Bazel limits how
+many run concurrently:
+
+```starlark
+uv.override_package(
+    lock = "//:uv.lock",
+    name = "native-package",
+    resource_set = "mem_8g",
+)
+```
+
+`resource_set` accepts bazel-lib's predefined values — the same vocabulary
+`ts_project` uses: `"mem_512m"`, `"mem_1g"`, `"mem_2g"`, `"mem_4g"`,
+`"mem_8g"`, `"mem_16g"`, `"mem_32g"`, `"cpu_2"`, `"cpu_4"`, or `"default"`
+(reserve nothing extra). A memory request is rounded up to the named bucket.
+
+Resource reservations are only honored when Bazel runs with
+`--experimental_action_resource_set`; add it to your `.bazelrc`.
+
 ### Full replacement
 
 To replace a package entirely with a custom target (existing functionality):

--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -121,9 +121,6 @@ uv.override_package(
 `"mem_8g"`, `"mem_16g"`, `"mem_32g"`, `"cpu_2"`, `"cpu_4"`, or `"default"`
 (reserve nothing extra). A memory request is rounded up to the named bucket.
 
-Resource reservations are only honored when Bazel runs with
-`--experimental_action_resource_set`; add it to your `.bazelrc`.
-
 `resource_set` only applies to packages built from an sdist. Setting it on a
 package that resolves to a prebuilt wheel (no source build) fails the build
 rather than silently dropping the reservation — force a source build with

--- a/e2e/.bazelrc
+++ b/e2e/.bazelrc
@@ -33,6 +33,12 @@ common --java_runtime_version=remotejdk_11
 # configuration-stripped cache keys; those that don't still work normally.
 build --experimental_output_paths=strip
 
+# Honor resource_set on actions so cases/uv-sdist-native-build's
+# uv.override_package(resource_set = ...) actually reserves local memory for
+# the geohash native build. Without this flag the reservation is silently
+# ignored (the build still succeeds).
+common --experimental_action_resource_set
+
 # Build without the bytes
 common:ci --remote_download_outputs=minimal
 common:ci --nobuild_runfile_links

--- a/e2e/.bazelrc
+++ b/e2e/.bazelrc
@@ -33,12 +33,6 @@ common --java_runtime_version=remotejdk_11
 # configuration-stripped cache keys; those that don't still work normally.
 build --experimental_output_paths=strip
 
-# Honor resource_set on actions so cases/uv-sdist-native-build's
-# uv.override_package(resource_set = ...) actually reserves local memory for
-# the geohash native build. Without this flag the reservation is silently
-# ignored (the build still succeeds).
-common --experimental_action_resource_set
-
 # Build without the bytes
 common:ci --remote_download_outputs=minimal
 common:ci --nobuild_runfile_links

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -122,6 +122,15 @@ write_source_files(
         # rule expands env keys correctly given an explicit fixture.
         "snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel": "@sdist_build__uv_sdist_jdk_build__jpype1__1_7_1//:BUILD.bazel",
 
+        # @sdist_build for python-geohash with uv.override_package(resource_set)
+        # ----------------------------------------------------------------------
+        # Covers the override_package -> repo-rule -> BUILD-template plumbing
+        # for `resource_set`. The runtime //cases/uv-sdist-native-build:test
+        # only proves the wheel still builds; this snapshot pins that
+        # `resource_set = "mem_4g"` actually lands on the generated
+        # pep517_native_whl(...) call so the reservation reaches the action.
+        "snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel": "@sdist_build__uv_sdist_native_build__python_geohash__0_8_5//:BUILD.bazel",
+
         # Venv site-packages .pth files. Pin the line shapes that
         # assemble_venv emits, so any change to `.pth` emission
         # surfaces here. Wheel keys are an 8-hex hash of the wheel's

--- a/e2e/cases/uv-sdist-native-build/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-native-build/setup.MODULE.bazel
@@ -25,4 +25,12 @@ uv.override_package(
     lock = "//cases/uv-sdist-native-build:uv.lock",
     resource_set = "mem_4g",
 )
-use_repo(uv, "pypi_uv_sdist_native_build")
+
+# Expose the sdist_build repo so e2e/BUILD.bazel can snapshot the generated
+# pep517_native_whl call and pin that `resource_set = "mem_4g"` actually
+# threads onto the build action (not just that the wheel still builds).
+use_repo(
+    uv,
+    "pypi_uv_sdist_native_build",
+    "sdist_build__uv_sdist_native_build__python_geohash__0_8_5",
+)

--- a/e2e/cases/uv-sdist-native-build/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-native-build/setup.MODULE.bazel
@@ -1,6 +1,12 @@
 """Verify that native_build_toolchain_type is registered via @rules_py_tools//:all
 so that sdist packages with C extensions can be built with pep517_native_whl.
 python-geohash is sdist-only and contains a C++ extension (_geohash).
+
+Also exercises `uv.override_package(resource_set = ...)`: the chosen bazel-lib
+resource set must thread through the extension and sdist_build's generated
+pep517_native_whl(...) call so the native build action carries a local memory
+reservation (honored under --experimental_action_resource_set, set in the e2e
+.bazelrc). The geohash wheel must still build and import.
 """
 
 uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
@@ -13,5 +19,10 @@ uv.project(
     hub_name = "pypi_uv_sdist_native_build",
     lock = "//cases/uv-sdist-native-build:uv.lock",
     pyproject = "//cases/uv-sdist-native-build:pyproject.toml",
+)
+uv.override_package(
+    name = "python-geohash",
+    lock = "//cases/uv-sdist-native-build:uv.lock",
+    resource_set = "mem_4g",
 )
 use_repo(uv, "pypi_uv_sdist_native_build")

--- a/e2e/cases/uv-sdist-native-build/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-native-build/setup.MODULE.bazel
@@ -5,8 +5,7 @@ python-geohash is sdist-only and contains a C++ extension (_geohash).
 Also exercises `uv.override_package(resource_set = ...)`: the chosen bazel-lib
 resource set must thread through the extension and sdist_build's generated
 pep517_native_whl(...) call so the native build action carries a local memory
-reservation (honored under --experimental_action_resource_set, set in the e2e
-.bazelrc). The geohash wheel must still build and import.
+reservation. The geohash wheel must still build and import.
 """
 
 uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")

--- a/e2e/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
+++ b/e2e/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
@@ -1,0 +1,35 @@
+
+load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+
+py_binary(
+    name = "build_tool",
+    main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
+    srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
+    deps = ["@@aspect_rules_py++uv+project__uv_sdist_native_build//:build", "@@aspect_rules_py++uv+project__uv_sdist_native_build//:setuptools", "@whl_install__uv_sdist_native_build__setuptools__75_8_2//:install"],
+)
+
+pep517_native_whl(
+    name = "whl",
+    src = "@@aspect_rules_py++uv+sdist__python_geohash__05a21fcf4eda1a5e//file:file",
+    tool = ":build_tool",
+    version = "0.8.5",
+    args = [],
+    resource_set = "mem_4g",
+    toolchains = [
+        "@bazel_tools//tools/cpp:current_cc_toolchain",
+    ],
+    env = {
+        "AR": "$(AR)",
+        "CC": "$(CC)",
+        "CXX": "$(CC)",
+        "LD": "$(LD)",
+        "STRIP": "$(STRIP)",
+    },
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -30,6 +30,7 @@ bzl_library(
         "//uv/private/uv_project:repository",
         "//uv/private/whl_install:repository",
         "@bazel_features//:features",
+        "@bazel_lib//lib:resource_sets",
         "@bazel_skylib//lib:sets",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
     ],

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -446,6 +446,9 @@ def _parse_projects(module_ctx, hub_specs):
                     extra_deps = [str(d) for d in pkg_override.extra_deps]
                     extra_data = [str(d) for d in pkg_override.extra_data]
 
+                if pkg_override and pkg_override.resource_set != "default" and not has_sbuild:
+                    fail("uv.override_package() for '{}': `resource_set` reserves resources for the sdist wheel-build action, but this package resolves to a prebuilt wheel (there is no sdist build to reserve for). Remove `resource_set`, or force a source build via `[tool.uv] no-binary-package`.".format(pkg_override.name))
+
                 # uv can emit multiple lock records for the same package/version
                 # (e.g. resolution-marker forks), each carrying a different
                 # subset of wheels. Merge with any previously translated record

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -52,6 +52,7 @@ resolved dependencies available in the `@uv` repository.
 """
 
 load("@bazel_features//:features.bzl", features = "bazel_features")
+load("@bazel_lib//lib:resource_sets.bzl", "resource_set_values")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("//py/private/interpreter:resolve.bzl", "resolve_host_interpreter_label")
@@ -252,14 +253,15 @@ def _parse_projects(module_ctx, hub_specs):
                     override.extra_deps or
                     override.extra_data or
                     override.toolchains or
-                    override.env
+                    override.env or
+                    override.resource_set != "default"
                 )
 
                 if has_target and has_modifications:
-                    fail("uv.override_package() for '{}': `target` is mutually exclusive with patch/exclude attributes. Use `target` for full replacement OR patch/exclude attributes for modifications, not both.".format(override.name))
+                    fail("uv.override_package() for '{}': `target` is mutually exclusive with modification attributes. Use `target` for full replacement OR build, patch, and data attributes for modifications, not both.".format(override.name))
 
                 if not has_target and not has_modifications:
-                    fail("uv.override_package() for '{}': must specify either `target` for full replacement or at least one modification attribute (pre_build_patches, post_install_patches, extra_deps, extra_data).".format(override.name))
+                    fail("uv.override_package() for '{}': must specify either `target` for full replacement or at least one modification attribute (pre_build_patches, post_install_patches, extra_deps, extra_data, toolchains, env, resource_set).".format(override.name))
 
                 package_overrides[override_key] = override
 
@@ -410,9 +412,11 @@ def _parse_projects(module_ctx, hub_specs):
                     # they don't replace them. Empty == no augmentation.
                     extra_toolchains = []
                     extra_env = {}
+                    resource_set = "default"
                     if pkg_override:
                         extra_toolchains = [str(t) for t in pkg_override.toolchains]
                         extra_env = pkg_override.env
+                        resource_set = pkg_override.resource_set
 
                     sbuild_specs[sbuild_id] = struct(
                         src = sdist,
@@ -425,6 +429,7 @@ def _parse_projects(module_ctx, hub_specs):
                         configure_command = project.unstable_configure_command,
                         extra_toolchains = extra_toolchains,
                         extra_env = extra_env,
+                        resource_set = resource_set,
                     )
 
                     has_sbuild = True
@@ -649,6 +654,8 @@ def _uv_impl(module_ctx):
             sbuild_kwargs["extra_toolchains"] = sbuild_cfg.extra_toolchains
         if sbuild_cfg.extra_env:
             sbuild_kwargs["extra_env"] = sbuild_cfg.extra_env
+        if sbuild_cfg.resource_set != "default":
+            sbuild_kwargs["resource_set"] = sbuild_cfg.resource_set
         sdist_build(**sbuild_kwargs)
 
     for install_id, install_cfg in cfg.install_cfgs.items():
@@ -745,6 +752,21 @@ _override_package_tag = tag_class(
         # Full replacement: provide a target that substitutes for the package entirely.
         # Mutually exclusive with patch/exclude attributes.
         "target": attr.label(mandatory = False),
+
+        # Per-package local execution resources for the wheel build action.
+        # Uses bazel-lib's predefined resource_set vocabulary (the same enum
+        # `ts_project` accepts), so Bazel reserves the named amount of RAM/CPU
+        # and won't overschedule concurrent native wheel builds. Honored only
+        # under `--experimental_action_resource_set`; `"default"` reserves
+        # nothing extra.
+        "resource_set": attr.string(
+            default = "default",
+            values = resource_set_values,
+            doc = "Local execution resources to reserve for this package's wheel build action. " +
+                  "One of bazel-lib's predefined resource sets ('mem_512m', 'mem_1g', … 'mem_32g', " +
+                  "'cpu_2', 'cpu_4', 'default'). Bazel rounds a memory request up to the named " +
+                  "bucket. Requires `--experimental_action_resource_set`.",
+        ),
 
         # Per-package toolchain plumbing for native sdist builds. Both
         # attributes AUGMENT the defaults baked into sdist_build's

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -759,16 +759,15 @@ _override_package_tag = tag_class(
         # Per-package local execution resources for the wheel build action.
         # Uses bazel-lib's predefined resource_set vocabulary (the same enum
         # `ts_project` accepts), so Bazel reserves the named amount of RAM/CPU
-        # and won't overschedule concurrent native wheel builds. Honored only
-        # under `--experimental_action_resource_set`; `"default"` reserves
-        # nothing extra.
+        # and won't overschedule concurrent native wheel builds. `"default"`
+        # reserves nothing extra.
         "resource_set": attr.string(
             default = "default",
             values = resource_set_values,
             doc = "Local execution resources to reserve for this package's wheel build action. " +
                   "One of bazel-lib's predefined resource sets ('mem_512m', 'mem_1g', … 'mem_32g', " +
                   "'cpu_2', 'cpu_4', 'default'). Bazel rounds a memory request up to the named " +
-                  "bucket. Requires `--experimental_action_resource_set`.",
+                  "bucket.",
         ),
 
         # Per-package toolchain plumbing for native sdist builds. Both

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -16,7 +16,10 @@ exports_files(
 bzl_library(
     name = "rule",
     srcs = ["rule.bzl"],
-    deps = ["//py/private/toolchain:types"],
+    deps = [
+        "//py/private/toolchain:types",
+        "@bazel_lib//lib:resource_sets",
+    ],
 )
 
 bzl_library(

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -5,6 +5,7 @@ Uses `python -m build` (the pypa/build frontend) which delegates to whatever
 build backend the sdist declares in its `[build-system]` table.
 """
 
+load("@bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
 
@@ -118,6 +119,7 @@ def _pep517_whl(ctx):
         outputs = [wheel_dir],
         env = _common_env(ctx),
         exec_group = "target",
+        resource_set = resource_set(ctx.attr),
     )
 
     return [DefaultInfo(files = depset([wheel_dir]))]
@@ -158,6 +160,7 @@ def _pep517_native_whl(ctx):
         outputs = [wheel_dir],
         env = env,
         exec_group = "target",
+        resource_set = resource_set(ctx.attr),
     )
 
     return [DefaultInfo(files = depset([wheel_dir]))]
@@ -179,7 +182,7 @@ _pep517_whl_attrs = {
     "tool": attr.label(executable = True, cfg = "exec"),
     "version": attr.string(),
     "args": attr.string_list(default = ["--validate-anyarch"]),
-} | _PATCH_ATTRS
+} | _PATCH_ATTRS | resource_set_attr
 
 pep517_whl = rule(
     implementation = _pep517_whl,

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -172,6 +172,11 @@ def _sdist_build_impl(repository_ctx):
             # If the tool provided complete build file content, use it directly.
             build_file_content = inspection.get("build_file_content")
             if build_file_content:
+                if repository_ctx.attr.resource_set != "default":
+                    fail("sdist_build for '{}': the configure tool returned complete `build_file_content`, which bypasses the generated `pep517_*whl(...)` call, so `resource_set = \"{}\"` cannot be applied. Drop `resource_set` from the override, or have the configure tool set `resource_set` in its own `build_file_content`.".format(
+                        repository_ctx.name,
+                        repository_ctx.attr.resource_set,
+                    ))
                 repository_ctx.file("BUILD.bazel", content = build_file_content)
                 return
 

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -250,6 +250,10 @@ def _sdist_build_impl(repository_ctx):
             env = "\n".join(["        \"{}\": \"{}\",".format(k, v) for k, v in sorted(env.items())]),
         )
 
+    resource_set_attr = ""
+    if repository_ctx.attr.resource_set != "default":
+        resource_set_attr = "\n    resource_set = \"{}\",".format(repository_ctx.attr.resource_set)
+
     repository_ctx.file("BUILD.bazel", content = """
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{rule}")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
@@ -266,7 +270,7 @@ py_binary(
     src = "{src}",
     tool = ":build_tool",
     version = "{version}",
-    args = [],{patch_attrs}{toolchain_attrs}
+    args = [],{resource_set_attr}{patch_attrs}{toolchain_attrs}
     visibility = ["//visibility:public"],
 )
 
@@ -279,6 +283,7 @@ exports_files(
         deps = repr(all_deps),
         rule = "pep517_native_whl" if is_native else "pep517_whl",
         version = repository_ctx.attr.version,
+        resource_set_attr = resource_set_attr,
         patch_attrs = patch_attrs,
         toolchain_attrs = toolchain_attrs,
     ))
@@ -303,6 +308,12 @@ sdist_build = repository_rule(
                   "two arguments. See //uv/private/sdist_configure:defs.bzl.",
         ),
         "version": attr.string(),
+        "resource_set": attr.string(
+            default = "default",
+            doc = "bazel-lib resource_set name forwarded to the generated pep517_*whl(...) " +
+                  "`resource_set` attribute, reserving local RAM/CPU for the wheel build " +
+                  "action. Set via `uv.override_package(resource_set = ...)`.",
+        ),
         "pre_build_patches": attr.label_list(default = []),
         "pre_build_patch_strip": attr.int(default = 0),
         "extra_toolchains": attr.string_list(


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Enable overriding wheel build resources via `uv.override_package(resource_set)`

### Test plan

- Covered by existing test cases
- New test cases added
