### PR TITLE
fix(py): avoid ambiguous Linux exec tools

### DIFF
--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -215,6 +215,11 @@ The following platforms are registered by default:
 Not all Python versions are available on all platforms. Unavailable combinations
 are silently skipped during toolchain resolution.
 
+All listed PBS platforms emit Python runtime registrations. PBS exec-tools
+registrations are emitted only for supported execution platforms: macOS,
+Windows, and GNU Linux. PBS-backed Linux exec registrations support glibc; musl
+interpreters remain available as Linux target runtimes.
+
 ## Compatibility with rules_python
 
 This interpreter provisioning is designed to coexist with `rules_python`:

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -296,6 +296,7 @@ def _python_interpreters_impl(module_ctx):
                 "config_settings": tag.config_settings,
                 "target_compatible_with": tag.target_compatible_with,
                 "exec_compatible_with": tag.exec_compatible_with,
+                "register_exec_tools": True,
             }))
 
     # Keep generated output stable: regular configs, then freethreaded configs.
@@ -364,6 +365,7 @@ def _python_interpreters_impl(module_ctx):
                     "config_settings": tag.config_settings,
                     "target_compatible_with": tag.target_compatible_with,
                     "exec_compatible_with": tag.exec_compatible_with,
+                    "register_exec_tools": platform_info["register_exec_tools"],
                 }))
 
         if not version_found:

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -329,8 +329,15 @@ toolchain(
     toolchain = "@{repo}//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
+""".format(
+            name = info["name"],
+            repo = info["repo"],
+            target_compatible_with = target_compatible_with,
+            target_settings = target_settings,
+        ))
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
+        if info["register_exec_tools"]:
+            content.append("""# Exec tools toolchain: selected by exec platform (not target platform) so
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
@@ -340,12 +347,10 @@ toolchain(
     toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
 )
 """.format(
-            name = info["name"],
-            repo = info["repo"],
-            exec_compatible_with = exec_compatible_with,
-            target_compatible_with = target_compatible_with,
-            target_settings = target_settings,
-        ))
+                name = info["name"],
+                repo = info["repo"],
+                exec_compatible_with = exec_compatible_with,
+            ))
 
     content.append("""
 exports_files(

--- a/py/private/interpreter/versions.bzl
+++ b/py/private/interpreter/versions.bzl
@@ -38,6 +38,13 @@ DEFAULT_RELEASE_DATES = [
 #
 # - compatible_with: constraint_values for exec_compatible_with / target_compatible_with
 # - target_settings: additional config_settings the toolchain must match (optional)
+# - register_exec_tools: whether the hub emits the platform's exec registration
+#
+# `platform_libc` is a target flag, so GNU and musl have identical exec OS/CPU
+# constraints. The default target-pattern registration expands
+# lexicographically, so GNU currently wins only by registration order. PBS
+# Linux exec registrations support glibc hosts, so only GNU emits one:
+# https://bazel.build/extending/toolchains#registering-building-toolchains
 #
 # buildifier: disable=unsorted-dict-items
 PLATFORMS = {
@@ -46,6 +53,7 @@ PLATFORMS = {
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
+        "register_exec_tools": True,
     },
     "aarch64-unknown-linux-gnu": {
         "compatible_with": [
@@ -55,6 +63,7 @@ PLATFORMS = {
         "target_settings": {
             PLATFORM_LIBC_FLAG: "glibc",
         },
+        "register_exec_tools": True,
     },
     "aarch64-unknown-linux-musl": {
         "compatible_with": [
@@ -64,12 +73,14 @@ PLATFORMS = {
         "target_settings": {
             PLATFORM_LIBC_FLAG: "musl",
         },
+        "register_exec_tools": False,
     },
     "x86_64-apple-darwin": {
         "compatible_with": [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
+        "register_exec_tools": True,
     },
     "x86_64-unknown-linux-gnu": {
         "compatible_with": [
@@ -79,6 +90,7 @@ PLATFORMS = {
         "target_settings": {
             PLATFORM_LIBC_FLAG: "glibc",
         },
+        "register_exec_tools": True,
     },
     "x86_64-unknown-linux-musl": {
         "compatible_with": [
@@ -88,24 +100,28 @@ PLATFORMS = {
         "target_settings": {
             PLATFORM_LIBC_FLAG: "musl",
         },
+        "register_exec_tools": False,
     },
     "x86_64-pc-windows-msvc": {
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
+        "register_exec_tools": True,
     },
     "aarch64-pc-windows-msvc": {
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:aarch64",
         ],
+        "register_exec_tools": True,
     },
     "i686-pc-windows-msvc": {
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_32",
         ],
+        "register_exec_tools": True,
     },
 }
 

--- a/uv/private/uv_hub/BUILD.bazel
+++ b/uv/private/uv_hub/BUILD.bazel
@@ -62,9 +62,8 @@ write_source_files(
         # used by whl_install to pick the right pre-built wheel. Largest
         # snapshot (~1200 lines) — the resolver's flattened output shape.
         "snapshots/pip_configurations.BUILD.bazel": "@aspect_rules_py_pip_configurations//:BUILD.bazel",
-        # python_toolchains: interpreter toolchain hub. Pins the public
-        # toolchain registration surface (toolchain + exec_tools toolchain
-        # rules per PBS release × Python version × platform).
+        # python_toolchains: interpreter toolchain hub. Pins runtime rules for
+        # every PBS platform and exec_tools rules for supported exec platforms.
         "snapshots/python_interpreters.BUILD.bazel": "@python_interpreters//:BUILD.bazel",
         # whl_install: per-wheel install BUILD. attrs is a stable
         # pure-Python wheel — pins the select_chain + gazelle_index_whl

--- a/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
@@ -112,16 +112,6 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_musl_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_musl//:exec_tools_toolchain",
-    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
-)
-
 
 # The Python interpreter toolchain has no exec_compatible_with: the interpreter
 # runs on the TARGET platform (inside the virtualenv), not on the exec host.
@@ -188,16 +178,6 @@ toolchain(
     target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_musl"],
     toolchain = "@python_3_13_x86_64_unknown_linux_musl//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_musl_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_musl//:exec_tools_toolchain",
-    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
 )
 
 
@@ -346,16 +326,6 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_musl_install_only_stripped_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_musl_install_only_stripped//:exec_tools_toolchain",
-    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
-)
-
 
 # The Python interpreter toolchain has no exec_compatible_with: the interpreter
 # runs on the TARGET platform (inside the virtualenv), not on the exec host.
@@ -422,16 +392,6 @@ toolchain(
     target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_musl"],
     toolchain = "@python_3_13_x86_64_unknown_linux_musl_install_only_stripped//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_musl_install_only_stripped_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_musl_install_only_stripped//:exec_tools_toolchain",
-    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
 )
 
 
@@ -684,16 +644,6 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_musl_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_musl_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
-)
-
 
 # The Python interpreter toolchain has no exec_compatible_with: the interpreter
 # runs on the TARGET platform (inside the virtualenv), not on the exec host.
@@ -760,16 +710,6 @@ toolchain(
     target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
     toolchain = "@python_3_13_x86_64_unknown_linux_musl_freethreaded_debug//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_musl_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_musl_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
 )
 
 


### PR DESCRIPTION
PBS publishes GNU and musl Linux exec-tools registrations with identical
execution-platform constraints because libc is a target setting. The
default `@python_interpreters//:all` target-pattern registration
currently chooses GNU only because its label sorts first. Binding each
registration to its own PBS runtime would therefore make Linux libc
selection depend on order.

Emit PBS exec-tools registrations only for GNU Linux while retaining
both GNU and musl target runtimes. Supported Linux execution hosts use
glibc, so the generated graph has one Linux exec candidate without
restricting cross-compiled musl targets.

The generated musl exec-toolchain labels disappear rather than becoming
aliases; aliases would preserve the ambiguous registrations. Their
physical repositories still expose `exec_tools_toolchain` targets.
