### PR TITLE
fix(uv): isolate PEP 517 runfiles

### DIFF
--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -100,6 +100,20 @@ def _override_tool(env, key, wrapper):
 
 def _compiler_env(tmpdir):
     env = dict(os.environ)
+    # The helper's launcher exports RUNFILES_DIR, RUNFILES_MANIFEST_FILE, and
+    # JAVA_RUNFILES:
+    # https://github.com/hermeticbuild/hermetic-launcher/blob/381814d0818af0573263323dc0dd0e4e208fc3fa/README.md#runfiles-discovery
+    # Bazel adds RUNFILES_MANIFEST_ONLY when runfiles trees are disabled:
+    # https://github.com/bazelbuild/bazel/blob/9.1.1/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java#L192-L201
+    # Nested Bazel executables check that inherited state before adjacent
+    # runfiles, so remove the parent's identity before package code runs.
+    for key in (
+        "JAVA_RUNFILES",
+        "RUNFILES_DIR",
+        "RUNFILES_MANIFEST_FILE",
+        "RUNFILES_MANIFEST_ONLY",
+    ):
+        env.pop(key, None)
     env["PATH"] = pathsep.join([
         path.dirname(sys.executable),
         env.get("PATH", defpath),

--- a/uv/private/pep517_whl/test.bzl
+++ b/uv/private/pep517_whl/test.bzl
@@ -8,24 +8,25 @@ build to verify the env wiring.
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 
 _ACTION_ENV = "//command_line_option:action_env"
-_HOST_PYTHON_ENV = [
+_HOST_ENV = [
     "PYTHONHOME=/host/home",
     "PYTHONPATH=/host/path",
     "PYTHONPLATLIBDIR=host-lib",
     "PYTHONSAFEPATH=1",
+    "RUNFILES_MANIFEST_ONLY=1",
 ]
 
-def _hostile_python_env_transition_impl(settings, _attr):
-    names = {entry.split("=", 1)[0]: True for entry in _HOST_PYTHON_ENV}
+def _hostile_env_transition_impl(settings, _attr):
+    names = {entry.split("=", 1)[0]: True for entry in _HOST_ENV}
     action_env = [
         entry
         for entry in settings[_ACTION_ENV]
         if entry.split("=", 1)[0].upper() not in names
     ]
-    return {_ACTION_ENV: action_env + _HOST_PYTHON_ENV}
+    return {_ACTION_ENV: action_env + _HOST_ENV}
 
-_hostile_python_env_transition = transition(
-    implementation = _hostile_python_env_transition_impl,
+_hostile_env_transition = transition(
+    implementation = _hostile_env_transition_impl,
     inputs = [_ACTION_ENV],
     outputs = [_ACTION_ENV],
 )
@@ -37,7 +38,7 @@ hostile_python_env_target = rule(
     implementation = _hostile_python_env_target_impl,
     attrs = {
         "target": attr.label(
-            cfg = _hostile_python_env_transition,
+            cfg = _hostile_env_transition,
             mandatory = True,
         ),
         "_allowlist_function_transition": attr.label(

--- a/uv/private/pep517_whl/tests/python_env_backend/backend.py
+++ b/uv/private/pep517_whl/tests/python_env_backend/backend.py
@@ -13,9 +13,19 @@ _DIST_INFO = "python_env_backend-0.0.1.dist-info"
 
 
 def _check_environment() -> None:
-    for name in ("PYTHONHOME", "PYTHONPLATLIBDIR"):
+    # JAVA_RUNFILES is Bazel's legacy runfiles locator, not a Java toolchain
+    # variable. Compiler and Java tool variables remain available to backends;
+    # only the parent launcher's runfiles identity must be removed.
+    for name in (
+        "JAVA_RUNFILES",
+        "PYTHONHOME",
+        "PYTHONPLATLIBDIR",
+        "RUNFILES_DIR",
+        "RUNFILES_MANIFEST_FILE",
+        "RUNFILES_MANIFEST_ONLY",
+    ):
         if name in os.environ:
-            raise RuntimeError(f"host {name} reached the PEP 517 backend")
+            raise RuntimeError(f"inherited {name} reached the PEP 517 backend")
 
     expected_pythonpath = os.environ.get("EXPECTED_PYTHONPATH")
     if expected_pythonpath is None:


### PR DESCRIPTION
The PEP 517 helper is a Bazel executable. Its launcher exports
RUNFILES_DIR, RUNFILES_MANIFEST_FILE, and JAVA_RUNFILES for the helper
runfiles tree. Bazel also sets RUNFILES_MANIFEST_ONLY when directory
runfiles are disabled. build_helper.py copies that identity into the
backend environment.

A Bazel executable invoked by the backend then prefers the inherited
source to its own adjacent runfiles. It resolves its interpreter in the
helper tree and fails with execve/ENOENT.

Remove all four variables from the copied backend environment. The
helper retains its own environment, while tools invoked by the backend
discover their own materialized runfiles.