### PR TITLE
refactor(py): retain PBS release versions

### DIFF
--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load(":exclude_feature.bzl", "exclude_feature_flag")
+load(":release_index_test.bzl", "release_index_test_suite")
 load(":version_util_test.bzl", "version_util_test_suite")
 
 package(default_visibility = ["//visibility:public"])
@@ -18,6 +19,7 @@ bzl_library(
     srcs = ["extension.bzl"],
     deps = [
         ":exclude_feature_bzl",
+        ":release_index",
         ":repository",
         ":version_util",
         ":versions",
@@ -73,6 +75,8 @@ bool_flag(
     build_setting_default = False,
 )
 
+release_index_test_suite()
+
 version_util_test_suite()
 
 # keep
@@ -87,6 +91,15 @@ bzl_library(
     deps = [
         ":exclude_feature_bzl",  # keep
         "@bazel_features//:features",
+    ],
+)
+
+bzl_library(
+    name = "release_index",
+    srcs = ["release_index.bzl"],
+    deps = [
+        ":version_util",
+        ":versions",
     ],
 )
 

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -1,89 +1,17 @@
 """Module extension for provisioning Python interpreters from python-build-standalone."""
 
+load(":release_index.bzl", "find_asset", "parse_sha256sums")
 load(":repository.bzl", "local_python_interpreter", "python_interpreter", "python_toolchains")
-load(":version_util.bzl", "is_pre_release", "version_gt")
+load(":version_util.bzl", "is_pre_release")
 load(":versions.bzl", "BUILD_CONFIGS", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS")
 
 # The GitHub API endpoint for resolving "latest" releases.
 _GITHUB_API_LATEST = "https://api.github.com/repos/{owner}/{repo}/releases/latest"
+_RELEASE_INDEX_SCHEMA = 1
 
 def _sanitize(s):
     """Replace characters that are invalid in Bazel repo names."""
     return s.replace(".", "_").replace("-", "_").replace("+", "_")
-
-def _parse_sha256sums(content, release_date):
-    """Parse a SHA256SUMS file into a structured index.
-
-    Returns a dict mapping (major_minor, platform, build_config) -> {
-        "sha256": str,
-        "filename": str,
-        "full_version": str,
-    }
-
-    When multiple patch versions exist for the same major.minor, only the
-    newest is kept.
-    """
-    index = {}
-
-    for line in content.split("\n"):
-        line = line.strip()
-        if not line or not line[0].isalnum():
-            continue
-
-        parts = line.split("  ", 1)
-        if len(parts) != 2:
-            parts = line.split(" ", 1)
-            if len(parts) != 2:
-                continue
-
-        sha256 = parts[0].strip()
-        filename = parts[1].strip()
-
-        if not filename.startswith("cpython-"):
-            continue
-
-        # Parse: cpython-{version}+{date}-{platform}-{suffix}.{ext}
-        plus_idx = filename.find("+")
-        if plus_idx < 0:
-            continue
-        version = filename[len("cpython-"):plus_idx]
-
-        version_parts = version.split(".")
-        if len(version_parts) < 2:
-            continue
-        major_minor = "{}.{}".format(version_parts[0], version_parts[1])
-
-        # Match against known build configs (check suffix + extension)
-        remainder = filename[plus_idx + 1 + len(release_date) + 1:]  # skip "{date}-"
-        matched_config = None
-        matched_platform = None
-
-        for config_name, config_info in BUILD_CONFIGS.items():
-            expected_tail = "-{}.{}".format(config_info["suffix"], config_info["extension"])
-            if remainder.endswith(expected_tail):
-                platform_str = remainder[:len(remainder) - len(expected_tail)]
-                if platform_str in PLATFORMS:
-                    matched_config = config_name
-                    matched_platform = platform_str
-                    break
-
-        if not matched_config:
-            continue
-
-        key = "{}/{}/{}".format(major_minor, matched_platform, matched_config)
-
-        # Keep the newest patch version
-        existing = index.get(key)
-        if existing and not version_gt(version, existing["full_version"]):
-            continue
-
-        index[key] = {
-            "sha256": sha256,
-            "filename": filename,
-            "full_version": version,
-        }
-
-    return index
 
 def _owner_repo_from_base_url(base_url):
     """Extract GitHub owner/repo from a base URL like https://github.com/{owner}/{repo}/releases/download."""
@@ -121,12 +49,15 @@ def _resolve_latest(module_ctx, base_url):
         fail('Could not resolve "latest" release from {}'.format(api_url))
     return tag
 
+def _release_index_facts_key(release_date, base_url):
+    return "release_index_v{}_{}_{}".format(_RELEASE_INDEX_SCHEMA, release_date, base_url)
+
 def _fetch_release_index(module_ctx, release_date, base_url, facts):
     """Fetch and parse SHA256SUMS for a release, using facts as cache.
 
     Returns the parsed index dict for this release date.
     """
-    facts_key = "release_index_{}_{}".format(release_date, base_url)
+    facts_key = _release_index_facts_key(release_date, base_url)
     cached = facts.get(facts_key)
     if cached:
         return cached
@@ -141,7 +72,7 @@ def _fetch_release_index(module_ctx, release_date, base_url, facts):
     )
     content = module_ctx.read(sha256sums_path)
 
-    index = _parse_sha256sums(content, release_date)
+    index = parse_sha256sums(content, release_date)
     if not index:
         fail(
             "No CPython assets found in SHA256SUMS for release date \"{}\". ".format(release_date) +
@@ -247,7 +178,7 @@ def _python_interpreters_impl(module_ctx):
             release_indices[date] = index
 
             # Cache in facts for next run — but never cache under "latest"
-            facts_key = "release_index_{}_{}".format(date, base_url)
+            facts_key = _release_index_facts_key(date, base_url)
             new_facts[facts_key] = index
 
     else:
@@ -319,7 +250,7 @@ def _python_interpreters_impl(module_ctx):
                     repo_name += "_" + _sanitize(config_name)
 
                 # Find the best release for this version/platform/config
-                asset_info = _find_asset(
+                asset_info = find_asset(
                     major_minor,
                     platform_triple,
                     config_name,
@@ -383,21 +314,6 @@ def _python_interpreters_impl(module_ctx):
     )
 
     return _return_metadata(module_ctx, has_facts, new_facts, is_reproducible, resolved_latest)
-
-def _find_asset(major_minor, platform, build_config, release_dates, release_indices):
-    """Find the best asset across releases, preferring newer releases."""
-    for date in release_dates:
-        index = release_indices.get(date, {})
-        key = "{}/{}/{}".format(major_minor, platform, build_config)
-        entry = index.get(key)
-        if entry:
-            return {
-                "release_date": date,
-                "sha256": entry["sha256"],
-                "filename": entry["filename"],
-                "full_version": entry["full_version"],
-            }
-    return None
 
 def _return_metadata(module_ctx, has_facts, facts, is_reproducible, resolved_latest):
     """Return extension_metadata with facts and reproducibility info."""

--- a/py/private/interpreter/release_index.bzl
+++ b/py/private/interpreter/release_index.bzl
@@ -1,0 +1,89 @@
+"""PBS release-index parsing and asset selection."""
+
+load(":version_util.bzl", "version_gt")
+load(":versions.bzl", "BUILD_CONFIGS", "PLATFORMS")
+
+def parse_sha256sums(content, release_date):
+    """Parse configured CPython assets from a PBS SHA256SUMS file.
+
+    Returns a dict mapping (major_minor, platform, build_config) to every full
+    version published in the release. Each version maps to its filename and
+    checksum.
+    """
+    index = {}
+
+    for line in content.split("\n"):
+        line = line.strip()
+        if not line or not line[0].isalnum():
+            continue
+
+        parts = line.split("  ", 1)
+        if len(parts) != 2:
+            parts = line.split(" ", 1)
+            if len(parts) != 2:
+                continue
+
+        sha256 = parts[0].strip()
+        filename = parts[1].strip()
+
+        if not filename.startswith("cpython-"):
+            continue
+
+        # Parse: cpython-{version}+{date}-{platform}-{suffix}.{ext}
+        plus_idx = filename.find("+")
+        if plus_idx < 0:
+            continue
+        version = filename[len("cpython-"):plus_idx]
+
+        version_parts = version.split(".")
+        if len(version_parts) < 2:
+            continue
+        major_minor = "{}.{}".format(version_parts[0], version_parts[1])
+
+        # Match against known build configs (check suffix + extension)
+        remainder = filename[plus_idx + 1 + len(release_date) + 1:]  # skip "{date}-"
+        matched_config = None
+        matched_platform = None
+
+        for config_name, config_info in BUILD_CONFIGS.items():
+            expected_tail = "-{}.{}".format(config_info["suffix"], config_info["extension"])
+            if remainder.endswith(expected_tail):
+                platform_str = remainder[:len(remainder) - len(expected_tail)]
+                if platform_str in PLATFORMS:
+                    matched_config = config_name
+                    matched_platform = platform_str
+                    break
+
+        if not matched_config:
+            continue
+
+        key = "{}/{}/{}".format(major_minor, matched_platform, matched_config)
+        versions = index.get(key)
+        if versions == None:
+            versions = {}
+            index[key] = versions
+        if version in versions:
+            continue
+        versions[version] = {
+            "sha256": sha256,
+            "filename": filename,
+        }
+
+    return index
+
+def find_asset(major_minor, platform, build_config, release_dates, release_indices):
+    """Select the newest asset from the first release containing the key."""
+    key = "{}/{}/{}".format(major_minor, platform, build_config)
+    for release_date in release_dates:
+        versions = release_indices.get(release_date, {}).get(key, {})
+        selected_version = None
+        for full_version in versions:
+            if selected_version == None or version_gt(full_version, selected_version):
+                selected_version = full_version
+        if selected_version != None:
+            return dict(
+                versions[selected_version],
+                full_version = selected_version,
+                release_date = release_date,
+            )
+    return None

--- a/py/private/interpreter/release_index_test.bzl
+++ b/py/private/interpreter/release_index_test.bzl
@@ -1,0 +1,71 @@
+"""Tests for PBS release-index parsing and selection."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":release_index.bzl", "find_asset", "parse_sha256sums")
+
+_SHA = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+_RELEASE_NEW = "20260202"
+_RELEASE_OLD = "20260101"
+_LINUX = "x86_64-unknown-linux-gnu"
+_WINDOWS = "x86_64-pc-windows-msvc"
+
+def _retains_every_full_version_test_impl(ctx):
+    env = unittest.begin(ctx)
+    index = parse_sha256sums("\n".join([
+        "{} cpython-3.15.0a1+{}-{}-install_only.tar.gz".format(_SHA, _RELEASE_OLD, _LINUX),
+        "{} cpython-3.15.0a2+{}-{}-install_only.tar.gz".format(_SHA, _RELEASE_OLD, _LINUX),
+        "{} cpython-3.15.0a1+{}-{}-install_only.tar.gz".format(_SHA, _RELEASE_OLD, _WINDOWS),
+    ]), _RELEASE_OLD)
+
+    asserts.equals(
+        env,
+        ["3.15.0a1", "3.15.0a2"],
+        sorted(index["3.15/{}/install_only".format(_LINUX)].keys()),
+        "Linux release index should retain both published versions",
+    )
+    asserts.equals(
+        env,
+        ["3.15.0a1"],
+        sorted(index["3.15/{}/install_only".format(_WINDOWS)].keys()),
+        "Windows release index should retain its older companion version",
+    )
+    return unittest.end(env)
+
+retains_every_full_version_test = unittest.make(_retains_every_full_version_test_impl)
+
+def _selects_newest_version_from_first_release_test_impl(ctx):
+    env = unittest.begin(ctx)
+    key = "3.15/{}/install_only".format(_LINUX)
+    asset = find_asset(
+        "3.15",
+        _LINUX,
+        "install_only",
+        [_RELEASE_NEW, _RELEASE_OLD],
+        {
+            _RELEASE_NEW: {
+                key: {
+                    "3.15.0a1": {"filename": "new-a1", "sha256": _SHA},
+                    "3.15.0a2": {"filename": "new-a2", "sha256": _SHA},
+                },
+            },
+            _RELEASE_OLD: {
+                key: {
+                    "3.15.0": {"filename": "old-final", "sha256": _SHA},
+                },
+            },
+        },
+    )
+
+    asserts.equals(env, _RELEASE_NEW, asset["release_date"])
+    asserts.equals(env, "3.15.0a2", asset["full_version"])
+    asserts.equals(env, "new-a2", asset["filename"])
+    return unittest.end(env)
+
+selects_newest_version_from_first_release_test = unittest.make(_selects_newest_version_from_first_release_test_impl)
+
+def release_index_test_suite():
+    unittest.suite(
+        "release_index_tests",
+        retains_every_full_version_test,
+        selects_newest_version_from_first_release_test,
+    )


### PR DESCRIPTION
Retain every full Python version for each platform and build configuration
in a PBS release index. The current parser collapses each entry to its newest
full version. When platform versions differ, that loses the older artifact
needed to describe an exact target/execution interpreter cohort.

Keep runtime selection unchanged: choose the first configured release that
contains the key, then its newest full version. Version the module-extension
facts key so cached indices are refetched in the new shape.

Malformed and duplicate manifest lines keep their existing permissive
behavior. Rejecting them would be a separate behavior change for mirrors.