### PR TITLE
feat(uv): describe installed wheel topology metadata

### DIFF
--- a/e2e/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
+++ b/e2e/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
@@ -107,6 +107,56 @@ whl_install(
             "cffi-2.0.0.dist-info",
         ],
     },
+    directory_top_levels = {
+        "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-win32.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-win_amd64.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+        "cffi-2.0.0-cp312-cp312-win_arm64.whl": [
+            "cffi",
+            "cffi-2.0.0.dist-info",
+        ],
+    },
     namespace_top_levels = {},
     console_scripts = {},
     visibility = ["//visibility:private"],

--- a/e2e/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
+++ b/e2e/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
@@ -332,6 +332,124 @@ whl_install(
             "cryptography-46.0.5.dist-info",
         ],
     },
+    directory_top_levels = {
+        "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp311-abi3-win32.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp311-abi3-win_amd64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+            "cryptography.libs",
+        ],
+        "cryptography-46.0.5-cp38-abi3-win32.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+        "cryptography-46.0.5-cp38-abi3-win_amd64.whl": [
+            "cryptography",
+            "cryptography-46.0.5.dist-info",
+        ],
+    },
     namespace_top_levels = {
         "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl": [
             "cryptography.libs",

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
@@ -39,6 +39,12 @@ whl_install(
             "azure_core-1.38.0.dist-info",
         ],
     },
+    directory_top_levels = {
+        "azure_core-1.38.0-py3-none-any.whl": [
+            "azure",
+            "azure_core-1.38.0.dist-info",
+        ],
+    },
     namespace_top_levels = {
         "azure_core-1.38.0-py3-none-any.whl": [
             "azure",

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
@@ -39,6 +39,12 @@ whl_install(
             "azure_core_tracing_opentelemetry-1.0.0b11.dist-info",
         ],
     },
+    directory_top_levels = {
+        "azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl": [
+            "azure",
+            "azure_core_tracing_opentelemetry-1.0.0b11.dist-info",
+        ],
+    },
     namespace_top_levels = {
         "azure_core_tracing_opentelemetry-1.0.0b11-py3-none-any.whl": [
             "azure",

--- a/e2e/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
+++ b/e2e/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
@@ -234,6 +234,168 @@ whl_install(
             "grpcio-1.80.0.dist-info",
         ],
     },
+    directory_top_levels = {
+        "grpcio-1.80.0-cp311-cp311-linux_armv7l.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-win32.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp311-cp311-win_amd64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-linux_armv7l.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-win32.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp312-cp312-win_amd64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-linux_armv7l.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-win32.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp313-cp313-win_amd64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-linux_armv7l.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-win32.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+        "grpcio-1.80.0-cp314-cp314-win_amd64.whl": [
+            "grpc",
+            "grpcio-1.80.0.dist-info",
+        ],
+    },
     namespace_top_levels = {},
     console_scripts = {},
     visibility = ["//visibility:private"],

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -27,10 +27,10 @@ executable wrappers under `<venv>/bin/<name>` for console scripts.
     namespace top-levels (site-packages-relative `/`-joined paths). May be absent
     on structs from older producers; consumers use `getattr` with a `()` default.
   * `regular_roots`: tuple[str] — minimal directories under the namespace
-    top-levels carrying an `__init__.py`. Cross-referencing a wheel's
-    `regular_roots` with another wheel's `namespace_dirs` detects regular
-    packages spanning wheels, which venv assembly must physically merge.
-    May be absent on structs from older producers.
+    top-levels carrying a recognized package initializer. Cross-referencing a
+    wheel's `regular_roots` with another wheel's `namespace_dirs` detects
+    regular packages spanning wheels, which venv assembly must physically
+    merge. May be absent on structs from older producers.
   * `site_packages_rfpath`: str — runfiles-root-relative path to the wheel's site-packages.
   * `console_scripts`: tuple[str] — entry points encoded as `"name=module:func"`.
 """,

--- a/uv/private/uv_hub/snapshots/whl_install.attrs.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/whl_install.attrs.BUILD.bazel
@@ -40,6 +40,13 @@ whl_install(
             "attrs-23.2.0.dist-info",
         ],
     },
+    directory_top_levels = {
+        "attrs-23.2.0-py3-none-any.whl": [
+            "attr",
+            "attrs",
+            "attrs-23.2.0.dist-info",
+        ],
+    },
     namespace_top_levels = {},
     console_scripts = {},
     visibility = ["//visibility:private"],

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -75,9 +75,17 @@ def site_packages_segments(path, data_directory):
     segments = path.split("/")
     if segments[0] != data_directory:
         return segments
-    if len(segments) < 3 or segments[1] not in ("purelib", "platlib"):
+    if len(segments) < 3:
         return []
-    return segments[2:]
+    category = segments[1]
+    if category in ("purelib", "platlib"):
+        return segments[2:]
+    if category in ("data", "headers", "scripts"):
+        return []
+
+    # Keep this in sync with py/tools/unpack/unpack.py: unknown categories
+    # retain their category prefix under site-packages.
+    return segments[1:]
 
 def parse_console_script(line):
     """Parse one `[console_scripts]` entry into a canonical `name=module:func`.
@@ -104,18 +112,33 @@ def parse_console_script(line):
 def _find_whl_file(repository_ctx, whl_label):
     """Resolve an http_file-style wheel label to the actual .whl path on disk.
 
-    whl_label typically points at an http_file's filegroup (`//file:file`),
-    so `repository_ctx.path` returns the filegroup's logical path — not
-    the actual .whl file, which is a sibling in the same directory under
-    its downloaded filename. Scan the parent directory to find it.
+    Prefer a label that resolves directly to a wheel. An http_file filegroup
+    (`//file:file`) instead resolves to a nonexistent logical path; in that
+    case its downloaded wheel is a sibling in the same directory.
 
     Returns None if no .whl file is found.
     """
     logical_path = repository_ctx.path(whl_label)
+    if logical_path.exists and logical_path.basename.endswith(".whl"):
+        return logical_path
+
     parent = logical_path.dirname
-    for entry in parent.readdir():
-        if entry.basename.endswith(".whl"):
-            return entry
+    if not parent.exists:
+        return None
+    candidates = {
+        entry.basename: entry
+        for entry in parent.readdir()
+        if entry.basename.endswith(".whl")
+    }
+    candidate_names = sorted(candidates.keys())
+    if len(candidate_names) == 1:
+        return candidates[candidate_names[0]]
+    if len(candidate_names) > 1:
+        fail("{}: wheel label {} does not resolve directly and its parent contains multiple .whl files: {}".format(
+            repository_ctx.name,
+            whl_label,
+            candidate_names,
+        ))
     return None
 
 def _extract_wheel_metadata(repository_ctx, whl_label):
@@ -139,28 +162,10 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
                  label_list attr so Bazel wires up repo visibility.
 
     Returns:
-      Tuple (top_levels_set, regular_top_levels_set, console_scripts_set,
-             namespace_entries_set, dirs_set, init_dirs_set):
-        * top_levels_set: dict[name → True] — all first-path-segment
-          names in RECORD (excluding `*.data/` staging entries).
-        * regular_top_levels_set: subset that had an `__init__.py` at
-          depth 1, i.e. regular packages. Its complement (within
-          top_levels_set, minus `.dist-info/`) is the PEP 420 namespace
-          set for this wheel.
-        * console_scripts_set: dict[script_name → "name=module:func"].
-        * namespace_entries_set: dict[path → True] — for each top-level
-          that looks like a PEP 420 namespace in THIS wheel, the
-          `/`-joined paths of the concrete entries beneath it: the
-          shallowest directory holding a direct `__init__.py` (recursing
-          through nested namespace dirs like `google/cloud/`), or the
-          file itself for plain modules / data files. Lets venv assembly
-          materialise a merged namespace dir out of per-entry symlinks.
-        * dirs_set: dict[path → True] — every directory implied by a
-          RECORD entry, as a `/`-joined relative path.
-        * init_dirs_set: dict[path → True] — subset of dirs_set that
-          directly contain an `__init__.py` (regular packages). Powers
-          the per-wheel namespace_dirs / regular_roots derivation, which
-          venv assembly uses to detect regular packages spanning wheels.
+      Tuple (whl_basename, layout, console_scripts):
+        * whl_basename: basename of the wheel file resolved from whl_label.
+        * layout: classified site-packages names and package topology.
+        * console_scripts: canonical "name=module:func" entries.
     """
     whl_path = _find_whl_file(repository_ctx, whl_label)
     if whl_path == None:
@@ -208,82 +213,7 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
         entry_points = repository_ctx.read(entry_points_path)
     repository_ctx.delete(metadata_dir)
     data_directory = metadata_directory[:-len(".dist-info")] + ".data"
-
-    # RECORD: authoritative list of every installed file. First path segment
-    # = top-level name after translating wheel install-scheme paths.
-    top_levels_set = {}
-
-    # Tracks which top-levels contain a direct `<toplevel>/__init__.py` —
-    # i.e., are regular packages. The complement (top_levels that never
-    # appear with an `__init__.py` at depth 1) are PEP 420 namespace
-    # packages that expect to be merged across wheels.
-    regular_top_levels = {}
-
-    # Raw material for the namespace derivations below: every kept RECORD
-    # path (as segment lists) plus the full directory skeleton and the set
-    # of directories that hold a direct `__init__.py` at any depth.
-    record_segments = []
-    dirs_set = {}
-    init_dirs = {}
-    if record:
-        for line in record.splitlines():
-            path = parse_record_path(line)
-            if not path:
-                continue
-            segments = site_packages_segments(path, data_directory)
-            if not segments:
-                continue
-
-            first_segment = segments[0]
-
-            # Filter RECORD entries that escape the install root. Some
-            # wheels (notably setuptools-family) emit lines like
-            # `../../bin/foo` for entry-point scripts. We don't want
-            # `..` / `.` / absolute paths / empty strings in top_levels
-            # because downstream `ctx.actions.declare_symlink` normalises
-            # paths and would create phantom outputs at parent dirs,
-            # producing prefix-collision errors.
-            if not first_segment:
-                continue
-            if first_segment in (".", ".."):
-                continue
-            if first_segment.startswith("/"):
-                continue
-            top_levels_set[first_segment] = True
-
-            # Single-file modules (e.g. `six.py` at top level) aren't
-            # namespace packages — treat them as regular.
-            if len(segments) == 1 or (len(segments) >= 2 and segments[1] == "__init__.py"):
-                regular_top_levels[first_segment] = True
-
-            record_segments.append(segments)
-
-            # Record every directory along the path, and which of them
-            # directly contain an `__init__.py`.
-            for i in range(1, len(segments)):
-                dirs_set["/".join(segments[:i])] = True
-            if len(segments) >= 2 and segments[-1] == "__init__.py":
-                init_dirs["/".join(segments[:-1])] = True
-
-    # Namespace entries: for each path under a (per-this-wheel) namespace
-    # top-level, descend until hitting the shallowest concrete prefix — a
-    # directory with a direct `__init__.py`, or the file itself when no
-    # such directory exists on the way down (plain modules like
-    # `jaraco/context.py`, or bare data files). Nested namespaces
-    # (`google/cloud/storage/…`) recurse naturally: `google/cloud` has no
-    # `__init__.py`, so the walk continues to `google/cloud/storage`.
-    # Entries for top-levels that turn out regular are filtered out here.
-    namespace_entries = {}
-    for segments in record_segments:
-        if segments[0] in regular_top_levels or segments[0].endswith(".dist-info"):
-            continue
-        if len(segments) < 2:
-            continue
-        for depth in range(2, len(segments) + 1):
-            prefix = "/".join(segments[:depth])
-            if depth == len(segments) or prefix in init_dirs:
-                namespace_entries[prefix] = True
-                break
+    layout = wheel_layout_from_record(record, data_directory)
 
     # entry_points.txt: INI-style file. Only `[console_scripts]` interests
     # us — pip/uv synthesize executables under `bin/<name>` from those at
@@ -309,16 +239,20 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
             name, normalised = entry
             console_scripts[name] = normalised
 
-    return whl_path.basename, top_levels_set, regular_top_levels, console_scripts, namespace_entries, dirs_set, init_dirs
+    return (
+        whl_path.basename,
+        layout,
+        sorted(console_scripts.values()),
+    )
 
 def _namespace_dirs_and_roots(dirs_set, init_dirs, namespace_top_levels_set):
     """Split a wheel's directory skeleton into the implicit-namespace dirs
     and the minimal regular-package roots, restricted to the wheel's
     namespace top-levels.
 
-    Walking from the top, content is an implicit-namespace portion until
-    the first directory carrying an `__init__.py` — that directory is a
-    "regular root" and everything below it is interior to a regular
+    Walking from the top, content is an implicit-namespace portion until the
+    first directory carrying a recognized package initializer. That directory
+    is a "regular root" and everything below it is interior to a regular
     package.
 
       * namespace_dirs: the implicit-namespace skeleton, minus the depth-1
@@ -356,6 +290,113 @@ def _namespace_dirs_and_roots(dirs_set, init_dirs, namespace_top_levels_set):
         elif boundary == d:
             regular_roots.append(d)
     return namespace_dirs, regular_roots
+
+def _is_package_initializer(name):
+    """Whether a RECORD basename might make its directory a regular package.
+
+    Repository metadata is produced before a target configuration selects one
+    Python runtime, so this must be a conservative cross-platform superset, not
+    an exact match for the repository host. CPython's FileFinder classifies
+    packages by `__init__` plus each configured loader suffix, and CPython 3.14
+    derives `.fwork` suffixes from extension suffixes on Apple mobile targets:
+    https://github.com/python/cpython/blob/3.14/Lib/importlib/_bootstrap_external.py#L1331-L1385
+    https://github.com/python/cpython/blob/3.14/Lib/importlib/_bootstrap_external.py#L1534-L1549
+
+    `__init__.pyi` is additionally package-defining for static tooling even
+    though it is not a default CPython source suffix. Overclassification is
+    conservative: venv assembly may physically merge an extra directory;
+    underclassification could incorrectly split a regular package.
+    """
+    lower_name = name.lower()
+    return (
+        lower_name in (
+            "__init__.py",
+            "__init__.pyc",
+            "__init__.pyi",
+            "__init__.pyw",
+        ) or
+        (lower_name.startswith("__init__.") and
+         (lower_name.endswith(".so") or
+          lower_name.endswith(".pyd") or
+          lower_name.endswith(".fwork")))
+    )
+
+def wheel_layout_from_record(record, data_directory):
+    """Classify the site-packages layout described by a wheel RECORD."""
+    top_levels_set = {}
+    directory_top_levels = {}
+    regular_top_levels = {}
+    record_segments = []
+    dirs_set = {}
+    init_dirs = {}
+    for line in record.splitlines():
+        path = parse_record_path(line)
+        if not path:
+            continue
+        segments = site_packages_segments(path, data_directory)
+        if not segments:
+            continue
+
+        first_segment = segments[0]
+
+        # Some setuptools-family wheels record scripts outside the install
+        # root. These cannot become declared site-packages outputs.
+        if (
+            not first_segment or
+            first_segment in (".", "..") or
+            first_segment.startswith("/")
+        ):
+            continue
+        top_levels_set[first_segment] = True
+        if len(segments) > 1:
+            directory_top_levels[first_segment] = True
+
+        # Single-file modules and directories carrying any conservatively
+        # recognized initializer are regular packages, not PEP 420 namespaces.
+        if len(segments) == 1 or (
+            len(segments) >= 2 and
+            _is_package_initializer(segments[1])
+        ):
+            regular_top_levels[first_segment] = True
+
+        record_segments.append(segments)
+        for i in range(1, len(segments)):
+            dirs_set["/".join(segments[:i])] = True
+        if len(segments) >= 2 and _is_package_initializer(segments[-1]):
+            init_dirs["/".join(segments[:-1])] = True
+
+    namespace_top_levels = sorted([
+        top_level
+        for top_level in top_levels_set
+        if top_level not in regular_top_levels and not top_level.endswith(".dist-info")
+    ])
+    namespace_set = {top_level: True for top_level in namespace_top_levels}
+
+    # Under each namespace, select the shallowest regular-package boundary or
+    # concrete file. Nested namespaces recurse until one of those is reached.
+    namespace_entries_set = {}
+    for segments in record_segments:
+        if segments[0] not in namespace_set or len(segments) < 2:
+            continue
+        for depth in range(2, len(segments) + 1):
+            prefix = "/".join(segments[:depth])
+            if depth == len(segments) or prefix in init_dirs:
+                namespace_entries_set[prefix] = True
+                break
+
+    namespace_dirs, regular_roots = _namespace_dirs_and_roots(
+        dirs_set,
+        init_dirs,
+        namespace_set,
+    )
+    return struct(
+        directory_top_levels = sorted(directory_top_levels.keys()),
+        namespace_dirs = namespace_dirs,
+        namespace_entries = sorted(namespace_entries_set.keys()),
+        namespace_top_levels = namespace_top_levels,
+        regular_roots = regular_roots,
+        top_levels = sorted(top_levels_set.keys()),
+    )
 
 def indent(text, space = " "):
     return "\n".join(["{}{}".format(space, l) for l in text.splitlines()])
@@ -647,8 +688,9 @@ filegroup(
     # wheel, and peeking at them would force a useless download.
     #
     # The sbuild fallback, whose contents are unknowable until build time,
-    # is never peeked at here: it emits no PyWheelsInfo and consumers use
-    # .pth-based resolution.
+    # is never peeked at here and therefore retains no analysis-time
+    # metadata. Consumers preserve the complete wheel through .pth-based
+    # resolution.
     #
     # We read from `whl_files` (a real label_list) rather than `whls` (a
     # JSON-encoded string of labels) because only the former adds the
@@ -667,6 +709,7 @@ filegroup(
         whl_file_index += 1
 
     top_levels_by_whl = {}
+    directory_top_levels_by_whl = {}
     namespace_top_levels_by_whl = {}
     namespace_entries_by_whl = {}
     namespace_dirs_by_whl = {}
@@ -675,57 +718,37 @@ filegroup(
     for target, whl_file_label in whl_file_labels.items():
         if target not in arm_targets:
             continue
-        whl_name, tls, regular, css, ns_entries, dirs_set, init_dirs = _extract_wheel_metadata(
+        whl_name, layout, css = _extract_wheel_metadata(
             repository_ctx,
             whl_file_label,
         )
-        if tls:
-            top_levels_by_whl[whl_name] = sorted(tls.keys())
-
-            # A top-level counts as a PEP 420 namespace for this wheel if
-            # its RECORD shows no `<toplevel>/__init__.py` at depth 1.
-            namespaces = sorted([
-                tl
-                for tl in tls
-                if tl not in regular and not tl.endswith(".dist-info")
-            ])
-            if namespaces:
-                namespace_top_levels_by_whl[whl_name] = namespaces
-                namespace_set = {tl: True for tl in namespaces}
-
-                # Concrete entries beneath this wheel's namespace
-                # top-levels (`jaraco/functools`) — for the per-entry
-                # symlink merge that makes the namespace mypy/pyright
-                # visible.
-                entries = sorted([
-                    entry
-                    for entry in ns_entries
-                    if entry.split("/")[0] in namespace_set
-                ])
-                if entries:
-                    namespace_entries_by_whl[whl_name] = entries
-
-                # Implicit-namespace dir skeleton + minimal regular roots
-                # under this wheel's namespace top-levels — for detecting
-                # a regular package that spans wheels (azure-core case).
-                ndirs, rroots = _namespace_dirs_and_roots(dirs_set, init_dirs, namespace_set)
-                if ndirs:
-                    namespace_dirs_by_whl[whl_name] = ndirs
-                if rroots:
-                    regular_roots_by_whl[whl_name] = rroots
+        if layout.top_levels:
+            top_levels_by_whl[whl_name] = layout.top_levels
+        if layout.directory_top_levels:
+            directory_top_levels_by_whl[whl_name] = layout.directory_top_levels
+        if layout.namespace_top_levels:
+            namespace_top_levels_by_whl[whl_name] = layout.namespace_top_levels
+        if layout.namespace_entries:
+            namespace_entries_by_whl[whl_name] = layout.namespace_entries
+        if layout.namespace_dirs:
+            namespace_dirs_by_whl[whl_name] = layout.namespace_dirs
+        if layout.regular_roots:
+            regular_roots_by_whl[whl_name] = layout.regular_roots
         if css:
-            console_scripts_by_whl[whl_name] = sorted(css.values())
+            console_scripts_by_whl[whl_name] = css
 
     install_attrs = """
     src = ":whl",
     compile_pyc = {compile_pyc},
     pyc_invalidation_mode = {pyc_invalidation_mode},
     top_levels = {top_levels},
+    directory_top_levels = {directory_top_levels},
     namespace_top_levels = {namespace_top_levels},
     console_scripts = {console_scripts},""".format(
         compile_pyc = compile_pyc_select,
         pyc_invalidation_mode = pyc_invalidation_mode_select,
         top_levels = indent(pprint(top_levels_by_whl), " " * 4).lstrip(),
+        directory_top_levels = indent(pprint(directory_top_levels_by_whl), " " * 4).lstrip(),
         namespace_top_levels = indent(pprint(namespace_top_levels_by_whl), " " * 4).lstrip(),
         console_scripts = indent(pprint(console_scripts_by_whl), " " * 4).lstrip(),
     )

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -233,15 +233,19 @@ under `<venv>/bin/<name>` so `subprocess.run(["<name>", ...])` works.
 """,
             default = {},
         ),
+        "directory_top_levels": attr.string_list_dict(
+            doc = "Per-wheel subset of `top_levels` installed as directories.",
+            default = {},
+        ),
         "namespace_top_levels": attr.string_list_dict(
             doc = """Per-wheel subset of `top_levels` that are PEP 420 namespace packages, keyed by wheel file basename.
 
-A top-level is a namespace if the wheel's RECORD shows no
-`<toplevel>/__init__.py`. When multiple wheels contribute to the same
-namespace (e.g. `jaraco-classes` and `jaraco-functools` both claim
-`jaraco`), `py_binary`'s collision detector treats the overlap as
-benign and falls back to `.pth`-based resolution so Python's namespace
-machinery merges the contributions at runtime.
+A top-level is a namespace if the wheel's RECORD shows no recognized package
+initializer directly beneath it. When multiple wheels contribute to the same
+namespace (e.g. `jaraco-classes` and `jaraco-functools` both claim `jaraco`),
+`py_binary`'s collision detector treats the overlap as benign and falls back to
+`.pth`-based resolution so Python's namespace machinery merges the
+contributions at runtime.
 """,
             default = {},
         ),
@@ -249,14 +253,13 @@ machinery merges the contributions at runtime.
             doc = """Per-wheel concrete entries beneath the wheel's `namespace_top_levels`, keyed by wheel file basename.
 
 Each entry is a `/`-joined site-packages-relative path to the shallowest
-non-namespace member: a package directory holding a direct `__init__.py`
-(`jaraco/functools`, `google/cloud/storage` — nested namespaces are
-recursed through), or a plain module / data file (`jaraco/context.py`).
-venv assembly symlinks each entry individually, materialising a merged
-namespace directory in `site-packages/` so tools that inspect it directly
-(mypy, pyright) see every contribution — and its `py.typed` markers —
-without executing `.pth` files. Only the entry matching the selected wheel
-(see `top_levels`) is used.
+non-namespace member: a package directory holding a direct recognized
+initializer (`jaraco/functools`, `google/cloud/storage` — nested namespaces are
+recursed through), or a plain module / data file (`jaraco/context.py`). venv
+assembly symlinks each entry individually, materialising a merged namespace
+directory in `site-packages/` so tools that inspect it directly (mypy, pyright)
+see every contribution — and its `py.typed` markers — without executing `.pth`
+files. Only the entry matching the selected wheel (see `top_levels`) is used.
 """,
             default = {},
         ),
@@ -264,7 +267,7 @@ without executing `.pth` files. Only the entry matching the selected wheel
             doc = """Per-wheel implicit-namespace directory skeleton under the wheel's namespace top-levels, keyed by wheel file basename.
 
 Every directory (as a `/`-joined path relative to site-packages) the wheel
-installs files under without an `__init__.py` anywhere on the path. E.g.
+installs files under without crossing a recognized package initializer. E.g.
 azure-core-tracing-opentelemetry: `["azure/core", "azure/core/tracing",
 "azure/core/tracing/ext"]`. venv assembly cross-references this with other
 wheels' `regular_roots` to find regular packages that span wheels.
@@ -275,11 +278,11 @@ wheels' `regular_roots` to find regular packages that span wheels.
             doc = """Per-wheel minimal regular-package directories under the wheel's namespace top-levels, keyed by wheel file basename.
 
 The shallowest directories (as `/`-joined paths relative to site-packages)
-carrying an `__init__.py`. E.g. azure-core: `["azure/core"]`. When such a
-root shows up in another wheel's `namespace_dirs`, that other wheel grafts
-content inside this regular package — venv assembly must physically merge
-the subtree since Python locks a regular package's `__path__` to one
-directory.
+carrying a recognized package initializer. E.g. azure-core:
+`["azure/core"]`. When such a root shows up in another wheel's
+`namespace_dirs`, that other wheel grafts content inside this regular package —
+venv assembly must physically merge the subtree since Python locks a regular
+package's `__path__` to one directory.
 """,
             default = {},
         ),

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -3,7 +3,7 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//py/private:providers.bzl", "PyWheelsInfo")
-load(":repository.bzl", "compatible_python_tags", "parse_console_script", "parse_record_path", "select_key", "site_packages_segments", "sort_select_arms", "source_specificity")
+load(":repository.bzl", "compatible_python_tags", "parse_console_script", "parse_record_path", "select_key", "site_packages_segments", "sort_select_arms", "source_specificity", "wheel_layout_from_record")
 load(":rule.bzl", "whl_install")
 
 def _whl_sorting_test_impl(ctx):
@@ -143,6 +143,18 @@ def _site_packages_segments_test_impl(ctx):
         data + "/scripts/tool",
         data,
     ))
+    asserts.equals(env, [], site_packages_segments(
+        data + "/headers/pkg/header.h",
+        data,
+    ))
+    asserts.equals(env, [], site_packages_segments(
+        data + "/data/config.json",
+        data,
+    ))
+    asserts.equals(env, ["custom", "pkg", "module.py"], site_packages_segments(
+        data + "/custom/pkg/module.py",
+        data,
+    ))
     return unittest.end(env)
 
 site_packages_segments_test = unittest.make(_site_packages_segments_test_impl)
@@ -188,6 +200,65 @@ def _console_script_test_impl(ctx):
     return unittest.end(env)
 
 console_script_test = unittest.make(_console_script_test_impl)
+
+def _wheel_layout_metadata_test_impl(ctx):
+    env = unittest.begin(ctx)
+    layout = wheel_layout_from_record(
+        "\n".join([
+            # Repository classification deliberately covers possible target
+            # loaders and static tooling, not only the repository host's
+            # active FileFinder suffixes.
+            "top_source/__init__.py,,",
+            "top_pyi/__init__.pyi,,",
+            "top_pyw/__init__.pyw,,",
+            "top_pyc/__init__.pyc,,",
+            "top_case/__INIT__.Py,,",
+            "top_native/__init__.cpython-311-x86_64-linux-gnu.so,,",
+            "namespace/framework_plugin/__INIT__.cpython-314-ios-arm64.FWORK,,",
+            "namespace/pyi_plugin/__init__.pyi,,",
+            "namespace/pyw_plugin/__init__.pyw,,",
+            "namespace/pyc_plugin/__init__.pyc,,",
+            "namespace/native_plugin/__init__.abi3.so,,",
+            "namespace/windows_plugin/__init__.cp311-win_amd64.pyd,,",
+            "namespace/plain/module.py,,",
+            "demo-1.0.dist-info/RECORD,,",
+        ]),
+        "demo-1.0.data",
+    )
+
+    asserts.equals(env, [
+        "demo-1.0.dist-info",
+        "namespace",
+        "top_case",
+        "top_native",
+        "top_pyc",
+        "top_pyi",
+        "top_pyw",
+        "top_source",
+    ], layout.top_levels)
+    asserts.equals(env, layout.top_levels, layout.directory_top_levels)
+    asserts.equals(env, ["namespace"], layout.namespace_top_levels)
+    asserts.equals(env, [
+        "namespace/framework_plugin",
+        "namespace/native_plugin",
+        "namespace/plain/module.py",
+        "namespace/pyc_plugin",
+        "namespace/pyi_plugin",
+        "namespace/pyw_plugin",
+        "namespace/windows_plugin",
+    ], layout.namespace_entries)
+    asserts.equals(env, ["namespace/plain"], layout.namespace_dirs)
+    asserts.equals(env, [
+        "namespace/framework_plugin",
+        "namespace/native_plugin",
+        "namespace/pyc_plugin",
+        "namespace/pyi_plugin",
+        "namespace/pyw_plugin",
+        "namespace/windows_plugin",
+    ], layout.regular_roots)
+    return unittest.end(env)
+
+wheel_layout_metadata_test = unittest.make(_wheel_layout_metadata_test_impl)
 
 # --- whl_install metadata selection ---------------------------------------
 #
@@ -370,4 +441,8 @@ def whl_install_suite():
     unittest.suite(
         "console_script_tests",
         console_script_test,
+    )
+    unittest.suite(
+        "wheel_layout_metadata_tests",
+        wheel_layout_metadata_test,
     )


### PR DESCRIPTION
Plumb two pieces of descriptive metadata through repository-phase
extraction for downstream venv analysis:

  * `directory_top_levels`: the subset of each wheel's top-levels that
    install as directories (vs single-file modules), exposed as a new
    `whl_install` attr.
  * console_scripts is now emitted for every active wheel, including an
    empty list, so a consumer can distinguish a wheel with no scripts
    from one whose metadata was never extracted.

Neither has a consumer yet; this is groundwork. Regenerates the affected
BUILD snapshots.

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
