### PR TITLE
refactor(py): remove inert interpreter default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,14 @@ interpreter extension—rules_python is not required as a toolchain provider.
 
 ```python
 interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
-interpreters.toolchain(python_version = "3.12", is_default = True)
+interpreters.toolchain(python_version = "3.12")
 use_repo(interpreters, "python_interpreters")
 register_toolchains("@python_interpreters//:all")
+```
+
+```text
+# .bazelrc
+common --@aspect_rules_py//py:python_version=3.12
 ```
 
 This enables cross-compilation from any host to any target without host-installed Python, and is the foundation for

--- a/benchmark/startup/MODULE.bazel
+++ b/benchmark/startup/MODULE.bazel
@@ -17,7 +17,6 @@ bazel_dep(name = "rules_python", version = "1.0.0")
 # Python interpreters provisioned from python-build-standalone via aspect_rules_py
 interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
 interpreters.toolchain(
-    is_default = True,
     python_version = "3.11",
 )
 

--- a/benchmark/startup/MODULE.bazel.template
+++ b/benchmark/startup/MODULE.bazel.template
@@ -13,7 +13,6 @@ bazel_dep(name = "rules_python", version = "1.0.0")
 # Python interpreters provisioned from python-build-standalone via aspect_rules_py
 interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
 interpreters.toolchain(
-    is_default = True,
     python_version = "3.11",
 )
 

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -29,12 +29,17 @@ bazel_dep(name = "aspect_rules_py", version = "1.6.7")  # Or later
 
 interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
 interpreters.toolchain(
-    is_default = True,
     python_version = "3.12",
 )
 interpreters.toolchain(python_version = "3.11")
 use_repo(interpreters, "python_interpreters")
 register_toolchains("@python_interpreters//:all")
+```
+
+Select the build-wide Python version in `.bazelrc`:
+
+```text
+common --@aspect_rules_py//py:python_version=3.12
 ```
 
 That's all you need. The extension uses a set of default PBS release dates that
@@ -53,7 +58,7 @@ interpreters.configure(
     releases = ["20260303", "20241002"],
 )
 
-interpreters.toolchain(python_version = "3.12", is_default = True)
+interpreters.toolchain(python_version = "3.12")
 interpreters.toolchain(python_version = "3.8")  # Resolved from 20241002
 
 use_repo(interpreters, "python_interpreters")
@@ -95,16 +100,15 @@ The `base_url` must point to a directory structure matching PBS releases, where
 
 ## Module scoping
 
-The `configure()` tag and the `is_default` / `pre_release` flags on `toolchain()`
-are only honored from the root module. This gives the root module full control
-over the build environment while allowing dependency modules to declare which
-Python versions they need.
+The `configure()` tag and the `pre_release` flag on `toolchain()` are only
+honored from the root module. This gives the root module full control over the
+build environment while allowing dependency modules to declare which Python
+versions they need.
 
 | Setting                           | Root module                          | Non-root module    |
 | --------------------------------- | ------------------------------------ | ------------------ |
 | `configure()`                     | Sets release search space and mirror | Silently ignored   |
 | `toolchain(python_version = ...)` | Adds to global set                   | Adds to global set |
-| `toolchain(is_default = True)`    | Honored                              | Silently ignored   |
 | `toolchain(pre_release = True)`   | Honored                              | Silently ignored   |
 
 If a dependency module requests a Python version that isn't available in any
@@ -113,22 +117,12 @@ message identifying which module requested it.
 
 ## Selecting Python versions
 
-There are three layers of version control, from broadest to most specific.
+There are two layers of version control, from broadest to most specific.
 
-### 1. The default version (MODULE.bazel)
-
-The `is_default = True` toolchain is what Bazel selects when nothing else
-overrides it:
-
-```starlark
-interpreters.toolchain(python_version = "3.12", is_default = True)
-```
-
-### 2. A build-wide default (.bazelrc)
+### 1. A build-wide version (.bazelrc)
 
 Set `--@aspect_rules_py//py:python_version` in `.bazelrc` to lock the
-entire build to a specific version. This is a good practice even when it matches
-the `is_default` toolchain — it makes the choice explicit and visible in version
+entire build to a specific version and keep the selection explicit in version
 control:
 
 ```
@@ -144,7 +138,7 @@ a different version:
 bazel test //... --@aspect_rules_py//py:python_version=3.11
 ```
 
-### 3. Per-target overrides (python_version attribute)
+### 2. Per-target overrides (python_version attribute)
 
 Individual `py_binary`, `py_venv_binary`, `py_test`, and `py_venv_test` targets
 can pin to a specific version using the `python_version` attribute. This takes
@@ -177,11 +171,10 @@ versions:
 
 | Mechanism                               | Scope                  | Set by                     |
 | --------------------------------------- | ---------------------- | -------------------------- |
-| `is_default = True` on `toolchain()`    | Whole build (fallback) | `MODULE.bazel`             |
 | `--@aspect_rules_py//py:python_version` | Whole build            | `.bazelrc` or command line |
 | `python_version` attribute              | Single target          | `BUILD.bazel`              |
 
-The most specific wins: attribute > flag > default toolchain.
+The target attribute takes precedence over the build-wide flag.
 
 ## Build configurations
 

--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -40,7 +40,6 @@ interpreters.toolchain(
     python_version = "3.10",
 )
 interpreters.toolchain(
-    is_default = True,
     python_version = "3.11",
 )
 interpreters.toolchain(

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -198,8 +198,7 @@ def _python_interpreters_impl(module_ctx):
     release_dates = sorted(release_dates, reverse = True)
 
     # Collect all requested Python versions. Any module can request a version,
-    # but only the root module's is_default and pre_release flags are honored.
-    default_version = None
+    # but only the root module's pre_release flag is honored.
     requested_versions = []
     version_sources = {}  # major_minor -> list of module names (for error messages)
     allow_pre_release = {}  # major_minor -> bool
@@ -213,15 +212,6 @@ def _python_interpreters_impl(module_ctx):
             if len(parts) < 2:
                 fail("python_version must be at least major.minor, got '{}'".format(version))
             major_minor = "{}.{}".format(parts[0], parts[1])
-
-            # is_default is root-module-only
-            if tag.is_default and mod.is_root:
-                if default_version and default_version != major_minor:
-                    fail("Multiple default Python versions specified: {} and {}".format(
-                        default_version,
-                        major_minor,
-                    ))
-                default_version = major_minor
 
             if major_minor not in requested_versions:
                 requested_versions.append(major_minor)
@@ -247,13 +237,7 @@ def _python_interpreters_impl(module_ctx):
         return _return_metadata(module_ctx, has_facts, facts, is_reproducible, resolved_latest)
 
     new_facts = {}
-    ordered_versions = []
-
     if requested_versions:
-        # If no default, pick the first one
-        if not default_version:
-            default_version = sorted(requested_versions)[0]
-
         # Fetch and parse release indices (cached via facts)
         release_indices = {}
 
@@ -266,22 +250,15 @@ def _python_interpreters_impl(module_ctx):
             facts_key = "release_index_{}_{}".format(date, base_url)
             new_facts[facts_key] = index
 
-        # Order: default version first, then sorted
-        for version in sorted(requested_versions):
-            if version == default_version:
-                ordered_versions.insert(0, version)
-            else:
-                ordered_versions.append(version)
     else:
         release_indices = {}
 
     # Create per-platform, per-build-config interpreter repos and collect
-    # toolchain entries.  Non-freethreaded configs are registered first so
-    # they win by default when the freethreaded flag is not set.
+    # toolchain entries. Version and freethreaded target settings determine
+    # which entries are eligible.
     toolchain_entries = []
 
-    # Process local interpreter tags first — they get higher toolchain
-    # resolution priority than PBS interpreters.
+    # Collect local interpreter tags before PBS entries.
     for mod in module_ctx.modules:
         if not mod.is_root:
             continue
@@ -321,13 +298,16 @@ def _python_interpreters_impl(module_ctx):
                 "exec_compatible_with": tag.exec_compatible_with,
             }))
 
-    # Order build configs: non-freethreaded first (default wins), then freethreaded
+    # Keep generated output stable: regular configs, then freethreaded configs.
     ordered_configs = (
         [(name, cfg) for name, cfg in BUILD_CONFIGS.items() if not cfg["freethreaded"]] +
         [(name, cfg) for name, cfg in BUILD_CONFIGS.items() if cfg["freethreaded"]]
     )
 
-    for major_minor in ordered_versions:
+    # Target-pattern registration orders toolchains lexicographically by name,
+    # so BUILD declaration order cannot select a default toolchain:
+    # https://bazel.build/extending/toolchains#registering-building-toolchains
+    for major_minor in sorted(requested_versions):
         version_found = False
         for config_name, config_info in ordered_configs:
             for platform_triple, platform_info in PLATFORMS.items():
@@ -496,10 +476,6 @@ exec_compatible_with list.
 Only honored from the root module.
 """,
         ),
-        "is_default": attr.bool(
-            default = False,
-            doc = "Only honored from the root module.",
-        ),
         "pre_release": attr.bool(
             default = False,
             doc = """\
@@ -570,8 +546,7 @@ probed for version info at repository-rule time. If the interpreter is
 unavailable (path missing, env var unset), the toolchain is registered
 but inactive — it will never match during toolchain resolution.
 
-Local toolchains are registered before PBS toolchains, giving them higher
-priority. Use config_settings to gate activation on a custom flag.
+Use config_settings to gate a local toolchain on a custom flag.
 
 Only honored from the root module.
 """,


### PR DESCRIPTION
`interpreters.toolchain(is_default = True)` only moved one version to
the front of the generated BUILD file. Consumers register the hub with
`@python_interpreters//:all`, and Bazel registers matching toolchains
lexicographically by target name, so declaration order cannot choose a
default:
https://bazel.build/extending/toolchains#registering-building-toolchains

Remove the ineffective tag and the other declaration-order priority
claims. Document the build-wide Python version flag and per-target
`python_version` attribute as the controls that actually select a
version.
