### PR TITLE
fix(py): preserve per-version toolchain settings

### DIFF
--- a/e2e/cases/interpreter-toolchain-settings/BUILD.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/BUILD.bazel
@@ -1,0 +1,38 @@
+load(":toolchain_test.bzl", "interpreter_toolchain_check")
+
+config_setting(
+    name = "config_311",
+    define_values = {"interpreter_setting": "311"},
+)
+
+config_setting(
+    name = "config_311_secondary",
+    define_values = {"interpreter_setting_secondary": "311"},
+)
+
+config_setting(
+    name = "config_312",
+    define_values = {"interpreter_setting": "312"},
+)
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+interpreter_toolchain_check(
+    name = "resolved_311",
+    expected_interpreter = "@python_3_11_x86_64_unknown_linux_gnu//:bin/python3",
+    python_version = "3.11",
+    tags = ["manual"],
+)
+
+interpreter_toolchain_check(
+    name = "resolved_312",
+    expected_interpreter = "@python_3_12_x86_64_unknown_linux_gnu//:bin/python3",
+    python_version = "3.12",
+    tags = ["manual"],
+)

--- a/e2e/cases/interpreter-toolchain-settings/MODULE.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/MODULE.bazel
@@ -1,0 +1,38 @@
+module(name = "interpreter_toolchain_settings")
+
+bazel_dep(name = "aspect_rules_py")
+bazel_dep(name = "platforms", version = "1.1.0")
+
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(releases = ["20260303"])
+interpreters.toolchain(
+    config_settings = [
+        "//:config_311",
+        "//:config_311_secondary",
+    ],
+    python_version = "3.11",
+)
+interpreters.toolchain(
+    config_settings = [
+        "//:config_311_secondary",
+        "//:config_311",
+    ],
+    python_version = "3.11.14",
+)
+interpreters.toolchain(
+    config_settings = ["//:config_312"],
+    python_version = "3.12",
+)
+use_repo(
+    interpreters,
+    "python_3_11_x86_64_unknown_linux_gnu",
+    "python_3_12_x86_64_unknown_linux_gnu",
+    "python_interpreters",
+)
+
+register_toolchains("@python_interpreters//:all")

--- a/e2e/cases/interpreter-toolchain-settings/conflict/BUILD.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/conflict/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/cases/interpreter-toolchain-settings/conflict/MODULE.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/conflict/MODULE.bazel
@@ -1,0 +1,18 @@
+module(name = "interpreter_toolchain_settings_conflict")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.toolchain(
+    config_settings = ["//:first"],
+    python_version = "3.11",
+)
+interpreters.toolchain(
+    config_settings = ["//:second"],
+    python_version = "3.11.14",
+)
+use_repo(interpreters, "python_interpreters")

--- a/e2e/cases/interpreter-toolchain-settings/test.sh
+++ b/e2e/cases/interpreter-toolchain-settings/test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+cd "$(dirname "$0")" || exit 1
+
+BAZEL="${BAZEL:-bazel}"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+check_toolchain() {
+    local version="$1"
+    local setting="$2"
+    shift 2
+
+    "$BAZEL" build \
+        --lockfile_mode=off \
+        "--@aspect_rules_py//py:python_version=${version}" \
+        --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+        "--define=interpreter_setting=${setting}" \
+        --platforms=//:linux_x86_64 \
+        "$@" \
+        -- "//:resolved_${setting}" \
+        || fail "Python ${version} did not resolve with its root config_setting"
+}
+
+check_toolchain 3.11 311 --define=interpreter_setting_secondary=311
+check_toolchain 3.12 312
+
+failure_log="$(mktemp)"
+trap 'rm -f "$failure_log"' EXIT
+
+if "$BAZEL" build \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.11 \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --define=interpreter_setting=312 \
+    --platforms=//:linux_x86_64 \
+    -- //:resolved_311 >"$failure_log" 2>&1; then
+    fail "Python 3.11 resolved with Python 3.12 root config_settings"
+fi
+
+if (cd conflict && "$BAZEL" query \
+    --lockfile_mode=off \
+    -- '@python_interpreters//:*') >"$failure_log" 2>&1; then
+    fail "conflicting normalized root declarations were accepted"
+fi
+if ! grep -q "Conflicting root toolchain settings for Python 3.11" "$failure_log"; then
+    cat "$failure_log" >&2
+    fail "conflicting normalized root declarations lacked a clear diagnostic"
+fi
+
+echo "PASS: each Python version retained its root toolchain settings"

--- a/e2e/cases/interpreter-toolchain-settings/toolchain_test.bzl
+++ b/e2e/cases/interpreter-toolchain-settings/toolchain_test.bzl
@@ -1,0 +1,33 @@
+"""Analysis check for the selected Python runtime toolchain."""
+
+_RUNTIME_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
+
+def _interpreter_toolchain_check_impl(ctx):
+    runtime = ctx.toolchains[_RUNTIME_TOOLCHAIN].py3_runtime
+    if runtime == None:
+        fail("Python {} runtime toolchain was not resolved".format(ctx.attr.python_version))
+    if runtime.interpreter == None:
+        fail("Python {} runtime toolchain is not hermetic".format(ctx.attr.python_version))
+    if runtime.interpreter != ctx.file.expected_interpreter:
+        fail(
+            "expected Python {} PBS interpreter {}, got {}".format(
+                ctx.attr.python_version,
+                ctx.file.expected_interpreter,
+                runtime.interpreter,
+            ),
+        )
+
+    version_info = runtime.interpreter_version_info
+    actual = "{}.{}".format(version_info.major, version_info.minor)
+    if actual != ctx.attr.python_version:
+        fail("expected Python {} runtime, got {}".format(ctx.attr.python_version, actual))
+    return []
+
+interpreter_toolchain_check = rule(
+    implementation = _interpreter_toolchain_check_impl,
+    attrs = {
+        "expected_interpreter": attr.label(allow_single_file = True, mandatory = True),
+        "python_version": attr.string(mandatory = True),
+    },
+    toolchains = [_RUNTIME_TOOLCHAIN],
+)

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -198,10 +198,12 @@ def _python_interpreters_impl(module_ctx):
     release_dates = sorted(release_dates, reverse = True)
 
     # Collect all requested Python versions. Any module can request a version,
-    # but only the root module's pre_release flag is honored.
+    # but only the root module's pre_release flag and toolchain settings are
+    # honored.
     requested_versions = []
     version_sources = {}  # major_minor -> list of module names (for error messages)
     allow_pre_release = {}  # major_minor -> bool
+    root_settings = {}  # major_minor -> root-owned toolchain settings
 
     for mod in module_ctx.modules:
         for tag in mod.tags.toolchain:
@@ -212,6 +214,25 @@ def _python_interpreters_impl(module_ctx):
             if len(parts) < 2:
                 fail("python_version must be at least major.minor, got '{}'".format(version))
             major_minor = "{}.{}".format(parts[0], parts[1])
+
+            if mod.is_root:
+                settings = {
+                    "config_settings": sorted([str(label) for label in tag.config_settings]),
+                    "exec_compatible_with": sorted([str(label) for label in tag.exec_compatible_with]),
+                    "target_compatible_with": sorted([str(label) for label in tag.target_compatible_with]),
+                }
+                if major_minor in root_settings and root_settings[major_minor] != settings:
+                    fail(
+                        "Conflicting root toolchain settings for Python {}: {} and {}. ".format(
+                            major_minor,
+                            root_settings[major_minor],
+                            settings,
+                        ) +
+                        "Tags whose python_version values normalize to the same major.minor " +
+                        "must use identical config_settings, target_compatible_with, and " +
+                        "exec_compatible_with.",
+                    )
+                root_settings[major_minor] = settings
 
             if major_minor not in requested_versions:
                 requested_versions.append(major_minor)
@@ -310,6 +331,11 @@ def _python_interpreters_impl(module_ctx):
     # https://bazel.build/extending/toolchains#registering-building-toolchains
     for major_minor in sorted(requested_versions):
         version_found = False
+        settings = root_settings.get(major_minor, {
+            "config_settings": [],
+            "exec_compatible_with": [],
+            "target_compatible_with": [],
+        })
         for config_name, config_info in ordered_configs:
             for platform_triple, platform_info in PLATFORMS.items():
                 repo_name = "python_{}_{}".format(
@@ -362,9 +388,9 @@ def _python_interpreters_impl(module_ctx):
                     "freethreaded": config_info["freethreaded"],
                     "compatible_with": platform_info["compatible_with"],
                     "platform_target_settings": platform_info.get("target_settings", {}),
-                    "config_settings": tag.config_settings,
-                    "target_compatible_with": tag.target_compatible_with,
-                    "exec_compatible_with": tag.exec_compatible_with,
+                    "config_settings": settings["config_settings"],
+                    "target_compatible_with": settings["target_compatible_with"],
+                    "exec_compatible_with": settings["exec_compatible_with"],
                     "register_exec_tools": platform_info["register_exec_tools"],
                 }))
 
@@ -458,18 +484,18 @@ without error, but it will be silently ignored.
 
 _toolchain_tag = tag_class(
     attrs = {
-        "config_settings": attr.string_list(
+        "config_settings": attr.label_list(
             default = [],
             doc = """\
 Additional config_setting labels that must match for this toolchain to be selected.
 Use this to gate a toolchain on a custom flag, e.g.
-["@//:use_hermetic_python"]. The settings are added to the toolchain's
+["//:use_hermetic_python"]. The settings are added to the toolchain's
 target_settings alongside the version and platform constraints.
 
 Only honored from the root module.
 """,
         ),
-        "exec_compatible_with": attr.string_list(
+        "exec_compatible_with": attr.label_list(
             default = [],
             doc = """\
 Additional exec platform constraints appended to each platform variant's
@@ -494,7 +520,7 @@ Only honored from the root module.
             mandatory = True,
             doc = "Python version to provision, e.g. '3.11' or '3.11.14'. The newest available patch version is used.",
         ),
-        "target_compatible_with": attr.string_list(
+        "target_compatible_with": attr.label_list(
             default = [],
             doc = """\
 Additional target platform constraints appended to each platform variant's


### PR DESCRIPTION
Interpreter toolchain tags are grouped by normalized Python version,
but PBS records currently read settings from the final `tag` visited
during module-extension evaluation. With multiple root versions, every
generated runtime can therefore inherit another version's
`config_settings`, `target_compatible_with`, and
`exec_compatible_with`. A non-root tag visited last can also leak
settings that should be ignored.

Store one canonical settings triple for each root-requested major.minor
and apply it only to that version's PBS records. Versions requested only
by dependencies get empty root settings. Equivalent duplicate root tags
may differ in list order; conflicting declarations for the same
normalized version now fail because one generated toolchain set cannot
represent both.

Treat these values as labels and serialize their canonical forms before
writing the generated hub. This preserves the declaring module's
repository identity when the hub references root-owned settings.
