### PR TITLE
fix(py): bind selected PBS exec runtime

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -60,6 +60,22 @@ jobs:
             - name: Test
               working-directory: ${{ matrix.workspace.path }}
               run: aspect test --task-key=test-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} -- //...
+            # This fixture's root toolchain declarations live in its own module,
+            # not the parent e2e module used by the matrix entry above.
+            - name: Interpreter toolchain settings
+              if: matrix.workspace.slug == 'e2e'
+              working-directory: e2e/cases/interpreter-toolchain-settings
+              run: |
+                aspect test \
+                  --task-key=test-interpreter-toolchain-settings-${{ matrix.bazel.id }} \
+                  ${{ matrix.bazel.flags }} \
+                  --bazel-flag=--lockfile_mode=off \
+                  -- \
+                  //:resolved_311_test \
+                  //:resolved_312_test \
+                  //:resolved_313_freethreaded_test \
+                  //:resolved_313_glibc_test \
+                  //:resolved_313_musl_test
             # Standalone scripts that drive bazel directly (e.g. asserting a
             # build *fails*), so they can't be an `sh_test` under `//...` above.
             - name: e2e standalone test.sh scripts

--- a/e2e/cases/interpreter-toolchain-settings/BUILD.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/BUILD.bazel
@@ -1,30 +1,110 @@
-load(":toolchain_test.bzl", "interpreter_toolchain_check")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load(":toolchain_test.bzl", "exec_toolchain_check", "interpreter_toolchain_check", "toolchain_resolution_test")
+
+string_flag(
+    name = "interpreter_setting",
+    build_setting_default = "",
+)
+
+string_flag(
+    name = "interpreter_setting_secondary",
+    build_setting_default = "",
+)
 
 config_setting(
     name = "config_311",
-    define_values = {"interpreter_setting": "311"},
+    flag_values = {":interpreter_setting": "311"},
 )
 
 config_setting(
     name = "config_311_secondary",
-    define_values = {"interpreter_setting_secondary": "311"},
+    flag_values = {":interpreter_setting_secondary": "311"},
 )
 
 config_setting(
     name = "config_312",
-    define_values = {"interpreter_setting": "312"},
+    flag_values = {":interpreter_setting": "312"},
+)
+
+constraint_setting(name = "python_target")
+
+constraint_setting(name = "python_exec")
+
+constraint_value(
+    name = "python_exec_supported",
+    constraint_setting = ":python_exec",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "python_target_supported",
+    constraint_setting = ":python_target",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "python_target_unsupported",
+    constraint_setting = ":python_target",
+    visibility = ["//visibility:public"],
 )
 
 platform(
     name = "linux_x86_64",
+    constraint_values = [
+        ":python_target_supported",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_x86_64_exec",
     constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
 )
 
+platform(
+    name = "linux_x86_64_exec_supported",
+    constraint_values = [
+        ":python_exec_supported",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_aarch64",
+    constraint_values = [
+        ":python_target_supported",
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_x86_64_unsupported",
+    constraint_values = [
+        ":python_target_unsupported",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+# This package is also visible from the parent e2e workspace, whose module does
+# not declare these root toolchain settings. CI names the tests explicitly from
+# this fixture's module; `manual` keeps parent-workspace wildcards from selecting
+# their checks or wrappers under the wrong module graph.
 interpreter_toolchain_check(
     name = "resolved_311",
+    expected_interpreter = "@python_3_11_x86_64_unknown_linux_gnu//:bin/python3",
+    python_version = "3.11",
+    tags = ["manual"],
+)
+
+exec_toolchain_check(
+    name = "resolved_311_exec",
     expected_interpreter = "@python_3_11_x86_64_unknown_linux_gnu//:bin/python3",
     python_version = "3.11",
     tags = ["manual"],
@@ -35,4 +115,77 @@ interpreter_toolchain_check(
     expected_interpreter = "@python_3_12_x86_64_unknown_linux_gnu//:bin/python3",
     python_version = "3.12",
     tags = ["manual"],
+)
+
+exec_toolchain_check(
+    name = "resolved_312_exec",
+    expected_interpreter = "@python_3_12_x86_64_unknown_linux_gnu//:bin/python3",
+    python_version = "3.12",
+    tags = ["manual"],
+)
+
+exec_toolchain_check(
+    name = "resolved_313_exec",
+    expected_interpreter = "@python_3_13_x86_64_unknown_linux_gnu//:bin/python3",
+    python_version = "3.13",
+    tags = ["manual"],
+)
+
+exec_toolchain_check(
+    name = "resolved_313_freethreaded_exec",
+    expected_interpreter = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:bin/python3",
+    freethreaded = True,
+    python_version = "3.13",
+    tags = ["manual"],
+)
+
+toolchain_resolution_test(
+    name = "resolved_311_test",
+    checks = [
+        ":resolved_311",
+        ":resolved_311_exec",
+    ],
+    execution_platform = ":linux_x86_64_exec",
+    interpreter_setting = "311",
+    interpreter_setting_secondary = "311",
+    python_version = "3.11",
+    target_platform = ":linux_x86_64",
+)
+
+toolchain_resolution_test(
+    name = "resolved_312_test",
+    checks = [
+        ":resolved_312",
+        ":resolved_312_exec",
+    ],
+    execution_platform = ":linux_x86_64_exec",
+    interpreter_setting = "312",
+    python_version = "3.12",
+    target_platform = ":linux_x86_64",
+)
+
+toolchain_resolution_test(
+    name = "resolved_313_glibc_test",
+    checks = [":resolved_313_exec"],
+    execution_platform = ":linux_x86_64_exec_supported",
+    python_version = "3.13",
+    target_platform = ":linux_aarch64",
+)
+
+toolchain_resolution_test(
+    name = "resolved_313_musl_test",
+    checks = [":resolved_313_exec"],
+    execution_platform = ":linux_x86_64_exec_supported",
+    libc = "musl",
+    python_version = "3.13",
+    target_platform = ":linux_aarch64",
+)
+
+toolchain_resolution_test(
+    name = "resolved_313_freethreaded_test",
+    checks = [":resolved_313_freethreaded_exec"],
+    execution_platform = ":linux_x86_64_exec_supported",
+    freethreaded = True,
+    python_version = "3.13",
+    target_platform = ":linux_aarch64",
 )

--- a/e2e/cases/interpreter-toolchain-settings/MODULE.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/MODULE.bazel
@@ -1,7 +1,12 @@
 module(name = "interpreter_toolchain_settings")
 
 bazel_dep(name = "aspect_rules_py")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "platforms", version = "1.1.0")
+
+# The fixture directly inspects rules_python's exec-tools provider;
+# aspect_rules_py does not expose an alias for that toolchain type.
+bazel_dep(name = "rules_python", version = "1.9.0")
 
 local_path_override(
     module_name = "aspect_rules_py",
@@ -28,10 +33,17 @@ interpreters.toolchain(
     config_settings = ["//:config_312"],
     python_version = "3.12",
 )
+interpreters.toolchain(
+    exec_compatible_with = ["//:python_exec_supported"],
+    python_version = "3.13",
+    target_compatible_with = ["//:python_target_supported"],
+)
 use_repo(
     interpreters,
     "python_3_11_x86_64_unknown_linux_gnu",
     "python_3_12_x86_64_unknown_linux_gnu",
+    "python_3_13_x86_64_unknown_linux_gnu",
+    "python_3_13_x86_64_unknown_linux_gnu_freethreaded",
     "python_interpreters",
 )
 

--- a/e2e/cases/interpreter-toolchain-settings/exec_interpreter_check.py
+++ b/e2e/cases/interpreter-toolchain-settings/exec_interpreter_check.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import sysconfig
+from pathlib import Path
+
+expected_version = tuple(map(int, sys.argv[1].split(".")))
+expected_freethreaded = sys.argv[2] == "1"
+expected_interpreter = sys.argv[3]
+
+if not os.path.samefile(sys.executable, expected_interpreter):
+    raise SystemExit(
+        f"expected interpreter {expected_interpreter}, got {sys.executable}"
+    )
+if sys.version_info[:2] != expected_version:
+    raise SystemExit(
+        f"expected Python {expected_version}, got {sys.version_info[:2]}"
+    )
+actual_freethreaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+if actual_freethreaded != expected_freethreaded:
+    raise SystemExit(
+        f"expected free-threaded={expected_freethreaded}, "
+        f"got {actual_freethreaded}"
+    )
+
+Path(sys.argv[4]).touch()

--- a/e2e/cases/interpreter-toolchain-settings/test.sh
+++ b/e2e/cases/interpreter-toolchain-settings/test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Successful resolution is covered by BUILD tests. This script keeps cases
+# whose expected result is an analysis or module-evaluation failure.
 
 set -uo pipefail
 
@@ -11,36 +13,64 @@ fail() {
     exit 1
 }
 
-check_toolchain() {
-    local version="$1"
-    local setting="$2"
-    shift 2
-
-    "$BAZEL" build \
-        --lockfile_mode=off \
-        "--@aspect_rules_py//py:python_version=${version}" \
-        --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
-        "--define=interpreter_setting=${setting}" \
-        --platforms=//:linux_x86_64 \
-        "$@" \
-        -- "//:resolved_${setting}" \
-        || fail "Python ${version} did not resolve with its root config_setting"
-}
-
-check_toolchain 3.11 311 --define=interpreter_setting_secondary=311
-check_toolchain 3.12 312
-
 failure_log="$(mktemp)"
 trap 'rm -f "$failure_log"' EXIT
 
 if "$BAZEL" build \
+    --nobuild \
     --lockfile_mode=off \
     --@aspect_rules_py//py:python_version=3.11 \
     --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
-    --define=interpreter_setting=312 \
+    --//:interpreter_setting=312 \
     --platforms=//:linux_x86_64 \
     -- //:resolved_311 >"$failure_log" 2>&1; then
     fail "Python 3.11 resolved with Python 3.12 root config_settings"
+fi
+
+if "$BAZEL" build \
+    --nobuild \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.11 \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --//:interpreter_setting=311 \
+    --extra_execution_platforms=//:linux_x86_64_exec \
+    --platforms=//:linux_x86_64 \
+    -- //:resolved_311_exec >"$failure_log" 2>&1; then
+    fail "Python 3.11 exec tools ignored their root config_settings"
+fi
+if ! grep -Fq "expected PBS exec runtime" "$failure_log"; then
+    cat "$failure_log" >&2
+    fail "Python 3.11 exec-tool mismatch failed for an unrelated reason"
+fi
+
+if "$BAZEL" build \
+    --nobuild \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.13 \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --extra_execution_platforms=//:linux_x86_64_exec_supported \
+    --platforms=//:linux_x86_64_unsupported \
+    -- //:resolved_313_exec >"$failure_log" 2>&1; then
+    fail "Python 3.13 exec tools ignored target_compatible_with"
+fi
+if ! grep -Fq "expected PBS exec runtime" "$failure_log"; then
+    cat "$failure_log" >&2
+    fail "Python 3.13 selected the constrained PBS runtime"
+fi
+
+if "$BAZEL" build \
+    --nobuild \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.13 \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --extra_execution_platforms=//:linux_x86_64_exec \
+    --platforms=//:linux_aarch64 \
+    -- //:resolved_313_exec >"$failure_log" 2>&1; then
+    fail "Python 3.13 exec tools ignored exec_compatible_with"
+fi
+if ! grep -Fq "expected PBS exec runtime" "$failure_log"; then
+    cat "$failure_log" >&2
+    fail "Python 3.13 exec incompatibility failed for an unrelated reason"
 fi
 
 if (cd conflict && "$BAZEL" query \
@@ -53,4 +83,4 @@ if ! grep -q "Conflicting root toolchain settings for Python 3.11" "$failure_log
     fail "conflicting duplicate root declarations lacked a clear diagnostic"
 fi
 
-echo "PASS: each Python version retained its root toolchain settings"
+echo "PASS: invalid toolchain configurations were rejected"

--- a/e2e/cases/interpreter-toolchain-settings/toolchain_test.bzl
+++ b/e2e/cases/interpreter-toolchain-settings/toolchain_test.bzl
@@ -1,6 +1,11 @@
-"""Analysis check for the selected Python runtime toolchain."""
+"""Checks selected Python runtime and exec-tools toolchains."""
 
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+# Python runtimes use Bazel's standard toolchain contract. The separate
+# build-time interpreter contract is public API supplied by rules_python.
 _RUNTIME_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
+_EXEC_TOOLS_TOOLCHAIN = "@rules_python//python:exec_tools_toolchain_type"
 
 def _interpreter_toolchain_check_impl(ctx):
     runtime = ctx.toolchains[_RUNTIME_TOOLCHAIN].py3_runtime
@@ -31,3 +36,124 @@ interpreter_toolchain_check = rule(
     },
     toolchains = [_RUNTIME_TOOLCHAIN],
 )
+
+def _exec_toolchain_check_impl(ctx):
+    exec_tools = ctx.toolchains[_EXEC_TOOLS_TOOLCHAIN].exec_tools
+    if exec_tools.exec_interpreter == None:
+        fail("PBS exec toolchain has no interpreter")
+    if exec_tools.exec_runtime == None:
+        fail("PBS exec toolchain has no runtime")
+    if exec_tools.exec_runtime.interpreter != ctx.file.expected_interpreter:
+        fail(
+            "expected PBS exec runtime {}, got {}".format(
+                ctx.file.expected_interpreter,
+                exec_tools.exec_runtime.interpreter,
+            ),
+        )
+
+    output = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.run(
+        arguments = [
+            ctx.file._exec_interpreter_check.path,
+            ctx.attr.python_version,
+            "1" if ctx.attr.freethreaded else "0",
+            ctx.file.expected_interpreter.path,
+            output.path,
+        ],
+        executable = exec_tools.exec_interpreter[DefaultInfo].files_to_run,
+        inputs = [ctx.file._exec_interpreter_check, ctx.file.expected_interpreter],
+        mnemonic = "ExecInterpreterSmoke",
+        outputs = [output],
+    )
+    return [DefaultInfo(files = depset([output]))]
+
+exec_toolchain_check = rule(
+    implementation = _exec_toolchain_check_impl,
+    attrs = {
+        "expected_interpreter": attr.label(allow_single_file = True, mandatory = True),
+        "freethreaded": attr.bool(),
+        "python_version": attr.string(mandatory = True),
+        "_exec_interpreter_check": attr.label(
+            allow_single_file = True,
+            default = ":exec_interpreter_check.py",
+        ),
+    },
+    toolchains = [_EXEC_TOOLS_TOOLCHAIN],
+)
+
+def _toolchain_test_transition_impl(_settings, attr):
+    return {
+        "//:interpreter_setting": attr.interpreter_setting,
+        "//:interpreter_setting_secondary": attr.interpreter_setting_secondary,
+        "//command_line_option:extra_execution_platforms": [str(attr.execution_platform)],
+        "//command_line_option:platforms": [str(attr.target_platform)],
+        "@aspect_rules_py//py/private/interpreter:freethreaded": attr.freethreaded,
+        "@aspect_rules_py//py:python_version": attr.python_version,
+        "@aspect_rules_py//uv/private/constraints/platform:platform_libc": attr.libc,
+    }
+
+_toolchain_test_transition = transition(
+    implementation = _toolchain_test_transition_impl,
+    inputs = [],
+    outputs = [
+        "//:interpreter_setting",
+        "//:interpreter_setting_secondary",
+        "//command_line_option:extra_execution_platforms",
+        "//command_line_option:platforms",
+        "@aspect_rules_py//py/private/interpreter:freethreaded",
+        "@aspect_rules_py//py:python_version",
+        "@aspect_rules_py//uv/private/constraints/platform:platform_libc",
+    ],
+)
+
+def _configured_toolchain_checks_impl(ctx):
+    return [DefaultInfo(files = depset(
+        transitive = [target[DefaultInfo].files for target in ctx.attr.checks],
+    ))]
+
+_configured_toolchain_checks = rule(
+    implementation = _configured_toolchain_checks_impl,
+    attrs = {
+        "checks": attr.label_list(cfg = _toolchain_test_transition, mandatory = True),
+        "execution_platform": attr.label(mandatory = True),
+        "freethreaded": attr.bool(),
+        "interpreter_setting": attr.string(),
+        "interpreter_setting_secondary": attr.string(),
+        "libc": attr.string(mandatory = True),
+        "python_version": attr.string(mandatory = True),
+        "target_platform": attr.label(mandatory = True),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)
+
+def toolchain_resolution_test(
+        name,
+        checks,
+        execution_platform,
+        python_version,
+        target_platform,
+        libc = "glibc",
+        freethreaded = False,
+        interpreter_setting = "",
+        interpreter_setting_secondary = ""):
+    """Tests toolchain resolution under an explicit target/exec configuration."""
+    configured_checks = name + "_configured"
+    _configured_toolchain_checks(
+        name = configured_checks,
+        checks = checks,
+        execution_platform = execution_platform,
+        freethreaded = freethreaded,
+        interpreter_setting = interpreter_setting,
+        interpreter_setting_secondary = interpreter_setting_secondary,
+        libc = libc,
+        python_version = python_version,
+        tags = ["manual"],
+        target_platform = target_platform,
+    )
+    build_test(
+        name = name,
+        tags = ["manual"],
+        targets = [configured_checks],
+    )

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -95,6 +95,11 @@ bzl_library(
 )
 
 bzl_library(
+    name = "interpreter_executable",
+    srcs = ["interpreter_executable.bzl"],
+)
+
+bzl_library(
     name = "resolve",
     srcs = ["resolve.bzl"],
 )

--- a/py/private/interpreter/interpreter_executable.bzl
+++ b/py/private/interpreter/interpreter_executable.bzl
@@ -1,0 +1,43 @@
+"""Expose a supplied Python runtime pair as an executable target."""
+
+def _interpreter_executable_impl(ctx):
+    toolchain = ctx.attr.runtime_pair[platform_common.ToolchainInfo]
+    runtime = toolchain.py3_runtime
+    if runtime.interpreter == None:
+        fail("interpreter_executable requires a hermetic Python runtime")
+
+    # rules_python's default exec_interpreter resolves its Python toolchain in
+    # cfg = "exec". PBS repositories instead need to preserve their supplied
+    # runtime pair while satisfying exec_interpreter's executable contract:
+    # https://github.com/bazel-contrib/rules_python/blob/1.9.0/python/private/py_exec_tools_toolchain.bzl#L61-L106
+    # Keep the executable symlink shape used by rules_python's own adapter:
+    # https://github.com/bazel-contrib/rules_python/blob/1.9.0/python/private/py_exec_tools_toolchain.bzl#L108-L129
+    executable = ctx.actions.declare_file(
+        "{}/{}".format(ctx.label.name, runtime.interpreter.basename),
+    )
+    ctx.actions.symlink(
+        output = executable,
+        target_file = runtime.interpreter,
+        is_executable = True,
+    )
+    return [
+        toolchain,
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.runfiles(
+                files = [executable],
+                transitive_files = runtime.files,
+            ),
+        ),
+    ]
+
+interpreter_executable = rule(
+    implementation = _interpreter_executable_impl,
+    attrs = {
+        "runtime_pair": attr.label(
+            mandatory = True,
+            providers = [platform_common.ToolchainInfo],
+        ),
+    },
+    executable = True,
+)

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -182,6 +182,7 @@ cc_library(
     return """\
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@aspect_rules_py//py/private/interpreter:interpreter_executable.bzl", "interpreter_executable")
 load("@rules_python//python:py_runtime.bzl", "py_runtime")
 load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
 load("@rules_python//python:py_exec_tools_toolchain.bzl", "py_exec_tools_toolchain")
@@ -246,8 +247,15 @@ py_runtime_pair(
     py3_runtime = ":py3_runtime",
 )
 
+interpreter_executable(
+    name = "exec_interpreter",
+    runtime_pair = ":runtime_pair",
+    visibility = ["//visibility:private"],
+)
+
 py_exec_tools_toolchain(
     name = "exec_tools_toolchain",
+    exec_interpreter = ":exec_interpreter",
 )
 
 py_cc_toolchain(
@@ -401,13 +409,30 @@ config_setting(
         version_setting = ":" + _version_setting_name(info["python_version"])
         freethreaded_setting = ":" + _freethreaded_setting_name(info.get("freethreaded", False))
 
-        target_settings = [
+        python_target_settings = [
             version_setting,
             freethreaded_setting,
-        ] + [":" + name for name in platform_setting_names] + extra_config_settings
+        ]
+        runtime_target_settings = (
+            python_target_settings +
+            [":" + name for name in platform_setting_names] +
+            extra_config_settings
+        )
 
-        target_compatible_with = info["compatible_with"] + extra_target_compatible
+        # target_settings are evaluated against the target configuration even
+        # for a toolchain whose implementation runs on the execution platform:
+        # https://bazel.build/reference/be/general#toolchain.target_settings
+        # Select the requested Python version and mode, but do not require the
+        # execution interpreter to match target-platform settings such as libc.
+        exec_target_settings = python_target_settings + extra_config_settings
+
+        runtime_target_compatible_with = info["compatible_with"] + extra_target_compatible
         exec_compatible_with = info["compatible_with"] + extra_exec_compatible
+
+        # Root target constraints describe which targets may use the exec
+        # toolchain. PBS OS/CPU constraints describe only its exec platform:
+        # https://bazel.build/reference/be/general#toolchain.target_compatible_with
+        exec_target_compatible_with = extra_target_compatible
 
         content.append("""
 # The Python interpreter toolchain has no exec_compatible_with: the interpreter
@@ -419,33 +444,34 @@ config_setting(
 # sufficient to pick the right interpreter for the target.
 toolchain(
     name = "{name}",
-    target_compatible_with = {target_compatible_with},
-    target_settings = {target_settings},
+    target_compatible_with = {runtime_target_compatible_with},
+    target_settings = {runtime_target_settings},
     toolchain = "@{repo}//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
 toolchain(
     name = "{name}_py_cc",
-    target_compatible_with = {target_compatible_with},
-    target_settings = {target_settings},
+    target_compatible_with = {runtime_target_compatible_with},
+    target_settings = {runtime_target_settings},
     toolchain = "@{repo}//:py_cc_toolchain",
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 """.format(
             name = info["name"],
             repo = info["repo"],
-            target_compatible_with = target_compatible_with,
-            target_settings = target_settings,
+            runtime_target_settings = runtime_target_settings,
+            runtime_target_compatible_with = runtime_target_compatible_with,
         ))
 
         if info["register_exec_tools"]:
-            content.append("""# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
+            # Exec tools run on the selected execution platform for the
+            # target's Python mode.
+            content.append("""toolchain(
     name = "{name}_exec_tools",
     exec_compatible_with = {exec_compatible_with},
+    target_compatible_with = {exec_target_compatible_with},
+    target_settings = {exec_target_settings},
     toolchain = "@{repo}//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -453,6 +479,8 @@ toolchain(
                 name = info["name"],
                 repo = info["repo"],
                 exec_compatible_with = exec_compatible_with,
+                exec_target_compatible_with = exec_target_compatible_with,
+                exec_target_settings = exec_target_settings,
             ))
 
     content.append("""

--- a/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
@@ -68,12 +68,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_apple_darwin_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_apple_darwin//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -102,12 +103,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_unknown_linux_gnu_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_unknown_linux_gnu//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -160,12 +162,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_apple_darwin_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_apple_darwin//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -194,12 +197,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_unknown_linux_gnu_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_unknown_linux_gnu//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -252,12 +256,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_pc_windows_msvc_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_pc_windows_msvc//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -286,12 +291,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_pc_windows_msvc_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_pc_windows_msvc//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -320,12 +326,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_i686_pc_windows_msvc_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_i686_pc_windows_msvc//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -354,12 +361,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_apple_darwin_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -388,12 +396,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -446,12 +455,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_apple_darwin_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -480,12 +490,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -538,12 +549,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_x86_64_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -572,12 +584,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_aarch64_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -606,12 +619,13 @@ toolchain(
     toolchain_type = "@rules_python//python/cc:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_i686_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_i686_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )


### PR DESCRIPTION
PBS exec-tools registrations select a runtime by execution OS and CPU,
but rules_python's default `exec_interpreter` resolves Python again
under `cfg = "exec"`. A registration can therefore advertise one PBS
archive while invoking a different interpreter.

Bind each physical PBS runtime pair to an executable adapter that
implements rules_python's `exec_interpreter` contract. Constrain each
registration by canonical Python version, free-threaded mode, root
configuration settings, and root target compatibility. Keep target-only
libc settings out of execution selection and apply PBS OS and CPU
constraints to execution platforms.

The end-to-end fixture builds for Linux arm64 while executing on Linux
x86_64, then checks the selected interpreter's file, Python version, and
GIL mode. Its negative cases establish that incompatible root target or
execution constraints cannot select the PBS runtime.