### PR TITLE
fix(py): retain metadata-free wheel trees

### DIFF
--- a/e2e/cases/pth-install-tree-fallback/BUILD.bazel
+++ b/e2e/cases/pth-install-tree-fallback/BUILD.bazel
@@ -65,6 +65,7 @@ py_unpacked_wheel(
     # site-packages exactly as uv's whl_install would.
     top_levels = [
         "apkg",
+        "itfa-1.0.dist-info",
         "shared",
         "marker.pth",
     ],
@@ -75,6 +76,7 @@ py_unpacked_wheel(
     src = ":itfb-1.0-py3-none-any.whl",
     top_levels = [
         "bpkg",
+        "itfb-1.0.dist-info",
         "shared",
         "marker.pth",
     ],

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -25,7 +25,10 @@ py_unpacked_wheel(
     name = "jaraco_functools_no_entries",
     src = "@pypi_pth_namespace_547//jaraco_functools:whl",
     namespace_top_levels = ["jaraco"],
-    top_levels = ["jaraco"],
+    top_levels = [
+        "jaraco",
+        "jaraco_functools-4.4.0.dist-info",
+    ],
 )
 
 py_test(

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -41,9 +41,9 @@ py_test(
 )
 
 # Regression gate for assemble_venv's non-keyed `_format_imp` branch.
-# `py_unpacked_wheel` without `top_levels` emits no PyWheelsInfo, so
-# setuptools' root `distutils-precedence.pth` is only reachable via
-# the wheel's own site-packages — that branch must use
+# `py_unpacked_wheel` without `top_levels` carries an unknown layout, so
+# setuptools' root `distutils-precedence.pth` is only reachable via the
+# wheel's own site-packages — that branch must use
 # `site.addsitedir` (not a plain path entry) or `_distutils_hack`
 # never lands in `sys.modules` at site-init.
 py_unpacked_wheel(

--- a/e2e/cases/uv-sdist-fallback/BUILD.bazel
+++ b/e2e/cases/uv-sdist-fallback/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_image_layer", "py_test")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 # Regression coverage for the sdist-fallback behavior preserved by the
 # "always keep sdist fallbacks when sources exist" fix. cowsay 6.0 has both
@@ -14,4 +15,47 @@ py_test(
     deps = [
         "@pypi_sdist_fallback//cowsay",
     ],
+)
+
+# Repository analysis cannot inspect source-built cowsay's wheel metadata.
+# Image layering must still discover its install tree through PyWheelsInfo.
+py_binary(
+    name = "image_bin",
+    testonly = True,
+    srcs = ["__test__.py"],
+    dep_group = "uv_sdist_fallback",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = ["@pypi_sdist_fallback//cowsay"],
+)
+
+py_image_layer(
+    name = "image_layers",
+    testonly = True,
+    binary = ":image_bin",
+)
+
+filegroup(
+    name = "image_dependency_layers",
+    testonly = True,
+    srcs = [":image_layers"],
+    output_group = "deps",
+)
+
+genrule(
+    name = "source_wheel_image_contents",
+    testonly = True,
+    srcs = [":image_dependency_layers"],
+    outs = ["source_wheel_image_contents.txt"],
+    cmd = """
+for layer in $(SRCS); do
+  $(BSDTAR_BIN) -tf "$$layer"
+done | grep -F '/site-packages/cowsay/__init__.py' > $@
+""",
+    toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
+)
+
+build_test(
+    name = "source_wheel_image_test",
+    targets = [":source_wheel_image_contents"],
 )

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -1,26 +1,24 @@
 """Providers to share information between targets in the graph."""
 
 PyWheelsInfo = provider(
-    doc = """Per-wheel metadata used to assemble a Python venv via symlinks at build time.
+    doc = """Installed wheel records used by venv assembly and image layering.
 
 Each element of `wheels` describes one wheel in the transitive closure of a
-target: the top-level names (packages / modules / *.dist-info directories)
-it installs into `site-packages`, which of those are PEP 420 namespace
-packages, the runfiles-root-relative path to the wheel's site-packages,
-and the wheel's declared console-script entry points.
+target. Every record carries the complete installed tree. Repository-inspected
+wheels also carry their site-packages layout and console scripts; source-built
+wheels may leave that analysis-time metadata empty.
 
-Downstream rules (notably `py_binary`) use this to create one
-`ctx.actions.symlink` per top-level name, merging wheels into a single
-`site-packages/` tree without invoking a runtime tool, and to generate
-executable wrappers under `<venv>/bin/<name>` for console scripts.
+Venv rules project known layouts and generate console-script wrappers. Image
+rules use `install_tree` to retain each wheel as a package leaf independently
+of whether its metadata was available during analysis.
 """,
     fields = {
-        "wheels": """Depset of `struct(top_levels, namespace_top_levels, namespace_entries, site_packages_rfpath, console_scripts)`
-— one per wheel in the transitive closure. rules_py aggregates this field in
-postorder. Producers must use `default` or `postorder`, the orders Bazel permits
-in that aggregate. For collision classes that select one claimant, permissive
-handling gives the later distinct element in the flattened sequence precedence.
-Duplicate dependency edges do not create another precedence position. Fields:
+        "wheels": """Depset of wheel record structs, one per wheel in the transitive
+closure. rules_py aggregates this field in postorder. Producers must use
+`default` or `postorder`, the orders Bazel permits in that aggregate. For
+collision classes that select one claimant, permissive handling gives the later
+distinct element in the flattened sequence precedence. Duplicate dependency
+edges do not create another precedence position. Fields:
   * `top_levels`: tuple[str] — complete set of immediate `site-packages`
     entry names when nonempty; an empty tuple means the layout is unknown.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
@@ -38,6 +36,7 @@ Duplicate dependency edges do not create another precedence position. Fields:
     May be absent on structs from older producers.
   * `site_packages_rfpath`: str — runfiles-root-relative path to the wheel's site-packages.
   * `console_scripts`: tuple[str] — entry points encoded as `"name=module:func"`.
+  * `install_tree`: File — complete installed wheel tree.
 """,
     },
 )

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -21,7 +21,8 @@ postorder. Producers must use `default` or `postorder`, the orders Bazel permits
 in that aggregate. For collision classes that select one claimant, permissive
 handling gives the later distinct element in the flattened sequence precedence.
 Duplicate dependency edges do not create another precedence position. Fields:
-  * `top_levels`: tuple[str] — top-level names the wheel installs into site-packages.
+  * `top_levels`: tuple[str] — complete set of immediate `site-packages`
+    entry names when nonempty; an empty tuple means the layout is unknown.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
   * `namespace_entries`: tuple[str] — `/`-joined paths of the concrete entries beneath
     the namespace top-levels (e.g. `jaraco/functools`), used to materialise a merged

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -79,18 +79,17 @@ def _py_unpacked_wheel_impl(ctx):
         ),
     ]
 
-    if ctx.attr.top_levels or ctx.attr.console_scripts:
-        providers.append(PyWheelsInfo(
-            wheels = depset(direct = [struct(
-                top_levels = tuple(ctx.attr.top_levels),
-                namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
-                namespace_entries = tuple(ctx.attr.namespace_entries),
-                site_packages_rfpath = site_packages_rfpath,
-                console_scripts = tuple(ctx.attr.console_scripts),
-                # See whl_install rule for the rationale.
-                install_tree = unpack_directory,
-            )]),
-        ))
+    providers.append(PyWheelsInfo(
+        wheels = depset(direct = [struct(
+            top_levels = tuple(ctx.attr.top_levels),
+            namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
+            namespace_entries = tuple(ctx.attr.namespace_entries),
+            site_packages_rfpath = site_packages_rfpath,
+            console_scripts = tuple(ctx.attr.console_scripts),
+            # See whl_install rule for the rationale.
+            install_tree = unpack_directory,
+        )]),
+    ))
 
     return providers
 
@@ -107,12 +106,11 @@ _attrs = {
     "top_levels": attr.string_list(
         doc = """Complete list of immediate entries the wheel installs into site-packages.
 
-When set, the target emits a `PyWheelsInfo` provider describing this wheel.
-Downstream rules (such as `py_binary`) can consume this to assemble a merged
-`site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth`
-entries. The list must include packages, modules, `.pth` files, and
-`*.dist-info` directories. If left empty (the default), other rules preserve
-the complete wheel root and fall back to `.pth`-based import resolution.
+When set, downstream rules can assemble a merged `site-packages/` tree via
+`ctx.actions.symlink` instead of relying on `.pth` entries. The list must
+include packages, modules, `.pth` files, and `*.dist-info` directories. If left
+empty (the default), other rules preserve the complete wheel root and fall back
+to `.pth`-based import resolution.
 
 Typically populated by the `uv` wheel-install repo rule. Hand-written
 `py_unpacked_wheel` targets may populate this to opt into symlink-based

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -105,13 +105,14 @@ _attrs = {
         mandatory = True,
     ),
     "top_levels": attr.string_list(
-        doc = """Names of the top-level packages / modules / *.dist-info directories the wheel installs into its site-packages.
+        doc = """Complete list of immediate entries the wheel installs into site-packages.
 
 When set, the target emits a `PyWheelsInfo` provider describing this wheel.
 Downstream rules (such as `py_binary`) can consume this to assemble a merged
 `site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth`
-entries. If left empty (the default), the target behaves as before — other
-rules fall back to `.pth`-based import resolution.
+entries. The list must include packages, modules, `.pth` files, and
+`*.dist-info` directories. If left empty (the default), other rules preserve
+the complete wheel root and fall back to `.pth`-based import resolution.
 
 Typically populated by the `uv` wheel-install repo rule. Hand-written
 `py_unpacked_wheel` targets may populate this to opt into symlink-based

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -539,8 +539,10 @@ def assemble_venv(
     # bazel-bin-walking tool.
     site_packages_to_wheels_root = "/".join([".."] * 3) + "/_wheels"
 
-    # Map from site_packages_rfpath → wheel key for wheels that carry
-    # install_tree. The key is an 8-hex hash of the wheel's
+    # Map from site_packages_rfpath → wheel key for wheels whose analysis-time
+    # metadata lets the venv project entries or scripts. Metadata-free wheel
+    # records retain their runfiles path and do not need another tree symlink.
+    # The key is an 8-hex hash of the wheel's
     # `install_tree.short_path` (globally unique among File objects), so:
     #
     #   * adding/removing a wheel doesn't shift the keys of other wheels
@@ -552,7 +554,11 @@ def assemble_venv(
     #
     # We fail loudly on the rare 32-bit hash collision; the caller can
     # widen the key or rename a wheel rule.
-    wheels_with_trees = [w for w in wheels if getattr(w, "install_tree", None) != None]
+    localized_wheels = [
+        w
+        for w in wheels
+        if getattr(w, "install_tree", None) != None and (w.top_levels or w.console_scripts)
+    ]
     known_layout_site_pkgs = {
         w.site_packages_rfpath: True
         for w in wheels
@@ -560,7 +566,7 @@ def assemble_venv(
     }
     wheel_key_by_sp = {}
     wheel_by_key = {}
-    for w in wheels_with_trees:
+    for w in localized_wheels:
         key = _wheel_key(w)
         prior = wheel_by_key.get(key)
         if prior != None and prior.install_tree.short_path != w.install_tree.short_path:
@@ -577,7 +583,7 @@ def assemble_venv(
     # Hop 1: per-wheel directory under _wheels/<key>/. Bazel picks an
     # absolute path under bazel-bin; the output is a tree artifact whose
     # contents dereference the install_tree.
-    for w in wheels_with_trees:
+    for w in localized_wheels:
         key = wheel_key_by_sp[w.site_packages_rfpath]
         wheel_dir = ctx.actions.declare_directory(
             "{}/_wheels/{}".format(venv_name, key),

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -383,6 +383,8 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     # namespace) symlinks.
     fully_covered = {}
     for w in wheels:
+        if not w.top_levels:
+            continue
         skipped = skipped_per_wheel.get(w.site_packages_rfpath, {})
         ns_covered = ns_covered_per_wheel.get(w.site_packages_rfpath, {})
         covered = True
@@ -551,6 +553,11 @@ def assemble_venv(
     # We fail loudly on the rare 32-bit hash collision; the caller can
     # widen the key or rename a wheel rule.
     wheels_with_trees = [w for w in wheels if getattr(w, "install_tree", None) != None]
+    known_layout_site_pkgs = {
+        w.site_packages_rfpath: True
+        for w in wheels
+        if w.top_levels
+    }
     wheel_key_by_sp = {}
     wheel_by_key = {}
     for w in wheels_with_trees:
@@ -683,22 +690,30 @@ def assemble_venv(
         )
         declared.append(merged_dir)
 
-    # Keyed wheels (have `_wheels/<key>/`) emit a plain relative path:
-    # site.py joins it with the .pth's directory and appends to
-    # sys.path. Safe because root `*.pth` filenames are depth-1 RECORD
-    # entries that Hop 2 already symlinked at the venv root. Non-keyed
-    # wheels (`py_unpacked_wheel` without `top_levels`) emit
-    # `site.addsitedir` so wheel-root `.pth` shims still fire — a
-    # plain path entry would skip the .pth scan. First-party imports
-    # emit a plain path line.
+    # A key only means that a wheel has an install tree. Wheels may emit
+    # PyWheelsInfo for console scripts while leaving `top_levels` empty, so
+    # their immediate layout is unknown and no root entries were projected by
+    # Hop 2. Those wheels need `site.addsitedir` to process root `.pth` files.
+    # Known layouts use a plain path because their root `.pth` files were
+    # already projected or deliberately suppressed by collision resolution.
     def _format_imp(imp):
         if imp in fully_covered_site_pkgs:
             return None
         if imp.endswith("site-packages"):
             key = wheel_key_by_sp.get(imp)
+            if imp in known_layout_site_pkgs:
+                if key != None:
+                    return "{wheels_root}/{key}/lib/{py_ver}/site-packages".format(
+                        wheels_root = site_packages_to_wheels_root,
+                        key = key,
+                        py_ver = wheel_py_ver,
+                    )
+                return "{}/{}".format(escape, imp)
             if key != None:
-                return "{wheels_root}/{key}/lib/{py_ver}/site-packages".format(
-                    wheels_root = site_packages_to_wheels_root,
+                return ("import os, sys, site; " +
+                        "site.addsitedir(os.path.normpath(os.path.join(" +
+                        "sys.prefix, \"_wheels\", \"{key}\", \"lib\", " +
+                        "\"{py_ver}\", \"site-packages\")))").format(
                     key = key,
                     py_ver = wheel_py_ver,
                 )
@@ -715,8 +730,8 @@ def assemble_venv(
     pth_lines.set_param_file_format("multiline")
     pth_lines.add(escape)
 
-    # allow_closure lets _format_imp capture fully_covered_site_pkgs / wheel_key_by_sp
-    # so we don't have to materialise imports_depset via .to_list().
+    # allow_closure lets _format_imp capture the wheel metadata maps so we
+    # don't have to materialise imports_depset via .to_list().
     pth_lines.add_all(imports_depset, map_each = _format_imp, allow_closure = True)
 
     site_packages_pth_file = ctx.actions.declare_file(

--- a/py/tests/wheel-root-pth-double/BUILD.bazel
+++ b/py/tests/wheel-root-pth-double/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//py:defs.bzl", "py_test", "py_unpacked_wheel")
+load(":metadata_test.bzl", "metadata_free_wheel_test")
 
 # Regression gate for assemble_venv's `_format_imp` fallback (see
 # double_pth_test.py). Two hand-built wheels, each emitting PyWheelsInfo
@@ -80,9 +81,20 @@ py_unpacked_wheel(
 py_unpacked_wheel(
     name = "pthtest_unknown_layout",
     src = ":pthtest_a-1.0-py3-none-any.whl",
-    # Console scripts make this target emit PyWheelsInfo, while omitting
-    # top_levels requires venv assembly to preserve the complete wheel root.
+    # Omitting top_levels requires venv assembly to preserve the complete wheel
+    # root; the script still gets a wrapper from the observed metadata.
     console_scripts = ["pthtest=apkg:main"],
+)
+
+py_unpacked_wheel(
+    name = "pthtest_metadata_free",
+    src = ":pthtest_a-1.0-py3-none-any.whl",
+    tags = ["manual"],
+)
+
+metadata_free_wheel_test(
+    name = "metadata_free_wheel_test",
+    target_under_test = ":pthtest_metadata_free",
 )
 
 py_test(

--- a/py/tests/wheel-root-pth-double/BUILD.bazel
+++ b/py/tests/wheel-root-pth-double/BUILD.bazel
@@ -18,6 +18,7 @@ genrule(
         "a/apkg/__init__.py",
         "a/shared/__init__.py",
         "a/a_marker.pth",
+        "a/entry_points.txt",
         "a/METADATA",
     ],
     outs = ["pthtest_a-1.0-py3-none-any.whl"],
@@ -26,6 +27,7 @@ genrule(
         "apkg/__init__.py=$(execpath a/apkg/__init__.py)",
         "shared/__init__.py=$(execpath a/shared/__init__.py)",
         "a_marker.pth=$(execpath a/a_marker.pth)",
+        "pthtest_a-1.0.dist-info/entry_points.txt=$(execpath a/entry_points.txt)",
         "pthtest_a-1.0.dist-info/METADATA=$(execpath a/METADATA)",
     ]),
     tools = ["@bazel_tools//tools/zip:zipper"],
@@ -58,6 +60,7 @@ py_unpacked_wheel(
     # the venv site-packages exactly as uv's whl_install would.
     top_levels = [
         "apkg",
+        "pthtest_a-1.0.dist-info",
         "shared",
         "a_marker.pth",
     ],
@@ -68,9 +71,18 @@ py_unpacked_wheel(
     src = ":pthtest_b-1.0-py3-none-any.whl",
     top_levels = [
         "bpkg",
+        "pthtest_b-1.0.dist-info",
         "shared",
         "b_marker.pth",
     ],
+)
+
+py_unpacked_wheel(
+    name = "pthtest_unknown_layout",
+    src = ":pthtest_a-1.0-py3-none-any.whl",
+    # Console scripts make this target emit PyWheelsInfo, while omitting
+    # top_levels requires venv assembly to preserve the complete wheel root.
+    console_scripts = ["pthtest=apkg:main"],
 )
 
 py_test(
@@ -88,4 +100,12 @@ py_test(
         ":pthtest_a",
         ":pthtest_b",
     ],
+)
+
+py_test(
+    name = "unknown_layout_pth_test",
+    srcs = ["unknown_layout_pth_test.py"],
+    isolated = False,
+    main = "unknown_layout_pth_test.py",
+    deps = [":pthtest_unknown_layout"],
 )

--- a/py/tests/wheel-root-pth-double/a/apkg/__init__.py
+++ b/py/tests/wheel-root-pth-double/a/apkg/__init__.py
@@ -1,1 +1,5 @@
 VALUE = "apkg"
+
+
+def main():
+    return 0

--- a/py/tests/wheel-root-pth-double/a/entry_points.txt
+++ b/py/tests/wheel-root-pth-double/a/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+pthtest = apkg:main

--- a/py/tests/wheel-root-pth-double/metadata_test.bzl
+++ b/py/tests/wheel-root-pth-double/metadata_test.bzl
@@ -1,0 +1,22 @@
+"""Analysis test for metadata-free wheel identity."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//py/private:providers.bzl", "PyWheelsInfo")
+
+def _metadata_free_wheel_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    asserts.true(env, PyWheelsInfo in target)
+    if PyWheelsInfo in target:
+        wheels = target[PyWheelsInfo].wheels.to_list()
+        asserts.equals(env, 1, len(wheels))
+        if wheels:
+            wheel = wheels[0]
+            asserts.equals(env, (), wheel.top_levels)
+            asserts.equals(env, (), wheel.console_scripts)
+            asserts.true(env, wheel.install_tree in target[DefaultInfo].files.to_list())
+
+    return analysistest.end(env)
+
+metadata_free_wheel_test = analysistest.make(_metadata_free_wheel_test_impl)

--- a/py/tests/wheel-root-pth-double/unknown_layout_pth_test.py
+++ b/py/tests/wheel-root-pth-double/unknown_layout_pth_test.py
@@ -1,0 +1,17 @@
+"""Unknown wheel layouts must still process root .pth files."""
+
+import sys
+
+
+def main():
+    if "rules_py_pth_sentinel_a" not in sys.path:
+        raise SystemExit("unknown-layout wheel root .pth did not execute")
+
+    import apkg
+
+    if apkg.VALUE != "apkg":
+        raise SystemExit("unknown-layout wheel package did not import")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -646,9 +646,10 @@ filegroup(
     # platform/interpreter) are skipped — they can never be the active
     # wheel, and peeking at them would force a useless download.
     #
-    # The sbuild fallback, whose contents are unknowable until build time,
-    # is never peeked at here: it emits no PyWheelsInfo and consumers use
-    # .pth-based resolution.
+    # The sbuild fallback, whose contents are unknowable until build time, is
+    # never peeked at here. Its PyWheelsInfo record has unknown metadata, so
+    # venv consumers use .pth-based resolution while image layering still
+    # retains the installed wheel tree.
     #
     # We read from `whl_files` (a real label_list) rather than `whls` (a
     # JSON-encoded string of labels) because only the former adds the

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -108,9 +108,10 @@ def _whl_install(ctx):
     # wheel that is actually installed — metadata from inactive platform
     # wheels must not leak in (e.g. another platform's C-extension
     # suffix, or a console script shipped only by the win32 wheel).
-    # A lookup miss (sbuild fallback, failed extraction at repo-fetch
-    # time) emits no PyWheelsInfo and consumers fall back to .pth-based
-    # resolution.
+    # A lookup miss (sbuild fallback, failed extraction at repo-fetch time)
+    # leaves the metadata empty. PyWheelsInfo still carries the install tree:
+    # venv assembly treats empty top_levels as an unknown layout, while image
+    # layering uses install_tree to retain the wheel as a package leaf.
     whl_basename = ctx.file.src.basename
     top_levels = ctx.attr.top_levels.get(whl_basename, [])
     namespace_top_levels = ctx.attr.namespace_top_levels.get(whl_basename, [])
@@ -119,48 +120,47 @@ def _whl_install(ctx):
     regular_roots = ctx.attr.regular_roots.get(whl_basename, [])
     console_scripts = ctx.attr.console_scripts.get(whl_basename, [])
 
-    if top_levels or console_scripts:
-        providers.append(PyWheelsInfo(
-            wheels = depset(direct = [struct(
-                top_levels = tuple(top_levels),
-                # PEP 420 namespace packages this wheel contributes to.
-                # When multiple wheels claim the same top-level and ALL of
-                # them flag it as namespace, py_binary merges the namespace
-                # CONCRETELY from `namespace_entries` per-entry symlinks
-                # (so tools that inspect site-packages directly — mypy,
-                # pyright — see the packages and their py.typed markers),
-                # unless a regular package spans the wheels (detected via
-                # `regular_roots` × `namespace_dirs`), which needs a
-                # physical merge instead. Falls back to .pth-based
-                # resolution when entry metadata is missing.
-                namespace_top_levels = tuple(namespace_top_levels),
-                # Concrete per-wheel paths beneath namespace top-levels
-                # (e.g. `jaraco/functools`) that venv assembly symlinks
-                # individually to materialise a merged namespace directory.
-                namespace_entries = tuple(namespace_entries),
-                # Directory skeleton under namespace top-levels: which dirs
-                # are implicit-namespace portions (`namespace_dirs`) and
-                # which are the minimal regular-package roots
-                # (`regular_roots`). venv assembly cross-references these
-                # across wheels to detect a regular package spanning wheels
-                # (Python can't merge a regular package's __path__ at
-                # runtime, so the subtree is physically merged).
-                namespace_dirs = tuple(namespace_dirs),
-                regular_roots = tuple(regular_roots),
-                site_packages_rfpath = site_packages_rfpath,
-                # Each entry is "name=module:func"; py_binary parses into
-                # wrapper scripts at <venv>/bin/<name> at analysis time.
-                console_scripts = tuple(console_scripts),
-                # Tree artifact holding this wheel's installed file tree
-                # (`install/`, whose internal shape is
-                # `lib/python<M>.<m>/site-packages/...`). Downstream
-                # venv-assembly uses this as a `target_file` for a
-                # per-wheel directory symlink, so the per-top-level
-                # symlinks inside the venv can be intra-venv relative
-                # (identical resolution in bazel-bin and runfiles).
-                install_tree = install_dir,
-            )]),
-        ))
+    providers.append(PyWheelsInfo(
+        wheels = depset(direct = [struct(
+            top_levels = tuple(top_levels),
+            # PEP 420 namespace packages this wheel contributes to.
+            # When multiple wheels claim the same top-level and ALL of
+            # them flag it as namespace, py_binary merges the namespace
+            # CONCRETELY from `namespace_entries` per-entry symlinks
+            # (so tools that inspect site-packages directly — mypy,
+            # pyright — see the packages and their py.typed markers),
+            # unless a regular package spans the wheels (detected via
+            # `regular_roots` × `namespace_dirs`), which needs a
+            # physical merge instead. Falls back to .pth-based
+            # resolution when entry metadata is missing.
+            namespace_top_levels = tuple(namespace_top_levels),
+            # Concrete per-wheel paths beneath namespace top-levels
+            # (e.g. `jaraco/functools`) that venv assembly symlinks
+            # individually to materialise a merged namespace directory.
+            namespace_entries = tuple(namespace_entries),
+            # Directory skeleton under namespace top-levels: which dirs
+            # are implicit-namespace portions (`namespace_dirs`) and
+            # which are the minimal regular-package roots
+            # (`regular_roots`). venv assembly cross-references these
+            # across wheels to detect a regular package spanning wheels
+            # (Python can't merge a regular package's __path__ at
+            # runtime, so the subtree is physically merged).
+            namespace_dirs = tuple(namespace_dirs),
+            regular_roots = tuple(regular_roots),
+            site_packages_rfpath = site_packages_rfpath,
+            # Each entry is "name=module:func"; py_binary parses into
+            # wrapper scripts at <venv>/bin/<name> at analysis time.
+            console_scripts = tuple(console_scripts),
+            # Tree artifact holding this wheel's installed file tree
+            # (`install/`, whose internal shape is
+            # `lib/python<M>.<m>/site-packages/...`). Downstream
+            # venv-assembly uses this as a `target_file` for a
+            # per-wheel directory symlink, so the per-top-level
+            # symlinks inside the venv can be intra-venv relative
+            # (identical resolution in bazel-bin and runfiles).
+            install_tree = install_dir,
+        )]),
+    ))
 
     return providers
 
@@ -212,10 +212,11 @@ key matches the basename of the wheel `src` resolved to (the selected wheel
 for the active configuration) is used; entries for other platform wheels are
 ignored so their package surface cannot leak into this configuration.
 
-When the lookup hits, the target emits a `PyWheelsInfo` provider describing
-the selected wheel. Downstream rules (such as `py_binary`) consume this to
-assemble a merged `site-packages/` tree via `ctx.actions.symlink` instead of
-relying on `.pth` entries. A miss preserves the `.pth`-based behavior.
+When the lookup hits, the selected wheel's `PyWheelsInfo` record carries this
+layout and downstream rules can assemble a merged `site-packages/` tree via
+`ctx.actions.symlink`. A miss leaves the layout unknown and preserves
+`.pth`-based import behavior; the record still identifies the install tree for
+consumers such as image layering.
 
 Typically populated automatically by the `whl_install` repo rule from each
 wheel's `*.dist-info/RECORD` at repo-fetch time.

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -241,6 +241,7 @@ def _metadata_selection_test_impl(ctx):
     asserts.equals(env, 1, len(wheels), "expected exactly one wheel struct in PyWheelsInfo")
 
     wheel = wheels[0]
+    asserts.true(env, wheel.install_tree != None, "wheel record must retain its install tree")
     asserts.equals(env, tuple(ctx.attr.expected_top_levels), wheel.top_levels)
     asserts.equals(env, tuple(ctx.attr.expected_namespace_top_levels), wheel.namespace_top_levels)
     asserts.equals(env, tuple(ctx.attr.expected_console_scripts), wheel.console_scripts)
@@ -272,20 +273,6 @@ _metadata_selection_test = analysistest.make(
         "leaked_console_scripts": attr.string_list(),
     },
 )
-
-def _metadata_miss_test_impl(ctx):
-    env = analysistest.begin(ctx)
-    target = analysistest.target_under_test(env)
-
-    asserts.false(
-        env,
-        PyWheelsInfo in target,
-        "a wheel without a metadata entry (sbuild fallback) must not emit PyWheelsInfo",
-    )
-
-    return analysistest.end(env)
-
-_metadata_miss_test = analysistest.make(_metadata_miss_test_impl)
 
 def metadata_selection_test_suite(name):
     """Fixtures + analysis tests for per-configuration metadata selection.
@@ -341,9 +328,14 @@ def metadata_selection_test_suite(name):
         leaked_console_scripts = [],
     )
 
-    _metadata_miss_test(
+    _metadata_selection_test(
         name = name + "_sbuild_fallback_test",
         target_under_test = ":__metadata_sbuild_fixture",
+        expected_top_levels = [],
+        expected_namespace_top_levels = [],
+        expected_console_scripts = [],
+        leaked_top_levels = [],
+        leaked_console_scripts = [],
     )
 
 def whl_install_suite():


### PR DESCRIPTION
This depends on
https://github.com/tamird/rules_py/commit/b5252ca9379f72d66642d0b28e85e0f633c2d852.
The metadata-free wheel change is
https://github.com/tamird/rules_py/commit/c9512079ec266f62c65fef26b1d308765a3bbcf6.
The prerequisite is independently submitted and will be removed when it
reaches `main`.

Repository analysis cannot inspect source-built wheels, so
`whl_install` currently omits `PyWheelsInfo` for them. `py_image_layer`
uses that provider to classify wheel package leaves and read
`install_tree`; its generic `PyInfo` path deliberately skips wheel
files. Metadata-free source wheels can therefore disappear from
dependency layers.

Make installed-tree identity unconditional for both wheel producers
while keeping layout and console-script metadata optional. Venv
assembly localizes only records with actionable metadata, preserving
the existing runfiles fallback for metadata-free wheels. Image
layering can now retain every wheel tree as a package leaf.