### PR TITLE
fix(py): validate interpreter inputs

### DIFF
--- a/e2e/cases/interpreter-input-validation/dependency-invalid-python/BUILD.bazel
+++ b/e2e/cases/interpreter-input-validation/dependency-invalid-python/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/cases/interpreter-input-validation/dependency-invalid-python/MODULE.bazel
+++ b/e2e/cases/interpreter-input-validation/dependency-invalid-python/MODULE.bazel
@@ -1,0 +1,16 @@
+module(name = "dependency_invalid_python")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../../..",
+)
+
+bazel_dep(name = "invalid_python_dependency")
+local_path_override(
+    module_name = "invalid_python_dependency",
+    path = "dep",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+use_repo(interpreters, "python_interpreters")

--- a/e2e/cases/interpreter-input-validation/dependency-invalid-python/dep/BUILD.bazel
+++ b/e2e/cases/interpreter-input-validation/dependency-invalid-python/dep/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: this module contributes only an extension tag.

--- a/e2e/cases/interpreter-input-validation/dependency-invalid-python/dep/MODULE.bazel
+++ b/e2e/cases/interpreter-input-validation/dependency-invalid-python/dep/MODULE.bazel
@@ -1,0 +1,6 @@
+module(name = "invalid_python_dependency")
+
+bazel_dep(name = "aspect_rules_py")
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.toolchain(python_version = "3.14.3.1")

--- a/e2e/cases/interpreter-input-validation/dependency-invalid-release/BUILD.bazel
+++ b/e2e/cases/interpreter-input-validation/dependency-invalid-release/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/cases/interpreter-input-validation/dependency-invalid-release/MODULE.bazel
+++ b/e2e/cases/interpreter-input-validation/dependency-invalid-release/MODULE.bazel
@@ -1,0 +1,17 @@
+module(name = "dependency_invalid_release")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../../..",
+)
+
+bazel_dep(name = "invalid_release_dependency")
+local_path_override(
+    module_name = "invalid_release_dependency",
+    path = "dep",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.toolchain(python_version = "3.14.0a")
+use_repo(interpreters, "python_interpreters")

--- a/e2e/cases/interpreter-input-validation/dependency-invalid-release/dep/BUILD.bazel
+++ b/e2e/cases/interpreter-input-validation/dependency-invalid-release/dep/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: this module contributes only an extension tag.

--- a/e2e/cases/interpreter-input-validation/dependency-invalid-release/dep/MODULE.bazel
+++ b/e2e/cases/interpreter-input-validation/dependency-invalid-release/dep/MODULE.bazel
@@ -1,0 +1,6 @@
+module(name = "invalid_release_dependency")
+
+bazel_dep(name = "aspect_rules_py")
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(releases = ["not-a-date"])

--- a/e2e/cases/interpreter-input-validation/root-invalid-python/BUILD.bazel
+++ b/e2e/cases/interpreter-input-validation/root-invalid-python/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/cases/interpreter-input-validation/root-invalid-python/MODULE.bazel
+++ b/e2e/cases/interpreter-input-validation/root-invalid-python/MODULE.bazel
@@ -1,0 +1,11 @@
+module(name = "root_invalid_python")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.toolchain(python_version = "3.14.3garbage")
+use_repo(interpreters, "python_interpreters")

--- a/e2e/cases/interpreter-input-validation/root-invalid-python/MODULE.bazel
+++ b/e2e/cases/interpreter-input-validation/root-invalid-python/MODULE.bazel
@@ -7,5 +7,5 @@ local_path_override(
 )
 
 interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
-interpreters.toolchain(python_version = "3.14.3garbage")
+interpreters.toolchain(python_version = "3.14.3")
 use_repo(interpreters, "python_interpreters")

--- a/e2e/cases/interpreter-input-validation/root-invalid-release/BUILD.bazel
+++ b/e2e/cases/interpreter-input-validation/root-invalid-release/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/cases/interpreter-input-validation/root-invalid-release/MODULE.bazel
+++ b/e2e/cases/interpreter-input-validation/root-invalid-release/MODULE.bazel
@@ -1,0 +1,12 @@
+module(name = "root_invalid_release")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(releases = ["2026-03-03"])
+interpreters.toolchain(python_version = "3.14")
+use_repo(interpreters, "python_interpreters")

--- a/e2e/cases/interpreter-input-validation/test.sh
+++ b/e2e/cases/interpreter-input-validation/test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# These cases assert module-extension evaluation failures, so they cannot be
+# sh_tests under //...; CI runs this script directly.
+set -uo pipefail
+
+case_dir="$(cd "$(dirname "$0")" && pwd)"
+BAZEL="${BAZEL:-bazel}"
+failure_log="$(mktemp)"
+trap 'rm -f "$failure_log"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+expect_failure() {
+    local fixture="$1"
+    local expected="$2"
+
+    if (
+        cd "$case_dir/$fixture" &&
+            "$BAZEL" query --lockfile_mode=off -- '@python_interpreters//:*'
+    ) >"$failure_log" 2>&1; then
+        fail "$fixture unexpectedly succeeded"
+    fi
+    if ! grep -Fq "$expected" "$failure_log"; then
+        cat "$failure_log" >&2
+        fail "$fixture did not report: $expected"
+    fi
+}
+
+expect_failure \
+    root-invalid-python \
+    "module 'root_invalid_python' requested invalid python_version '3.14.3garbage'"
+expect_failure \
+    dependency-invalid-python \
+    "module 'invalid_python_dependency' requested invalid python_version '3.14.3.1'"
+expect_failure \
+    root-invalid-release \
+    "PBS release identifiers must be eight decimal digits, got '2026-03-03'"
+# Dependency modules do not own release selection. The invalid root tag must be
+# reached without rejecting the dependency's deliberately invalid release tag.
+expect_failure \
+    dependency-invalid-release \
+    "module 'dependency_invalid_release' requested invalid python_version '3.14.0a'"
+
+echo "PASS: interpreter configuration is validated at the owning module boundary"

--- a/e2e/cases/interpreter-input-validation/test.sh
+++ b/e2e/cases/interpreter-input-validation/test.sh
@@ -32,10 +32,10 @@ expect_failure() {
 
 expect_failure \
     root-invalid-python \
-    "module 'root_invalid_python' requested invalid python_version '3.14.3garbage'"
+    "module 'root_invalid_python' requested invalid python_version '3.14.3'; expected major.minor"
 expect_failure \
     dependency-invalid-python \
-    "module 'invalid_python_dependency' requested invalid python_version '3.14.3.1'"
+    "module 'invalid_python_dependency' requested invalid python_version '3.14.3.1'; expected major.minor"
 expect_failure \
     root-invalid-release \
     "PBS release identifiers must be eight decimal digits, got '2026-03-03'"

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -1,7 +1,7 @@
 """Module extension for provisioning Python interpreters from python-build-standalone."""
 
 load(":repository.bzl", "local_python_interpreter", "python_interpreter", "python_toolchains")
-load(":version_util.bzl", "is_pre_release", "is_valid_python_tag", "version_gt")
+load(":version_util.bzl", "is_decimal", "is_pre_release", "version_gt")
 load(":versions.bzl", "BUILD_CONFIGS", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS")
 
 # The GitHub API endpoint for resolving "latest" releases.
@@ -185,11 +185,7 @@ def _python_interpreters_impl(module_ctx):
                     is_reproducible = False
                     date = _resolve_latest(module_ctx, base_url)
                     resolved_latest = date
-                invalid_release = len(date) != 8
-                for char in date.elems():
-                    if char not in "0123456789":
-                        invalid_release = True
-                if invalid_release:
+                if len(date) != 8 or not is_decimal(date):
                     fail(
                         "PBS release identifiers must be eight decimal digits, got '{}'".format(date),
                     )
@@ -216,19 +212,18 @@ def _python_interpreters_impl(module_ctx):
         for tag in mod.tags.toolchain:
             version = tag.python_version
 
-            # Normalize: "3.11.14" -> major_minor "3.11"
-            if not is_valid_python_tag(version):
+            parts = version.split(".")
+            if len(parts) != 2 or not is_decimal(parts[0]) or not is_decimal(parts[1]):
                 fail(
                     (
                         "module '{}' requested invalid python_version '{}'; expected " +
-                        "major.minor or a full final, alpha, beta, or release-candidate version"
+                        "major.minor"
                     ).format(
                         mod.name,
                         version,
                     ),
                 )
-            parts = version.split(".")
-            major_minor = "{}.{}".format(parts[0], parts[1])
+            major_minor = version
 
             # is_default is root-module-only
             if tag.is_default and mod.is_root:
@@ -245,9 +240,9 @@ def _python_interpreters_impl(module_ctx):
             version_sources[major_minor].append(mod.name)
 
             # Pre-release policy is root-module-only. A non-root module
-            # requesting "3.15.0a2" will need the root to also allow
-            # pre-releases for that version.
-            if mod.is_root and (tag.pre_release or is_pre_release(version)):
+            # requesting 3.15 needs the root to allow pre-releases for that
+            # version.
+            if mod.is_root and tag.pre_release:
                 allow_pre_release[major_minor] = True
             elif major_minor not in allow_pre_release:
                 allow_pre_release[major_minor] = False
@@ -531,9 +526,9 @@ Only honored from the root module.
         "python_version": attr.string(
             mandatory = True,
             doc = """\
-Python version to request as major.minor or a full final/a/b/rc version. Full
-versions are normalized to major.minor; a pre-release version also enables
-pre-release selection. The newest available patch version is provisioned.
+Python major.minor version to request, such as 3.11. The newest available patch
+version is provisioned. Set pre_release to allow alpha, beta, or
+release-candidate versions.
 """,
         ),
         "target_compatible_with": attr.string_list(

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -1,7 +1,7 @@
 """Module extension for provisioning Python interpreters from python-build-standalone."""
 
 load(":repository.bzl", "local_python_interpreter", "python_interpreter", "python_toolchains")
-load(":version_util.bzl", "is_pre_release", "version_gt")
+load(":version_util.bzl", "is_pre_release", "is_valid_python_tag", "version_gt")
 load(":versions.bzl", "BUILD_CONFIGS", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS")
 
 # The GitHub API endpoint for resolving "latest" releases.
@@ -185,6 +185,14 @@ def _python_interpreters_impl(module_ctx):
                     is_reproducible = False
                     date = _resolve_latest(module_ctx, base_url)
                     resolved_latest = date
+                invalid_release = len(date) != 8
+                for char in date.elems():
+                    if char not in "0123456789":
+                        invalid_release = True
+                if invalid_release:
+                    fail(
+                        "PBS release identifiers must be eight decimal digits, got '{}'".format(date),
+                    )
                 if date not in release_dates:
                     release_dates.append(date)
                     release_base_urls[date] = base_url
@@ -209,9 +217,17 @@ def _python_interpreters_impl(module_ctx):
             version = tag.python_version
 
             # Normalize: "3.11.14" -> major_minor "3.11"
+            if not is_valid_python_tag(version):
+                fail(
+                    (
+                        "module '{}' requested invalid python_version '{}'; expected " +
+                        "major.minor or a full final, alpha, beta, or release-candidate version"
+                    ).format(
+                        mod.name,
+                        version,
+                    ),
+                )
             parts = version.split(".")
-            if len(parts) < 2:
-                fail("python_version must be at least major.minor, got '{}'".format(version))
             major_minor = "{}.{}".format(parts[0], parts[1])
 
             # is_default is root-module-only
@@ -514,7 +530,11 @@ Only honored from the root module.
         ),
         "python_version": attr.string(
             mandatory = True,
-            doc = "Python version to provision, e.g. '3.11' or '3.11.14'. The newest available patch version is used.",
+            doc = """\
+Python version to request as major.minor or a full final/a/b/rc version. Full
+versions are normalized to major.minor; a pre-release version also enables
+pre-release selection. The newest available patch version is provisioned.
+""",
         ),
         "target_compatible_with": attr.string_list(
             default = [],

--- a/py/private/interpreter/version_util.bzl
+++ b/py/private/interpreter/version_util.bzl
@@ -15,6 +15,40 @@ _PRE_RELEASE_ORDER = {
 }
 _RELEASE_ORDER = 3  # No suffix = final release
 
+def _is_decimal(value):
+    if not value:
+        return False
+    for char in value.elems():
+        if char not in "0123456789":
+            return False
+    return True
+
+def is_valid_python_version(version):
+    """Whether a PBS Python version is final, alpha, beta, or release candidate."""
+    parts = version.split(".")
+    if len(parts) != 3 or not _is_decimal(parts[0]) or not _is_decimal(parts[1]):
+        return False
+
+    patch = parts[2]
+    if _is_decimal(patch):
+        return True
+
+    for marker in ["rc", "b", "a"]:
+        marker_index = patch.find(marker)
+        if marker_index > 0:
+            return (
+                _is_decimal(patch[:marker_index]) and
+                _is_decimal(patch[marker_index + len(marker):])
+            )
+    return False
+
+def is_valid_python_tag(version):
+    """Whether a requested version is major.minor or a valid PBS version."""
+    parts = version.split(".")
+    if len(parts) == 2:
+        return _is_decimal(parts[0]) and _is_decimal(parts[1])
+    return is_valid_python_version(version)
+
 def _parse_pre_release(s):
     """Parse a version component that may contain a pre-release suffix.
 

--- a/py/private/interpreter/version_util.bzl
+++ b/py/private/interpreter/version_util.bzl
@@ -15,39 +15,14 @@ _PRE_RELEASE_ORDER = {
 }
 _RELEASE_ORDER = 3  # No suffix = final release
 
-def _is_decimal(value):
+def is_decimal(value):
+    """Whether value consists of one or more ASCII decimal digits."""
     if not value:
         return False
     for char in value.elems():
         if char not in "0123456789":
             return False
     return True
-
-def is_valid_python_version(version):
-    """Whether a PBS Python version is final, alpha, beta, or release candidate."""
-    parts = version.split(".")
-    if len(parts) != 3 or not _is_decimal(parts[0]) or not _is_decimal(parts[1]):
-        return False
-
-    patch = parts[2]
-    if _is_decimal(patch):
-        return True
-
-    for marker in ["rc", "b", "a"]:
-        marker_index = patch.find(marker)
-        if marker_index > 0:
-            return (
-                _is_decimal(patch[:marker_index]) and
-                _is_decimal(patch[marker_index + len(marker):])
-            )
-    return False
-
-def is_valid_python_tag(version):
-    """Whether a requested version is major.minor or a valid PBS version."""
-    parts = version.split(".")
-    if len(parts) == 2:
-        return _is_decimal(parts[0]) and _is_decimal(parts[1])
-    return is_valid_python_version(version)
 
 def _parse_pre_release(s):
     """Parse a version component that may contain a pre-release suffix.

--- a/py/private/interpreter/version_util_test.bzl
+++ b/py/private/interpreter/version_util_test.bzl
@@ -1,7 +1,32 @@
 """Tests for version_util.bzl."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//py/private/interpreter:version_util.bzl", "is_pre_release", "version_gt", "version_key")
+load("//py/private/interpreter:version_util.bzl", "is_pre_release", "is_valid_python_tag", "version_gt", "version_key")
+
+def _is_valid_python_tag_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    for version in [
+        "3.14",
+        "3.14.3",
+        "3.15.0a6",
+        "3.14.0b1",
+        "3.14.0rc2",
+    ]:
+        asserts.true(env, is_valid_python_tag(version), version)
+
+    for version in [
+        "3",
+        "3.14.3.1",
+        "3.14.3garbage",
+        "3.14.0a",
+        "3.14.0rc1garbage",
+    ]:
+        asserts.false(env, is_valid_python_tag(version), version)
+
+    return unittest.end(env)
+
+is_valid_python_tag_test = unittest.make(_is_valid_python_tag_test_impl)
 
 def _version_key_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -106,6 +131,7 @@ is_pre_release_test = unittest.make(_is_pre_release_test_impl)
 def version_util_test_suite():
     unittest.suite(
         "version_util_tests",
+        is_valid_python_tag_test,
         version_key_test,
         version_gt_basic_test,
         version_gt_prerelease_test,

--- a/py/private/interpreter/version_util_test.bzl
+++ b/py/private/interpreter/version_util_test.bzl
@@ -1,32 +1,7 @@
 """Tests for version_util.bzl."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//py/private/interpreter:version_util.bzl", "is_pre_release", "is_valid_python_tag", "version_gt", "version_key")
-
-def _is_valid_python_tag_test_impl(ctx):
-    env = unittest.begin(ctx)
-
-    for version in [
-        "3.14",
-        "3.14.3",
-        "3.15.0a6",
-        "3.14.0b1",
-        "3.14.0rc2",
-    ]:
-        asserts.true(env, is_valid_python_tag(version), version)
-
-    for version in [
-        "3",
-        "3.14.3.1",
-        "3.14.3garbage",
-        "3.14.0a",
-        "3.14.0rc1garbage",
-    ]:
-        asserts.false(env, is_valid_python_tag(version), version)
-
-    return unittest.end(env)
-
-is_valid_python_tag_test = unittest.make(_is_valid_python_tag_test_impl)
+load("//py/private/interpreter:version_util.bzl", "is_pre_release", "version_gt", "version_key")
 
 def _version_key_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -131,7 +106,6 @@ is_pre_release_test = unittest.make(_is_pre_release_test_impl)
 def version_util_test_suite():
     unittest.suite(
         "version_util_tests",
-        is_valid_python_tag_test,
         version_key_test,
         version_gt_basic_test,
         version_gt_prerelease_test,


### PR DESCRIPTION
Require each toolchain python_version tag to be a decimal major.minor,
the actual selection granularity, and reject malformed root-owned PBS
release identifiers before fetching a release manifest.

The exact-runtime cohort work uses both values as structured selection keys.
Previously, 3.14.3garbage silently selected 3.14, making exact-looking input
misleading, while 2026-03-03 became a failed network request. Keep
pre-release policy on the explicit pre_release attribute. Validate every
module's toolchain requests, but continue ignoring release configuration from
dependencies because the root module owns the release search space.