### PR TITLE
fix(py): preserve permissive collision order

### DIFF
--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -4,8 +4,8 @@ load("//tools:pth_snapshot.bzl", "extract_venv_pth")
 # setuptools vendors `packaging` (among others), which collides at
 # the top-level with the real packaging wheel pulled in via pytest.
 # Not a PEP 420 namespace on either side, so our analysis-time check
-# flags it — but first-seen wins is correct here (vendored copy
-# stays invisible). Downgrade to warning.
+# flags it. This fixture permits the known overlap while continuing
+# to require both setuptools and pytest to import.
 
 py_test(
     name = "include_group",

--- a/e2e/snapshots/pth_install_tree_fallback.venv.pth
+++ b/e2e/snapshots/pth_install_tree_fallback.venv.pth
@@ -1,3 +1,3 @@
 ../../../../../../..
+../../../_wheels/c586d08b/lib/python3.11/site-packages
 ../../../../../../../_main
-../../../_wheels/c586d08c/lib/python3.11/site-packages

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -16,7 +16,11 @@ executable wrappers under `<venv>/bin/<name>` for console scripts.
 """,
     fields = {
         "wheels": """Depset of `struct(top_levels, namespace_top_levels, namespace_entries, site_packages_rfpath, console_scripts)`
-— one per wheel in the transitive closure. Fields:
+— one per wheel in the transitive closure. rules_py aggregates this field in
+postorder. Producers must use `default` or `postorder`, the orders Bazel permits
+in that aggregate. For collision classes that select one claimant, permissive
+handling gives the later distinct element in the flattened sequence precedence.
+Duplicate dependency edges do not create another precedence position. Fields:
   * `top_levels`: tuple[str] — top-level names the wheel installs into site-packages.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
   * `namespace_entries`: tuple[str] — `/`-joined paths of the concrete entries beneath

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -112,7 +112,12 @@ def _make_wheels_depset(ctx, extra_transitive = []):
 
     Used by downstream rules that want a flat list of wheels (with their
     declared top-level names) in the transitive closure, for building a
-    merged site-packages via symlinks.
+    merged site-packages via symlinks. Postorder defines permissive collision
+    precedence: left-to-right transitive children precede direct elements.
+    Depsets remove duplicates, so a later edge cannot refresh an element's
+    position.
+
+    https://bazel.build/rules/lib/builtins/depset#order
     """
     transitive = [
         target[PyWheelsInfo].wheels
@@ -123,7 +128,7 @@ def _make_wheels_depset(ctx, extra_transitive = []):
         if PyWheelsInfo in target:
             transitive.append(target[PyWheelsInfo].wheels)
     transitive.extend(extra_transitive)
-    return depset(transitive = transitive)
+    return depset(order = "postorder", transitive = transitive)
 
 def _make_merged_runfiles(ctx, extra_depsets = [], extra_runfiles = [], extra_runfiles_depsets = []):
     runfiles_targets = getattr(ctx.attr, "deps", []) + getattr(ctx.attr, "data", [])

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -188,14 +188,20 @@ Only works with the Aspect rules_py uv machinery.
         doc = """Whether to build this target and its transitive deps for a specific python version.""",
     ),
     "package_collisions": attr.string(
-        doc = """What to do when two wheels both claim the same top-level or console-script name.
+        doc = """What to do when metadata-resolved wheel contents collide.
 
-See `py_binary`'s attribute of the same name for full semantics — the
-two rules share the underlying collision detector.
+See `py_binary`'s attribute of the same name for full semantics — the two rules
+share the underlying collision detector. PEP 420 namespace top-levels merge.
+For ordinary top-levels, exact namespace entries, and console scripts,
+permissive modes select the last distinct claimant in the postorder wheel
+sequence. Regular-package spans overlay in that sequence; incompatible
+namespace prefixes retain the shallower entry. Wheels not represented in
+`PyWheelsInfo` remain on the `.pth` fallback. A duplicate dependency edge does
+not reinsert a wheel.
 
-* "error": Fail analysis.
-* "warning" (default): Print a warning; first-seen wins.
-* "ignore": First-seen wins silently.
+* "error": Fail analysis or the physical merge action.
+* "warning" (default): Print a warning and apply the permissive behavior above.
+* "ignore": Apply the permissive behavior silently.
 """,
         default = "warning",
         values = ["error", "warning", "ignore"],

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -225,6 +225,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                                 entry_owner[entry] = c
                             elif prior.site_packages != c.site_packages:
                                 _complain("namespace entry", entry, prior.site_packages, c.site_packages)
+                                entry_owner[entry] = c
                     for entry, c in entry_owner.items():
                         top_level_to_site_pkgs[entry] = c.site_packages
                 continue
@@ -247,14 +248,13 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             if not entried:
                 continue
 
-            # Per-entry merge over the entries-bearing claimants: first
-            # wheel to claim an entry wins. A later distinct wheel shipping
+            # Per-entry merge over the entries-bearing claimants: the last
+            # distinct wheel to claim an entry wins. An earlier wheel shipping
             # the same entry is a genuine collision (same subpackage twice)
-            # — complain per policy and leave the loser on the .pth path.
+            # — complain per policy and leave the earlier claimant on the
+            # .pth path.
             # (An entryless claimant shipping the same subpackage can't be
-            # detected here; the concrete symlink wins deterministically
-            # over its .pth portion — the same first-on-path resolution the
-            # old all-.pth path gave, only now order-independent.)
+            # detected here; the concrete symlink wins over its .pth portion.)
             entry_owner = {}
             for c in entried:
                 for entry in c.ns_entries:
@@ -263,7 +263,8 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                         entry_owner[entry] = c
                     elif prior.site_packages != c.site_packages:
                         _complain("namespace entry", entry, prior.site_packages, c.site_packages)
-                        skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+                        skipped_per_wheel.setdefault(prior.site_packages, {})[tl] = True
+                        entry_owner[entry] = c
 
             # A nested-namespace mismatch (wheel A ships
             # `google/cloud/__init__.py` while wheel B treats
@@ -313,15 +314,16 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                     ns_covered_per_wheel.setdefault(c.site_packages, {})[tl] = True
             continue
 
-        first = claimants[0]
-        top_level_to_site_pkgs[tl] = first.site_packages
-        seen_losers = {}
+        winner = claimants[0]
+        seen = {winner.site_packages: True}
         for c in claimants[1:]:
-            if c.site_packages == first.site_packages or c.site_packages in seen_losers:
+            if c.site_packages in seen:
                 continue
-            _complain("top-level", tl, first.site_packages, c.site_packages)
-            seen_losers[c.site_packages] = True
-            skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+            _complain("top-level", tl, winner.site_packages, c.site_packages)
+            skipped_per_wheel.setdefault(winner.site_packages, {})[tl] = True
+            winner = c
+            seen[c.site_packages] = True
+        top_level_to_site_pkgs[tl] = winner.site_packages
 
     # Pass 2a: fold conflicted roots into merge groups. Keep only the
     # minimal (shallowest) roots — a conflicted root nested inside
@@ -365,14 +367,15 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             c = claimants[0]
             console_scripts_map[name] = struct(module = c.module, func = c.func)
             continue
-        first = claimants[0]
-        console_scripts_map[name] = struct(module = first.module, func = first.func)
-        seen_losers = {}
+        winner = claimants[0]
+        seen = {winner.site_packages: True}
         for c in claimants[1:]:
-            if c.site_packages == first.site_packages or c.site_packages in seen_losers:
+            if c.site_packages in seen:
                 continue
-            _complain("console script", name, first.site_packages, c.site_packages)
-            seen_losers[c.site_packages] = True
+            _complain("console script", name, winner.site_packages, c.site_packages)
+            winner = c
+            seen[c.site_packages] = True
+        console_scripts_map[name] = struct(module = winner.module, func = winner.func)
 
     # Pass 3: wheels fully covered by direct (or complete per-entry
     # namespace) symlinks.

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -102,7 +102,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
       merge_groups: list of struct(root, site_packages_list) — regular
           package dirs (site-packages-relative paths) that span wheels
           and need a physical merge, with the contributing wheels'
-          site-packages paths in first-wins priority order.
+          site-packages paths in wheel traversal order.
     """
 
     def _complain(what, name, a, b):
@@ -328,7 +328,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     # another conflicted root is covered by merging the outer one. For
     # each root, the contributors are every namespace-claimant wheel
     # that has the root in its skeleton (content below it) or as its
-    # own regular root, in wheel order (= first-wins priority).
+    # own regular root, in wheel traversal order.
     merge_groups = []
     minimal_roots = []
     for root in sorted(conflicted_roots.keys()):
@@ -341,7 +341,12 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             minimal_roots.append(root)
     for root in minimal_roots:
         group_sps = []
-        for sp in ns_claimant_sps.keys():
+        group_sps_seen = {}
+        for ordered_w in wheels:
+            sp = ordered_w.site_packages_rfpath
+            if sp in group_sps_seen or sp not in ns_claimant_sps:
+                continue
+            group_sps_seen[sp] = True
             w = wheel_by_sp[sp]
             if (root in getattr(w, "regular_roots", ()) or
                 root in getattr(w, "namespace_dirs", ())):

--- a/py/tests/py_venv_conflict/BUILD.bazel
+++ b/py/tests/py_venv_conflict/BUILD.bazel
@@ -1,6 +1,9 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//py:defs.bzl", "py_library", "py_test", "py_venv")
+load("//py/tests/py_venv_conflict:collision_order_test.bzl", "collision_order_test_suite")
 load("//py/tests/py_venv_conflict:site_merge_order_test.bzl", "site_merge_order_test_suite")
+
+collision_order_test_suite()
 
 site_merge_order_test_suite()
 

--- a/py/tests/py_venv_conflict/BUILD.bazel
+++ b/py/tests/py_venv_conflict/BUILD.bazel
@@ -1,5 +1,8 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//py:defs.bzl", "py_library", "py_test", "py_venv")
+load("//py/tests/py_venv_conflict:site_merge_order_test.bzl", "site_merge_order_test_suite")
+
+site_merge_order_test_suite()
 
 py_library(
     name = "lib",

--- a/py/tests/py_venv_conflict/collision_order_test.bzl
+++ b/py/tests/py_venv_conflict/collision_order_test.bzl
@@ -1,0 +1,175 @@
+"""Tests for permissive wheel-collision precedence."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py:defs.bzl", "py_binary", "py_library", "py_test")
+load("//py/private:providers.bzl", "PyWheelsInfo")
+load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
+
+def _wheel_impl(ctx):
+    py_runtime = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
+    install_tree = ctx.actions.declare_directory(ctx.label.name + ".install")
+    major = py_runtime.interpreter_version_info.major
+    minor = py_runtime.interpreter_version_info.minor
+    command = """
+set -eu
+site="$1/lib/python$2.$3/site-packages"
+mkdir -p "$site/collision_namespace"
+printf 'VALUE = %s\n' "$4" > "$site/collision_namespace/shared.py"
+printf 'VALUE = %s\n\ndef main():\n    print(VALUE)\n' "$4" > "$site/collision_namespace/$5.py"
+"""
+    top_levels = ("collision_namespace",)
+    console_scripts = ()
+    if ctx.attr.ordinary:
+        command += """
+printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
+"""
+        top_levels += ("collision_order.py",)
+        console_scripts = ("collision-order=collision_namespace.{}:main".format(ctx.attr.value),)
+    ctx.actions.run_shell(
+        outputs = [install_tree],
+        command = command,
+        arguments = [
+            install_tree.path,
+            str(major),
+            str(minor),
+            json.encode(ctx.attr.value),
+            ctx.attr.value,
+        ],
+    )
+    site_packages = "/".join([
+        segment
+        for segment in [
+            ctx.label.repo_name or ctx.workspace_name,
+            ctx.label.package,
+            install_tree.basename,
+        ]
+        if segment
+    ] + ["lib/python{}.{}/site-packages".format(major, minor)])
+    wheel = struct(
+        top_levels = top_levels,
+        namespace_top_levels = ("collision_namespace",),
+        namespace_entries = (
+            "collision_namespace/shared.py",
+            "collision_namespace/{}.py".format(ctx.attr.value),
+        ),
+        namespace_dirs = (),
+        regular_roots = (),
+        site_packages_rfpath = site_packages,
+        console_scripts = console_scripts,
+        install_tree = install_tree,
+    )
+    return [
+        DefaultInfo(
+            files = depset([install_tree]),
+            runfiles = ctx.runfiles(files = [install_tree]),
+        ),
+        PyInfo(
+            imports = depset([site_packages]),
+            transitive_sources = depset([install_tree]),
+            has_py2_only_sources = False,
+            has_py3_only_sources = True,
+            uses_shared_libraries = False,
+        ),
+        PyWheelsInfo(wheels = depset([wheel])),
+    ]
+
+_wheel = rule(
+    implementation = _wheel_impl,
+    attrs = {
+        "ordinary": attr.bool(),
+        "value": attr.string(mandatory = True),
+    },
+    toolchains = [PY_TOOLCHAIN],
+)
+
+def _collision_error_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(env, "namespace entry `collision_namespace/shared.py`")
+    return analysistest.end(env)
+
+_collision_error_test = analysistest.make(
+    _collision_error_test_impl,
+    expect_failure = True,
+)
+
+def collision_order_test_suite():
+    _wheel(
+        name = "_collision_first",
+        ordinary = True,
+        value = "first",
+        tags = ["manual"],
+    )
+    _wheel(
+        name = "_collision_second",
+        ordinary = True,
+        value = "second",
+        tags = ["manual"],
+    )
+    py_library(
+        name = "_collision_branch",
+        deps = [":_collision_first"],
+        tags = ["manual"],
+    )
+    py_test(
+        name = "later_direct_claimant_wins_test",
+        srcs = ["test_collision_order.py"],
+        args = ["second"],
+        main = "test_collision_order.py",
+        package_collisions = "ignore",
+        deps = [
+            ":_collision_branch",
+            ":_collision_second",
+        ],
+    )
+    py_test(
+        name = "later_transitive_claimant_wins_test",
+        srcs = ["test_collision_order.py"],
+        args = ["first"],
+        main = "test_collision_order.py",
+        package_collisions = "ignore",
+        deps = [
+            ":_collision_second",
+            ":_collision_branch",
+        ],
+    )
+    py_binary(
+        name = "_collision_error_binary",
+        srcs = ["test_collision_order.py"],
+        main = "test_collision_order.py",
+        package_collisions = "error",
+        tags = ["manual"],
+        deps = [
+            ":_collision_first",
+            ":_collision_second",
+        ],
+    )
+    _collision_error_test(
+        name = "collision_error_test",
+        target_under_test = ":_collision_error_binary",
+    )
+
+    _wheel(
+        name = "_namespace_first",
+        value = "first",
+        tags = ["manual"],
+    )
+    _wheel(
+        name = "_namespace_second",
+        value = "second",
+        tags = ["manual"],
+    )
+    py_test(
+        name = "namespace_fallback_order_test",
+        srcs = ["test_namespace_fallback.py"],
+        args = [
+            "second",
+            "first",
+        ],
+        main = "test_namespace_fallback.py",
+        package_collisions = "ignore",
+        deps = [
+            ":_namespace_first",
+            ":_namespace_second",
+        ],
+    )

--- a/py/tests/py_venv_conflict/site_merge_order_test.bzl
+++ b/py/tests/py_venv_conflict/site_merge_order_test.bzl
@@ -36,11 +36,13 @@ site="$1/lib/python$2.$3/site-packages"
 mkdir -p "$site/mixed/root"
 printf '' > "$site/mixed/root/__init__.py"
 printf 'VALUE = %s\n' "$4" > "$site/mixed/root/collision.py"
+printf 'VALUE = %s\n' "$4" > "$site/mixed/sibling.py"
 """
             top_levels = ("mixed",)
             namespace_entries = (
                 "mixed/root/__init__.py",
                 "mixed/root/collision.py",
+                "mixed/sibling.py",
             )
             namespace_dirs = ()
             regular_roots = ("mixed/root",)
@@ -51,11 +53,13 @@ site="$1/lib/python$2.$3/site-packages"
 mkdir -p "$site/mixed/root"
 printf 'VALUE = %s\n' "$4" > "$site/mixed/root/collision.py"
 printf 'VALUE = %s\n' "$4" > "$site/mixed/root/graft_unique.py"
+printf 'VALUE = %s\n' "$4" > "$site/mixed/sibling.py"
 """
             top_levels = ("mixed",)
             namespace_entries = (
                 "mixed/root/collision.py",
                 "mixed/root/graft_unique.py",
+                "mixed/sibling.py",
             )
             namespace_dirs = ("mixed/root",)
             regular_roots = ()
@@ -66,12 +70,14 @@ site="$1/lib/python$2.$3/site-packages"
 mkdir -p "$site/mixed/root" "$site/other"
 printf 'VALUE = %s\n' "$4" > "$site/mixed/root/collision.py"
 printf 'VALUE = %s\n' "$4" > "$site/mixed/root/final_unique.py"
+printf 'VALUE = %s\n' "$4" > "$site/mixed/sibling.py"
 printf 'VALUE = %s\n' "$4" > "$site/other/from_final.py"
 """
             top_levels = ("mixed", "other")
             namespace_entries = (
                 "mixed/root/collision.py",
                 "mixed/root/final_unique.py",
+                "mixed/sibling.py",
                 "other/from_final.py",
             )
             namespace_dirs = ("mixed/root",)

--- a/py/tests/py_venv_conflict/site_merge_order_test.bzl
+++ b/py/tests/py_venv_conflict/site_merge_order_test.bzl
@@ -1,0 +1,143 @@
+"""End-to-end coverage for regular-package physical merge order."""
+
+load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py:defs.bzl", "py_test")
+load("//py/private:providers.bzl", "PyWheelsInfo")
+load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
+
+def _wheel_set_impl(ctx):
+    py_runtime = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
+    major = py_runtime.interpreter_version_info.major
+    minor = py_runtime.interpreter_version_info.minor
+    install_trees = []
+    site_packages_paths = []
+    wheels = []
+
+    # `final` also claims the earlier `other` bucket. A global claimant map
+    # therefore moves it ahead of the regular-package contributors, while the
+    # canonical wheel sequence below keeps it last.
+    for kind in ["other", "regular", "graft", "final"]:
+        install_tree = ctx.actions.declare_directory("{}.install".format(kind))
+        if kind == "other":
+            command = """
+set -eu
+site="$1/lib/python$2.$3/site-packages"
+mkdir -p "$site/other"
+printf 'VALUE = %s\n' "$4" > "$site/other/from_other.py"
+"""
+            top_levels = ("other",)
+            namespace_entries = ("other/from_other.py",)
+            namespace_dirs = ()
+            regular_roots = ()
+        elif kind == "regular":
+            command = """
+set -eu
+site="$1/lib/python$2.$3/site-packages"
+mkdir -p "$site/mixed/root"
+printf '' > "$site/mixed/root/__init__.py"
+printf 'VALUE = %s\n' "$4" > "$site/mixed/root/collision.py"
+"""
+            top_levels = ("mixed",)
+            namespace_entries = (
+                "mixed/root/__init__.py",
+                "mixed/root/collision.py",
+            )
+            namespace_dirs = ()
+            regular_roots = ("mixed/root",)
+        elif kind == "graft":
+            command = """
+set -eu
+site="$1/lib/python$2.$3/site-packages"
+mkdir -p "$site/mixed/root"
+printf 'VALUE = %s\n' "$4" > "$site/mixed/root/collision.py"
+printf 'VALUE = %s\n' "$4" > "$site/mixed/root/graft_unique.py"
+"""
+            top_levels = ("mixed",)
+            namespace_entries = (
+                "mixed/root/collision.py",
+                "mixed/root/graft_unique.py",
+            )
+            namespace_dirs = ("mixed/root",)
+            regular_roots = ()
+        else:
+            command = """
+set -eu
+site="$1/lib/python$2.$3/site-packages"
+mkdir -p "$site/mixed/root" "$site/other"
+printf 'VALUE = %s\n' "$4" > "$site/mixed/root/collision.py"
+printf 'VALUE = %s\n' "$4" > "$site/mixed/root/final_unique.py"
+printf 'VALUE = %s\n' "$4" > "$site/other/from_final.py"
+"""
+            top_levels = ("mixed", "other")
+            namespace_entries = (
+                "mixed/root/collision.py",
+                "mixed/root/final_unique.py",
+                "other/from_final.py",
+            )
+            namespace_dirs = ("mixed/root",)
+            regular_roots = ()
+
+        ctx.actions.run_shell(
+            outputs = [install_tree],
+            command = command,
+            arguments = [
+                install_tree.path,
+                str(major),
+                str(minor),
+                json.encode(kind),
+            ],
+        )
+        site_packages = "/".join([
+            segment
+            for segment in [
+                ctx.label.repo_name or ctx.workspace_name,
+                ctx.label.package,
+                install_tree.basename,
+            ]
+            if segment
+        ] + ["lib/python{}.{}/site-packages".format(major, minor)])
+        install_trees.append(install_tree)
+        site_packages_paths.append(site_packages)
+        wheels.append(struct(
+            top_levels = top_levels,
+            namespace_top_levels = top_levels,
+            namespace_entries = namespace_entries,
+            namespace_dirs = namespace_dirs,
+            regular_roots = regular_roots,
+            site_packages_rfpath = site_packages,
+            console_scripts = (),
+            install_tree = install_tree,
+        ))
+
+    return [
+        DefaultInfo(
+            files = depset(install_trees),
+            runfiles = ctx.runfiles(files = install_trees),
+        ),
+        PyInfo(
+            imports = depset(site_packages_paths),
+            transitive_sources = depset(install_trees),
+            has_py2_only_sources = False,
+            has_py3_only_sources = True,
+            uses_shared_libraries = False,
+        ),
+        PyWheelsInfo(wheels = depset(direct = wheels, order = "postorder")),
+    ]
+
+_wheel_set = rule(
+    implementation = _wheel_set_impl,
+    toolchains = [PY_TOOLCHAIN],
+)
+
+def site_merge_order_test_suite():
+    _wheel_set(
+        name = "_site_merge_wheels",
+        tags = ["manual"],
+    )
+
+    py_test(
+        name = "site_merge_order_test",
+        srcs = ["test_site_merge_order.py"],
+        package_collisions = "ignore",
+        deps = [":_site_merge_wheels"],
+    )

--- a/py/tests/py_venv_conflict/test_collision_order.py
+++ b/py/tests/py_venv_conflict/test_collision_order.py
@@ -1,0 +1,21 @@
+import importlib
+import subprocess
+import sys
+
+import collision_order
+from collision_namespace import shared
+
+
+expected = sys.argv[1]
+assert collision_order.VALUE == expected, (collision_order.VALUE, expected)
+assert shared.VALUE == expected, (shared.VALUE, expected)
+for unique in ("first", "second"):
+    module = importlib.import_module(f"collision_namespace.{unique}")
+    assert module.VALUE == unique, (module.VALUE, unique)
+result = subprocess.run(
+    [sys.prefix + "/bin/collision-order"],
+    check=True,
+    capture_output=True,
+    text=True,
+)
+assert result.stdout == expected + "\n", result.stdout

--- a/py/tests/py_venv_conflict/test_namespace_fallback.py
+++ b/py/tests/py_venv_conflict/test_namespace_fallback.py
@@ -1,0 +1,22 @@
+import importlib
+from pathlib import Path
+import sys
+
+from collision_namespace import shared
+
+
+expected, fallback = sys.argv[1:3]
+assert shared.VALUE == expected, (shared.VALUE, expected)
+for unique in ("first", "second"):
+    module = importlib.import_module(f"collision_namespace.{unique}")
+    assert module.VALUE == unique, (module.VALUE, unique)
+
+fallback_values = []
+for entry in sys.path:
+    root = Path(entry)
+    if "_wheels" not in root.parts:
+        continue
+    for unique in ("first", "second"):
+        if (root / "collision_namespace" / f"{unique}.py").is_file():
+            fallback_values.append(unique)
+assert fallback_values == [fallback], fallback_values

--- a/py/tests/py_venv_conflict/test_site_merge_order.py
+++ b/py/tests/py_venv_conflict/test_site_merge_order.py
@@ -1,0 +1,9 @@
+from mixed.root import collision, final_unique, graft_unique
+from other import from_final, from_other
+
+
+assert collision.VALUE == "final", collision.VALUE
+assert final_unique.VALUE == "final", final_unique.VALUE
+assert graft_unique.VALUE == "graft", graft_unique.VALUE
+assert from_final.VALUE == "final", from_final.VALUE
+assert from_other.VALUE == "other", from_other.VALUE

--- a/py/tests/py_venv_conflict/test_site_merge_order.py
+++ b/py/tests/py_venv_conflict/test_site_merge_order.py
@@ -1,3 +1,4 @@
+from mixed import sibling
 from mixed.root import collision, final_unique, graft_unique
 from other import from_final, from_other
 
@@ -5,5 +6,6 @@ from other import from_final, from_other
 assert collision.VALUE == "final", collision.VALUE
 assert final_unique.VALUE == "final", final_unique.VALUE
 assert graft_unique.VALUE == "graft", graft_unique.VALUE
+assert sibling.VALUE == "final", sibling.VALUE
 assert from_final.VALUE == "final", from_final.VALUE
 assert from_other.VALUE == "other", from_other.VALUE

--- a/py/tools/site_merge/BUILD.bazel
+++ b/py/tools/site_merge/BUILD.bazel
@@ -1,4 +1,16 @@
+load("//py:defs.bzl", "py_test")
+
 exports_files(
     ["site_merge.py"],
     visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "site_merge_test",
+    srcs = [
+        "site_merge.py",
+        "site_merge_test.py",
+    ],
+    imports = ["."],
+    main = "site_merge_test.py",
 )

--- a/py/tools/site_merge/site_merge.py
+++ b/py/tools/site_merge/site_merge.py
@@ -17,17 +17,40 @@ Invoked by Bazel as::
 
     <exec_python> site_merge.py --into <dir> [--collision-policy P] --src <dir> [--src <dir> ...]
 
-Each ``--src`` is one wheel's copy of the package directory, in
-priority order: on file-level conflicts the first wheel providing a
-path wins. Sources that don't exist are skipped (platform wheels for
-other architectures may not ship the directory).
+Each ``--src`` is one wheel's copy of the package directory, in overlay
+order: on conflicts the later wheel overlays the earlier one. Sources
+that don't exist are skipped (platform wheels for other architectures
+may not ship the directory).
 """
 
 import argparse
 import filecmp
 import os
 import shutil
+import stat
+import sys
 from pathlib import Path
+
+
+def _remove(path):
+    """Remove an output copied from a potentially read-only input."""
+
+    def retry_readonly(function, candidate, exc_info):
+        error = exc_info[1]
+        if not isinstance(error, PermissionError):
+            raise error
+        candidate = Path(candidate)
+        candidate.chmod(candidate.stat().st_mode | stat.S_IWRITE)
+        function(candidate)
+
+    if path.is_dir():
+        shutil.rmtree(path, onerror=retry_readonly)
+        return
+    try:
+        path.unlink()
+    except PermissionError:
+        path.chmod(path.stat().st_mode | stat.S_IWRITE)
+        path.unlink()
 
 
 def merge(into, sources):
@@ -39,34 +62,35 @@ def merge(into, sources):
         if not src.is_dir():
             continue
         for root, dirs, files in os.walk(src):
+            dirs.sort()
+            files.sort()
             rel_root = Path(root).relative_to(src)
-            for d in sorted(dirs):
+            for d in dirs:
+                rel = rel_root / d
                 dest_dir = into / rel_root / d
                 if dest_dir.exists() and not dest_dir.is_dir():
-                    raise ValueError(
-                        "Type conflict at {}: was a file (from {}), now a directory (from {}).".format(
-                            rel_root / d, owners.get(rel_root / d, "unknown"), src
-                        )
-                    )
+                    conflicts.append((rel, owners.get(rel), src))
+                    _remove(dest_dir)
                 dest_dir.mkdir(parents=True, exist_ok=True)
-            for f in sorted(files):
+                owners[rel] = src
+            for f in files:
                 rel = rel_root / f
                 dest = into / rel
                 src_file = Path(root) / f
                 if dest.is_dir():
-                    raise ValueError(
-                        "Type conflict at {}: was a directory, now a file (from {}).".format(
-                            rel, src
-                        )
-                    )
+                    conflicts.append((rel, owners.get(rel), src))
+                    _remove(dest)
                 prior = owners.get(rel)
-                if prior is not None:
-                    # First wheel wins; byte-identical duplicates (e.g.
+                if dest.exists():
+                    # Byte-identical duplicates (e.g.
                     # an empty __init__.py or py.typed shipped by both
                     # wheels) are benign and not reported.
-                    if not filecmp.cmp(str(src_file), str(dest), shallow=False):
-                        conflicts.append((rel, prior, src))
-                    continue
+                    if filecmp.cmp(str(src_file), str(dest), shallow=False):
+                        shutil.copymode(str(src_file), str(dest))
+                        owners[rel] = src
+                        continue
+                    conflicts.append((rel, prior, src))
+                    _remove(dest)
                 shutil.copy(str(src_file), str(dest))
                 owners[rel] = src
 
@@ -84,20 +108,15 @@ def main():
     )
     args = ap.parse_args()
 
-    try:
-        conflicts = merge(args.into, args.sources)
-    except ValueError as exc:
-        if args.collision_policy == "error":
-            raise SystemExit(str(exc))
-        print(str(exc))
-        conflicts = []
+    conflicts = merge(args.into, args.sources)
 
     if conflicts and args.collision_policy != "ignore":
-        for rel, winner, loser in conflicts:
+        for rel, previous, current in conflicts:
             print(
                 "Package collision while merging {}: `{}` is provided by both {} and {}.".format(
-                    args.into, rel, winner, loser
-                )
+                    args.into, rel, previous, current
+                ),
+                file=sys.stderr,
             )
         if args.collision_policy == "error":
             raise SystemExit(

--- a/py/tools/site_merge/site_merge_test.py
+++ b/py/tools/site_merge/site_merge_test.py
@@ -1,0 +1,116 @@
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from site_merge import merge
+
+
+def _write(path, content, mode=None):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    if mode is not None:
+        path.chmod(mode)
+
+
+class SiteMergeTest(unittest.TestCase):
+    def test_later_source_overlays_earlier_source(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            first = root / "first"
+            second = root / "second"
+            output = root / "output"
+
+            _write(first / "distinct", "first", 0o444)
+            _write(first / "identical", "same", 0o444)
+            _write(first / "file_to_directory", "first", 0o444)
+            _write(first / "directory_to_file/child.py", "first", 0o444)
+            _write(first / "union/first.py", "first")
+
+            _write(second / "distinct", "second")
+            _write(second / "identical", "same", 0o755)
+            _write(second / "file_to_directory/child.py", "second")
+            _write(second / "directory_to_file", "second")
+            _write(second / "union/second.py", "second")
+
+            conflicts = merge(output, [first, second])
+
+            self.assertEqual(
+                {
+                    (path, previous.name, current.name)
+                    for path, previous, current in conflicts
+                },
+                {
+                    (Path("distinct"), "first", "second"),
+                    (Path("file_to_directory"), "first", "second"),
+                    (Path("directory_to_file"), "first", "second"),
+                },
+            )
+            self.assertEqual((output / "distinct").read_text(), "second")
+            self.assertEqual(
+                (output / "file_to_directory/child.py").read_text(), "second"
+            )
+            self.assertEqual((output / "directory_to_file").read_text(), "second")
+            self.assertEqual((output / "union/first.py").read_text(), "first")
+            self.assertEqual((output / "union/second.py").read_text(), "second")
+            self.assertEqual(
+                stat.S_IMODE((output / "identical").stat().st_mode),
+                0o755,
+            )
+
+            self.assertEqual((first / "distinct").read_text(), "first")
+            self.assertEqual(
+                (first / "directory_to_file/child.py").read_text(), "first"
+            )
+            self.assertEqual(stat.S_IMODE((first / "distinct").stat().st_mode), 0o444)
+
+    def test_collision_policy_controls_reporting_and_status(self):
+        for policy in ("warning", "ignore", "error"):
+            with (
+                self.subTest(policy=policy),
+                tempfile.TemporaryDirectory() as temporary_directory,
+            ):
+                root = Path(temporary_directory)
+                first = root / "first"
+                second = root / "second"
+                output = root / "output"
+                _write(first / "entry", "first")
+                _write(second / "entry/child.py", "second")
+
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(Path(__file__).with_name("site_merge.py")),
+                        "--into",
+                        str(output),
+                        "--collision-policy",
+                        policy,
+                        "--src",
+                        str(first),
+                        "--src",
+                        str(second),
+                    ],
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertEqual(result.stdout, "")
+                if policy == "ignore":
+                    self.assertEqual(result.returncode, 0)
+                    self.assertEqual(result.stderr, "")
+                else:
+                    self.assertIn("Package collision", result.stderr)
+                    self.assertIn(str(first), result.stderr)
+                    self.assertIn(str(second), result.stderr)
+                    if policy == "warning":
+                        self.assertEqual(result.returncode, 0)
+                    else:
+                        self.assertNotEqual(result.returncode, 0)
+                if policy != "error":
+                    self.assertEqual((output / "entry/child.py").read_text(), "second")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -332,7 +332,7 @@ def _namespace_dirs_and_roots(dirs_set, init_dirs, namespace_top_levels_set):
     appearing in another wheel's namespace skeleton means a regular
     package SPANS wheels — Python's namespace machinery cannot merge that,
     so the subtree must be physically merged. Dirs under regular
-    top-levels are skipped (handled by the top-level first-wins policy).
+    top-levels are skipped (handled by the top-level collision policy).
     """
     namespace_dirs = []
     regular_roots = []


### PR DESCRIPTION
rules_py 1.11.2 resolved permissive venv collisions by keeping the
last command for each destination. The analysis-time assembler selects
the first metadata claimant and leaves wheel depset order implicit,
reversing that precedence for known wheel layouts.

Aggregate wheel metadata in left-to-right postorder and select the last
distinct claimant for ordinary top-level paths, exact namespace entries,
and console scripts. Build regular-package merge groups from the same
sequence and overlay their inputs in order.

This is sequence-based precedence, not direct-requirement priority.
Depsets remove duplicate elements, so another dependency edge does not
refresh its position. PEP 420 top-levels continue to merge. Namespace
prefix overlaps retain the shallower path, and wheels outside
`PyWheelsInfo` remain on the `.pth` fallback. Error mode continues to
reject collisions.