### PR TITLE
fix(py): detect execute-bit collisions

### DIFF
--- a/py/tools/site_merge/site_merge.py
+++ b/py/tools/site_merge/site_merge.py
@@ -82,10 +82,14 @@ def merge(into, sources):
                     _remove(dest)
                 prior = owners.get(rel)
                 if dest.exists():
-                    # Byte-identical duplicates (e.g.
-                    # an empty __init__.py or py.typed shipped by both
-                    # wheels) are benign and not reported.
+                    # The wheel extractor treats any execute bit as executable
+                    # (py/tools/unpack/unpack.py). Other mode differences may
+                    # reflect executor umask and are benign for identical data.
                     if filecmp.cmp(str(src_file), str(dest), shallow=False):
+                        src_executable = bool(src_file.stat().st_mode & 0o111)
+                        dest_executable = bool(dest.stat().st_mode & 0o111)
+                        if src_executable != dest_executable:
+                            conflicts.append((rel, prior, src))
                         shutil.copymode(str(src_file), str(dest))
                         owners[rel] = src
                         continue

--- a/py/tools/site_merge/site_merge_test.py
+++ b/py/tools/site_merge/site_merge_test.py
@@ -24,13 +24,17 @@ class SiteMergeTest(unittest.TestCase):
             output = root / "output"
 
             _write(first / "distinct", "first", 0o444)
-            _write(first / "identical", "same", 0o444)
+            _write(first / "identical", "same", 0o644)
+            _write(first / "identical_executable", "same", 0o700)
+            _write(first / "executable_changed", "same", 0o644)
             _write(first / "file_to_directory", "first", 0o444)
             _write(first / "directory_to_file/child.py", "first", 0o444)
             _write(first / "union/first.py", "first")
 
             _write(second / "distinct", "second")
-            _write(second / "identical", "same", 0o755)
+            _write(second / "identical", "same", 0o600)
+            _write(second / "identical_executable", "same", 0o711)
+            _write(second / "executable_changed", "same", 0o755)
             _write(second / "file_to_directory/child.py", "second")
             _write(second / "directory_to_file", "second")
             _write(second / "union/second.py", "second")
@@ -46,6 +50,7 @@ class SiteMergeTest(unittest.TestCase):
                     (Path("distinct"), "first", "second"),
                     (Path("file_to_directory"), "first", "second"),
                     (Path("directory_to_file"), "first", "second"),
+                    (Path("executable_changed"), "first", "second"),
                 },
             )
             self.assertEqual((output / "distinct").read_text(), "second")
@@ -57,6 +62,14 @@ class SiteMergeTest(unittest.TestCase):
             self.assertEqual((output / "union/second.py").read_text(), "second")
             self.assertEqual(
                 stat.S_IMODE((output / "identical").stat().st_mode),
+                0o600,
+            )
+            self.assertEqual(
+                stat.S_IMODE((output / "identical_executable").stat().st_mode),
+                0o711,
+            )
+            self.assertEqual(
+                stat.S_IMODE((output / "executable_changed").stat().st_mode),
                 0o755,
             )
 


### PR DESCRIPTION
Physical package merges consider byte-identical files non-conflicting
and adopt the later file mode. That silently accepts a collision when one
wheel marks a file executable and another does not, so strict collision
policy can produce order-dependent runtime behavior.

Treat executability changes as collisions while preserving the
permissive later-file overlay. Compare executable status rather than
exact owner, group, and other execute masks: the wheel extractor already
normalizes any source execute bit to executable, while read and write
differences can vary with extraction permissions.