### PR TITLE
fix(uv): retain anyarch validation

### DIFF
--- a/e2e/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
+++ b/e2e/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
@@ -14,7 +14,6 @@ pep517_native_whl(
     src = "@@aspect_rules_py++uv+sdist__jpype1__3cd88838dc3d2d54//file:file",
     tool = ":build_tool",
     version = "1.7.1",
-    args = [],
     toolchains = [
         "@bazel_tools//tools/cpp:current_cc_toolchain",
         "@@bazel_tools//tools/jdk:current_java_runtime",

--- a/e2e/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
+++ b/e2e/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
@@ -14,7 +14,6 @@ pep517_native_whl(
     src = "@@aspect_rules_py++uv+sdist__python_geohash__05a21fcf4eda1a5e//file:file",
     tool = ":build_tool",
     version = "0.8.5",
-    args = [],
     resource_set = "mem_4g",
     toolchains = [
         "@bazel_tools//tools/cpp:current_cc_toolchain",

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -259,6 +259,8 @@ def _sdist_build_impl(repository_ctx):
     if repository_ctx.attr.resource_set != "default":
         resource_set_attr = "\n    resource_set = \"{}\",".format(repository_ctx.attr.resource_set)
 
+    # Leave args unset: the pure rule validates anyarch wheels by default,
+    # while the native rule defaults to no validation.
     repository_ctx.file("BUILD.bazel", content = """
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{rule}")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
@@ -274,8 +276,7 @@ py_binary(
     name = "whl",
     src = "{src}",
     tool = ":build_tool",
-    version = "{version}",
-    args = [],{resource_set_attr}{patch_attrs}{toolchain_attrs}
+    version = "{version}",{resource_set_attr}{patch_attrs}{toolchain_attrs}
     visibility = ["//visibility:public"],
 )
 

--- a/uv/private/uv_hub/snapshots/sdist_build.bravado_core.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/sdist_build.bravado_core.BUILD.bazel
@@ -14,7 +14,6 @@ pep517_whl(
     src = "@@+uv+sdist__bravado_core__8cf1f7bbac2f7c69//file:file",
     tool = ":build_tool",
     version = "6.1.1",
-    args = [],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Source-build configuration depends on `sdist_build`'s pure/native
classification, but its generated target sets `args = []` for either
result. This overrides the `--validate-anyarch` default on `pep517_whl`,
so an archive classified as pure can emit a platform-specific wheel
without failing the fallback check.

Let generated targets inherit their rule-owned defaults. Pure builds
keep `--validate-anyarch`, while native builds keep an empty argument
list.
