### PR TITLE
fix(uv): classify custom .data categories

### DIFF
--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -75,9 +75,17 @@ def site_packages_segments(path, data_directory):
     segments = path.split("/")
     if segments[0] != data_directory:
         return segments
-    if len(segments) < 3 or segments[1] not in ("purelib", "platlib"):
+    if len(segments) < 3:
         return []
-    return segments[2:]
+    category = segments[1]
+    if category in ("purelib", "platlib"):
+        return segments[2:]
+    if category in ("data", "headers", "scripts"):
+        return []
+
+    # Keep this in sync with py/tools/unpack/unpack.py: unknown categories
+    # retain their category prefix under site-packages.
+    return segments[1:]
 
 def parse_console_script(line):
     """Parse one `[console_scripts]` entry into a canonical `name=module:func`.

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -143,6 +143,18 @@ def _site_packages_segments_test_impl(ctx):
         data + "/scripts/tool",
         data,
     ))
+    asserts.equals(env, [], site_packages_segments(
+        data + "/headers/pkg/header.h",
+        data,
+    ))
+    asserts.equals(env, [], site_packages_segments(
+        data + "/data/config.json",
+        data,
+    ))
+    asserts.equals(env, ["custom", "pkg", "module.py"], site_packages_segments(
+        data + "/custom/pkg/module.py",
+        data,
+    ))
     return unittest.end(env)
 
 site_packages_segments_test = unittest.make(_site_packages_segments_test_impl)


### PR DESCRIPTION
Wheel unpacking preserves unknown `.data/<category>/...` entries
under site-packages with the category prefix. Repository metadata drops
every category except `purelib` and `platlib`, so it can describe an
installed layout that omits files the unpacker retained.

Route only the standard `data`, `headers`, and `scripts` categories
away from site-packages. Preserve unknown categories exactly as the
unpacker does so RECORD-derived metadata matches the installed tree.