### PR TITLE
fix(uv): preserve explicit compiler env

### DIFF
--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -782,19 +782,18 @@ _override_package_tag = tag_class(
                   "bucket.",
         ),
 
-        # Per-package toolchain plumbing for native sdist builds. Both
-        # attributes AUGMENT the defaults baked into sdist_build's
-        # generated `pep517_native_whl(...)` call (the CC toolchain +
-        # CC/CXX/AR/LD/STRIP env) — they don't replace them. Use these
-        # to layer extra toolchains (Java runtime, Rust, …) and extra
-        # env vars on top of the defaults.
+        # Per-package toolchain and environment plumbing for native sdist builds.
+        # Toolchains are appended to the defaults baked into sdist_build's
+        # generated `pep517_native_whl(...)` call. Environment variables are
+        # merged over its CC/CXX/AR/LD/STRIP defaults, so matching names
+        # replace the generated value.
         "toolchains": attr.label_list(
             default = [],
             doc = "Extra toolchain targets appended to the generated pep517_native_whl(...) call's `toolchains` list. Each target's TemplateVariableInfo make-variables become available for $(VAR) expansion in `env`.",
         ),
         "env": attr.string_dict(
             default = {},
-            doc = "Extra environment variables merged into the build action's `env` dict. Values may reference $(VAR) make-variables sourced from the default CC toolchain or any extra `toolchains` listed above.",
+            doc = "Environment variables merged into the build action's `env` dict, replacing generated defaults with matching names. Values may reference $(VAR) make-variables sourced from the default CC toolchain or any extra `toolchains` listed above.",
         ),
 
         # Pre-build patches: applied to extracted sdist source before wheel build.

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -135,15 +135,13 @@ build_test(
     visibility = ["//visibility:public"],
 )
 
-# Fixture replicates the toolchains + env defaults emitted by sdist_build's
-# BUILD template (see uv/private/sdist_build/repository.bzl). The analysis
-# test below asserts these expand to non-empty toolchain paths.
+# Fixture combines pep517_native_whl's compiler defaults with the toolchain and
+# env defaults emitted by sdist_build's BUILD template. The analysis test below
+# asserts that all of them resolve to non-empty toolchain paths.
 pep517_native_whl(
     name = "__toolchain_env_fixture",
     src = ":__stub_sdist",
     env = {
-        "CC": "$(CC)",
-        "CXX": "$(CC)",
         "AR": "$(AR)",
         "LD": "$(LD)",
         "STRIP": "$(STRIP)",

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -155,13 +155,12 @@ def _pep517_native_whl(ctx):
     cc_files, cc_compiler = _cc_toolchain_inputs_and_compiler(ctx)
     if cc_files:
         extra_inputs.append(cc_files)
-
-    for k, v in ctx.attr.env.items():
-        env[k] = ctx.expand_make_variables("env", v, known_variables)
-
     if cc_compiler:
         env["CC"] = cc_compiler
         env["CXX"] = cc_compiler
+
+    for k, v in ctx.attr.env.items():
+        env[k] = ctx.expand_make_variables("env", v, known_variables)
 
     ctx.actions.run(
         mnemonic = "PySdistNativeBuild",
@@ -251,7 +250,8 @@ constraints of the target platform.
             doc = "Environment variables to set on the build action. Values may " +
                   "contain `$(VAR)` references to make-variables exposed by any " +
                   "target in the rule's `toolchains` attribute (via " +
-                  "`TemplateVariableInfo`).",
+                  "`TemplateVariableInfo`). Matching names replace generated " +
+                  "defaults, including `CC` and `CXX`.",
         ),
     },
     toolchains = [

--- a/uv/private/pep517_whl/test.bzl
+++ b/uv/private/pep517_whl/test.bzl
@@ -46,9 +46,10 @@ hostile_python_env_target = rule(
     },
 )
 
-# Env vars sourced from the CC toolchain's TemplateVariableInfo. SYSROOT is
-# omitted because some toolchains legitimately have an empty sysroot and
-# it isn't exposed as a TemplateVariableInfo make variable today.
+# CC and CXX default to the resolved C++ toolchain compiler. The other values
+# come from its TemplateVariableInfo. SYSROOT is omitted because some
+# toolchains legitimately have an empty sysroot and do not expose it as a
+# make variable today.
 _CC_ENV_KEYS = ["CC", "CXX", "AR", "LD", "STRIP"]
 
 # Env vars sourced from the Java runtime toolchain's TemplateVariableInfo.
@@ -83,9 +84,8 @@ def _toolchain_env_test_impl(ctx):
             "${} should resolve to a non-empty toolchain path".format(key),
         )
 
-    # CC and CXX both derive from cc_toolchain's $(CC) make variable today.
-    # If we ever switch CXX to a c++ compile driver (e.g. via a custom
-    # TemplateVariableInfo shim), this assertion can be relaxed.
+    # CC and CXX both default to the compiler discovered from the resolved C++
+    # toolchain. If the defaults diverge in the future, relax this assertion.
     asserts.equals(
         env,
         action_env.get("CC"),
@@ -103,3 +103,31 @@ def _toolchain_env_test_impl(ctx):
     return analysistest.end(env)
 
 pep517_native_whl_toolchain_env_test = analysistest.make(_toolchain_env_test_impl)
+
+def _compiler_env_override_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    build_actions = [a for a in target.actions if a.mnemonic == "PySdistNativeBuild"]
+    asserts.equals(
+        env,
+        1,
+        len(build_actions),
+        "expected exactly one PySdistNativeBuild action",
+    )
+
+    action_env = build_actions[0].env
+    asserts.true(
+        env,
+        action_env.get("CC", "").endswith(" -DEXPLICIT_CC=1"),
+        "explicit CC command was overwritten: {}".format(action_env.get("CC")),
+    )
+    asserts.true(
+        env,
+        action_env.get("CXX", "").endswith(" -DEXPLICIT_CXX=1"),
+        "explicit CXX command was overwritten: {}".format(action_env.get("CXX")),
+    )
+
+    return analysistest.end(env)
+
+pep517_native_whl_compiler_env_override_test = analysistest.make(_compiler_env_override_test_impl)

--- a/uv/private/pep517_whl/tests/compiler_env_override/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/compiler_env_override/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("//uv/private/pep517_whl:test.bzl", "pep517_native_whl_compiler_env_override_test")
+
+pep517_native_whl(
+    name = "fixture",
+    testonly = True,
+    src = "//uv/private/pep517_whl:__stub_sdist",
+    env = {
+        "CC": "$(CC) -DEXPLICIT_CC=1",
+        "CXX": "$(CC) -DEXPLICIT_CXX=1",
+    },
+    tags = ["manual"],
+    tool = "//uv/private/pep517_whl:__stub_tool",
+    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
+    version = "0.0.1",
+)
+
+pep517_native_whl_compiler_env_override_test(
+    name = "test",
+    target_under_test = ":fixture",
+)

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -237,9 +237,9 @@ def _sdist_build_impl(repository_ctx):
     # a single driver binary for both languages, and meson-python /
     # cmake-based backends look for CXX independently of CC.
     #
-    # `extra_toolchains` and `extra_env` augment (do not replace) the
-    # defaults — set via `uv.override_package(toolchains = [...],
-    # env = {...})` to layer JDK / Rust / etc. plumbing on top.
+    # `extra_toolchains` extends the defaults. `extra_env` is merged over the
+    # default environment, so matching keys replace generated values. Both are
+    # set via `uv.override_package(toolchains = [...], env = {...})`.
     toolchain_attrs = ""
     if is_native:
         toolchains = [
@@ -342,7 +342,7 @@ sdist_build = repository_rule(
         ),
         "extra_env": attr.string_dict(
             default = {},
-            doc = "Environment variables merged into the default CC env dict in the generated pep517_native_whl(...) `env` dict. Values may reference $(VAR) make-variables from any toolchain. Set via `uv.override_package(env = {...})`.",
+            doc = "Environment variables merged into the default CC env dict in the generated pep517_native_whl(...) `env` dict, replacing generated values with matching names. Values may reference $(VAR) make-variables from any toolchain. Set via `uv.override_package(env = {...})`.",
         ),
     },
 )


### PR DESCRIPTION
`pep517_native_whl` expands its `env` attribute and then replaces `CC`
and `CXX` with the resolved C++ toolchain compiler. This silently
discards matching `uv.override_package(env = ...)` values, including
custom wrappers and flags.

Establish the resolved compiler as a hermetic default before applying
the user environment. Matching keys now replace defaults, while omitted
keys still use the resolved toolchain and its declared inputs. Clarify
that `env` is a key-wise override rather than additions-only.