### PR TITLE
feat(py): expose PBS bytecode magic

### DIFF
--- a/e2e/cases/interpreter-bytecode-magic/BUILD.bazel
+++ b/e2e/cases/interpreter-bytecode-magic/BUILD.bazel
@@ -1,0 +1,59 @@
+load(":bytecode_magic_test.bzl", "bytecode_magic_test")
+
+bytecode_magic_test(
+    name = "python_3_13",
+    expected_magic_number = 3571,
+    expected_python_version = "3.13",
+    runtime_pair = "@python_3_13_x86_64_unknown_linux_gnu//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_13_freethreaded",
+    expected_magic_number = 3571,
+    expected_python_version = "3.13",
+    runtime_pair = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_13_windows",
+    expected_magic_number = 3571,
+    expected_python_version = "3.13",
+    runtime_pair = "@python_3_13_x86_64_pc_windows_msvc//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_14",
+    expected_magic_number = 3627,
+    expected_python_version = "3.14",
+    runtime_pair = "@python_3_14_x86_64_unknown_linux_gnu//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_14_freethreaded",
+    expected_magic_number = 3627,
+    expected_python_version = "3.14",
+    runtime_pair = "@python_3_14_x86_64_unknown_linux_gnu_freethreaded//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_14_windows",
+    expected_magic_number = 3627,
+    expected_python_version = "3.14",
+    runtime_pair = "@python_3_14_x86_64_pc_windows_msvc//:runtime_pair",
+    tags = ["manual"],
+)
+
+# CPython changed 3.15's magic number without changing its major/minor identity:
+# https://github.com/python/cpython/commit/ae53da57807467f638bfa0e2cb0e04c55758b0df
+bytecode_magic_test(
+    name = "python_3_15",
+    expected_magic_number = 3660,
+    expected_python_version = "3.15",
+    runtime_pair = "@python_3_15_x86_64_unknown_linux_gnu//:runtime_pair",
+    tags = ["manual"],
+)

--- a/e2e/cases/interpreter-bytecode-magic/MODULE.bazel
+++ b/e2e/cases/interpreter-bytecode-magic/MODULE.bazel
@@ -1,0 +1,26 @@
+module(name = "interpreter_bytecode_magic")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(releases = ["20260303"])
+interpreters.toolchain(python_version = "3.13")
+interpreters.toolchain(python_version = "3.14")
+interpreters.toolchain(
+    pre_release = True,
+    python_version = "3.15",
+)
+use_repo(
+    interpreters,
+    "python_3_13_x86_64_pc_windows_msvc",
+    "python_3_13_x86_64_unknown_linux_gnu",
+    "python_3_13_x86_64_unknown_linux_gnu_freethreaded",
+    "python_3_14_x86_64_pc_windows_msvc",
+    "python_3_14_x86_64_unknown_linux_gnu",
+    "python_3_14_x86_64_unknown_linux_gnu_freethreaded",
+    "python_3_15_x86_64_unknown_linux_gnu",
+)

--- a/e2e/cases/interpreter-bytecode-magic/bytecode_magic_test.bzl
+++ b/e2e/cases/interpreter-bytecode-magic/bytecode_magic_test.bzl
@@ -1,0 +1,40 @@
+"""Checks bytecode identity on a provisioned PBS runtime pair."""
+
+def _bytecode_magic_test_impl(ctx):
+    runtime_pair = ctx.attr.runtime_pair[platform_common.ToolchainInfo]
+    if runtime_pair.py2_runtime != None:
+        fail("PBS runtime pair unexpectedly contains a Python 2 runtime")
+    if runtime_pair.py3_runtime == None:
+        fail("PBS runtime pair lost its Python 3 runtime")
+
+    version = runtime_pair.py3_runtime.interpreter_version_info
+    actual_version = "{}.{}".format(version.major, version.minor)
+    if actual_version != ctx.attr.expected_python_version:
+        fail("expected Python {}, got {}".format(
+            ctx.attr.expected_python_version,
+            actual_version,
+        ))
+
+    actual = getattr(runtime_pair, "pyc_magic_number", None)
+    if actual != ctx.attr.expected_magic_number:
+        fail("expected PYC_MAGIC_NUMBER {}, got {}".format(
+            ctx.attr.expected_magic_number,
+            actual,
+        ))
+
+    executable = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(executable, "#!/usr/bin/env sh\n", is_executable = True)
+    return [DefaultInfo(executable = executable)]
+
+bytecode_magic_test = rule(
+    implementation = _bytecode_magic_test_impl,
+    attrs = {
+        "expected_magic_number": attr.int(mandatory = True),
+        "expected_python_version": attr.string(mandatory = True),
+        "runtime_pair": attr.label(
+            mandatory = True,
+            providers = [platform_common.ToolchainInfo],
+        ),
+    },
+    test = True,
+)

--- a/e2e/cases/interpreter-bytecode-magic/test.sh
+++ b/e2e/cases/interpreter-bytecode-magic/test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# These checks load generated repositories from a nested module, so CI runs
+# them directly rather than through the parent e2e workspace.
+set -uo pipefail
+
+case_dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$case_dir" || exit 1
+
+BAZEL="${BAZEL:-bazel}"
+if ! "$BAZEL" test --lockfile_mode=off -- \
+    //:python_3_13 \
+    //:python_3_13_freethreaded \
+    //:python_3_13_windows \
+    //:python_3_14 \
+    //:python_3_14_freethreaded \
+    //:python_3_14_windows \
+    //:python_3_15; then
+    echo "FAIL: PBS bytecode magic does not match its interpreter" >&2
+    exit 1
+fi
+
+echo "PASS: PBS runtime pairs expose their bytecode magic"

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -95,6 +95,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "pbs_runtime_pair",
+    srcs = ["pbs_runtime_pair.bzl"],
+    deps = ["@rules_python//python:py_runtime_info_bzl"],  # keep
+)
+
+bzl_library(
     name = "resolve",
     srcs = ["resolve.bzl"],
 )

--- a/py/private/interpreter/pbs_runtime_pair.bzl
+++ b/py/private/interpreter/pbs_runtime_pair.bzl
@@ -1,0 +1,30 @@
+"""Attach CPython bytecode identity to a PBS runtime pair.
+
+The returned ToolchainInfo extends rules_python's public runtime-pair schema
+with `pyc_magic_number`, CPython's 16-bit PYC_MAGIC_NUMBER value:
+https://github.com/bazel-contrib/rules_python/blob/1.9.0/python/py_runtime_pair.bzl#L31-L41
+"""
+
+load("@rules_python//python:py_runtime_info.bzl", "PyRuntimeInfo")
+
+def _pbs_runtime_pair_impl(ctx):
+    runtime = ctx.attr.py3_runtime[PyRuntimeInfo]
+    if runtime.python_version != "PY3":
+        fail("pbs_runtime_pair requires a Python 3 runtime")
+    return [platform_common.ToolchainInfo(
+        py2_runtime = None,
+        py3_runtime = runtime,
+        pyc_magic_number = ctx.attr.pyc_magic_number,
+    )]
+
+pbs_runtime_pair = rule(
+    implementation = _pbs_runtime_pair_impl,
+    attrs = {
+        "pyc_magic_number": attr.int(mandatory = True),
+        "py3_runtime": attr.label(
+            cfg = "target",
+            mandatory = True,
+            providers = [PyRuntimeInfo],
+        ),
+    },
+)

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -8,6 +8,76 @@ _RPY_VERSION_FLAG = "@rules_python//python/config_settings:python_version"
 _FREETHREADING_FLAG = "@aspect_rules_py//py/private/interpreter:freethreaded"
 _EXCLUDE_FEATURE_FLAG = "@aspect_rules_py//py/private/interpreter:exclude_feature"
 
+# CPython through 3.13 defines the bytecode magic in the frozen importlib
+# source. Python 3.14 moved its authoritative value to an internal header:
+# https://github.com/python/cpython/blob/v3.13.2/Lib/importlib/_bootstrap_external.py
+# https://github.com/python/cpython/blob/v3.14.0/Include/internal/pycore_magic_number.h
+def _parse_pyc_magic_number(content, source_kind, description):
+    matches = []
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if source_kind == "header":
+            tokens = [
+                token
+                for token in line.replace("\t", " ").split(" ")
+                if token
+            ]
+            if tokens[:2] == ["#define", "PYC_MAGIC_NUMBER"]:
+                if len(tokens) < 3:
+                    fail("{} has a malformed definition: {}".format(description, repr(raw_line)))
+                matches.append((tokens[2], raw_line))
+        else:
+            source_prefix = "MAGIC_NUMBER = ("
+            if line.startswith(source_prefix):
+                value = line[len(source_prefix):]
+                if ")" not in value:
+                    fail("{} has a malformed assignment: {}".format(description, repr(raw_line)))
+                matches.append((value.split(")")[0], raw_line))
+
+    if len(matches) != 1:
+        fail("{} must contain exactly one PYC_MAGIC_NUMBER, found {}".format(
+            description,
+            len(matches),
+        ))
+
+    value, raw_line = matches[0]
+    if not value or not all([char in "0123456789" for char in value.elems()]):
+        fail("{} has a non-decimal value: {}".format(description, repr(raw_line)))
+
+    magic_number = int(value)
+    if magic_number > 0xffff:
+        fail("{} has a value outside the 16-bit range: {}".format(description, magic_number))
+    return magic_number
+
+def _read_pyc_magic_number(rctx, major, minor, abi_flags, is_windows):
+    version = "{}.{}{}".format(major, minor, abi_flags)
+    if is_windows:
+        paths = [
+            "include/internal/pycore_magic_number.h",
+            "Lib/importlib/_bootstrap_external.py",
+        ]
+    else:
+        paths = [
+            "include/python{}/internal/pycore_magic_number.h".format(version),
+            "lib/python{}/importlib/_bootstrap_external.py".format(version),
+        ]
+
+    mode = "free-threaded" if "t" in abi_flags else "regular"
+    description = "PBS Python {} for {} ({})".format(
+        rctx.attr.python_version,
+        rctx.attr.platform,
+        mode,
+    )
+    for path, source_kind in [(paths[0], "header"), (paths[1], "source")]:
+        if rctx.path(path).exists:
+            return _parse_pyc_magic_number(
+                rctx.read(path),
+                source_kind,
+                "{} {}".format(description, path),
+            )
+
+    fail("{} contains neither {} nor {}".format(description, paths[0], paths[1]))
+
 def _python_interpreter_impl(rctx):
     """Downloads and extracts a Python interpreter from PBS."""
     url = rctx.attr.url
@@ -38,6 +108,13 @@ def _python_interpreter_impl(rctx):
             micro = micro[:marker_index] or "0"
             releaselevel = level
             break
+    pyc_magic_number = _read_pyc_magic_number(
+        rctx,
+        major,
+        minor,
+        rctx.attr.abi_flags,
+        is_windows,
+    )
 
     # Delete terminfo symlink loops on newer PBS releases (linux only)
     if "linux" in platform:
@@ -49,6 +126,7 @@ def _python_interpreter_impl(rctx):
         minor = minor,
         micro = micro,
         python_bin = python_bin,
+        pyc_magic_number = pyc_magic_number,
         is_windows = is_windows,
         releaselevel = releaselevel,
         serial = serial,
@@ -93,7 +171,7 @@ filegroup(
 
     return "\n".join(lines), all_excludes
 
-def _build_file_content(major, minor, micro, python_bin, is_windows, abi_flags, releaselevel, serial):
+def _build_file_content(major, minor, micro, python_bin, pyc_magic_number, is_windows, abi_flags, releaselevel, serial):
     """Generate the full BUILD.bazel content for an interpreter repo."""
 
     feature_targets, feature_excludes = _feature_filegroups(major, minor, is_windows)
@@ -182,8 +260,8 @@ cc_library(
     return """\
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@aspect_rules_py//py/private/interpreter:pbs_runtime_pair.bzl", "pbs_runtime_pair")
 load("@rules_python//python:py_runtime.bzl", "py_runtime")
-load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
 load("@rules_python//python:py_exec_tools_toolchain.bzl", "py_exec_tools_toolchain")
 load("@rules_python//python/cc:py_cc_toolchain.bzl", "py_cc_toolchain")
 
@@ -240,9 +318,9 @@ py_runtime(
     python_version = "PY3",
 )
 
-py_runtime_pair(
+pbs_runtime_pair(
     name = "runtime_pair",
-    py2_runtime = None,
+    pyc_magic_number = {pyc_magic_number},
     py3_runtime = ":py3_runtime",
 )
 
@@ -269,6 +347,7 @@ py_cc_toolchain(
         micro = micro,
         releaselevel = releaselevel,
         serial = serial,
+        pyc_magic_number = pyc_magic_number,
         feature_targets = feature_targets,
         feature_selects = feature_selects,
         core_include = core_include,


### PR DESCRIPTION
Wheel bytecode compilation runs with an exec-configured interpreter
while the resulting wheel tree is consumed by a target-configured
runtime. Those toolchains can resolve independently. Python version
and cache-tag metadata do not prove that their bytecode formats match:
CPython can change its magic number within a prerelease and retain it
across micro releases.

Read `PYC_MAGIC_NUMBER` from each extracted PBS interpreter and add it
to the generated runtime-pair `ToolchainInfo`. Preserve the
`rules_python` runtime fields so existing toolchain consumers remain
unchanged.

The fixture covers source-based 3.13 metadata, header-based 3.14
metadata, and a 3.15 prerelease whose magic changed without changing
its major/minor identity.

This gives wheel compilation rules a concrete compatibility identity
before an exec interpreter writes bytecode for a target runtime.