### PR TITLE
test(uv): verify inactive marker packages resolve to empty targets

### DIFF
--- a/e2e/cases/arch-alias-marker/BUILD.bazel
+++ b/e2e/cases/arch-alias-marker/BUILD.bazel
@@ -4,6 +4,20 @@
 # mainstream Bazel host, platform_machine emits aarch64 or x86_64, so the
 # marker only matches once decide_marker normalizes the aliases.
 load("@aspect_rules_py//py:defs.bzl", "py_test")
+load(":inactive_marker_test.bzl", "inactive_marker_package_test", "inactive_marker_wheel_test")
+
+platform(
+    name = "inactive_linux_x86_64",
+    constraint_values = [
+        "@llvm//constraints/libc:gnu.2.28",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    flags = [
+        "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
+        "--@aspect_rules_py//uv/private/constraints/platform:platform_version=2.28",
+    ],
+)
 
 py_test(
     name = "arch_alias_marker",
@@ -14,4 +28,16 @@ py_test(
     deps = [
         "@pypi_arch_alias_marker//cowsay",
     ],
+)
+
+# colorama is Windows-only, so this Linux platform selects the empty package
+# and wheel defaults generated for an inactive marker-only SCC.
+inactive_marker_package_test(
+    name = "inactive_marker_package_test",
+    target_under_test = "@pypi_arch_alias_marker//colorama",
+)
+
+inactive_marker_wheel_test(
+    name = "inactive_marker_wheel_test",
+    target_under_test = "@pypi_arch_alias_marker//colorama:whl",
 )

--- a/e2e/cases/arch-alias-marker/inactive_marker_test.bzl
+++ b/e2e/cases/arch-alias-marker/inactive_marker_test.bzl
@@ -1,0 +1,33 @@
+"""Analysis tests for inactive marker-only package and wheel aliases."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_python//python:defs.bzl", "PyInfo")
+
+_CONFIG_SETTINGS = {
+    "//command_line_option:platforms": str(Label("//cases/arch-alias-marker:inactive_linux_x86_64")),
+    str(Label("@aspect_rules_py//uv/private/constraints/dep_group:dep_group")): "arch_alias_marker",
+}
+
+def _inactive_marker_package_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    asserts.true(env, PyInfo in target)
+    if PyInfo in target:
+        asserts.equals(env, [], target[PyInfo].transitive_sources.to_list())
+    return analysistest.end(env)
+
+inactive_marker_package_test = analysistest.make(
+    _inactive_marker_package_test_impl,
+    config_settings = _CONFIG_SETTINGS,
+)
+
+def _inactive_marker_wheel_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    asserts.equals(env, [], target[DefaultInfo].files.to_list())
+    return analysistest.end(env)
+
+inactive_marker_wheel_test = analysistest.make(
+    _inactive_marker_wheel_test_impl,
+    config_settings = _CONFIG_SETTINGS,
+)

--- a/e2e/cases/arch-alias-marker/pyproject.toml
+++ b/e2e/cases/arch-alias-marker/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
     # emits aarch64/x86_64, so without the alias normalization in
     # uv/private/markers/defs.bzl this dep is never pulled in on any host.
     "cowsay; platform_machine == 'arm64' or platform_machine == 'amd64'",
+    "colorama; sys_platform == 'win32'",
 ]

--- a/e2e/cases/arch-alias-marker/uv.lock
+++ b/e2e/cases/arch-alias-marker/uv.lock
@@ -7,11 +7,24 @@ name = "arch-alias-marker"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "cowsay", marker = "platform_machine == 'amd64' or platform_machine == 'arm64'" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "cowsay", marker = "platform_machine == 'amd64' or platform_machine == 'arm64'" }]
+requires-dist = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "cowsay", marker = "platform_machine == 'amd64' or platform_machine == 'arm64'" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
 
 [[package]]
 name = "cowsay"


### PR DESCRIPTION
Adds a Windows-only dependency (colorama) to the arch-alias-marker e2e case along with a synthetic Linux x86_64 platform and two analysis tests. The tests assert that when a package's marker doesn't match the current platform, the generated hub aliases resolve to an empty py_library with no transitive sources and an empty wheel filegroup, confirming that inactive marker-only dependencies are a no-op rather than a build failure.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
