### PR TITLE
fix(py): describe PBS runtime metadata

### DIFF
--- a/e2e/cases/interpreter-runtime-metadata/BUILD.bazel
+++ b/e2e/cases/interpreter-runtime-metadata/BUILD.bazel
@@ -1,0 +1,22 @@
+load(":runtime_metadata_test.bzl", "runtime_metadata_test")
+
+runtime_metadata_test(
+    name = "regular",
+    abi_flags = "",
+    runtime = "@python_3_15_x86_64_unknown_linux_gnu//:py3_runtime",
+    tags = ["manual"],
+)
+
+runtime_metadata_test(
+    name = "freethreaded",
+    abi_flags = "t",
+    runtime = "@python_3_15_x86_64_unknown_linux_gnu_freethreaded_pgo_lto//:py3_runtime",
+    tags = ["manual"],
+)
+
+runtime_metadata_test(
+    name = "freethreaded_debug",
+    abi_flags = "td",
+    runtime = "@python_3_15_x86_64_unknown_linux_gnu_freethreaded_debug//:py3_runtime",
+    tags = ["manual"],
+)

--- a/e2e/cases/interpreter-runtime-metadata/MODULE.bazel
+++ b/e2e/cases/interpreter-runtime-metadata/MODULE.bazel
@@ -1,0 +1,22 @@
+module(name = "interpreter_runtime_metadata")
+
+bazel_dep(name = "aspect_rules_py")
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(releases = ["20260303"])
+interpreters.toolchain(
+    pre_release = True,
+    python_version = "3.15",
+)
+use_repo(
+    interpreters,
+    "python_3_15_x86_64_unknown_linux_gnu",
+    "python_3_15_x86_64_unknown_linux_gnu_freethreaded_debug",
+    "python_3_15_x86_64_unknown_linux_gnu_freethreaded_pgo_lto",
+)

--- a/e2e/cases/interpreter-runtime-metadata/runtime_metadata_test.bzl
+++ b/e2e/cases/interpreter-runtime-metadata/runtime_metadata_test.bzl
@@ -1,0 +1,36 @@
+"""Checks metadata on a provisioned PBS Python runtime."""
+
+load("@rules_python//python:py_runtime_info.bzl", "PyRuntimeInfo")
+
+def _assert_equal(description, expected, actual):
+    if actual != expected:
+        fail("{}: expected {}, got {}".format(description, expected, actual))
+
+def _runtime_metadata_test_impl(ctx):
+    runtime = ctx.attr.runtime[PyRuntimeInfo]
+    version = runtime.interpreter_version_info
+
+    _assert_equal("implementation", "cpython", runtime.implementation_name)
+    _assert_equal("major", 3, version.major)
+    _assert_equal("minor", 15, version.minor)
+    _assert_equal("micro", 0, version.micro)
+    _assert_equal("release level", "alpha", version.releaselevel)
+    _assert_equal("release serial", 6, version.serial)
+    _assert_equal("ABI flags", ctx.attr.abi_flags, runtime.abi_flags)
+
+    # Free-threaded CPython keeps the same cache tag without its `t` ABI flag:
+    # https://github.com/python/cpython/blob/v3.15.0a5/Python/sysmodule.c#L3570-L3576
+    _assert_equal("pyc tag", "cpython-315", runtime.pyc_tag)
+
+    executable = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(executable, "#!/usr/bin/env sh\n", is_executable = True)
+    return [DefaultInfo(executable = executable)]
+
+runtime_metadata_test = rule(
+    implementation = _runtime_metadata_test_impl,
+    attrs = {
+        "abi_flags": attr.string(mandatory = True),
+        "runtime": attr.label(mandatory = True, providers = [PyRuntimeInfo]),
+    },
+    test = True,
+)

--- a/e2e/cases/interpreter-runtime-metadata/test.sh
+++ b/e2e/cases/interpreter-runtime-metadata/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# These checks load generated repositories from a nested module, so CI runs
+# them directly rather than through the parent e2e workspace.
+set -uo pipefail
+
+case_dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$case_dir" || exit 1
+
+BAZEL="${BAZEL:-bazel}"
+if ! "$BAZEL" test --lockfile_mode=off -- \
+    //:regular \
+    //:freethreaded \
+    //:freethreaded_debug; then
+    echo "FAIL: prerelease runtime metadata did not match" >&2
+    exit 1
+fi
+
+echo "PASS: PBS runtime metadata matches the selected interpreter"

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -331,6 +331,7 @@ def _python_interpreters_impl(module_ctx):
                 )
                 python_interpreter(
                     name = repo_name,
+                    abi_flags = config_info["abi_flags"],
                     python_version = asset_info["full_version"],
                     platform = platform_triple,
                     url = url,

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -29,17 +29,29 @@ def _python_interpreter_impl(rctx):
     major = version_parts[0]
     minor = version_parts[1]
     micro = version_parts[2] if len(version_parts) > 2 else "0"
+    releaselevel = "final"
+    serial = "0"
+    for marker, level in [("rc", "candidate"), ("b", "beta"), ("a", "alpha")]:
+        marker_index = micro.find(marker)
+        if marker_index >= 0:
+            serial = micro[marker_index + len(marker):] or "0"
+            micro = micro[:marker_index] or "0"
+            releaselevel = level
+            break
 
     # Delete terminfo symlink loops on newer PBS releases (linux only)
     if "linux" in platform:
         rctx.delete("share/terminfo")
 
     rctx.file("BUILD.bazel", content = _build_file_content(
+        abi_flags = rctx.attr.abi_flags,
         major = major,
         minor = minor,
         micro = micro,
         python_bin = python_bin,
         is_windows = is_windows,
+        releaselevel = releaselevel,
+        serial = serial,
     ))
 
     if not features.external_deps.extension_metadata_has_reproducible:
@@ -81,7 +93,7 @@ filegroup(
 
     return "\n".join(lines), all_excludes
 
-def _build_file_content(major, minor, micro, python_bin, is_windows):
+def _build_file_content(major, minor, micro, python_bin, is_windows, abi_flags, releaselevel, serial):
     """Generate the full BUILD.bazel content for an interpreter repo."""
 
     feature_targets, feature_excludes = _feature_filegroups(major, minor, is_windows)
@@ -141,12 +153,15 @@ filegroup(
 
 py_runtime(
     name = "py3_runtime",
+    abi_flags = "{abi_flags}",
     files = [":files"],
     interpreter = "{python_bin}",
     interpreter_version_info = {{
         "major": "{major}",
         "minor": "{minor}",
         "micro": "{micro}",
+        "releaselevel": "{releaselevel}",
+        "serial": "{serial}",
     }},
     python_version = "PY3",
 )
@@ -161,10 +176,13 @@ py_exec_tools_toolchain(
     name = "exec_tools_toolchain",
 )
 """.format(
+        abi_flags = abi_flags,
         python_bin = python_bin,
         major = major,
         minor = minor,
         micro = micro,
+        releaselevel = releaselevel,
+        serial = serial,
         feature_targets = feature_targets,
         feature_selects = feature_selects,
         core_include = core_include,
@@ -174,6 +192,7 @@ py_exec_tools_toolchain(
 python_interpreter = repository_rule(
     implementation = _python_interpreter_impl,
     attrs = {
+        "abi_flags": attr.string(default = ""),
         "freethreaded": attr.bool(default = False),
         "platform": attr.string(mandatory = True),
         "python_version": attr.string(default = ""),

--- a/py/private/interpreter/versions.bzl
+++ b/py/private/interpreter/versions.bzl
@@ -130,28 +130,33 @@ PLATFORMS = {
 # - extension: the archive file extension
 # - strip_prefix: the prefix to strip when extracting
 # - freethreaded: whether this is a free-threaded build
+# - abi_flags: CPython ABI flags for the build
 #
 # buildifier: disable=unsorted-dict-items
 BUILD_CONFIGS = {
     "install_only": {
+        "abi_flags": "",
         "suffix": "install_only",
         "extension": "tar.gz",
         "strip_prefix": "python",
         "freethreaded": False,
     },
     "install_only_stripped": {
+        "abi_flags": "",
         "suffix": "install_only_stripped",
         "extension": "tar.gz",
         "strip_prefix": "python",
         "freethreaded": False,
     },
     "freethreaded+pgo+lto": {
+        "abi_flags": "t",
         "suffix": "freethreaded+pgo+lto-full",
         "extension": "tar.zst",
         "strip_prefix": "python/install",
         "freethreaded": True,
     },
     "freethreaded+debug": {
+        "abi_flags": "td",
         "suffix": "freethreaded+debug-full",
         "extension": "tar.zst",
         "strip_prefix": "python/install",


### PR DESCRIPTION
Populate PBS `PyRuntimeInfo` with complete version and ABI metadata.

Consumers comparing target and execution interpreter cohorts need the
prerelease and ABI fields to identify equivalent runtimes. Generated runtimes
currently leave `releaselevel` and `serial` at their defaults, put the
prerelease suffix in `micro`, and omit ABI flags.

Split PBS versions into the fields expected by `PyRuntimeInfo`, and take ABI
flags from the selected PBS build configuration. This distinguishes regular,
free-threaded, and free-threaded debug runtimes.