### PR TITLE
fix(py): retain unknown wheel roots

### DIFF
--- a/e2e/cases/pth-install-tree-fallback/BUILD.bazel
+++ b/e2e/cases/pth-install-tree-fallback/BUILD.bazel
@@ -65,6 +65,7 @@ py_unpacked_wheel(
     # site-packages exactly as uv's whl_install would.
     top_levels = [
         "apkg",
+        "itfa-1.0.dist-info",
         "shared",
         "marker.pth",
     ],
@@ -75,6 +76,7 @@ py_unpacked_wheel(
     src = ":itfb-1.0-py3-none-any.whl",
     top_levels = [
         "bpkg",
+        "itfb-1.0.dist-info",
         "shared",
         "marker.pth",
     ],

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -25,7 +25,10 @@ py_unpacked_wheel(
     name = "jaraco_functools_no_entries",
     src = "@pypi_pth_namespace_547//jaraco_functools:whl",
     namespace_top_levels = ["jaraco"],
-    top_levels = ["jaraco"],
+    top_levels = [
+        "jaraco",
+        "jaraco_functools-4.4.0.dist-info",
+    ],
 )
 
 py_test(

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -21,7 +21,8 @@ postorder. Producers must use `default` or `postorder`, the orders Bazel permits
 in that aggregate. For collision classes that select one claimant, permissive
 handling gives the later distinct element in the flattened sequence precedence.
 Duplicate dependency edges do not create another precedence position. Fields:
-  * `top_levels`: tuple[str] — top-level names the wheel installs into site-packages.
+  * `top_levels`: tuple[str] — complete set of immediate `site-packages`
+    entry names when nonempty; an empty tuple means the layout is unknown.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
   * `namespace_entries`: tuple[str] — `/`-joined paths of the concrete entries beneath
     the namespace top-levels (e.g. `jaraco/functools`), used to materialise a merged

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -105,13 +105,14 @@ _attrs = {
         mandatory = True,
     ),
     "top_levels": attr.string_list(
-        doc = """Names of the top-level packages / modules / *.dist-info directories the wheel installs into its site-packages.
+        doc = """Complete list of immediate entries the wheel installs into site-packages.
 
 When set, the target emits a `PyWheelsInfo` provider describing this wheel.
 Downstream rules (such as `py_binary`) can consume this to assemble a merged
 `site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth`
-entries. If left empty (the default), the target behaves as before — other
-rules fall back to `.pth`-based import resolution.
+entries. The list must include packages, modules, `.pth` files, and
+`*.dist-info` directories. If left empty (the default), other rules preserve
+the complete wheel root and fall back to `.pth`-based import resolution.
 
 Typically populated by the `uv` wheel-install repo rule. Hand-written
 `py_unpacked_wheel` targets may populate this to opt into symlink-based

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -383,6 +383,8 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     # namespace) symlinks.
     fully_covered = {}
     for w in wheels:
+        if not w.top_levels:
+            continue
         skipped = skipped_per_wheel.get(w.site_packages_rfpath, {})
         ns_covered = ns_covered_per_wheel.get(w.site_packages_rfpath, {})
         covered = True
@@ -551,6 +553,11 @@ def assemble_venv(
     # We fail loudly on the rare 32-bit hash collision; the caller can
     # widen the key or rename a wheel rule.
     wheels_with_trees = [w for w in wheels if getattr(w, "install_tree", None) != None]
+    known_layout_site_pkgs = {
+        w.site_packages_rfpath: True
+        for w in wheels
+        if w.top_levels
+    }
     wheel_key_by_sp = {}
     wheel_by_key = {}
     for w in wheels_with_trees:
@@ -683,22 +690,30 @@ def assemble_venv(
         )
         declared.append(merged_dir)
 
-    # Keyed wheels (have `_wheels/<key>/`) emit a plain relative path:
-    # site.py joins it with the .pth's directory and appends to
-    # sys.path. Safe because root `*.pth` filenames are depth-1 RECORD
-    # entries that Hop 2 already symlinked at the venv root. Non-keyed
-    # wheels (`py_unpacked_wheel` without `top_levels`) emit
-    # `site.addsitedir` so wheel-root `.pth` shims still fire — a
-    # plain path entry would skip the .pth scan. First-party imports
-    # emit a plain path line.
+    # A key only means that a wheel has an install tree. Wheels may emit
+    # PyWheelsInfo for console scripts while leaving `top_levels` empty, so
+    # their immediate layout is unknown and no root entries were projected by
+    # Hop 2. Those wheels need `site.addsitedir` to process root `.pth` files.
+    # Known layouts use a plain path because their root `.pth` files were
+    # already projected or deliberately suppressed by collision resolution.
     def _format_imp(imp):
         if imp in fully_covered_site_pkgs:
             return None
         if imp.endswith("site-packages"):
             key = wheel_key_by_sp.get(imp)
+            if imp in known_layout_site_pkgs:
+                if key != None:
+                    return "{wheels_root}/{key}/lib/{py_ver}/site-packages".format(
+                        wheels_root = site_packages_to_wheels_root,
+                        key = key,
+                        py_ver = wheel_py_ver,
+                    )
+                return "{}/{}".format(escape, imp)
             if key != None:
-                return "{wheels_root}/{key}/lib/{py_ver}/site-packages".format(
-                    wheels_root = site_packages_to_wheels_root,
+                return ("import os, sys, site; " +
+                        "site.addsitedir(os.path.normpath(os.path.join(" +
+                        "sys.prefix, \"_wheels\", \"{key}\", \"lib\", " +
+                        "\"{py_ver}\", \"site-packages\")))").format(
                     key = key,
                     py_ver = wheel_py_ver,
                 )
@@ -715,8 +730,8 @@ def assemble_venv(
     pth_lines.set_param_file_format("multiline")
     pth_lines.add(escape)
 
-    # allow_closure lets _format_imp capture fully_covered_site_pkgs / wheel_key_by_sp
-    # so we don't have to materialise imports_depset via .to_list().
+    # allow_closure lets _format_imp capture the wheel metadata maps so we
+    # don't have to materialise imports_depset via .to_list().
     pth_lines.add_all(imports_depset, map_each = _format_imp, allow_closure = True)
 
     site_packages_pth_file = ctx.actions.declare_file(

--- a/py/tests/wheel-root-pth-double/BUILD.bazel
+++ b/py/tests/wheel-root-pth-double/BUILD.bazel
@@ -18,6 +18,7 @@ genrule(
         "a/apkg/__init__.py",
         "a/shared/__init__.py",
         "a/a_marker.pth",
+        "a/entry_points.txt",
         "a/METADATA",
     ],
     outs = ["pthtest_a-1.0-py3-none-any.whl"],
@@ -26,6 +27,7 @@ genrule(
         "apkg/__init__.py=$(execpath a/apkg/__init__.py)",
         "shared/__init__.py=$(execpath a/shared/__init__.py)",
         "a_marker.pth=$(execpath a/a_marker.pth)",
+        "pthtest_a-1.0.dist-info/entry_points.txt=$(execpath a/entry_points.txt)",
         "pthtest_a-1.0.dist-info/METADATA=$(execpath a/METADATA)",
     ]),
     tools = ["@bazel_tools//tools/zip:zipper"],
@@ -58,6 +60,7 @@ py_unpacked_wheel(
     # the venv site-packages exactly as uv's whl_install would.
     top_levels = [
         "apkg",
+        "pthtest_a-1.0.dist-info",
         "shared",
         "a_marker.pth",
     ],
@@ -68,9 +71,18 @@ py_unpacked_wheel(
     src = ":pthtest_b-1.0-py3-none-any.whl",
     top_levels = [
         "bpkg",
+        "pthtest_b-1.0.dist-info",
         "shared",
         "b_marker.pth",
     ],
+)
+
+py_unpacked_wheel(
+    name = "pthtest_unknown_layout",
+    src = ":pthtest_a-1.0-py3-none-any.whl",
+    # Console scripts make this target emit PyWheelsInfo, while omitting
+    # top_levels requires venv assembly to preserve the complete wheel root.
+    console_scripts = ["pthtest=apkg:main"],
 )
 
 py_test(
@@ -88,4 +100,12 @@ py_test(
         ":pthtest_a",
         ":pthtest_b",
     ],
+)
+
+py_test(
+    name = "unknown_layout_pth_test",
+    srcs = ["unknown_layout_pth_test.py"],
+    isolated = False,
+    main = "unknown_layout_pth_test.py",
+    deps = [":pthtest_unknown_layout"],
 )

--- a/py/tests/wheel-root-pth-double/a/apkg/__init__.py
+++ b/py/tests/wheel-root-pth-double/a/apkg/__init__.py
@@ -1,1 +1,5 @@
 VALUE = "apkg"
+
+
+def main():
+    return 0

--- a/py/tests/wheel-root-pth-double/a/entry_points.txt
+++ b/py/tests/wheel-root-pth-double/a/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+pthtest = apkg:main

--- a/py/tests/wheel-root-pth-double/unknown_layout_pth_test.py
+++ b/py/tests/wheel-root-pth-double/unknown_layout_pth_test.py
@@ -1,0 +1,17 @@
+"""Unknown wheel layouts must still process root .pth files."""
+
+import sys
+
+
+def main():
+    if "rules_py_pth_sentinel_a" not in sys.path:
+        raise SystemExit("unknown-layout wheel root .pth did not execute")
+
+    import apkg
+
+    if apkg.VALUE != "apkg":
+        raise SystemExit("unknown-layout wheel package did not import")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Source-built wheels need to expose console scripts during analysis,
before the wheel exists to reveal its immediate layout. That valid state
exposed a pre-existing bug in `py_unpacked_wheel`: it may advertise
console scripts without declaring `top_levels`, but venv assembly treats
the empty layout as fully covered. The wheel can disappear from
`sys.path`; if its install tree keeps it reachable, a plain path still
skips root `.pth` processing.

Treat a nonempty `top_levels` list as the existing complete-layout
signal. Preserve unknown layouts through whole-wheel fallback and call
`site.addsitedir` on a venv-local wheel path. Known layouts retain plain
path handling because their root entries have already been projected or
suppressed by collision resolution.