### PR TITLE
fix: enforce format exclusions

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -8,26 +8,10 @@ load("@aspect//traits.axl", "BazelTrait")
 # CI and local users can run `aspect buildifier` to format Starlark files only.
 buildifier = format.alias(
     defaults = {
-        "formatter_target": "@buildifier_prebuilt//buildifier",
-        # Fires only when the format task would otherwise pass zero files
-        # to the formatter (e.g. `--scope=all`, or a `--scope=changed` run
-        # that degraded because no changed files matched). The bare
-        # buildifier binary needs `-r .` to walk the tree on its own. Inert
-        # whenever a file list is passed, so `--scope=changed` (the default)
-        # and per-file invocations are unaffected.
-        #
-        # Caveat: `buildifier -r .` auto-discovers only BUILD, BUILD.bazel,
-        # MODULE.bazel, WORKSPACE, WORKSPACE.bazel, *.bzl, and *.star, so
-        # `--scope=all` silently skips *.axl, *.MODULE.bazel, Tiltfile, and
-        # BUCK files from the `include_patterns` list below. `--scope=changed`
-        # passes the changed file list positionally, so those extensions are
-        # covered there. See
-        # https://docs.aspect.build/cli/tasks/buildifier#run-it-locally for
-        # the user-facing reference.
-        "formatter_args_for_tree_walk": ["-r", "."],
-        # buildifier_binary is a symlink to the raw Go binary; it does not
-        # switch to $BUILD_WORKING_DIRECTORY on its own, so we run it in
-        # the user's cwd to make relative paths resolve.
+        "formatter_target": "//tools:buildifier",
+        # The wrapper discovers files when the format task provides none, and
+        # runs in the user's cwd so relative paths resolve in either mode.
+        "formatter_args_for_tree_walk": ["--rules-py-discover"],
         "run_in": "cwd",
         "include_patterns": [
             "**/BUCK",
@@ -42,10 +26,11 @@ buildifier = format.alias(
             "**/*.bzl",
             "**/*.star",
         ],
-        # Snapshot files under **/snapshots/ are generated test fixtures
-        # (golden BUILD.bazel / *.bzl output) and must match the rules'
-        # emitted formatting verbatim, not buildifier's. Drop them from the
-        # file list before the formatter runs.
+        # Aspect delegates --scope=all discovery to the formatter and applies
+        # exclusions only to the post-format diff:
+        # https://github.com/aspect-build/aspect-cli/blob/efa2bc8def40def4934c15b1eece297c17bb6b3e/crates/aspect-cli/src/builtins/aspect/format.axl#L656-L659
+        # The wrapper therefore excludes snapshots during its own discovery.
+        # Keep these patterns in sync with //tools:buildifier.
         "exclude_patterns": [
             "**/snapshots/**",
         ],

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,9 +1,32 @@
 load("@bazel_env.bzl", "bazel_env")
 load("@multitool//:tools.bzl", MULTITOOL_TOOLS = "TOOLS")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 
 bazel_env(
     name = "bazel_env",
     tools = {
         "uv": "@uv",
     } | MULTITOOL_TOOLS,
+)
+
+py_binary(
+    name = "buildifier",
+    srcs = ["buildifier.py"],
+    data = ["@buildifier_prebuilt//buildifier"],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+py_test(
+    name = "buildifier_test",
+    srcs = [
+        "__init__.py",
+        "buildifier.py",
+        "buildifier_test.py",
+    ],
+    data = [":buildifier"],
+    env = {
+        "RULES_PY_BUILDIFIER": "$(rlocationpath :buildifier)",
+    },
+    main = "buildifier_test.py",
+    deps = ["@rules_python//python/runfiles"],
 )

--- a/tools/buildifier.py
+++ b/tools/buildifier.py
@@ -1,0 +1,75 @@
+"""Run buildifier without touching generated snapshots."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+_DISCOVER_ARGUMENT = "--rules-py-discover"
+# Aspect directly spawns formatter executables with only its computed
+# arguments, so py_binary.args cannot carry this data label's runfiles path:
+# https://github.com/aspect-build/aspect-cli/blob/efa2bc8def40def4934c15b1eece297c17bb6b3e/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl#L373-L404
+# @buildifier_prebuilt//buildifier declares buildifier/buildifier:
+# https://github.com/keith/buildifier-prebuilt/blob/bf945a59eaa436c8b4857774ae724b4c31a08643/buildifier/buildifier_binary.bzl#L7-L20
+_BUILDIFIER_RLOCATION = "buildifier_prebuilt/buildifier/buildifier"
+_STARLARK_FILENAMES = {
+    "BUCK",
+    "BUILD",
+    "BUILD.bazel",
+    "MODULE.bazel",
+    "Tiltfile",
+    "WORKSPACE",
+    "WORKSPACE.bazel",
+}
+_STARLARK_SUFFIXES = (".MODULE.bazel", ".axl", ".bzl", ".star")
+
+
+def _discover_files(root: Path) -> list[str]:
+    for workspace_root in (root, *root.parents):
+        if (workspace_root / ".git").exists():
+            break
+    else:
+        workspace_root = root
+    if "snapshots" in root.relative_to(workspace_root).parts:
+        return []
+
+    files = []
+    for directory, dirnames, filenames in os.walk(root):
+        # Per https://docs.python.org/3/library/os.html#os.walk:
+        #
+        # When topdown is True, the caller can modify the dirnames list
+        # in-place to prune the search.
+        dirnames[:] = [name for name in dirnames if name not in {".git", "snapshots"}]
+        directory = Path(directory)
+        for filename in filenames:
+            if filename not in _STARLARK_FILENAMES and not filename.endswith(
+                _STARLARK_SUFFIXES
+            ):
+                continue
+            files.append(str((directory / filename).relative_to(root)))
+    return files
+
+
+def main() -> int:
+    from python.runfiles import runfiles
+
+    arguments = sys.argv[1:]
+    discover = not arguments or _DISCOVER_ARGUMENT in arguments
+    arguments = [argument for argument in arguments if argument != _DISCOVER_ARGUMENT]
+    if discover:
+        files = _discover_files(Path.cwd())
+        if not files:
+            return 0
+        arguments.extend(files)
+
+    runtime_files = runfiles.Create()
+    if runtime_files is None:
+        raise RuntimeError("cannot locate buildifier runfiles")
+    buildifier = runtime_files.Rlocation(_BUILDIFIER_RLOCATION)
+    if buildifier is None:
+        raise RuntimeError("cannot locate the buildifier executable")
+    return subprocess.call([buildifier, *arguments])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/buildifier_test.py
+++ b/tools/buildifier_test.py
@@ -1,0 +1,83 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+import unittest
+
+from tools.buildifier import _discover_files
+
+
+class BuildifierTest(unittest.TestCase):
+    def test_discovers_starlark_files_and_prunes_generated_snapshots(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            expected = {
+                "BUILD",
+                "BUILD.bazel",
+                "MODULE.bazel",
+                "Tiltfile",
+                "WORKSPACE",
+                "WORKSPACE.bazel",
+                "package/BUCK",
+                "package/config.axl",
+                "package/defs.bzl",
+                "package/extension.MODULE.bazel",
+                "package/rules.star",
+            }
+            for path in expected | {
+                ".git/internal.bzl",
+                "package/module.py",
+                "package/snapshots/generated.BUILD.bazel",
+            }:
+                output = root / path
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.touch()
+
+            self.assertEqual(set(_discover_files(root)), expected)
+            self.assertEqual(_discover_files(root / "package" / "snapshots"), [])
+
+    def test_tree_walk_formats_sources_without_rewriting_snapshots(self):
+        buildifier_rlocation = os.environ.get("RULES_PY_BUILDIFIER")
+        if buildifier_rlocation is None:
+            self.skipTest("requires the Bazel buildifier target")
+        from python.runfiles import runfiles
+
+        runtime_files = runfiles.Create()
+        if runtime_files is None:
+            self.fail("cannot locate test runfiles")
+        buildifier = runtime_files.Rlocation(buildifier_rlocation)
+        if buildifier is None:
+            self.fail("cannot locate the buildifier wrapper")
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "BUILD.bazel"
+            snapshot = root / "package" / "snapshots" / "generated.BUILD.bazel"
+            snapshot.parent.mkdir(parents=True)
+            unformatted = 'foo(name="foo")\n'
+            source.write_text(unformatted)
+            snapshot.write_text(unformatted)
+
+            command = [buildifier]
+            result = subprocess.run(
+                [*command, "-mode=check", "--rules-py-discover"],
+                cwd=root,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(source.read_text(), unformatted)
+            self.assertEqual(snapshot.read_text(), unformatted)
+
+            subprocess.run(
+                [*command, "--rules-py-discover"],
+                cwd=root,
+                check=True,
+            )
+
+            self.assertEqual(source.read_text(), 'foo(name = "foo")\n')
+            self.assertEqual(snapshot.read_text(), unformatted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Aspect's format task filters `exclude_patterns` from changed-file
invocations. With `--scope=all`, it delegates discovery to the formatter
and removes excluded files only from the post-format diff. Recursive
buildifier can therefore rewrite generated snapshots without failing CI.

Run buildifier through a wrapper that owns all-scope discovery and prunes
snapshot directories before invoking the real binary. A private tree-walk
sentinel distinguishes an empty file list from formatter flags, while
changed-scope invocations continue to pass selected files through.

The pinned Aspect release spawns the formatter executable directly, so
the wrapper resolves buildifier through its own runfiles instead of
relying on `py_binary.args`. Invocation from inside a snapshot subtree is
treated as an empty discovery.