### PR TITLE
fix(uv): key wheel metadata by basename and decode %2B local versions

### DIFF
--- a/e2e/cases/uv-plus-version/BUILD.bazel
+++ b/e2e/cases/uv-plus-version/BUILD.bazel
@@ -1,4 +1,18 @@
 load("@aspect_rules_py//py:defs.bzl", "py_test")
+load(":metadata_test.bzl", "wheel_metadata_test")
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@llvm//constraints/libc:gnu.2.28",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    flags = [
+        "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
+        "--@aspect_rules_py//uv/private/constraints/platform:platform_version=2.39",
+    ],
+)
 
 py_test(
     name = "test",
@@ -10,6 +24,16 @@ py_test(
         "@pypi_uv_plus_version//jaxlib",
         "@pypi_uv_plus_version//metomi_isodatetime",
     ],
+)
+
+wheel_metadata_test(
+    name = "literal_plus_metadata_test",
+    target_under_test = "@whl_install__plus_version__jaxlib__0_4_25_cuda11_cudnn86//:install",
+)
+
+wheel_metadata_test(
+    name = "encoded_plus_metadata_test",
+    target_under_test = "@whl_install__plus_version_encoded__jaxlib__0_4_25_cuda11_cudnn86//:install",
 )
 
 py_test(

--- a/e2e/cases/uv-plus-version/metadata_test.bzl
+++ b/e2e/cases/uv-plus-version/metadata_test.bzl
@@ -1,0 +1,28 @@
+"""Analysis test for wheel metadata across equivalent URL spellings."""
+
+load("@aspect_rules_py//py/private:providers.bzl", "PyWheelsInfo")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+_PYTHON_VERSION_FLAG = str(Label("@aspect_rules_py//py/private/interpreter:python_version"))
+_RULES_PYTHON_VERSION_FLAG = str(Label("@rules_python//python/config_settings:python_version"))
+_TARGET_PLATFORM = str(Label("//cases/uv-plus-version:linux_x86_64"))
+
+def _wheel_metadata_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    asserts.true(env, PyWheelsInfo in target)
+    if PyWheelsInfo in target:
+        wheels = target[PyWheelsInfo].wheels.to_list()
+        asserts.equals(env, 1, len(wheels))
+        if wheels:
+            asserts.true(env, "jaxlib" in wheels[0].top_levels)
+    return analysistest.end(env)
+
+wheel_metadata_test = analysistest.make(
+    _wheel_metadata_test_impl,
+    config_settings = {
+        "//command_line_option:platforms": _TARGET_PLATFORM,
+        _PYTHON_VERSION_FLAG: "3.12",
+        _RULES_PYTHON_VERSION_FLAG: "3.12",
+    },
+)

--- a/e2e/cases/uv-plus-version/pyproject-encoded.toml
+++ b/e2e/cases/uv-plus-version/pyproject-encoded.toml
@@ -1,0 +1,11 @@
+[project]
+name = "plus-version-encoded"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+    "jaxlib",
+]
+
+[[tool.uv.index]]
+url = "https://storage.googleapis.com/jax-releases/jax_cuda_releases.html"
+format = "flat"

--- a/e2e/cases/uv-plus-version/setup.MODULE.bazel
+++ b/e2e/cases/uv-plus-version/setup.MODULE.bazel
@@ -8,3 +8,13 @@ uv.project(
     pyproject = "//cases/uv-plus-version:pyproject.toml",
 )
 use_repo(uv, "pypi_uv_plus_version")
+use_repo(uv, "whl_install__plus_version__jaxlib__0_4_25_cuda11_cudnn86")
+
+uv.declare_hub(hub_name = "pypi_uv_encoded_plus_version")
+uv.project(
+    hub_name = "pypi_uv_encoded_plus_version",
+    lock = "//cases/uv-plus-version:uv-encoded.lock",
+    pyproject = "//cases/uv-plus-version:pyproject-encoded.toml",
+)
+use_repo(uv, "pypi_uv_encoded_plus_version")
+use_repo(uv, "whl_install__plus_version_encoded__jaxlib__0_4_25_cuda11_cudnn86")

--- a/e2e/cases/uv-plus-version/uv-encoded.lock
+++ b/e2e/cases/uv-plus-version/uv-encoded.lock
@@ -1,0 +1,24 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "jaxlib"
+version = "0.4.25+cuda11.cudnn86"
+source = { registry = "https://storage.googleapis.com/jax-releases/jax_cuda_releases.html" }
+wheels = [
+    { url = "https://storage.googleapis.com/jax-releases/cuda11/jaxlib-0.4.25%2Bcuda11.cudnn86-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:b70dc64da9d8e0f13b07b34a053d8ae904f72d96bfc17c343af3056b8ab5ad93", size = 130366058 },
+]
+
+[[package]]
+name = "plus-version-encoded"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "jaxlib" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jaxlib" },
+]

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -473,12 +473,12 @@ def _parse_projects(module_ctx, hub_specs):
                         #
                         # Derive both halves from the wheel filename: it and
                         # the dist-info dir share the build backend's escaping,
-                        # so `1.0+cu118` correctly yields `1.0_cu118` and the
-                        # build tag (absent from dist-info) is dropped.
+                        # and URL-encoded `+` is literal in the archive member.
+                        # The build tag (absent from dist-info) is dropped.
                         whl_name = parse_whl_name(basename)
                         candidate = "{}-{}.dist-info".format(
                             whl_name.project,
-                            whl_name.version,
+                            whl_name.version.replace("%2B", "+").replace("%2b", "+"),
                         )
                         if metadata_directory != None and candidate != metadata_directory:
                             fail("wheel metadata directory mismatch for {}: {} vs {}".format(

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -294,7 +294,7 @@ def _extract_wheel_metadata(repository_ctx, whl_label):
             # Normalise to "name=module:func" so downstream parsing is trivial.
             console_scripts[name] = "{}={}".format(name, target)
 
-    return top_levels_set, regular_top_levels, console_scripts, namespace_entries, dirs_set, init_dirs
+    return whl_path.basename, top_levels_set, regular_top_levels, console_scripts, namespace_entries, dirs_set, init_dirs
 
 def _namespace_dirs_and_roots(dirs_set, init_dirs, namespace_top_levels_set):
     """Split a wheel's directory skeleton into the implicit-namespace dirs
@@ -639,7 +639,7 @@ filegroup(
     # JSON-encoded string of labels) because only the former adds the
     # wheel repos to our visibility so `rctx.path(Label(...))` can
     # resolve. `whl_files` mirrors the truthy `whls` values in order, so
-    # pair them up by index to recover the filename ↔ label association.
+    # pair them up by index to recover the target ↔ label association.
     # Both lists are generated together by the hub rule from the same
     # source data, so the ordering invariant is maintained at the point
     # of production and does not depend on runtime dict iteration order.
@@ -657,12 +657,12 @@ filegroup(
     namespace_dirs_by_whl = {}
     regular_roots_by_whl = {}
     console_scripts_by_whl = {}
-    for whl_name, target in prebuilds.items():
-        if not target or target not in arm_targets:
+    for target, whl_file_label in whl_file_labels.items():
+        if target not in arm_targets:
             continue
-        tls, regular, css, ns_entries, dirs_set, init_dirs = _extract_wheel_metadata(
+        whl_name, tls, regular, css, ns_entries, dirs_set, init_dirs = _extract_wheel_metadata(
             repository_ctx,
-            whl_file_labels[target],
+            whl_file_label,
         )
         if tls:
             top_levels_by_whl[whl_name] = sorted(tls.keys())


### PR DESCRIPTION
For a local-version wheel like `jaxlib-0.4.25+cuda11.cudnn86`, the URL (and downloaded filename) carries `%2B` while the `.dist-info` directory uses a literal `+`. Two problems followed: the dist-info prefix derived from the wheel name never matched, and metadata was keyed by the `prebuilds` dict key rather than the actual downloaded basename — so the consumer's `ctx.file.src.basename` lookup missed and the wheel silently got no PyWheelsInfo.

Decode `%2B`/`%2b` to `+` when deriving the dist-info prefix, and key the extracted metadata by `whl_path.basename` (iterating `whl_file_labels` directly). Both spellings are exercised by the uv-plus-version e2e metadata tests.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
