### PR TITLE
fix(py): select one PBS archive per mode

### DIFF
--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -176,25 +176,22 @@ versions:
 
 The target attribute takes precedence over the build-wide flag.
 
-## Build configurations
+## Runtime modes
 
-PBS provides several build configurations. The default is `install_only`, which
-is PGO+LTO optimized on platforms that support it. You can select a different
-configuration per toolchain:
+The extension registers one normal `install_only` PBS archive for each
+available Python version and platform. It also registers an optimized
+free-threaded archive where PBS publishes one, currently for Python 3.13 and
+newer. Normal mode is selected by default. Select free-threaded mode with the
+build setting:
 
-```starlark
-interpreters.toolchain(
-    python_version = "3.12",
-    build_config = "install_only_stripped",  # Smaller, debug symbols removed
-)
+```shell
+bazel build \
+    --@aspect_rules_py//py/private/interpreter:freethreaded=true \
+    //...
 ```
 
-Available configurations:
-
-- `install_only` — Standard optimized build (default)
-- `install_only_stripped` — Same but with debug symbols stripped
-- `freethreaded+pgo+lto` — Free-threaded (no GIL) with PGO+LTO optimization
-- `freethreaded+debug` — Free-threaded debug build
+`interpreters.toolchain()` chooses Python versions; the build setting above
+selects runtime mode.
 
 ## Platforms
 

--- a/e2e/cases/freethreaded-805/test.py
+++ b/e2e/cases/freethreaded-805/test.py
@@ -12,6 +12,11 @@ class FreethreadedTest(unittest.TestCase):
         gil_disabled = sysconfig.get_config_var("Py_GIL_DISABLED")
         self.assertEqual(gil_disabled, 1, "Expected Py_GIL_DISABLED=1 for a freethreaded build")
 
+    def test_interpreter_is_optimized(self):
+        """The interpreter must not be a debug build."""
+        py_debug = sysconfig.get_config_var("Py_DEBUG")
+        self.assertEqual(py_debug, 0, "Expected Py_DEBUG=0 for an optimized build")
+
     def test_abi_tag_contains_t(self):
         """The SOABI should contain 't' indicating the freethreaded ABI."""
         soabi = sysconfig.get_config_var("SOABI") or ""

--- a/e2e/cases/interpreter-runtime-metadata/BUILD.bazel
+++ b/e2e/cases/interpreter-runtime-metadata/BUILD.bazel
@@ -10,13 +10,6 @@ runtime_metadata_test(
 runtime_metadata_test(
     name = "freethreaded",
     abi_flags = "t",
-    runtime = "@python_3_15_x86_64_unknown_linux_gnu_freethreaded_pgo_lto//:py3_runtime",
-    tags = ["manual"],
-)
-
-runtime_metadata_test(
-    name = "freethreaded_debug",
-    abi_flags = "td",
-    runtime = "@python_3_15_x86_64_unknown_linux_gnu_freethreaded_debug//:py3_runtime",
+    runtime = "@python_3_15_x86_64_unknown_linux_gnu_freethreaded//:py3_runtime",
     tags = ["manual"],
 )

--- a/e2e/cases/interpreter-runtime-metadata/MODULE.bazel
+++ b/e2e/cases/interpreter-runtime-metadata/MODULE.bazel
@@ -17,6 +17,5 @@ interpreters.toolchain(
 use_repo(
     interpreters,
     "python_3_15_x86_64_unknown_linux_gnu",
-    "python_3_15_x86_64_unknown_linux_gnu_freethreaded_debug",
-    "python_3_15_x86_64_unknown_linux_gnu_freethreaded_pgo_lto",
+    "python_3_15_x86_64_unknown_linux_gnu_freethreaded",
 )

--- a/e2e/cases/interpreter-runtime-metadata/test.sh
+++ b/e2e/cases/interpreter-runtime-metadata/test.sh
@@ -10,8 +10,7 @@ cd "$case_dir" || exit 1
 BAZEL="${BAZEL:-bazel}"
 if ! "$BAZEL" test --lockfile_mode=off -- \
     //:regular \
-    //:freethreaded \
-    //:freethreaded_debug; then
+    //:freethreaded; then
     echo "FAIL: prerelease runtime metadata did not match" >&2
     exit 1
 fi

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -2,10 +2,14 @@
 
 load(":repository.bzl", "python_interpreter", "python_toolchains")
 load(":version_util.bzl", "is_decimal", "is_pre_release", "version_gt")
-load(":versions.bzl", "BUILD_CONFIGS", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS")
+load(":versions.bzl", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS", "RUNTIME_MODES")
 
 # The GitHub API endpoint for resolving "latest" releases.
 _GITHUB_API_LATEST = "https://api.github.com/repos/{owner}/{repo}/releases/latest"
+
+# Facts can outlive an extension implementation change, so index shape changes
+# must use a new key rather than accepting cached data from the old schema.
+_RELEASE_INDEX_SCHEMA = 1
 
 def _sanitize(s):
     """Replace characters that are invalid in Bazel repo names."""
@@ -14,7 +18,7 @@ def _sanitize(s):
 def _parse_sha256sums(content, release_date):
     """Parse a SHA256SUMS file into a structured index.
 
-    Returns a dict mapping (major_minor, platform, build_config) -> {
+    Returns a dict mapping (major_minor, platform, runtime_mode) -> {
         "sha256": str,
         "filename": str,
         "full_version": str,
@@ -24,6 +28,16 @@ def _parse_sha256sums(content, release_date):
     newest is kept.
     """
     index = {}
+    configured_assets = {}
+
+    for platform, platform_info in PLATFORMS.items():
+        for mode_name, mode_info in RUNTIME_MODES.items():
+            asset = "{}-{}.{}".format(
+                platform,
+                platform_info["asset_suffixes"][mode_name],
+                mode_info["extension"],
+            )
+            configured_assets[asset] = (platform, mode_name)
 
     for line in content.split("\n"):
         line = line.strip()
@@ -53,24 +67,14 @@ def _parse_sha256sums(content, release_date):
             continue
         major_minor = "{}.{}".format(version_parts[0], version_parts[1])
 
-        # Match against known build configs (check suffix + extension)
+        # Match the complete platform, suffix, and extension.
         remainder = filename[plus_idx + 1 + len(release_date) + 1:]  # skip "{date}-"
-        matched_config = None
-        matched_platform = None
-
-        for config_name, config_info in BUILD_CONFIGS.items():
-            expected_tail = "-{}.{}".format(config_info["suffix"], config_info["extension"])
-            if remainder.endswith(expected_tail):
-                platform_str = remainder[:len(remainder) - len(expected_tail)]
-                if platform_str in PLATFORMS:
-                    matched_config = config_name
-                    matched_platform = platform_str
-                    break
-
-        if not matched_config:
+        matched_asset = configured_assets.get(remainder)
+        if not matched_asset:
             continue
+        matched_platform, matched_mode = matched_asset
 
-        key = "{}/{}/{}".format(major_minor, matched_platform, matched_config)
+        key = "{}/{}/{}".format(major_minor, matched_platform, matched_mode)
 
         # Keep the newest patch version
         existing = index.get(key)
@@ -84,6 +88,9 @@ def _parse_sha256sums(content, release_date):
         }
 
     return index
+
+def _release_index_facts_key(release_date, base_url):
+    return "release_index_v{}_{}_{}".format(_RELEASE_INDEX_SCHEMA, release_date, base_url)
 
 def _owner_repo_from_base_url(base_url):
     """Extract GitHub owner/repo from a base URL like https://github.com/{owner}/{repo}/releases/download."""
@@ -126,7 +133,7 @@ def _fetch_release_index(module_ctx, release_date, base_url, facts):
 
     Returns the parsed index dict for this release date.
     """
-    facts_key = "release_index_{}_{}".format(release_date, base_url)
+    facts_key = _release_index_facts_key(release_date, base_url)
     cached = facts.get(facts_key)
     if cached:
         return cached
@@ -270,18 +277,18 @@ def _python_interpreters_impl(module_ctx):
         release_indices[date] = index
 
         # Cache in facts for next run — but never cache under "latest"
-        facts_key = "release_index_{}_{}".format(date, base_url)
+        facts_key = _release_index_facts_key(date, base_url)
         new_facts[facts_key] = index
 
-    # Create per-platform, per-build-config interpreter repos and collect
+    # Create per-platform, per-runtime-mode interpreter repos and collect
     # toolchain entries. Version and freethreaded target settings determine
     # which entries are eligible.
     toolchain_entries = []
 
-    # Keep generated output stable: regular configs, then freethreaded configs.
-    ordered_configs = (
-        [(name, cfg) for name, cfg in BUILD_CONFIGS.items() if not cfg["freethreaded"]] +
-        [(name, cfg) for name, cfg in BUILD_CONFIGS.items() if cfg["freethreaded"]]
+    # Keep generated output stable: regular modes, then freethreaded modes.
+    ordered_modes = (
+        [(name, mode) for name, mode in RUNTIME_MODES.items() if not mode["freethreaded"]] +
+        [(name, mode) for name, mode in RUNTIME_MODES.items() if mode["freethreaded"]]
     )
 
     # Target-pattern registration orders toolchains lexicographically by name,
@@ -294,26 +301,26 @@ def _python_interpreters_impl(module_ctx):
             "exec_compatible_with": [],
             "target_compatible_with": [],
         })
-        for config_name, config_info in ordered_configs:
+        for mode_name, mode_info in ordered_modes:
             for platform_triple, platform_info in PLATFORMS.items():
                 repo_name = "python_{}_{}".format(
                     _sanitize(major_minor),
                     _sanitize(platform_triple),
                 )
-                if config_name != "install_only":
-                    repo_name += "_" + _sanitize(config_name)
+                if mode_name != "install_only":
+                    repo_name += "_" + _sanitize(mode_name)
 
-                # Find the best release for this version/platform/config
+                # Find the best release for this version/platform/mode
                 asset_info = _find_asset(
                     major_minor,
                     platform_triple,
-                    config_name,
+                    mode_name,
                     release_dates,
                     release_indices,
                 )
 
                 if not asset_info:
-                    # Version/platform/config combo doesn't exist — skip it
+                    # Version/platform/mode combo doesn't exist — skip it
                     # rather than registering a stub toolchain.
                     continue
 
@@ -331,20 +338,20 @@ def _python_interpreters_impl(module_ctx):
                 )
                 python_interpreter(
                     name = repo_name,
-                    abi_flags = config_info["abi_flags"],
+                    abi_flags = mode_info["abi_flags"],
                     python_version = asset_info["full_version"],
                     platform = platform_triple,
                     url = url,
                     sha256 = asset_info["sha256"],
-                    strip_prefix = config_info["strip_prefix"],
-                    freethreaded = config_info["freethreaded"],
+                    strip_prefix = mode_info["strip_prefix"],
+                    freethreaded = mode_info["freethreaded"],
                 )
 
                 toolchain_entries.append(json.encode({
                     "name": repo_name,
                     "repo": repo_name,
                     "python_version": major_minor,
-                    "freethreaded": config_info["freethreaded"],
+                    "freethreaded": mode_info["freethreaded"],
                     "compatible_with": platform_info["compatible_with"],
                     "platform_target_settings": platform_info.get("target_settings", {}),
                     "config_settings": settings["config_settings"],
@@ -371,11 +378,11 @@ def _python_interpreters_impl(module_ctx):
 
     return _return_metadata(module_ctx, has_facts, new_facts, is_reproducible, resolved_latest)
 
-def _find_asset(major_minor, platform, build_config, release_dates, release_indices):
+def _find_asset(major_minor, platform, runtime_mode, release_dates, release_indices):
     """Find the best asset across releases, preferring newer releases."""
     for date in release_dates:
         index = release_indices.get(date, {})
-        key = "{}/{}/{}".format(major_minor, platform, build_config)
+        key = "{}/{}/{}".format(major_minor, platform, runtime_mode)
         entry = index.get(key)
         if entry:
             return {

--- a/py/private/interpreter/versions.bzl
+++ b/py/private/interpreter/versions.bzl
@@ -1,6 +1,6 @@
 """Python-build-standalone release metadata.
 
-This file contains platform mappings and build config definitions for CPython
+This file contains platform mappings and runtime mode definitions for CPython
 interpreters built by the python-build-standalone project
 (https://github.com/astral-sh/python-build-standalone).
 
@@ -35,7 +35,12 @@ DEFAULT_RELEASE_DATES = [
 # config the host's interpreter is being resolved under.
 
 # Mapping from PBS platform triple to Bazel platform constraints.
+# Optimized free-threaded archives use different suffixes on macOS/GNU Linux,
+# musl Linux, and Windows. These exact mappings are visible in PBS manifests:
+# https://github.com/astral-sh/python-build-standalone/releases/download/20260303/SHA256SUMS
+# https://github.com/astral-sh/python-build-standalone/releases/download/20251031/SHA256SUMS
 #
+# - asset_suffixes: exact PBS filename suffix for each logical runtime mode
 # - compatible_with: constraint_values for exec_compatible_with / target_compatible_with
 # - target_settings: additional config_settings the toolchain must match (optional)
 # - register_exec_tools: whether the hub emits the platform's exec registration
@@ -49,6 +54,10 @@ DEFAULT_RELEASE_DATES = [
 # buildifier: disable=unsorted-dict-items
 PLATFORMS = {
     "aarch64-apple-darwin": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
@@ -56,6 +65,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-unknown-linux-gnu": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
@@ -66,6 +79,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-unknown-linux-musl": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
@@ -76,6 +93,10 @@ PLATFORMS = {
         "register_exec_tools": False,
     },
     "x86_64-apple-darwin": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
@@ -83,6 +104,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "x86_64-unknown-linux-gnu": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
@@ -93,6 +118,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "x86_64-unknown-linux-musl": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
@@ -103,6 +132,10 @@ PLATFORMS = {
         "register_exec_tools": False,
     },
     "x86_64-pc-windows-msvc": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo-full",
+        },
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
@@ -110,6 +143,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-pc-windows-msvc": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo-full",
+        },
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:aarch64",
@@ -117,6 +154,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "i686-pc-windows-msvc": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo-full",
+        },
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_32",
@@ -125,39 +166,22 @@ PLATFORMS = {
     },
 }
 
-# Build configurations available from PBS. Each config specifies:
-# - suffix: the build config suffix in the asset filename
+# Logical runtime modes registered by this extension. Each mode specifies:
 # - extension: the archive file extension
 # - strip_prefix: the prefix to strip when extracting
 # - freethreaded: whether this is a free-threaded build
 # - abi_flags: CPython ABI flags for the build
 #
 # buildifier: disable=unsorted-dict-items
-BUILD_CONFIGS = {
+RUNTIME_MODES = {
     "install_only": {
         "abi_flags": "",
-        "suffix": "install_only",
         "extension": "tar.gz",
         "strip_prefix": "python",
         "freethreaded": False,
     },
-    "install_only_stripped": {
-        "abi_flags": "",
-        "suffix": "install_only_stripped",
-        "extension": "tar.gz",
-        "strip_prefix": "python",
-        "freethreaded": False,
-    },
-    "freethreaded+pgo+lto": {
+    "freethreaded": {
         "abi_flags": "t",
-        "suffix": "freethreaded+pgo+lto-full",
-        "extension": "tar.zst",
-        "strip_prefix": "python/install",
-        "freethreaded": True,
-    },
-    "freethreaded+debug": {
-        "abi_flags": "td",
-        "suffix": "freethreaded+debug-full",
         "extension": "tar.zst",
         "strip_prefix": "python/install",
         "freethreaded": True,

--- a/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
@@ -267,10 +267,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_aarch64_apple_darwin_install_only_stripped",
+    name = "python_3_13_aarch64_apple_darwin_freethreaded",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -278,9 +278,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_aarch64_apple_darwin_install_only_stripped_exec_tools",
+    name = "python_3_13_aarch64_apple_darwin_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -293,10 +293,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_install_only_stripped",
+    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded",
     target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
+    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -304,9 +304,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_install_only_stripped_exec_tools",
+    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -319,10 +319,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_aarch64_unknown_linux_musl_install_only_stripped",
+    name = "python_3_13_aarch64_unknown_linux_musl_freethreaded",
     target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_musl"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_musl_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
+    toolchain = "@python_3_13_aarch64_unknown_linux_musl_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -335,10 +335,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_x86_64_apple_darwin_install_only_stripped",
+    name = "python_3_13_x86_64_apple_darwin_freethreaded",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -346,9 +346,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_x86_64_apple_darwin_install_only_stripped_exec_tools",
+    name = "python_3_13_x86_64_apple_darwin_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -361,10 +361,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_install_only_stripped",
+    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded",
     target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
+    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -372,9 +372,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_install_only_stripped_exec_tools",
+    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -387,10 +387,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_x86_64_unknown_linux_musl_install_only_stripped",
+    name = "python_3_13_x86_64_unknown_linux_musl_freethreaded",
     target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_musl"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_musl_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
+    toolchain = "@python_3_13_x86_64_unknown_linux_musl_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -403,10 +403,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_x86_64_pc_windows_msvc_install_only_stripped",
+    name = "python_3_13_x86_64_pc_windows_msvc_freethreaded",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_x86_64_pc_windows_msvc_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_x86_64_pc_windows_msvc_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -414,9 +414,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_x86_64_pc_windows_msvc_install_only_stripped_exec_tools",
+    name = "python_3_13_x86_64_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_pc_windows_msvc_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_x86_64_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -429,10 +429,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_aarch64_pc_windows_msvc_install_only_stripped",
+    name = "python_3_13_aarch64_pc_windows_msvc_freethreaded",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_aarch64_pc_windows_msvc_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_aarch64_pc_windows_msvc_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -440,9 +440,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_aarch64_pc_windows_msvc_install_only_stripped_exec_tools",
+    name = "python_3_13_aarch64_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_pc_windows_msvc_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_aarch64_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -455,10 +455,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_i686_pc_windows_msvc_install_only_stripped",
+    name = "python_3_13_i686_pc_windows_msvc_freethreaded",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_i686_pc_windows_msvc_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_i686_pc_windows_msvc_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -466,250 +466,10 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_i686_pc_windows_msvc_install_only_stripped_exec_tools",
+    name = "python_3_13_i686_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
-    toolchain = "@python_3_13_i686_pc_windows_msvc_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_i686_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto",
-    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto_exec_tools",
-    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_pgo_lto",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded_pgo_lto//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_pgo_lto_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded_pgo_lto//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto",
-    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto_exec_tools",
-    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_pgo_lto",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded_pgo_lto//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_pgo_lto_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded_pgo_lto//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_apple_darwin_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_apple_darwin_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_musl_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_musl_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_apple_darwin_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_apple_darwin_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_musl_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_musl_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
 


### PR DESCRIPTION
PBS archive filenames encode physical build variants, but runtime
selection exposes only normal and free-threaded modes. The extension
currently registers normal and stripped archives with identical
constraints, and optimized and debug free-threaded archives with
identical constraints. Bazel then chooses by registration order: GNU
free-threaded targets use the debug archive, musl has only a debug
archive, and Windows has none.

Represent those two logical modes directly and map each supported
platform to one physical archive suffix. Normal mode uses
`install_only`; free-threaded mode uses the optimized archive that PBS
publishes for the platform. Version the cached manifest index and
replace documentation for the nonexistent `build_config` toolchain
attribute with the actual free-threaded build setting.

The generated `*_install_only_stripped` and
`*_freethreaded_debug` labels are removed, and
`*_freethreaded_pgo_lto` becomes `*_freethreaded`. Keeping aliases
would preserve the ambiguous registration surface.