### PR TITLE
fix(py): support dotted console entry points

### DIFF
--- a/e2e/cases/venv-bin-scripts-423/BUILD.bazel
+++ b/e2e/cases/venv-bin-scripts-423/BUILD.bazel
@@ -8,6 +8,7 @@ py_test(
     python_version = "3.11",
     deps = [
         "@pypi_venv_bin_scripts_423//dice",
+        "@pypi_venv_bin_scripts_423//invoke",
     ],
 )
 
@@ -20,6 +21,7 @@ py_test(
     python_version = "3.11",
     deps = [
         "@pypi_venv_bin_scripts_423//dice",
+        "@pypi_venv_bin_scripts_423//invoke",
     ],
 )
 
@@ -33,5 +35,6 @@ py_test(
     python_version = "3.11",
     deps = [
         "@pypi_venv_bin_scripts_423//dice",
+        "@pypi_venv_bin_scripts_423//invoke",
     ],
 )

--- a/e2e/cases/venv-bin-scripts-423/__test__.py
+++ b/e2e/cases/venv-bin-scripts-423/__test__.py
@@ -41,5 +41,24 @@ assert output.startswith("[") and output.endswith("]"), (
 value = int(output[1:-1])
 assert 1 <= value <= 6, f"Expected roll result 1-6, got {value}"
 
+invoke_script = os.path.join(bin_dir, "invoke")
+assert os.path.exists(invoke_script), f"Expected 'invoke' script at {invoke_script}"
+assert os.access(invoke_script, os.X_OK), (
+    f"'invoke' script at {invoke_script} is not executable"
+)
+
+# Invoke publishes `invoke.main:program.run`, which requires resolving the
+# dotted object path after importing the module.
+invoke_result = subprocess.run(
+    [invoke_script, "--version"],
+    capture_output=True,
+    text=True,
+)
+assert invoke_result.returncode == 0, (
+    f"'invoke --version' failed with rc={invoke_result.returncode}: "
+    f"{invoke_result.stderr}"
+)
+assert invoke_result.stdout.strip() == "Invoke 2.2.0", invoke_result.stdout
+
 print(f"roll 1d6 = {value}")
 print("All venv bin script tests passed.")

--- a/e2e/cases/venv-bin-scripts-423/pyproject.toml
+++ b/e2e/cases/venv-bin-scripts-423/pyproject.toml
@@ -1,7 +1,9 @@
 [project]
 name = "venv-bin-scripts-423"
 version = "0.0.0"
+requires-python = ">=3.11"
 authors = []
 dependencies = [
     "dice",
+    "invoke==2.2.0",
 ]

--- a/e2e/cases/venv-bin-scripts-423/uv.lock
+++ b/e2e/cases/venv-bin-scripts-423/uv.lock
@@ -15,6 +15,15 @@ wheels = [
 ]
 
 [[package]]
+name = "invoke"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/42/127e6d792884ab860defc3f4d80a8f9812e48ace584ffc5a346de58cdc6c/invoke-2.2.0.tar.gz", hash = "sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5", size = 299835, upload-time = "2023-07-12T18:05:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/66/7f8c48009c72d73bc6bbe6eb87ac838d6a526146f7dab14af671121eb379/invoke-2.2.0-py3-none-any.whl", hash = "sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820", size = 160274, upload-time = "2023-07-12T18:05:16.294Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -29,7 +38,11 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dice" },
+    { name = "invoke" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "dice" }]
+requires-dist = [
+    { name = "dice" },
+    { name = "invoke", specifier = "==2.2.0" },
+]

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -44,10 +44,12 @@ load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
 # tokenisation quirks with `$` in strings, and the inline Python is short
 # enough that not having a real `__file__` doesn't matter in practice.
 # `"$@"` preserves the original argv, while sys.argv[0] is patched so the
-# called function sees the script's own name.
+# called function sees the script's own name. Entry-point object references
+# may contain dotted attributes:
+# https://packaging.python.org/en/latest/specifications/entry-points/#data-model
 _CONSOLE_SCRIPT_TEMPLATE = """\
 #!/bin/sh
-exec "$(dirname "$0")/python" -c 'import sys; from {module} import {func}; sys.argv[0] = "{name}"; sys.exit({func}())' "$@"
+exec "$(dirname "$0")/python" -c 'import sys; from importlib import import_module; from operator import attrgetter; sys.argv[0] = "{name}"; sys.exit(attrgetter("{func}")(import_module("{module}"))())' "$@"
 """
 
 def _dict_to_exports(env):

--- a/py/tests/console-scripts/BUILD.bazel
+++ b/py/tests/console-scripts/BUILD.bazel
@@ -1,4 +1,35 @@
-load("//py:defs.bzl", "py_test")
+load("//py:defs.bzl", "py_test", "py_unpacked_wheel")
+
+genrule(
+    name = "dotted_entry_wheel",
+    srcs = [
+        "dotted_entry/METADATA",
+        "dotted_entry/RECORD",
+        "dotted_entry/WHEEL",
+        "dotted_entry/dotted_entry.py",
+        "dotted_entry/entry_points.txt",
+    ],
+    outs = ["dotted_entry-1.0-py3-none-any.whl"],
+    cmd = " ".join([
+        "$(execpath @bazel_tools//tools/zip:zipper) c $@",
+        "dotted_entry.py=$(execpath dotted_entry/dotted_entry.py)",
+        "dotted_entry-1.0.dist-info/METADATA=$(execpath dotted_entry/METADATA)",
+        "dotted_entry-1.0.dist-info/RECORD=$(execpath dotted_entry/RECORD)",
+        "dotted_entry-1.0.dist-info/WHEEL=$(execpath dotted_entry/WHEEL)",
+        "dotted_entry-1.0.dist-info/entry_points.txt=$(execpath dotted_entry/entry_points.txt)",
+    ]),
+    tools = ["@bazel_tools//tools/zip:zipper"],
+)
+
+py_unpacked_wheel(
+    name = "dotted_entry",
+    src = ":dotted_entry-1.0-py3-none-any.whl",
+    console_scripts = ["Dotted-Entry=dotted_entry:Commands.main"],
+    top_levels = [
+        "dotted_entry.py",
+        "dotted_entry-1.0.dist-info",
+    ],
+)
 
 # Exercises the console-script wrappers that py_binary/py_test generate under
 # <venv>/bin/<name> from each wheel's `[console_scripts]` entry points, and
@@ -13,6 +44,7 @@ py_test(
     name = "test_console_scripts",
     srcs = ["test_console_scripts.py"],
     deps = [
+        ":dotted_entry",
         # cowsay declares a `cowsay` console-script entry point in its wheel.
         "@pypi//cowsay",
     ],

--- a/py/tests/console-scripts/dotted_entry/METADATA
+++ b/py/tests/console-scripts/dotted_entry/METADATA
@@ -1,0 +1,3 @@
+Metadata-Version: 2.1
+Name: dotted-entry
+Version: 1.0

--- a/py/tests/console-scripts/dotted_entry/RECORD
+++ b/py/tests/console-scripts/dotted_entry/RECORD
@@ -1,0 +1,5 @@
+dotted_entry.py,sha256=1otdYi8bc_ljkbVF5maqrgEvhmDMNvzFP5q6HnkBdCw,87
+dotted_entry-1.0.dist-info/METADATA,sha256=R4SoWdXK2gk7omb2MYcApaufu-iNxTNuOPpvNVgrrHI,54
+dotted_entry-1.0.dist-info/WHEEL,sha256=_mQ6jtC77-3EcDTQBBtO_NF0NRaY-kXDCADucF4Pzr0,84
+dotted_entry-1.0.dist-info/entry_points.txt,sha256=ySujkBYAdwWKkXOM3AAdUBFRuQnZ9V_e-dyKrlNROjw,60
+dotted_entry-1.0.dist-info/RECORD,,

--- a/py/tests/console-scripts/dotted_entry/WHEEL
+++ b/py/tests/console-scripts/dotted_entry/WHEEL
@@ -1,0 +1,4 @@
+Wheel-Version: 1.0
+Generator: rules_py test
+Root-Is-Purelib: true
+Tag: py3-none-any

--- a/py/tests/console-scripts/dotted_entry/dotted_entry.py
+++ b/py/tests/console-scripts/dotted_entry/dotted_entry.py
@@ -1,0 +1,4 @@
+class Commands:
+    @staticmethod
+    def main():
+        print("dotted-entry-worked")

--- a/py/tests/console-scripts/dotted_entry/entry_points.txt
+++ b/py/tests/console-scripts/dotted_entry/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+Dotted-Entry = dotted_entry:Commands.main

--- a/py/tests/console-scripts/test_console_scripts.py
+++ b/py/tests/console-scripts/test_console_scripts.py
@@ -44,6 +44,22 @@ class ConsoleScriptsTest(unittest.TestCase):
         )
         self.assertIn("subprocess-invocation-worked", result.stdout)
 
+    def test_wrapper_invokes_dotted_entry_point(self):
+        result = subprocess.run(
+            ["Dotted-Entry"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            "dotted wrapper failed: stdout={!r} stderr={!r}".format(
+                result.stdout, result.stderr
+            ),
+        )
+        self.assertEqual("dotted-entry-worked\n", result.stdout)
+
 
 if __name__ == "__main__":
     sys.exit(unittest.main())

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -116,6 +116,7 @@ def install_wheel(version_major, version_minor, into, wheel_path):
 
     for ep_path in site_packages.glob("*.dist-info/entry_points.txt"):
         cp = configparser.ConfigParser(strict=False)
+        cp.optionxform = str
         cp.read(str(ep_path), encoding="utf-8")
         for section in ("console_scripts", "gui_scripts"):
             if section not in cp:
@@ -123,13 +124,23 @@ def install_wheel(version_major, version_minor, into, wheel_path):
             for raw_name, raw_ep in cp[section].items():
                 module, _, func_extras = raw_ep.strip().partition(":")
                 func = func_extras.split("[")[0].strip()
-                script_path = bin_dir / raw_name.strip()
+                name = raw_name.strip()
+                module = module.strip()
+                if not name or not module or not func:
+                    continue
+                script_path = bin_dir / name
+                # Entry-point object references may contain dotted attributes:
+                # https://packaging.python.org/en/latest/specifications/entry-points/#data-model
                 wrapper = (
                     _RELOCATABLE_SHEBANG
                     + "# -*- coding: utf-8 -*-\n"
-                    + "import re\nimport sys\n"
-                    + "from {} import {}\n".format(module.strip(), func)
-                    + "sys.exit({}())\n".format(func)
+                    + "import sys\n"
+                    + "from importlib import import_module\n"
+                    + "from operator import attrgetter\n"
+                    + "sys.exit(attrgetter({!r})(import_module({!r}))())\n".format(
+                        func,
+                        module,
+                    )
                 )
                 _write_executable(script_path, wrapper.encode())
                 installed.append(script_path)

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -1,8 +1,10 @@
+import hashlib
 import shutil
 import subprocess
 import sys
 import tempfile
 import zipfile
+from base64 import urlsafe_b64encode
 from pathlib import Path
 
 
@@ -12,16 +14,47 @@ def _write_member(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
     archive.writestr(info, data)
 
 
+def _write_wheel(path: Path, distribution: str, members: dict[str, bytes]) -> None:
+    dist_info = f"{distribution}-1.0.dist-info"
+    members = dict(members)
+    members[f"{dist_info}/METADATA"] = (
+        "Metadata-Version: 2.1\n"
+        f"Name: {distribution.replace('_', '-')}\n"
+        "Version: 1.0\n"
+    ).encode()
+    members[f"{dist_info}/WHEEL"] = (
+        "Wheel-Version: 1.0\n"
+        "Generator: rules_py test\n"
+        "Root-Is-Purelib: true\n"
+        "Tag: py3-none-any\n"
+    ).encode()
+    record_path = f"{dist_info}/RECORD"
+    record = []
+    for name, data in sorted(members.items()):
+        digest = urlsafe_b64encode(hashlib.sha256(data).digest()).decode().rstrip("=")
+        record.append(f"{name},sha256={digest},{len(data)}")
+    record.append(f"{record_path},,")
+    members[record_path] = ("\n".join(record) + "\n").encode()
+
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in members.items():
+            _write_member(archive, name, data)
+
+
 def _build_wheel(path: Path, *, legacy_syntax: bool) -> None:
     body = (
         b"raise RuntimeError, None, None\n"
         if legacy_syntax
         else b"def f():\n    return 1\n"
     )
-    with zipfile.ZipFile(path, "w") as archive:
-        _write_member(archive, "fixture/__init__.py", b"VALUE = 1\n")
-        _write_member(archive, "fixture/mod.py", body)
-        _write_member(archive, "fixture-1.0.dist-info/RECORD", b"")
+    _write_wheel(
+        path,
+        "fixture",
+        {
+            "fixture/__init__.py": b"VALUE = 1\n",
+            "fixture/mod.py": body,
+        },
+    )
 
 
 def _run_unpack(
@@ -104,6 +137,46 @@ def main() -> None:
         )
         assert failed.returncode != 0, "expected child interpreter failure"
         assert "CalledProcessError" in failed.stderr
+
+        entry_point_wheel = root / "entry_point-1.0-py3-none-any.whl"
+        _write_wheel(
+            entry_point_wheel,
+            "entry_point",
+            {
+                "fixture/__init__.py": b"class Commands:\n"
+                b"    @staticmethod\n"
+                b"    def main():\n"
+                b"        return 0\n",
+                "entry_point-1.0.dist-info/entry_points.txt": (
+                    b"[console_scripts]\n"
+                    b"Fixture-Cli = fixture:Commands.main [extra]\n"
+                ),
+            },
+        )
+
+        entry_point_out = root / "entry-point"
+        entry_point = _run_unpack(
+            unpack,
+            entry_point_wheel,
+            entry_point_out,
+            Path(sys.executable),
+        )
+        assert entry_point.returncode == 0, entry_point.stderr
+        assert {entry.name for entry in (entry_point_out / "bin").iterdir()} == {
+            "Fixture-Cli",
+        }, "console-script name was not preserved"
+        script = entry_point_out / "bin" / "Fixture-Cli"
+        site_packages = (
+            entry_point_out
+            / "lib"
+            / f"python{sys.version_info.major}.{sys.version_info.minor}"
+            / "site-packages"
+        )
+        subprocess.run(
+            [sys.executable, str(script)],
+            check=True,
+            env={"PYTHONPATH": str(site_packages)},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Entry-point object references may address a dotted attribute, and script
names are case-sensitive. Installed-wheel and generated-venv wrappers
currently render `from module import object`, which is invalid when the
object contains a dot; `ConfigParser` also lowercases installed script
names by default.

Preserve names while parsing `entry_points.txt` and resolve objects with
`import_module` plus `attrgetter` in both wrapper paths. Continue ignoring
legacy extras as before.