### PR TITLE
feat(uv): declare source-built scripts

### DIFF
--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -10,7 +10,10 @@ There are three kinds of overrides:
 - **Pre-build patches** (`pre_build_patches`): Patch the extracted source distribution before building a wheel. Useful for fixing build scripts or source code.
 - **Post-install patches** (`post_install_patches`): Patch the installed package tree after wheel unpacking. Useful for fixing installed library code.
 
-Additionally, `extra_deps` and `extra_data` allow adding dependencies or data files to the generated `py_library` target for a package.
+Additionally, `extra_deps` and `extra_data` allow adding dependencies or data
+files to the generated `py_library` target for a package.
+`console_scripts` declares the complete script map for a wheel built from an
+sdist so venv assembly can create wrappers during analysis.
 
 ## Prerequisites
 
@@ -177,6 +180,8 @@ uv.override_package(
 - Each `(lock, name, version)` triple may only have one `override_package` declaration. Duplicates are an error.
 - `target` is mutually exclusive with all other modification attributes. Use `target` for full replacement OR the patch/modification attributes, not both.
 - The `version` attribute is optional and defaults to whatever version the lockfile resolves.
+- `console_scripts` applies only when the lock record has a source
+  distribution. Prebuilt wheels use their inspected metadata.
 - Pre-build patches only apply to packages that have a source distribution in the lockfile. If a package only has pre-built wheels, `pre_build_patches` has no effect.
 
 ## Future work

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -334,6 +334,30 @@ An sdist (if available) will be built into a wheel for installation if no wheels
 are available, or no wheels matching the target configuration are found. Sdist
 builds occur using the configured Python and Cc toolchains.
 
+### Declaring source-built console scripts
+
+Downloaded wheels expose their console scripts while repositories are
+generated. A wheel built from an sdist does not exist until execution, after
+analysis has already assembled console-script wrappers. Declare the complete,
+nonempty script map on that package's override:
+
+```starlark
+uv.override_package(
+    lock = "//:uv.lock",
+    name = "example-package",
+    console_scripts = {
+        "example": "example_package.cli:main",
+    },
+)
+```
+
+The optional `version` on `override_package` follows the existing override
+rules: omit it when the lock resolves one version of the package. The
+declaration is attached only to the source-build select arm. If a prebuilt
+wheel is selected instead, its inspected metadata remains authoritative. The
+package layout remains unknown at analysis time, so the complete source-built
+wheel still participates in the normal `.pth` fallback.
+
 ## Best practices
 
 **Consolidate your hubs**. In `rules_python`, environments with multiple depsets
@@ -456,11 +480,10 @@ some key information. Such as what requirements apply when performing sdist
 builds. Annotations are the current workaround for how to associate such
 required but nonstandardized and missing dependency data with requirements.
 
-**Why aren't entrypoints automatically created?** `pip.parse` performs library
-installs at repository time, which allows it to inspect the installed files and
-detect entrypoints. Because uv does installs using normal build actions it has
-no way to see what binaries may be created or what `.dist-info/entry_points.txt`
-records exist.
+**Why aren't entrypoints automatically created?** Downloaded-wheel entrypoints
+are discovered while repositories are generated. Source-built wheels do not
+exist until execution, so declare their console scripts with
+`uv.override_package(console_scripts = {...})`.
 
 If you need a given entrypoint as a Bazel target, it needs to be manually
 declared. In most cases of normal entrypoints this is quite easy. Tools like

--- a/e2e/cases/pth-install-tree-fallback/BUILD.bazel
+++ b/e2e/cases/pth-install-tree-fallback/BUILD.bazel
@@ -65,6 +65,7 @@ py_unpacked_wheel(
     # site-packages exactly as uv's whl_install would.
     top_levels = [
         "apkg",
+        "itfa-1.0.dist-info",
         "shared",
         "marker.pth",
     ],
@@ -75,6 +76,7 @@ py_unpacked_wheel(
     src = ":itfb-1.0-py3-none-any.whl",
     top_levels = [
         "bpkg",
+        "itfb-1.0.dist-info",
         "shared",
         "marker.pth",
     ],

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -25,7 +25,10 @@ py_unpacked_wheel(
     name = "jaraco_functools_no_entries",
     src = "@pypi_pth_namespace_547//jaraco_functools:whl",
     namespace_top_levels = ["jaraco"],
-    top_levels = ["jaraco"],
+    top_levels = [
+        "jaraco",
+        "jaraco_functools-4.4.0.dist-info",
+    ],
 )
 
 py_test(

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -41,9 +41,9 @@ py_test(
 )
 
 # Regression gate for assemble_venv's non-keyed `_format_imp` branch.
-# `py_unpacked_wheel` without `top_levels` emits no PyWheelsInfo, so
-# setuptools' root `distutils-precedence.pth` is only reachable via
-# the wheel's own site-packages — that branch must use
+# `py_unpacked_wheel` without `top_levels` carries an unknown layout, so
+# setuptools' root `distutils-precedence.pth` is only reachable via the
+# wheel's own site-packages — that branch must use
 # `site.addsitedir` (not a plain path entry) or `_distutils_hack`
 # never lands in `sys.modules` at site-init.
 py_unpacked_wheel(

--- a/e2e/cases/uv-sdist-fallback/BUILD.bazel
+++ b/e2e/cases/uv-sdist-fallback/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_image_layer", "py_test")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 # Regression coverage for the sdist-fallback behavior preserved by the
 # "always keep sdist fallbacks when sources exist" fix. cowsay 6.0 has both
@@ -14,4 +15,47 @@ py_test(
     deps = [
         "@pypi_sdist_fallback//cowsay",
     ],
+)
+
+# Repository analysis cannot inspect source-built cowsay's wheel metadata.
+# Image layering must still discover its install tree through PyWheelsInfo.
+py_binary(
+    name = "image_bin",
+    testonly = True,
+    srcs = ["__test__.py"],
+    dep_group = "uv_sdist_fallback",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = ["@pypi_sdist_fallback//cowsay"],
+)
+
+py_image_layer(
+    name = "image_layers",
+    testonly = True,
+    binary = ":image_bin",
+)
+
+filegroup(
+    name = "image_dependency_layers",
+    testonly = True,
+    srcs = [":image_layers"],
+    output_group = "deps",
+)
+
+genrule(
+    name = "source_wheel_image_contents",
+    testonly = True,
+    srcs = [":image_dependency_layers"],
+    outs = ["source_wheel_image_contents.txt"],
+    cmd = """
+for layer in $(SRCS); do
+  $(BSDTAR_BIN) -tf "$$layer"
+done | grep -F '/site-packages/cowsay/__init__.py' > $@
+""",
+    toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
+)
+
+build_test(
+    name = "source_wheel_image_test",
+    targets = [":source_wheel_image_contents"],
 )

--- a/e2e/cases/uv-sdist-fallback/__test__.py
+++ b/e2e/cases/uv-sdist-fallback/__test__.py
@@ -6,8 +6,28 @@ package can be built from source. Importing and exercising cowsay verifies
 the sdist build pathway end-to-end.
 """
 
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
 import cowsay
 
 output = cowsay.get_output_string("cow", "sdist fallback works!")
 assert "sdist fallback works!" in output
+marker = "declared console script works"
+wrapper = shutil.which("cowsay")
+assert wrapper is not None, "cowsay wrapper is absent from PATH"
+expected_wrapper = Path(os.environ["VIRTUAL_ENV"]) / "bin" / "cowsay"
+assert Path(wrapper).resolve() == expected_wrapper.resolve(), (
+    wrapper,
+    expected_wrapper,
+)
+result = subprocess.run(
+    [wrapper, "--text", marker],
+    check=True,
+    capture_output=True,
+    text=True,
+)
+assert marker in result.stdout
 print("cowsay imported from sdist: OK")

--- a/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
@@ -18,6 +18,7 @@ uv.project(
 )
 uv.override_package(
     name = "cowsay",
+    console_scripts = {"cowsay": "cowsay.__main__:cli"},
     lock = "//cases/uv-sdist-fallback:uv.lock",
     monitor_memory = True,
 )

--- a/e2e/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
+++ b/e2e/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
@@ -1,7 +1,15 @@
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
-load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "source_built_wheel", "whl_install")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+
+source_built_wheel(
+    name = "source_built_wheel",
+    src = "@@aspect_rules_py++uv+sdist_build__abi3_compat__cffi__2_0_0//:whl",
+    console_scripts = [],
+    visibility = ["//visibility:private"],
+)
+
 
 select_chain(
    name = "whl",
@@ -20,7 +28,7 @@ select_chain(
         "@aspect_rules_py_pip_configurations//:cp312-win_amd64-cp312": "@whl__cffi__da68248800ad6320//file",
         "@aspect_rules_py_pip_configurations//:cp312-win_arm64-cp312": "@whl__cffi__4671d9dd5ec934cb//file"
    },
-   default_target = "@@aspect_rules_py++uv+sdist_build__abi3_compat__cffi__2_0_0//:whl",
+   default_target = ":source_built_wheel",
    visibility = ["//visibility:public"],
 )
 

--- a/e2e/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
+++ b/e2e/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
@@ -1,7 +1,15 @@
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
-load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "source_built_wheel", "whl_install")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+
+source_built_wheel(
+    name = "source_built_wheel",
+    src = "@@aspect_rules_py++uv+sdist_build__abi3_compat__cryptography__46_0_5//:whl",
+    console_scripts = [],
+    visibility = ["//visibility:private"],
+)
+
 
 select_chain(
    name = "whl",
@@ -189,7 +197,7 @@ select_chain(
         "@aspect_rules_py_pip_configurations//:cp38-win32-abi3": "@whl__cryptography__02f547fce831f509//file",
         "@aspect_rules_py_pip_configurations//:cp38-win_amd64-abi3": "@whl__cryptography__556e106ee01aa134//file"
    },
-   default_target = "@@aspect_rules_py++uv+sdist_build__abi3_compat__cryptography__46_0_5//:whl",
+   default_target = ":source_built_wheel",
    visibility = ["//visibility:public"],
 )
 

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
@@ -1,14 +1,22 @@
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
-load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "source_built_wheel", "whl_install")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+
+source_built_wheel(
+    name = "source_built_wheel",
+    src = "@@aspect_rules_py++uv+sdist_build__azure_core_tracing_import__azure_core__1_38_0//:whl",
+    console_scripts = [],
+    visibility = ["//visibility:private"],
+)
+
 
 select_chain(
    name = "whl",
    arms = {
         "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__azure_core__ab0c9b2cd71fecb1//file"
    },
-   default_target = "@@aspect_rules_py++uv+sdist_build__azure_core_tracing_import__azure_core__1_38_0//:whl",
+   default_target = ":source_built_wheel",
    visibility = ["//visibility:public"],
 )
 

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
@@ -1,14 +1,22 @@
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
-load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "source_built_wheel", "whl_install")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+
+source_built_wheel(
+    name = "source_built_wheel",
+    src = "@@aspect_rules_py++uv+sdist_build__azure_core_tracing_import__azure_core_tracing_opentelemetry__1_0_0b11//:whl",
+    console_scripts = [],
+    visibility = ["//visibility:private"],
+)
+
 
 select_chain(
    name = "whl",
    arms = {
         "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__azure_core_tracing_opentelemetry__016cefcaff2900fb//file"
    },
-   default_target = "@@aspect_rules_py++uv+sdist_build__azure_core_tracing_import__azure_core_tracing_opentelemetry__1_0_0b11//:whl",
+   default_target = ":source_built_wheel",
    visibility = ["//visibility:public"],
 )
 

--- a/e2e/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
+++ b/e2e/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
@@ -1,7 +1,15 @@
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
-load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "source_built_wheel", "whl_install")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+
+source_built_wheel(
+    name = "source_built_wheel",
+    src = "@@aspect_rules_py++uv+sdist_build__uv_bare_linux_wheels__grpcio__1_80_0//:whl",
+    console_scripts = [],
+    visibility = ["//visibility:private"],
+)
+
 
 select_chain(
    name = "whl",
@@ -47,7 +55,7 @@ select_chain(
         "@aspect_rules_py_pip_configurations//:cp311-win32-cp311": "@whl__grpcio__51b4a7189b0bef2a//file",
         "@aspect_rules_py_pip_configurations//:cp311-win_amd64-cp311": "@whl__grpcio__02e64bb0bb2da14d//file"
    },
-   default_target = "@@aspect_rules_py++uv+sdist_build__uv_bare_linux_wheels__grpcio__1_80_0//:whl",
+   default_target = ":source_built_wheel",
    visibility = ["//visibility:public"],
 )
 

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -21,7 +21,8 @@ postorder. Producers must use `default` or `postorder`, the orders Bazel permits
 in that aggregate. For collision classes that select one claimant, permissive
 handling gives the later distinct element in the flattened sequence precedence.
 Duplicate dependency edges do not create another precedence position. Fields:
-  * `top_levels`: tuple[str] — top-level names the wheel installs into site-packages.
+  * `top_levels`: tuple[str] — complete set of immediate `site-packages`
+    entry names when nonempty; an empty tuple means the layout is unknown.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
   * `namespace_entries`: tuple[str] — `/`-joined paths of the concrete entries beneath
     the namespace top-levels (e.g. `jaraco/functools`), used to materialise a merged

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -1,22 +1,19 @@
 """Providers to share information between targets in the graph."""
 
 PyWheelsInfo = provider(
-    doc = """Per-wheel metadata used to assemble a Python venv via symlinks at build time.
+    doc = """Installed wheel records used by venv assembly and image layering.
 
 Each element of `wheels` describes one wheel in the transitive closure of a
-target: the top-level names (packages / modules / *.dist-info directories)
-it installs into `site-packages`, which of those are PEP 420 namespace
-packages, the runfiles-root-relative path to the wheel's site-packages,
-and the wheel's declared console-script entry points.
+target. Every record carries the complete installed tree. Repository-inspected
+wheels also carry their site-packages layout and console scripts; source-built
+wheels may leave that analysis-time metadata empty.
 
-Downstream rules (notably `py_binary`) use this to create one
-`ctx.actions.symlink` per top-level name, merging wheels into a single
-`site-packages/` tree without invoking a runtime tool, and to generate
-executable wrappers under `<venv>/bin/<name>` for console scripts.
+Venv rules project known layouts and generate console-script wrappers. Image
+rules use `install_tree` to retain each wheel as a package leaf independently
+of whether its metadata was available during analysis.
 """,
     fields = {
-        "wheels": """Depset of `struct(top_levels, namespace_top_levels, namespace_entries, site_packages_rfpath, console_scripts)`
-— one per wheel in the transitive closure. rules_py aggregates this field in
+        "wheels": """Depset of wheel record structs, one per wheel in the transitive closure. rules_py aggregates this field in
 postorder. Producers must use `default` or `postorder`, the orders Bazel permits
 in that aggregate. For collision classes that select one claimant, permissive
 handling gives the later distinct element in the flattened sequence precedence.
@@ -38,6 +35,7 @@ Duplicate dependency edges do not create another precedence position. Fields:
     May be absent on structs from older producers.
   * `site_packages_rfpath`: str — runfiles-root-relative path to the wheel's site-packages.
   * `console_scripts`: tuple[str] — entry points encoded as `"name=module:func"`.
+  * `install_tree`: File — complete installed wheel tree.
 """,
     },
 )

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -79,18 +79,17 @@ def _py_unpacked_wheel_impl(ctx):
         ),
     ]
 
-    if ctx.attr.top_levels or ctx.attr.console_scripts:
-        providers.append(PyWheelsInfo(
-            wheels = depset(direct = [struct(
-                top_levels = tuple(ctx.attr.top_levels),
-                namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
-                namespace_entries = tuple(ctx.attr.namespace_entries),
-                site_packages_rfpath = site_packages_rfpath,
-                console_scripts = tuple(ctx.attr.console_scripts),
-                # See whl_install rule for the rationale.
-                install_tree = unpack_directory,
-            )]),
-        ))
+    providers.append(PyWheelsInfo(
+        wheels = depset(direct = [struct(
+            top_levels = tuple(ctx.attr.top_levels),
+            namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
+            namespace_entries = tuple(ctx.attr.namespace_entries),
+            site_packages_rfpath = site_packages_rfpath,
+            console_scripts = tuple(ctx.attr.console_scripts),
+            # See whl_install rule for the rationale.
+            install_tree = unpack_directory,
+        )]),
+    ))
 
     return providers
 
@@ -107,12 +106,11 @@ _attrs = {
     "top_levels": attr.string_list(
         doc = """Complete list of immediate entries the wheel installs into site-packages.
 
-When set, the target emits a `PyWheelsInfo` provider describing this wheel.
-Downstream rules (such as `py_binary`) can consume this to assemble a merged
-`site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth`
-entries. The list must include packages, modules, `.pth` files, and
-`*.dist-info` directories. If left empty (the default), other rules preserve
-the complete wheel root and fall back to `.pth`-based import resolution.
+When set, downstream rules can assemble a merged `site-packages/` tree via
+`ctx.actions.symlink` instead of relying on `.pth` entries. The list must
+include packages, modules, `.pth` files, and `*.dist-info` directories. If left
+empty (the default), other rules preserve the complete wheel root and fall back
+to `.pth`-based import resolution.
 
 Typically populated by the `uv` wheel-install repo rule. Hand-written
 `py_unpacked_wheel` targets may populate this to opt into symlink-based

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -105,13 +105,14 @@ _attrs = {
         mandatory = True,
     ),
     "top_levels": attr.string_list(
-        doc = """Names of the top-level packages / modules / *.dist-info directories the wheel installs into its site-packages.
+        doc = """Complete list of immediate entries the wheel installs into site-packages.
 
 When set, the target emits a `PyWheelsInfo` provider describing this wheel.
 Downstream rules (such as `py_binary`) can consume this to assemble a merged
 `site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth`
-entries. If left empty (the default), the target behaves as before — other
-rules fall back to `.pth`-based import resolution.
+entries. The list must include packages, modules, `.pth` files, and
+`*.dist-info` directories. If left empty (the default), other rules preserve
+the complete wheel root and fall back to `.pth`-based import resolution.
 
 Typically populated by the `uv` wheel-install repo rule. Hand-written
 `py_unpacked_wheel` targets may populate this to opt into symlink-based

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -539,8 +539,10 @@ def assemble_venv(
     # bazel-bin-walking tool.
     site_packages_to_wheels_root = "/".join([".."] * 3) + "/_wheels"
 
-    # Map from site_packages_rfpath → wheel key for wheels that carry
-    # install_tree. The key is an 8-hex hash of the wheel's
+    # Map from site_packages_rfpath → wheel key for wheels whose analysis-time
+    # metadata lets the venv project entries or scripts. Metadata-free wheel
+    # records retain their runfiles path and do not need another tree symlink.
+    # The key is an 8-hex hash of the wheel's
     # `install_tree.short_path` (globally unique among File objects), so:
     #
     #   * adding/removing a wheel doesn't shift the keys of other wheels
@@ -552,7 +554,11 @@ def assemble_venv(
     #
     # We fail loudly on the rare 32-bit hash collision; the caller can
     # widen the key or rename a wheel rule.
-    wheels_with_trees = [w for w in wheels if getattr(w, "install_tree", None) != None]
+    localized_wheels = [
+        w
+        for w in wheels
+        if getattr(w, "install_tree", None) != None and (w.top_levels or w.console_scripts)
+    ]
     known_layout_site_pkgs = {
         w.site_packages_rfpath: True
         for w in wheels
@@ -560,7 +566,7 @@ def assemble_venv(
     }
     wheel_key_by_sp = {}
     wheel_by_key = {}
-    for w in wheels_with_trees:
+    for w in localized_wheels:
         key = _wheel_key(w)
         prior = wheel_by_key.get(key)
         if prior != None and prior.install_tree.short_path != w.install_tree.short_path:
@@ -577,7 +583,7 @@ def assemble_venv(
     # Hop 1: per-wheel directory under _wheels/<key>/. Bazel picks an
     # absolute path under bazel-bin; the output is a tree artifact whose
     # contents dereference the install_tree.
-    for w in wheels_with_trees:
+    for w in localized_wheels:
         key = wheel_key_by_sp[w.site_packages_rfpath]
         wheel_dir = ctx.actions.declare_directory(
             "{}/_wheels/{}".format(venv_name, key),

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -383,6 +383,8 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     # namespace) symlinks.
     fully_covered = {}
     for w in wheels:
+        if not w.top_levels:
+            continue
         skipped = skipped_per_wheel.get(w.site_packages_rfpath, {})
         ns_covered = ns_covered_per_wheel.get(w.site_packages_rfpath, {})
         covered = True
@@ -551,6 +553,11 @@ def assemble_venv(
     # We fail loudly on the rare 32-bit hash collision; the caller can
     # widen the key or rename a wheel rule.
     wheels_with_trees = [w for w in wheels if getattr(w, "install_tree", None) != None]
+    known_layout_site_pkgs = {
+        w.site_packages_rfpath: True
+        for w in wheels
+        if w.top_levels
+    }
     wheel_key_by_sp = {}
     wheel_by_key = {}
     for w in wheels_with_trees:
@@ -683,22 +690,30 @@ def assemble_venv(
         )
         declared.append(merged_dir)
 
-    # Keyed wheels (have `_wheels/<key>/`) emit a plain relative path:
-    # site.py joins it with the .pth's directory and appends to
-    # sys.path. Safe because root `*.pth` filenames are depth-1 RECORD
-    # entries that Hop 2 already symlinked at the venv root. Non-keyed
-    # wheels (`py_unpacked_wheel` without `top_levels`) emit
-    # `site.addsitedir` so wheel-root `.pth` shims still fire — a
-    # plain path entry would skip the .pth scan. First-party imports
-    # emit a plain path line.
+    # A key only means that a wheel has an install tree. Wheels may emit
+    # PyWheelsInfo for console scripts while leaving `top_levels` empty, so
+    # their immediate layout is unknown and no root entries were projected by
+    # Hop 2. Those wheels need `site.addsitedir` to process root `.pth` files.
+    # Known layouts use a plain path because their root `.pth` files were
+    # already projected or deliberately suppressed by collision resolution.
     def _format_imp(imp):
         if imp in fully_covered_site_pkgs:
             return None
         if imp.endswith("site-packages"):
             key = wheel_key_by_sp.get(imp)
+            if imp in known_layout_site_pkgs:
+                if key != None:
+                    return "{wheels_root}/{key}/lib/{py_ver}/site-packages".format(
+                        wheels_root = site_packages_to_wheels_root,
+                        key = key,
+                        py_ver = wheel_py_ver,
+                    )
+                return "{}/{}".format(escape, imp)
             if key != None:
-                return "{wheels_root}/{key}/lib/{py_ver}/site-packages".format(
-                    wheels_root = site_packages_to_wheels_root,
+                return ("import os, sys, site; " +
+                        "site.addsitedir(os.path.normpath(os.path.join(" +
+                        "sys.prefix, \"_wheels\", \"{key}\", \"lib\", " +
+                        "\"{py_ver}\", \"site-packages\")))").format(
                     key = key,
                     py_ver = wheel_py_ver,
                 )
@@ -715,8 +730,8 @@ def assemble_venv(
     pth_lines.set_param_file_format("multiline")
     pth_lines.add(escape)
 
-    # allow_closure lets _format_imp capture fully_covered_site_pkgs / wheel_key_by_sp
-    # so we don't have to materialise imports_depset via .to_list().
+    # allow_closure lets _format_imp capture the wheel metadata maps so we
+    # don't have to materialise imports_depset via .to_list().
     pth_lines.add_all(imports_depset, map_each = _format_imp, allow_closure = True)
 
     site_packages_pth_file = ctx.actions.declare_file(

--- a/py/tests/wheel-root-pth-double/BUILD.bazel
+++ b/py/tests/wheel-root-pth-double/BUILD.bazel
@@ -18,6 +18,7 @@ genrule(
         "a/apkg/__init__.py",
         "a/shared/__init__.py",
         "a/a_marker.pth",
+        "a/entry_points.txt",
         "a/METADATA",
     ],
     outs = ["pthtest_a-1.0-py3-none-any.whl"],
@@ -26,6 +27,7 @@ genrule(
         "apkg/__init__.py=$(execpath a/apkg/__init__.py)",
         "shared/__init__.py=$(execpath a/shared/__init__.py)",
         "a_marker.pth=$(execpath a/a_marker.pth)",
+        "pthtest_a-1.0.dist-info/entry_points.txt=$(execpath a/entry_points.txt)",
         "pthtest_a-1.0.dist-info/METADATA=$(execpath a/METADATA)",
     ]),
     tools = ["@bazel_tools//tools/zip:zipper"],
@@ -58,6 +60,7 @@ py_unpacked_wheel(
     # the venv site-packages exactly as uv's whl_install would.
     top_levels = [
         "apkg",
+        "pthtest_a-1.0.dist-info",
         "shared",
         "a_marker.pth",
     ],
@@ -68,9 +71,18 @@ py_unpacked_wheel(
     src = ":pthtest_b-1.0-py3-none-any.whl",
     top_levels = [
         "bpkg",
+        "pthtest_b-1.0.dist-info",
         "shared",
         "b_marker.pth",
     ],
+)
+
+py_unpacked_wheel(
+    name = "pthtest_unknown_layout",
+    src = ":pthtest_a-1.0-py3-none-any.whl",
+    # Console scripts make this target emit PyWheelsInfo, while omitting
+    # top_levels requires venv assembly to preserve the complete wheel root.
+    console_scripts = ["pthtest=apkg:main"],
 )
 
 py_test(
@@ -88,4 +100,12 @@ py_test(
         ":pthtest_a",
         ":pthtest_b",
     ],
+)
+
+py_test(
+    name = "unknown_layout_pth_test",
+    srcs = ["unknown_layout_pth_test.py"],
+    isolated = False,
+    main = "unknown_layout_pth_test.py",
+    deps = [":pthtest_unknown_layout"],
 )

--- a/py/tests/wheel-root-pth-double/a/apkg/__init__.py
+++ b/py/tests/wheel-root-pth-double/a/apkg/__init__.py
@@ -1,1 +1,5 @@
 VALUE = "apkg"
+
+
+def main():
+    return 0

--- a/py/tests/wheel-root-pth-double/a/entry_points.txt
+++ b/py/tests/wheel-root-pth-double/a/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+pthtest = apkg:main

--- a/py/tests/wheel-root-pth-double/unknown_layout_pth_test.py
+++ b/py/tests/wheel-root-pth-double/unknown_layout_pth_test.py
@@ -1,0 +1,17 @@
+"""Unknown wheel layouts must still process root .pth files."""
+
+import sys
+
+
+def main():
+    if "rules_py_pth_sentinel_a" not in sys.path:
+        raise SystemExit("unknown-layout wheel root .pth did not execute")
+
+    import apkg
+
+    if apkg.VALUE != "apkg":
+        raise SystemExit("unknown-layout wheel package did not import")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -67,7 +67,7 @@ load("//uv/private/sdist_configure:defs.bzl", "DEFAULT_CONFIGURE_SCRIPT")
 load("//uv/private/tomltool:toml.bzl", "toml")
 load("//uv/private/uv_hub:repository.bzl", "uv_hub")
 load("//uv/private/uv_project:repository.bzl", "uv_project")
-load("//uv/private/whl_install:repository.bzl", "whl_install")
+load("//uv/private/whl_install:repository.bzl", "parse_console_script", "whl_install")
 load(":graph_utils.bzl", "activate_extras", "collect_sccs")
 load(":lockfile.bzl", "build_marker_graph", "collect_bdists", "collect_configurations", "collect_markers", "collect_sdists", "normalize_deps")
 load(":projectfile.bzl", "collate_versions_by_name", "collect_activated_extras", "extract_requirement_marker_pairs")
@@ -90,6 +90,32 @@ def url_basename(url):
     if not basename:
         fail("Invalid distribution URL (no file name): " + url)
     return basename
+
+def parse_declared_console_script(name, entry_point):
+    """Canonicalize one override_package console-script declaration.
+
+    Args:
+        name: Script name installed under the venv's bin directory.
+        entry_point: Python entry point encoded as module:object.
+
+    Returns:
+        The canonical name=module:object string, or None when invalid.
+    """
+    whitespace = [" ", "\t", "\n", "\r"]
+    if (
+        name in ("", ".", "..") or
+        "/" in name or
+        "\\" in name or
+        "=" in name or
+        "=" in entry_point or
+        "[" in entry_point or
+        "]" in entry_point or
+        len(entry_point.split(":")) != 2 or
+        any([char in name or char in entry_point for char in whitespace])
+    ):
+        return None
+    parsed = parse_console_script("{}={}".format(name, entry_point))
+    return parsed[1] if parsed != None else None
 
 def _merge_scc_dep_markers_by_surface_package(marked_deps):
     merged = {}
@@ -230,6 +256,7 @@ def _parse_projects(module_ctx, hub_specs):
 
             # Collect package overrides, validating no duplicates per (lock, name, version).
             package_overrides = {}
+            package_console_scripts = {}
             for override in mod.tags.override_package:
                 if override.lock != project.lock:
                     continue
@@ -246,8 +273,22 @@ def _parse_projects(module_ctx, hub_specs):
                         project.lock,
                     ))
 
+                console_scripts = []
+                for raw_script_name, raw_entry_point in sorted(override.console_scripts.items()):
+                    console_script = parse_declared_console_script(raw_script_name, raw_entry_point)
+                    if console_script == None:
+                        fail("uv.override_package() for '{}=={}' in lock '{}': `console_scripts` must map valid script names to `module:object` entry points; got {} = {}".format(
+                            override.name,
+                            v,
+                            project.lock,
+                            repr(raw_script_name),
+                            repr(raw_entry_point),
+                        ))
+                    console_scripts.append(console_script)
+
                 has_target = override.target != None
                 has_modifications = (
+                    override.console_scripts or
                     override.pre_build_patches or
                     override.post_install_patches or
                     override.extra_deps or
@@ -262,9 +303,10 @@ def _parse_projects(module_ctx, hub_specs):
                     fail("uv.override_package() for '{}': `target` is mutually exclusive with modification attributes. Use `target` for full replacement OR build, patch, and data attributes for modifications, not both.".format(override.name))
 
                 if not has_target and not has_modifications:
-                    fail("uv.override_package() for '{}': must specify either `target` for full replacement or at least one modification attribute (pre_build_patches, post_install_patches, extra_deps, extra_data, toolchains, env, monitor_memory, resource_set).".format(override.name))
+                    fail("uv.override_package() for '{}': must specify either `target` for full replacement or at least one modification attribute (console_scripts, pre_build_patches, post_install_patches, extra_deps, extra_data, toolchains, env, monitor_memory, resource_set).".format(override.name))
 
                 package_overrides[override_key] = override
+                package_console_scripts[override_key] = console_scripts
 
                 k = (project_id, normalize_name(override.name), v, "__base__")
                 if has_target:
@@ -360,6 +402,15 @@ def _parse_projects(module_ctx, hub_specs):
                 install_table[install_key] = install_target
                 sbuild_id = "sdist_build__{}__{}__{}".format(project_stamp, package["name"], normalize_version(package["version"]))
                 sdist = sdist_table.get(sbuild_id)
+                override_key = (normalize_name(package["name"]), package["version"])
+                pkg_override = package_overrides.get(override_key)
+                sbuild_console_scripts = package_console_scripts.get(override_key, [])
+                if sbuild_console_scripts and not sdist:
+                    fail("uv.override_package() for '{}=={}' in lock '{}': `console_scripts` requires a source distribution, but the lock record has only wheels".format(
+                        package["name"],
+                        package["version"],
+                        project.lock,
+                    ))
 
                 # WARNING: Loop invariant; this flag needs to be False by
                 # default and set if we do a build.
@@ -401,7 +452,6 @@ def _parse_projects(module_ctx, hub_specs):
                     build_deps = sets.to_list(sets.make(build_deps + lock_build_deps))
 
                     # Look up pre-build patches for this package
-                    pkg_override = package_overrides.get((normalize_name(package["name"]), package["version"]))
                     pre_build_patches = []
                     pre_build_patch_strip = 0
                     if pkg_override and pkg_override.pre_build_patches:
@@ -439,7 +489,6 @@ def _parse_projects(module_ctx, hub_specs):
                     has_sbuild = True
 
                 # Look up post-install patches and BUILD modifications
-                pkg_override = package_overrides.get((normalize_name(package["name"]), package["version"]))
                 post_install_patches = []
                 post_install_patch_strip = 0
                 extra_deps = []
@@ -498,6 +547,7 @@ def _parse_projects(module_ctx, hub_specs):
                     metadata_directory = metadata_directory or "",
                     whls = whls,
                     sbuild = "@{}//:whl".format(sbuild_id) if has_sbuild else None,
+                    sbuild_console_scripts = sbuild_console_scripts,
                     post_install_patches = post_install_patches,
                     post_install_patch_strip = post_install_patch_strip,
                     extra_deps = extra_deps,
@@ -674,6 +724,7 @@ def _uv_impl(module_ctx):
             "metadata_directory": install_cfg.metadata_directory,
             "name": install_id,
             "sbuild": install_cfg.sbuild,
+            "sbuild_console_scripts": install_cfg.sbuild_console_scripts,
             "whls": json.encode(install_cfg.whls),
             # Parallel list of the same wheel labels as a real label_list,
             # so the whl_install repo rule can `rctx.path()` them to peek
@@ -763,6 +814,9 @@ _override_package_tag = tag_class(
         # Full replacement: provide a target that substitutes for the package entirely.
         # Mutually exclusive with patch/exclude attributes.
         "target": attr.label(mandatory = False),
+        "console_scripts": attr.string_dict(
+            doc = "Complete console scripts for a source-built wheel, mapping script names to module:object entry points.",
+        ),
         "monitor_memory": attr.bool(
             default = False,
             doc = "Report approximate Linux process-tree RSS while building this package's wheel.",

--- a/uv/private/extension/test_defs.bzl
+++ b/uv/private/extension/test_defs.bzl
@@ -1,7 +1,7 @@
 """Unit tests for helpers in defs.bzl"""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":defs.bzl", "url_basename")
+load(":defs.bzl", "parse_declared_console_script", "url_basename")
 
 def _url_basename_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -52,8 +52,31 @@ def _url_basename_test_impl(ctx):
 
 url_basename_test = unittest.make(_url_basename_test_impl)
 
+def _declared_console_script_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "tool=package.cli:commands.main",
+        parse_declared_console_script("tool", "package.cli:commands.main"),
+    )
+    asserts.equals(
+        env,
+        None,
+        parse_declared_console_script("tool=other", "package.cli:main"),
+        "an equals sign in the script name must not change the encoded assignment",
+    )
+
+    return unittest.end(env)
+
+declared_console_script_test = unittest.make(_declared_console_script_test_impl)
+
 def defs_test_suite():
     unittest.suite(
         "url_basename_tests",
         url_basename_test,
+    )
+    unittest.suite(
+        "declared_console_script_tests",
+        declared_console_script_test,
     )

--- a/uv/private/uv_hub/snapshots/whl_install.attrs.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/whl_install.attrs.BUILD.bazel
@@ -1,14 +1,22 @@
 load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@aspect_rules_py//uv/private/whl_install:defs.bzl", "select_chain")
-load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "source_built_wheel", "whl_install")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+
+source_built_wheel(
+    name = "source_built_wheel",
+    src = "@@+uv+sdist_build__aspect_rules_py__attrs__23_2_0//:whl",
+    console_scripts = [],
+    visibility = ["//visibility:private"],
+)
+
 
 select_chain(
    name = "whl",
    arms = {
         "@aspect_rules_py_pip_configurations//:py3-any-none": "@whl__attrs__99b87a485a5820b2//file"
    },
-   default_target = "@@+uv+sdist_build__aspect_rules_py__attrs__23_2_0//:whl",
+   default_target = ":source_built_wheel",
    visibility = ["//visibility:public"],
 )
 

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -646,9 +646,10 @@ filegroup(
     # platform/interpreter) are skipped — they can never be the active
     # wheel, and peeking at them would force a useless download.
     #
-    # The sbuild fallback, whose contents are unknowable until build time,
-    # is never peeked at here: it emits no PyWheelsInfo and consumers use
-    # .pth-based resolution.
+    # The sbuild fallback, whose contents are unknowable until build time, is
+    # never peeked at here. Its PyWheelsInfo record has unknown metadata, so
+    # venv consumers use .pth-based resolution while image layering still
+    # retains the installed wheel tree.
     #
     # We read from `whl_files` (a real label_list) rather than `whls` (a
     # JSON-encoded string of labels) because only the former adds the

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -490,7 +490,7 @@ def _whl_install_impl(repository_ctx):
     content = [
         "load(\"@aspect_rules_py//py:defs.bzl\", \"py_library\")",
         "load(\"@aspect_rules_py//uv/private/whl_install:defs.bzl\", \"select_chain\")",
-        "load(\"@aspect_rules_py//uv/private/whl_install:rule.bzl\", \"whl_install\")",
+        "load(\"@aspect_rules_py//uv/private/whl_install:rule.bzl\", \"source_built_wheel\", \"whl_install\")",
         "load(\"@bazel_skylib//lib:selects.bzl\", \"selects\")",
     ]
 
@@ -566,7 +566,23 @@ def _whl_install_impl(repository_ctx):
         for k, v in select_arms.items()
     }
 
-    default_target = str(repository_ctx.attr.sbuild) if repository_ctx.attr.sbuild else None
+    sbuild_target = str(repository_ctx.attr.sbuild) if repository_ctx.attr.sbuild else None
+    default_target = sbuild_target
+    if sbuild_target:
+        default_target = ":source_built_wheel"
+        content.append(
+            """
+source_built_wheel(
+    name = "source_built_wheel",
+    src = {src},
+    console_scripts = {console_scripts},
+    visibility = ["//visibility:private"],
+)
+""".format(
+                src = repr(sbuild_target),
+                console_scripts = repr(repository_ctx.attr.sbuild_console_scripts),
+            ),
+        )
 
     if (select_arms or prebuilds) and not default_target:
         default_target = ":whl_missing"
@@ -647,9 +663,10 @@ filegroup(
     # wheel, and peeking at them would force a useless download.
     #
     # The sbuild fallback, whose contents are unknowable until build time, is
-    # never peeked at here. Its PyWheelsInfo record has unknown metadata, so
-    # venv consumers use .pth-based resolution while image layering still
-    # retains the installed wheel tree.
+    # never peeked at here. Its layout remains unknown; a user declaration may
+    # attach console scripts only to that select arm. Venv consumers retain the
+    # complete wheel through .pth-based resolution while image layering keeps
+    # the installed wheel tree.
     #
     # We read from `whl_files` (a real label_list) rather than `whls` (a
     # JSON-encoded string of labels) because only the former adds the
@@ -817,6 +834,7 @@ whl_install = repository_rule(
         # `*.dist-info/RECORD` — see `_extract_wheel_metadata` above.
         "whl_files": attr.label_list(allow_files = [".whl"]),
         "sbuild": attr.label(),
+        "sbuild_console_scripts": attr.string_list(),
         "post_install_patches": attr.string(default = ""),
         "post_install_patch_strip": attr.int(default = 0),
         "extra_deps": attr.string(default = ""),

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -5,6 +5,38 @@ load("@rules_python//python:defs.bzl", "PyInfo")
 load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
 
+SourceBuiltWheelInfo = provider(
+    doc = "Analysis-time metadata declared for a source-built wheel.",
+    fields = {
+        "console_scripts": "Complete tuple[str] encoded as name=module:object.",
+    },
+)
+
+def _source_built_wheel_impl(ctx):
+    source = ctx.attr.src[DefaultInfo]
+    return [
+        # whl_install consumes this target as a single file. Reconstruct
+        # DefaultInfo instead of forwarding the source target's executable,
+        # which Bazel requires to be created by the rule that advertises it.
+        DefaultInfo(files = source.files),
+        SourceBuiltWheelInfo(
+            console_scripts = tuple(ctx.attr.console_scripts),
+        ),
+    ]
+
+source_built_wheel = rule(
+    implementation = _source_built_wheel_impl,
+    doc = "Mark a wheel target as source-built and attach declared metadata.",
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "console_scripts": attr.string_list(),
+    },
+    provides = [SourceBuiltWheelInfo],
+)
+
 def _whl_install(ctx):
     py_toolchain = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
     exec_runtime = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN].exec_tools.exec_runtime
@@ -108,17 +140,26 @@ def _whl_install(ctx):
     # wheel that is actually installed — metadata from inactive platform
     # wheels must not leak in (e.g. another platform's C-extension
     # suffix, or a console script shipped only by the win32 wheel).
-    # A lookup miss (sbuild fallback, failed extraction at repo-fetch time)
-    # leaves the metadata empty. PyWheelsInfo still carries the install tree:
-    # venv assembly treats empty top_levels as an unknown layout, while image
-    # layering uses install_tree to retain the wheel as a package leaf.
-    whl_basename = ctx.file.src.basename
-    top_levels = ctx.attr.top_levels.get(whl_basename, [])
-    namespace_top_levels = ctx.attr.namespace_top_levels.get(whl_basename, [])
-    namespace_entries = ctx.attr.namespace_entries.get(whl_basename, [])
-    namespace_dirs = ctx.attr.namespace_dirs.get(whl_basename, [])
-    regular_roots = ctx.attr.regular_roots.get(whl_basename, [])
-    console_scripts = ctx.attr.console_scripts.get(whl_basename, [])
+    # Source-built wheels cannot be inspected during repository evaluation.
+    # Check their provenance before using the output basename: a custom source
+    # producer may reuse a locked bdist's filename, but its topology is still
+    # unknown. PyWheelsInfo always carries the install tree so venv and image
+    # consumers retain the wheel.
+    if SourceBuiltWheelInfo in ctx.attr.src:
+        top_levels = []
+        namespace_top_levels = []
+        namespace_entries = []
+        namespace_dirs = []
+        regular_roots = []
+        console_scripts = ctx.attr.src[SourceBuiltWheelInfo].console_scripts
+    else:
+        whl_basename = ctx.file.src.basename
+        top_levels = ctx.attr.top_levels.get(whl_basename, [])
+        namespace_top_levels = ctx.attr.namespace_top_levels.get(whl_basename, [])
+        namespace_entries = ctx.attr.namespace_entries.get(whl_basename, [])
+        namespace_dirs = ctx.attr.namespace_dirs.get(whl_basename, [])
+        regular_roots = ctx.attr.regular_roots.get(whl_basename, [])
+        console_scripts = ctx.attr.console_scripts.get(whl_basename, [])
 
     providers.append(PyWheelsInfo(
         wheels = depset(direct = [struct(

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -108,9 +108,10 @@ def _whl_install(ctx):
     # wheel that is actually installed — metadata from inactive platform
     # wheels must not leak in (e.g. another platform's C-extension
     # suffix, or a console script shipped only by the win32 wheel).
-    # A lookup miss (sbuild fallback, failed extraction at repo-fetch
-    # time) emits no PyWheelsInfo and consumers fall back to .pth-based
-    # resolution.
+    # A lookup miss (sbuild fallback, failed extraction at repo-fetch time)
+    # leaves the metadata empty. PyWheelsInfo still carries the install tree:
+    # venv assembly treats empty top_levels as an unknown layout, while image
+    # layering uses install_tree to retain the wheel as a package leaf.
     whl_basename = ctx.file.src.basename
     top_levels = ctx.attr.top_levels.get(whl_basename, [])
     namespace_top_levels = ctx.attr.namespace_top_levels.get(whl_basename, [])
@@ -119,48 +120,47 @@ def _whl_install(ctx):
     regular_roots = ctx.attr.regular_roots.get(whl_basename, [])
     console_scripts = ctx.attr.console_scripts.get(whl_basename, [])
 
-    if top_levels or console_scripts:
-        providers.append(PyWheelsInfo(
-            wheels = depset(direct = [struct(
-                top_levels = tuple(top_levels),
-                # PEP 420 namespace packages this wheel contributes to.
-                # When multiple wheels claim the same top-level and ALL of
-                # them flag it as namespace, py_binary merges the namespace
-                # CONCRETELY from `namespace_entries` per-entry symlinks
-                # (so tools that inspect site-packages directly — mypy,
-                # pyright — see the packages and their py.typed markers),
-                # unless a regular package spans the wheels (detected via
-                # `regular_roots` × `namespace_dirs`), which needs a
-                # physical merge instead. Falls back to .pth-based
-                # resolution when entry metadata is missing.
-                namespace_top_levels = tuple(namespace_top_levels),
-                # Concrete per-wheel paths beneath namespace top-levels
-                # (e.g. `jaraco/functools`) that venv assembly symlinks
-                # individually to materialise a merged namespace directory.
-                namespace_entries = tuple(namespace_entries),
-                # Directory skeleton under namespace top-levels: which dirs
-                # are implicit-namespace portions (`namespace_dirs`) and
-                # which are the minimal regular-package roots
-                # (`regular_roots`). venv assembly cross-references these
-                # across wheels to detect a regular package spanning wheels
-                # (Python can't merge a regular package's __path__ at
-                # runtime, so the subtree is physically merged).
-                namespace_dirs = tuple(namespace_dirs),
-                regular_roots = tuple(regular_roots),
-                site_packages_rfpath = site_packages_rfpath,
-                # Each entry is "name=module:func"; py_binary parses into
-                # wrapper scripts at <venv>/bin/<name> at analysis time.
-                console_scripts = tuple(console_scripts),
-                # Tree artifact holding this wheel's installed file tree
-                # (`install/`, whose internal shape is
-                # `lib/python<M>.<m>/site-packages/...`). Downstream
-                # venv-assembly uses this as a `target_file` for a
-                # per-wheel directory symlink, so the per-top-level
-                # symlinks inside the venv can be intra-venv relative
-                # (identical resolution in bazel-bin and runfiles).
-                install_tree = install_dir,
-            )]),
-        ))
+    providers.append(PyWheelsInfo(
+        wheels = depset(direct = [struct(
+            top_levels = tuple(top_levels),
+            # PEP 420 namespace packages this wheel contributes to.
+            # When multiple wheels claim the same top-level and ALL of
+            # them flag it as namespace, py_binary merges the namespace
+            # CONCRETELY from `namespace_entries` per-entry symlinks
+            # (so tools that inspect site-packages directly — mypy,
+            # pyright — see the packages and their py.typed markers),
+            # unless a regular package spans the wheels (detected via
+            # `regular_roots` × `namespace_dirs`), which needs a
+            # physical merge instead. Falls back to .pth-based
+            # resolution when entry metadata is missing.
+            namespace_top_levels = tuple(namespace_top_levels),
+            # Concrete per-wheel paths beneath namespace top-levels
+            # (e.g. `jaraco/functools`) that venv assembly symlinks
+            # individually to materialise a merged namespace directory.
+            namespace_entries = tuple(namespace_entries),
+            # Directory skeleton under namespace top-levels: which dirs
+            # are implicit-namespace portions (`namespace_dirs`) and
+            # which are the minimal regular-package roots
+            # (`regular_roots`). venv assembly cross-references these
+            # across wheels to detect a regular package spanning wheels
+            # (Python can't merge a regular package's __path__ at
+            # runtime, so the subtree is physically merged).
+            namespace_dirs = tuple(namespace_dirs),
+            regular_roots = tuple(regular_roots),
+            site_packages_rfpath = site_packages_rfpath,
+            # Each entry is "name=module:func"; py_binary parses into
+            # wrapper scripts at <venv>/bin/<name> at analysis time.
+            console_scripts = tuple(console_scripts),
+            # Tree artifact holding this wheel's installed file tree
+            # (`install/`, whose internal shape is
+            # `lib/python<M>.<m>/site-packages/...`). Downstream
+            # venv-assembly uses this as a `target_file` for a
+            # per-wheel directory symlink, so the per-top-level
+            # symlinks inside the venv can be intra-venv relative
+            # (identical resolution in bazel-bin and runfiles).
+            install_tree = install_dir,
+        )]),
+    ))
 
     return providers
 
@@ -212,10 +212,11 @@ key matches the basename of the wheel `src` resolved to (the selected wheel
 for the active configuration) is used; entries for other platform wheels are
 ignored so their package surface cannot leak into this configuration.
 
-When the lookup hits, the target emits a `PyWheelsInfo` provider describing
-the selected wheel. Downstream rules (such as `py_binary`) consume this to
-assemble a merged `site-packages/` tree via `ctx.actions.symlink` instead of
-relying on `.pth` entries. A miss preserves the `.pth`-based behavior.
+When the lookup hits, the selected wheel's `PyWheelsInfo` record carries this
+layout and downstream rules can assemble a merged `site-packages/` tree via
+`ctx.actions.symlink`. A miss leaves the layout unknown and preserves
+`.pth`-based import behavior; the record still identifies the install tree for
+consumers such as image layering.
 
 Typically populated automatically by the `whl_install` repo rule from each
 wheel's `*.dist-info/RECORD` at repo-fetch time.

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -241,6 +241,7 @@ def _metadata_selection_test_impl(ctx):
     asserts.equals(env, 1, len(wheels), "expected exactly one wheel struct in PyWheelsInfo")
 
     wheel = wheels[0]
+    asserts.true(env, wheel.install_tree != None, "wheel record must retain its install tree")
     asserts.equals(env, tuple(ctx.attr.expected_top_levels), wheel.top_levels)
     asserts.equals(env, tuple(ctx.attr.expected_namespace_top_levels), wheel.namespace_top_levels)
     asserts.equals(env, tuple(ctx.attr.expected_console_scripts), wheel.console_scripts)
@@ -272,20 +273,6 @@ _metadata_selection_test = analysistest.make(
         "leaked_console_scripts": attr.string_list(),
     },
 )
-
-def _metadata_miss_test_impl(ctx):
-    env = analysistest.begin(ctx)
-    target = analysistest.target_under_test(env)
-
-    asserts.false(
-        env,
-        PyWheelsInfo in target,
-        "a wheel without a metadata entry (sbuild fallback) must not emit PyWheelsInfo",
-    )
-
-    return analysistest.end(env)
-
-_metadata_miss_test = analysistest.make(_metadata_miss_test_impl)
 
 def metadata_selection_test_suite(name):
     """Fixtures + analysis tests for per-configuration metadata selection.
@@ -341,9 +328,14 @@ def metadata_selection_test_suite(name):
         leaked_console_scripts = [],
     )
 
-    _metadata_miss_test(
+    _metadata_selection_test(
         name = name + "_sbuild_fallback_test",
         target_under_test = ":__metadata_sbuild_fixture",
+        expected_top_levels = [],
+        expected_namespace_top_levels = [],
+        expected_console_scripts = [],
+        leaked_top_levels = [],
+        leaked_console_scripts = [],
     )
 
 def whl_install_suite():

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -4,7 +4,7 @@ load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//py/private:providers.bzl", "PyWheelsInfo")
 load(":repository.bzl", "compatible_python_tags", "parse_console_script", "parse_record_path", "select_key", "site_packages_segments", "sort_select_arms", "source_specificity")
-load(":rule.bzl", "whl_install")
+load(":rule.bzl", "source_built_wheel", "whl_install")
 
 def _whl_sorting_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -206,6 +206,7 @@ _MACOS_WHL = "demo-1.0.0-cp311-cp311-macosx_11_0_arm64.whl"
 # Built-from-source fallback: contents are unknowable at repo-fetch time, so
 # no metadata entry exists for it.
 _SBUILD_WHL = "demo-1.0.0-py3-none-any.whl"
+_DECLARED_SBUILD_CONSOLE_SCRIPTS = ["declared=demo.cli:main"]
 
 _TOP_LEVELS = {
     _LINUX_WHL: [
@@ -291,19 +292,46 @@ def metadata_selection_test_suite(name):
             tags = ["manual"],
         )
 
+    source_built_wheel(
+        name = "__metadata_sbuild_wheel",
+        testonly = True,
+        src = _SBUILD_WHL,
+        console_scripts = [],
+        tags = ["manual"],
+    )
+
+    source_built_wheel(
+        name = "__metadata_declared_sbuild_wheel",
+        testonly = True,
+        src = _LINUX_WHL,
+        console_scripts = _DECLARED_SBUILD_CONSOLE_SCRIPTS,
+        tags = ["manual"],
+    )
+
     for fixture_name, src in [
         ("__metadata_linux_fixture", _LINUX_WHL),
         ("__metadata_macos_fixture", _MACOS_WHL),
-        ("__metadata_sbuild_fixture", _SBUILD_WHL),
+        ("__metadata_sbuild_fixture", ":__metadata_sbuild_wheel"),
     ]:
         whl_install(
             name = fixture_name,
+            testonly = True,
             src = src,
             top_levels = _TOP_LEVELS,
             namespace_top_levels = _NAMESPACE_TOP_LEVELS,
             console_scripts = _CONSOLE_SCRIPTS,
             tags = ["manual"],
         )
+
+    whl_install(
+        name = "__metadata_declared_sbuild_fixture",
+        testonly = True,
+        src = ":__metadata_declared_sbuild_wheel",
+        top_levels = _TOP_LEVELS,
+        namespace_top_levels = _NAMESPACE_TOP_LEVELS,
+        console_scripts = _CONSOLE_SCRIPTS,
+        tags = ["manual"],
+    )
 
     _metadata_selection_test(
         name = name + "_linux_test",
@@ -336,6 +364,16 @@ def metadata_selection_test_suite(name):
         expected_console_scripts = [],
         leaked_top_levels = [],
         leaked_console_scripts = [],
+    )
+
+    _metadata_selection_test(
+        name = name + "_declared_sbuild_test",
+        target_under_test = ":__metadata_declared_sbuild_fixture",
+        expected_top_levels = [],
+        expected_namespace_top_levels = [],
+        expected_console_scripts = _DECLARED_SBUILD_CONSOLE_SCRIPTS,
+        leaked_top_levels = _TOP_LEVELS[_LINUX_WHL],
+        leaked_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
     )
 
 def whl_install_suite():


### PR DESCRIPTION
The source-script change is 02067ff6. Earlier commits on this branch
are independently submitted prerequisites and will be removed as they
reach `main`.

Source-built wheels do not exist until execution, but venv assembly
must create console-script wrappers during analysis. Downloaded-wheel
scripts can be inspected during repository evaluation; source-built
scripts therefore need an explicit analysis-time declaration.

Allow `override_package` to declare a complete name-to-entry-point map.
The generated install repository marks every source-build fallback
before wheel selection and attaches declarations only to that arm.
Prebuilt arms retain inspected metadata, custom source producers remain
opaque, and source topology stays unknown even if a producer reuses a
locked wheel filename.

The map is trusted analysis input and must be kept in sync with the
source-built wheel.