### PR TITLE
test(py): repair toolchain settings e2e

### DIFF
--- a/e2e/cases/interpreter-toolchain-settings/MODULE.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/MODULE.bazel
@@ -22,7 +22,7 @@ interpreters.toolchain(
         "//:config_311_secondary",
         "//:config_311",
     ],
-    python_version = "3.11.14",
+    python_version = "3.11",
 )
 interpreters.toolchain(
     config_settings = ["//:config_312"],

--- a/e2e/cases/interpreter-toolchain-settings/conflict/MODULE.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/conflict/MODULE.bazel
@@ -13,6 +13,6 @@ interpreters.toolchain(
 )
 interpreters.toolchain(
     config_settings = ["//:second"],
-    python_version = "3.11.14",
+    python_version = "3.11",
 )
 use_repo(interpreters, "python_interpreters")

--- a/e2e/cases/interpreter-toolchain-settings/test.sh
+++ b/e2e/cases/interpreter-toolchain-settings/test.sh
@@ -46,11 +46,11 @@ fi
 if (cd conflict && "$BAZEL" query \
     --lockfile_mode=off \
     -- '@python_interpreters//:*') >"$failure_log" 2>&1; then
-    fail "conflicting normalized root declarations were accepted"
+    fail "conflicting duplicate root declarations were accepted"
 fi
 if ! grep -q "Conflicting root toolchain settings for Python 3.11" "$failure_log"; then
     cat "$failure_log" >&2
-    fail "conflicting normalized root declarations lacked a clear diagnostic"
+    fail "conflicting duplicate root declarations lacked a clear diagnostic"
 fi
 
 echo "PASS: each Python version retained its root toolchain settings"

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -239,7 +239,7 @@ def _python_interpreters_impl(module_ctx):
                             root_settings[major_minor],
                             settings,
                         ) +
-                        "Tags whose python_version values normalize to the same major.minor " +
+                        "Tags requesting the same Python version " +
                         "must use identical config_settings, target_compatible_with, and " +
                         "exec_compatible_with.",
                     )


### PR DESCRIPTION
The toolchain-settings e2e still uses a `3.11.14` tag to exercise
duplicate declarations. Toolchain tags now intentionally require
`major.minor`, so every fork PR fails this standalone test before it
reaches the settings invariant.

Use duplicate `3.11` tags instead. Keep the conflict case and the
order-insensitive duplicate case intact, and describe them as duplicate
declarations rather than normalization.