### PR TITLE
fix(uv): validate bytecode runtime identity

### DIFF
--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -176,25 +176,22 @@ versions:
 
 The target attribute takes precedence over the build-wide flag.
 
-## Build configurations
+## Runtime modes
 
-PBS provides several build configurations. The default is `install_only`, which
-is PGO+LTO optimized on platforms that support it. You can select a different
-configuration per toolchain:
+The extension registers one normal `install_only` PBS archive for each
+available Python version and platform. It also registers an optimized
+free-threaded archive where PBS publishes one, currently for Python 3.13 and
+newer. Normal mode is selected by default. Select free-threaded mode with the
+build setting:
 
-```starlark
-interpreters.toolchain(
-    python_version = "3.12",
-    build_config = "install_only_stripped",  # Smaller, debug symbols removed
-)
+```shell
+bazel build \
+    --@aspect_rules_py//py/private/interpreter:freethreaded=true \
+    //...
 ```
 
-Available configurations:
-
-- `install_only` — Standard optimized build (default)
-- `install_only_stripped` — Same but with debug symbols stripped
-- `freethreaded+pgo+lto` — Free-threaded (no GIL) with PGO+LTO optimization
-- `freethreaded+debug` — Free-threaded debug build
+`interpreters.toolchain()` chooses Python versions; the build setting above
+selects runtime mode.
 
 ## Platforms
 

--- a/e2e/cases/freethreaded-805/test.py
+++ b/e2e/cases/freethreaded-805/test.py
@@ -12,6 +12,11 @@ class FreethreadedTest(unittest.TestCase):
         gil_disabled = sysconfig.get_config_var("Py_GIL_DISABLED")
         self.assertEqual(gil_disabled, 1, "Expected Py_GIL_DISABLED=1 for a freethreaded build")
 
+    def test_interpreter_is_optimized(self):
+        """The interpreter must not be a debug build."""
+        py_debug = sysconfig.get_config_var("Py_DEBUG")
+        self.assertEqual(py_debug, 0, "Expected Py_DEBUG=0 for an optimized build")
+
     def test_abi_tag_contains_t(self):
         """The SOABI should contain 't' indicating the freethreaded ABI."""
         soabi = sysconfig.get_config_var("SOABI") or ""

--- a/e2e/cases/interpreter-bytecode-magic/BUILD.bazel
+++ b/e2e/cases/interpreter-bytecode-magic/BUILD.bazel
@@ -1,0 +1,49 @@
+load(":bytecode_magic_test.bzl", "bytecode_magic_test")
+
+bytecode_magic_test(
+    name = "python_3_13",
+    expected_magic_number = 3571,
+    expected_python_version = "3.13",
+    runtime_pair = "@python_3_13_x86_64_unknown_linux_gnu//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_13_freethreaded",
+    expected_magic_number = 3571,
+    expected_python_version = "3.13",
+    runtime_pair = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_13_windows",
+    expected_magic_number = 3571,
+    expected_python_version = "3.13",
+    runtime_pair = "@python_3_13_x86_64_pc_windows_msvc//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_14",
+    expected_magic_number = 3627,
+    expected_python_version = "3.14",
+    runtime_pair = "@python_3_14_x86_64_unknown_linux_gnu//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_14_freethreaded",
+    expected_magic_number = 3627,
+    expected_python_version = "3.14",
+    runtime_pair = "@python_3_14_x86_64_unknown_linux_gnu_freethreaded//:runtime_pair",
+    tags = ["manual"],
+)
+
+bytecode_magic_test(
+    name = "python_3_14_windows",
+    expected_magic_number = 3627,
+    expected_python_version = "3.14",
+    runtime_pair = "@python_3_14_x86_64_pc_windows_msvc//:runtime_pair",
+    tags = ["manual"],
+)

--- a/e2e/cases/interpreter-bytecode-magic/MODULE.bazel
+++ b/e2e/cases/interpreter-bytecode-magic/MODULE.bazel
@@ -1,0 +1,21 @@
+module(name = "interpreter_bytecode_magic")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(releases = ["20260303"])
+interpreters.toolchain(python_version = "3.13")
+interpreters.toolchain(python_version = "3.14")
+use_repo(
+    interpreters,
+    "python_3_13_x86_64_pc_windows_msvc",
+    "python_3_13_x86_64_unknown_linux_gnu",
+    "python_3_13_x86_64_unknown_linux_gnu_freethreaded",
+    "python_3_14_x86_64_pc_windows_msvc",
+    "python_3_14_x86_64_unknown_linux_gnu",
+    "python_3_14_x86_64_unknown_linux_gnu_freethreaded",
+)

--- a/e2e/cases/interpreter-bytecode-magic/bytecode_magic_test.bzl
+++ b/e2e/cases/interpreter-bytecode-magic/bytecode_magic_test.bzl
@@ -1,0 +1,40 @@
+"""Checks bytecode identity on a provisioned PBS runtime pair."""
+
+def _bytecode_magic_test_impl(ctx):
+    runtime_pair = ctx.attr.runtime_pair[platform_common.ToolchainInfo]
+    if runtime_pair.py2_runtime != None:
+        fail("PBS runtime pair unexpectedly contains a Python 2 runtime")
+    if runtime_pair.py3_runtime == None:
+        fail("PBS runtime pair lost its Python 3 runtime")
+
+    version = runtime_pair.py3_runtime.interpreter_version_info
+    actual_version = "{}.{}".format(version.major, version.minor)
+    if actual_version != ctx.attr.expected_python_version:
+        fail("expected Python {}, got {}".format(
+            ctx.attr.expected_python_version,
+            actual_version,
+        ))
+
+    actual = getattr(runtime_pair, "pyc_magic_number", None)
+    if actual != ctx.attr.expected_magic_number:
+        fail("expected PYC_MAGIC_NUMBER {}, got {}".format(
+            ctx.attr.expected_magic_number,
+            actual,
+        ))
+
+    executable = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(executable, "#!/usr/bin/env sh\n", is_executable = True)
+    return [DefaultInfo(executable = executable)]
+
+bytecode_magic_test = rule(
+    implementation = _bytecode_magic_test_impl,
+    attrs = {
+        "expected_magic_number": attr.int(mandatory = True),
+        "expected_python_version": attr.string(mandatory = True),
+        "runtime_pair": attr.label(
+            mandatory = True,
+            providers = [platform_common.ToolchainInfo],
+        ),
+    },
+    test = True,
+)

--- a/e2e/cases/interpreter-bytecode-magic/test.sh
+++ b/e2e/cases/interpreter-bytecode-magic/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# These checks load generated repositories from a nested module, so CI runs
+# them directly rather than through the parent e2e workspace.
+set -uo pipefail
+
+case_dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$case_dir" || exit 1
+
+BAZEL="${BAZEL:-bazel}"
+if ! "$BAZEL" test --lockfile_mode=off -- \
+    //:python_3_13 \
+    //:python_3_13_freethreaded \
+    //:python_3_13_windows \
+    //:python_3_14 \
+    //:python_3_14_freethreaded \
+    //:python_3_14_windows; then
+    echo "FAIL: PBS bytecode magic does not match its interpreter" >&2
+    exit 1
+fi
+
+echo "PASS: PBS runtime pairs expose their bytecode magic"

--- a/e2e/cases/interpreter-runtime-metadata/BUILD.bazel
+++ b/e2e/cases/interpreter-runtime-metadata/BUILD.bazel
@@ -10,13 +10,6 @@ runtime_metadata_test(
 runtime_metadata_test(
     name = "freethreaded",
     abi_flags = "t",
-    runtime = "@python_3_15_x86_64_unknown_linux_gnu_freethreaded_pgo_lto//:py3_runtime",
-    tags = ["manual"],
-)
-
-runtime_metadata_test(
-    name = "freethreaded_debug",
-    abi_flags = "td",
-    runtime = "@python_3_15_x86_64_unknown_linux_gnu_freethreaded_debug//:py3_runtime",
+    runtime = "@python_3_15_x86_64_unknown_linux_gnu_freethreaded//:py3_runtime",
     tags = ["manual"],
 )

--- a/e2e/cases/interpreter-runtime-metadata/MODULE.bazel
+++ b/e2e/cases/interpreter-runtime-metadata/MODULE.bazel
@@ -17,6 +17,5 @@ interpreters.toolchain(
 use_repo(
     interpreters,
     "python_3_15_x86_64_unknown_linux_gnu",
-    "python_3_15_x86_64_unknown_linux_gnu_freethreaded_debug",
-    "python_3_15_x86_64_unknown_linux_gnu_freethreaded_pgo_lto",
+    "python_3_15_x86_64_unknown_linux_gnu_freethreaded",
 )

--- a/e2e/cases/interpreter-runtime-metadata/test.sh
+++ b/e2e/cases/interpreter-runtime-metadata/test.sh
@@ -10,8 +10,7 @@ cd "$case_dir" || exit 1
 BAZEL="${BAZEL:-bazel}"
 if ! "$BAZEL" test --lockfile_mode=off -- \
     //:regular \
-    //:freethreaded \
-    //:freethreaded_debug; then
+    //:freethreaded; then
     echo "FAIL: prerelease runtime metadata did not match" >&2
     exit 1
 fi

--- a/e2e/cases/interpreter-toolchain-settings/BUILD.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/BUILD.bazel
@@ -1,4 +1,4 @@
-load(":toolchain_test.bzl", "interpreter_toolchain_check")
+load(":toolchain_test.bzl", "exec_toolchain_check", "interpreter_toolchain_check")
 
 config_setting(
     name = "config_311",
@@ -15,9 +15,67 @@ config_setting(
     define_values = {"interpreter_setting": "312"},
 )
 
+constraint_setting(name = "python_target")
+
+constraint_setting(name = "python_exec")
+
+constraint_value(
+    name = "python_exec_supported",
+    constraint_setting = ":python_exec",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "python_target_supported",
+    constraint_setting = ":python_target",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "python_target_unsupported",
+    constraint_setting = ":python_target",
+    visibility = ["//visibility:public"],
+)
+
 platform(
     name = "linux_x86_64",
     constraint_values = [
+        ":python_target_supported",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_x86_64_exec",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_x86_64_exec_supported",
+    constraint_values = [
+        ":python_exec_supported",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_aarch64",
+    constraint_values = [
+        ":python_target_supported",
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_x86_64_unsupported",
+    constraint_values = [
+        ":python_target_unsupported",
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
@@ -30,9 +88,38 @@ interpreter_toolchain_check(
     tags = ["manual"],
 )
 
+exec_toolchain_check(
+    name = "resolved_311_exec",
+    expected_interpreter = "@python_3_11_x86_64_unknown_linux_gnu//:bin/python3",
+    python_version = "3.11",
+    tags = ["manual"],
+)
+
 interpreter_toolchain_check(
     name = "resolved_312",
     expected_interpreter = "@python_3_12_x86_64_unknown_linux_gnu//:bin/python3",
     python_version = "3.12",
+    tags = ["manual"],
+)
+
+exec_toolchain_check(
+    name = "resolved_312_exec",
+    expected_interpreter = "@python_3_12_x86_64_unknown_linux_gnu//:bin/python3",
+    python_version = "3.12",
+    tags = ["manual"],
+)
+
+exec_toolchain_check(
+    name = "resolved_313_exec",
+    expected_interpreter = "@python_3_13_x86_64_unknown_linux_gnu//:bin/python3",
+    python_version = "3.13",
+    tags = ["manual"],
+)
+
+exec_toolchain_check(
+    name = "resolved_313_freethreaded_exec",
+    expected_interpreter = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:bin/python3",
+    freethreaded = True,
+    python_version = "3.13",
     tags = ["manual"],
 )

--- a/e2e/cases/interpreter-toolchain-settings/MODULE.bazel
+++ b/e2e/cases/interpreter-toolchain-settings/MODULE.bazel
@@ -2,6 +2,7 @@ module(name = "interpreter_toolchain_settings")
 
 bazel_dep(name = "aspect_rules_py")
 bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_python", version = "1.9.0")
 
 local_path_override(
     module_name = "aspect_rules_py",
@@ -28,10 +29,17 @@ interpreters.toolchain(
     config_settings = ["//:config_312"],
     python_version = "3.12",
 )
+interpreters.toolchain(
+    exec_compatible_with = ["//:python_exec_supported"],
+    python_version = "3.13",
+    target_compatible_with = ["//:python_target_supported"],
+)
 use_repo(
     interpreters,
     "python_3_11_x86_64_unknown_linux_gnu",
     "python_3_12_x86_64_unknown_linux_gnu",
+    "python_3_13_x86_64_unknown_linux_gnu",
+    "python_3_13_x86_64_unknown_linux_gnu_freethreaded",
     "python_interpreters",
 )
 

--- a/e2e/cases/interpreter-toolchain-settings/test.sh
+++ b/e2e/cases/interpreter-toolchain-settings/test.sh
@@ -5,6 +5,11 @@ set -uo pipefail
 cd "$(dirname "$0")" || exit 1
 
 BAZEL="${BAZEL:-bazel}"
+BUILD_ARGS=()
+if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]] ||
+    ! getconf GNU_LIBC_VERSION >/dev/null 2>&1; then
+    BUILD_ARGS+=(--nobuild)
+fi
 
 fail() {
     echo "FAIL: $*" >&2
@@ -17,23 +22,47 @@ check_toolchain() {
     shift 2
 
     "$BAZEL" build \
+        "${BUILD_ARGS[@]}" \
         --lockfile_mode=off \
         "--@aspect_rules_py//py:python_version=${version}" \
         --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
         "--define=interpreter_setting=${setting}" \
+        --extra_execution_platforms=//:linux_x86_64_exec \
         --platforms=//:linux_x86_64 \
         "$@" \
-        -- "//:resolved_${setting}" \
+        -- "//:resolved_${setting}" "//:resolved_${setting}_exec" \
         || fail "Python ${version} did not resolve with its root config_setting"
+}
+
+check_exec_toolchain() {
+    local target="$1"
+    local libc="$2"
+    shift 2
+
+    "$BAZEL" build \
+        "${BUILD_ARGS[@]}" \
+        --lockfile_mode=off \
+        --@aspect_rules_py//py:python_version=3.13 \
+        "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=${libc}" \
+        --extra_execution_platforms=//:linux_x86_64_exec_supported \
+        --platforms=//:linux_aarch64 \
+        "$@" \
+        -- "//:${target}" \
+        || fail "${target} resolved the wrong PBS exec runtime for a ${libc} target"
 }
 
 check_toolchain 3.11 311 --define=interpreter_setting_secondary=311
 check_toolchain 3.12 312
+check_exec_toolchain resolved_313_exec glibc
+check_exec_toolchain resolved_313_exec musl
+check_exec_toolchain resolved_313_freethreaded_exec glibc \
+    --@aspect_rules_py//py/private/interpreter:freethreaded=true
 
 failure_log="$(mktemp)"
 trap 'rm -f "$failure_log"' EXIT
 
 if "$BAZEL" build \
+    "${BUILD_ARGS[@]}" \
     --lockfile_mode=off \
     --@aspect_rules_py//py:python_version=3.11 \
     --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
@@ -41,6 +70,52 @@ if "$BAZEL" build \
     --platforms=//:linux_x86_64 \
     -- //:resolved_311 >"$failure_log" 2>&1; then
     fail "Python 3.11 resolved with Python 3.12 root config_settings"
+fi
+
+if "$BAZEL" build \
+    "${BUILD_ARGS[@]}" \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.11 \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --define=interpreter_setting=311 \
+    --extra_execution_platforms=//:linux_x86_64_exec \
+    --platforms=//:linux_x86_64 \
+    -- //:resolved_311_exec >"$failure_log" 2>&1; then
+    fail "Python 3.11 exec tools ignored their root config_settings"
+fi
+if ! grep -Fq "expected PBS exec runtime" "$failure_log"; then
+    cat "$failure_log" >&2
+    fail "Python 3.11 exec-tool mismatch failed for an unrelated reason"
+fi
+
+if "$BAZEL" build \
+    "${BUILD_ARGS[@]}" \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.13 \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --extra_execution_platforms=//:linux_x86_64_exec_supported \
+    --platforms=//:linux_x86_64_unsupported \
+    -- //:resolved_313_exec >"$failure_log" 2>&1; then
+    fail "Python 3.13 exec tools ignored target_compatible_with"
+fi
+if ! grep -Fq "expected PBS exec runtime" "$failure_log"; then
+    cat "$failure_log" >&2
+    fail "Python 3.13 selected the constrained PBS runtime"
+fi
+
+if "$BAZEL" build \
+    "${BUILD_ARGS[@]}" \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.13 \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --extra_execution_platforms=//:linux_x86_64_exec \
+    --platforms=//:linux_aarch64 \
+    -- //:resolved_313_exec >"$failure_log" 2>&1; then
+    fail "Python 3.13 exec tools ignored exec_compatible_with"
+fi
+if ! grep -Fq "expected PBS exec runtime" "$failure_log"; then
+    cat "$failure_log" >&2
+    fail "Python 3.13 exec incompatibility failed for an unrelated reason"
 fi
 
 if (cd conflict && "$BAZEL" query \

--- a/e2e/cases/interpreter-toolchain-settings/toolchain_test.bzl
+++ b/e2e/cases/interpreter-toolchain-settings/toolchain_test.bzl
@@ -1,6 +1,35 @@
-"""Analysis check for the selected Python runtime toolchain."""
+"""Checks selected Python runtime and exec-tools toolchains."""
 
 _RUNTIME_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
+_EXEC_TOOLS_TOOLCHAIN = "@rules_python//python:exec_tools_toolchain_type"
+
+_EXEC_INTERPRETER_CHECK = """\
+import os
+import pathlib
+import sys
+import sysconfig
+
+expected_version = tuple(map(int, sys.argv[1].split(".")))
+expected_freethreaded = sys.argv[2] == "1"
+expected_interpreter = sys.argv[3]
+
+if not os.path.samefile(sys.executable, expected_interpreter):
+    raise SystemExit(
+        f"expected interpreter {expected_interpreter}, got {sys.executable}"
+    )
+if sys.version_info[:2] != expected_version:
+    raise SystemExit(
+        f"expected Python {expected_version}, got {sys.version_info[:2]}"
+    )
+actual_freethreaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+if actual_freethreaded != expected_freethreaded:
+    raise SystemExit(
+        f"expected free-threaded={expected_freethreaded}, "
+        f"got {actual_freethreaded}"
+    )
+
+pathlib.Path(sys.argv[4]).touch()
+"""
 
 def _interpreter_toolchain_check_impl(ctx):
     runtime = ctx.toolchains[_RUNTIME_TOOLCHAIN].py3_runtime
@@ -30,4 +59,45 @@ interpreter_toolchain_check = rule(
         "python_version": attr.string(mandatory = True),
     },
     toolchains = [_RUNTIME_TOOLCHAIN],
+)
+
+def _exec_toolchain_check_impl(ctx):
+    exec_tools = ctx.toolchains[_EXEC_TOOLS_TOOLCHAIN].exec_tools
+    if exec_tools.exec_interpreter == None:
+        fail("PBS exec toolchain has no interpreter")
+    if exec_tools.exec_runtime == None:
+        fail("PBS exec toolchain has no runtime")
+    if exec_tools.exec_runtime.interpreter != ctx.file.expected_interpreter:
+        fail(
+            "expected PBS exec runtime {}, got {}".format(
+                ctx.file.expected_interpreter,
+                exec_tools.exec_runtime.interpreter,
+            ),
+        )
+
+    output = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.run(
+        arguments = [
+            "-c",
+            _EXEC_INTERPRETER_CHECK,
+            ctx.attr.python_version,
+            "1" if ctx.attr.freethreaded else "0",
+            ctx.file.expected_interpreter.path,
+            output.path,
+        ],
+        executable = exec_tools.exec_interpreter[DefaultInfo].files_to_run,
+        inputs = [ctx.file.expected_interpreter],
+        mnemonic = "ExecInterpreterSmoke",
+        outputs = [output],
+    )
+    return [DefaultInfo(files = depset([output]))]
+
+exec_toolchain_check = rule(
+    implementation = _exec_toolchain_check_impl,
+    attrs = {
+        "expected_interpreter": attr.label(allow_single_file = True, mandatory = True),
+        "freethreaded": attr.bool(),
+        "python_version": attr.string(mandatory = True),
+    },
+    toolchains = [_EXEC_TOOLS_TOOLCHAIN],
 )

--- a/e2e/cases/interpreter-toolchain-settings/toolchain_test.bzl
+++ b/e2e/cases/interpreter-toolchain-settings/toolchain_test.bzl
@@ -74,6 +74,11 @@ def _exec_toolchain_check_impl(ctx):
                 exec_tools.exec_runtime.interpreter,
             ),
         )
+    exec_runtime_pair = exec_tools.exec_interpreter[platform_common.ToolchainInfo]
+    if getattr(exec_runtime_pair, "pyc_magic_number", None) == None:
+        fail("PBS exec toolchain did not forward its bytecode identity")
+    if exec_runtime_pair.py3_runtime != exec_tools.exec_runtime:
+        fail("PBS exec toolchain identity is not bound to its runtime")
 
     output = ctx.actions.declare_file(ctx.label.name + ".txt")
     ctx.actions.run(

--- a/e2e/cases/whl-install-pyc-runtime/BUILD.bazel
+++ b/e2e/cases/whl-install-pyc-runtime/BUILD.bazel
@@ -1,0 +1,279 @@
+load("@aspect_rules_py//py/private/interpreter:interpreter_executable.bzl", "interpreter_executable")
+load("@aspect_rules_py//uv/private/whl_install:rule.bzl", "whl_install")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_python//python:py_exec_tools_toolchain.bzl", "py_exec_tools_toolchain")
+load("@rules_python//python:py_runtime.bzl", "py_runtime")
+load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
+load(
+    ":tests.bzl",
+    "compatible_metadata_test",
+    "compile_disabled_test",
+    "exec_runtime_only_test",
+    "magic_mismatch_test",
+    "missing_exec_magic_test",
+    "missing_target_magic_test",
+    "ordinary_runtime_pairs_test",
+    "test_exec_tools",
+    "test_runtime_pair",
+    "unbound_exec_identity_test",
+)
+
+_TARGET_VERSION = {
+    "major": "3",
+    "micro": "1",
+    "minor": "13",
+    "releaselevel": "final",
+    "serial": "0",
+}
+
+_EXEC_VERSION = {
+    "major": "3",
+    "micro": "2",
+    "minor": "13",
+    "releaselevel": "final",
+    "serial": "0",
+}
+
+string_flag(
+    name = "scenario",
+    build_setting_default = "compatible_metadata",
+    tags = ["manual"],
+)
+
+config_setting(
+    name = "compatible_metadata",
+    flag_values = {":scenario": "compatible_metadata"},
+)
+
+config_setting(
+    name = "compile_disabled",
+    flag_values = {":scenario": "compile_disabled"},
+)
+
+config_setting(
+    name = "magic_mismatch",
+    flag_values = {":scenario": "magic_mismatch"},
+)
+
+config_setting(
+    name = "exec_runtime_only",
+    flag_values = {":scenario": "exec_runtime_only"},
+)
+
+config_setting(
+    name = "ordinary_runtime_pairs",
+    flag_values = {":scenario": "ordinary_runtime_pairs"},
+)
+
+config_setting(
+    name = "missing_exec_magic",
+    flag_values = {":scenario": "missing_exec_magic"},
+)
+
+config_setting(
+    name = "missing_target_magic",
+    flag_values = {":scenario": "missing_target_magic"},
+)
+
+config_setting(
+    name = "unbound_exec_identity",
+    flag_values = {":scenario": "unbound_exec_identity"},
+)
+
+write_file(
+    name = "target_interpreter",
+    out = "target-python",
+    content = ["#!/usr/bin/env sh"],
+    is_executable = True,
+    tags = ["manual"],
+)
+
+write_file(
+    name = "exec_interpreter_file",
+    out = "exec-python",
+    content = ["#!/usr/bin/env sh"],
+    is_executable = True,
+    tags = ["manual"],
+)
+
+write_file(
+    name = "wheel",
+    out = "demo-1.0-py3-none-any.whl",
+    tags = ["manual"],
+)
+
+py_runtime(
+    name = "target_runtime",
+    interpreter = ":target_interpreter",
+    interpreter_version_info = _TARGET_VERSION,
+    python_version = "PY3",
+    tags = ["manual"],
+)
+
+py_runtime(
+    name = "exec_runtime",
+    abi_flags = select({
+        ":compatible_metadata": "t",
+        "//conditions:default": "",
+    }),
+    interpreter = ":exec_interpreter_file",
+    interpreter_version_info = select({
+        ":compatible_metadata": _EXEC_VERSION,
+        "//conditions:default": _TARGET_VERSION,
+    }),
+    python_version = "PY3",
+    tags = ["manual"],
+)
+
+py_runtime_pair(
+    name = "_target_runtime_pair",
+    py3_runtime = ":target_runtime",
+    tags = ["manual"],
+)
+
+py_runtime_pair(
+    name = "_exec_runtime_pair",
+    py3_runtime = ":exec_runtime",
+    tags = ["manual"],
+)
+
+test_runtime_pair(
+    name = "target_runtime_pair",
+    pyc_magic_number = select({
+        ":missing_target_magic": -1,
+        "//conditions:default": 3571,
+    }),
+    runtime = ":target_runtime",
+    tags = ["manual"],
+)
+
+test_runtime_pair(
+    name = "exec_runtime_pair",
+    pyc_magic_number = select({
+        ":compile_disabled": 3572,
+        ":magic_mismatch": 3572,
+        ":missing_exec_magic": -1,
+        "//conditions:default": 3571,
+    }),
+    runtime = ":exec_runtime",
+    tags = ["manual"],
+)
+
+interpreter_executable(
+    name = "exec_interpreter",
+    runtime_pair = select({
+        ":ordinary_runtime_pairs": ":_exec_runtime_pair",
+        "//conditions:default": ":exec_runtime_pair",
+    }),
+    tags = ["manual"],
+)
+
+interpreter_executable(
+    name = "unbound_exec_interpreter",
+    runtime_pair = ":target_runtime_pair",
+    tags = ["manual"],
+)
+
+py_exec_tools_toolchain(
+    name = "exec_tools",
+    exec_interpreter = ":exec_interpreter",
+    tags = ["manual"],
+)
+
+test_exec_tools(
+    name = "exec_runtime_only_tools",
+    runtime = ":exec_runtime",
+    tags = ["manual"],
+)
+
+test_exec_tools(
+    name = "unbound_exec_tools",
+    exec_interpreter = ":unbound_exec_interpreter",
+    runtime = ":exec_runtime",
+    tags = ["manual"],
+)
+
+toolchain(
+    name = "target_toolchain",
+    tags = ["manual"],
+    toolchain = select({
+        ":exec_runtime_only": ":_target_runtime_pair",
+        ":ordinary_runtime_pairs": ":_target_runtime_pair",
+        "//conditions:default": ":target_runtime_pair",
+    }),
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "exec_toolchain",
+    tags = ["manual"],
+    toolchain = select({
+        ":exec_runtime_only": ":exec_runtime_only_tools",
+        ":unbound_exec_identity": ":unbound_exec_tools",
+        "//conditions:default": ":exec_tools",
+    }),
+    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
+)
+
+whl_install(
+    name = "fixture",
+    src = ":wheel",
+    compile_pyc = select({
+        ":compile_disabled": False,
+        "//conditions:default": True,
+    }),
+    tags = ["manual"],
+)
+
+magic_mismatch_test(
+    name = "magic_mismatch_test",
+    expected_failure = "PYC_MAGIC_NUMBER target=3571, exec=3572",
+    tags = ["manual"],
+    target_under_test = ":fixture",
+)
+
+missing_exec_magic_test(
+    name = "missing_exec_magic_test",
+    expected_failure = "exec runtime does not declare pyc_magic_number",
+    tags = ["manual"],
+    target_under_test = ":fixture",
+)
+
+missing_target_magic_test(
+    name = "missing_target_magic_test",
+    expected_failure = "target runtime does not declare pyc_magic_number",
+    tags = ["manual"],
+    target_under_test = ":fixture",
+)
+
+unbound_exec_identity_test(
+    name = "unbound_exec_identity_test",
+    expected_failure = "exec_interpreter bytecode identity is not bound to exec_runtime",
+    tags = ["manual"],
+    target_under_test = ":fixture",
+)
+
+compatible_metadata_test(
+    name = "compatible_metadata_test",
+    tags = ["manual"],
+    target_under_test = ":fixture",
+)
+
+exec_runtime_only_test(
+    name = "exec_runtime_only_test",
+    tags = ["manual"],
+    target_under_test = ":fixture",
+)
+
+compile_disabled_test(
+    name = "compile_disabled_test",
+    tags = ["manual"],
+    target_under_test = ":fixture",
+)
+
+ordinary_runtime_pairs_test(
+    name = "ordinary_runtime_pairs_test",
+    tags = ["manual"],
+    target_under_test = ":fixture",
+)

--- a/e2e/cases/whl-install-pyc-runtime/MODULE.bazel
+++ b/e2e/cases/whl-install-pyc-runtime/MODULE.bazel
@@ -1,0 +1,15 @@
+module(name = "whl_install_pyc_runtime")
+
+bazel_dep(name = "aspect_rules_py")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "1.9.0")
+
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+register_toolchains(
+    "//:exec_toolchain",
+    "//:target_toolchain",
+)

--- a/e2e/cases/whl-install-pyc-runtime/test.sh
+++ b/e2e/cases/whl-install-pyc-runtime/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# These checks register synthetic target and exec Python toolchains in a nested
+# module so they cannot affect the parent e2e workspace's toolchain resolution.
+set -uo pipefail
+
+case_dir="$(cd "$(dirname "$0")" && pwd)"
+cd "$case_dir" || exit 1
+
+BAZEL="${BAZEL:-bazel}"
+if ! "$BAZEL" test --lockfile_mode=off -- \
+    //:compatible_metadata_test \
+    //:compile_disabled_test \
+    //:exec_runtime_only_test \
+    //:magic_mismatch_test \
+    //:missing_exec_magic_test \
+    //:missing_target_magic_test \
+    //:ordinary_runtime_pairs_test \
+    //:unbound_exec_identity_test; then
+    echo "FAIL: whl_install .pyc runtime compatibility checks failed" >&2
+    exit 1
+fi
+
+echo "PASS: whl_install validates target and exec .pyc runtimes"

--- a/e2e/cases/whl-install-pyc-runtime/tests.bzl
+++ b/e2e/cases/whl-install-pyc-runtime/tests.bzl
@@ -1,0 +1,127 @@
+"""Real-rule analysis tests for whl_install .pyc runtime compatibility."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_python//python:py_runtime_info.bzl", "PyRuntimeInfo")
+
+def _test_runtime_pair_impl(ctx):
+    fields = {
+        "py2_runtime": None,
+        "py3_runtime": ctx.attr.runtime[PyRuntimeInfo],
+    }
+    if ctx.attr.pyc_magic_number >= 0:
+        fields["pyc_magic_number"] = ctx.attr.pyc_magic_number
+    return [platform_common.ToolchainInfo(**fields)]
+
+test_runtime_pair = rule(
+    implementation = _test_runtime_pair_impl,
+    attrs = {
+        "pyc_magic_number": attr.int(default = -1),
+        "runtime": attr.label(
+            mandatory = True,
+            providers = [PyRuntimeInfo],
+        ),
+    },
+)
+
+def _test_exec_tools_impl(ctx):
+    return [platform_common.ToolchainInfo(
+        exec_tools = struct(
+            exec_interpreter = ctx.attr.exec_interpreter,
+            exec_runtime = ctx.attr.runtime[PyRuntimeInfo],
+            precompiler = None,
+        ),
+    )]
+
+test_exec_tools = rule(
+    implementation = _test_exec_tools_impl,
+    attrs = {
+        "exec_interpreter": attr.label(),
+        "runtime": attr.label(
+            mandatory = True,
+            providers = [PyRuntimeInfo],
+        ),
+    },
+)
+
+def _incompatible_runtime_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(env, ctx.attr.expected_failure)
+    return analysistest.end(env)
+
+_INCOMPATIBLE_TEST_ATTRS = {
+    "expected_failure": attr.string(mandatory = True),
+}
+
+def _make_incompatible_runtime_test(scenario):
+    return analysistest.make(
+        _incompatible_runtime_test_impl,
+        attrs = _INCOMPATIBLE_TEST_ATTRS,
+        config_settings = {
+            str(Label("//:scenario")): scenario,
+        },
+        expect_failure = True,
+    )
+
+magic_mismatch_test = _make_incompatible_runtime_test("magic_mismatch")
+missing_exec_magic_test = _make_incompatible_runtime_test("missing_exec_magic")
+missing_target_magic_test = _make_incompatible_runtime_test("missing_target_magic")
+unbound_exec_identity_test = _make_incompatible_runtime_test("unbound_exec_identity")
+
+def _compatible_runtime_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    actions = analysistest.target_actions(env)
+    asserts.equals(
+        env,
+        ["WhlInstall"],
+        [action.mnemonic for action in actions],
+        "successful scenario should install one wheel",
+    )
+    asserts.equals(
+        env,
+        ctx.attr.expect_compile_pyc,
+        "--compile-pyc" in actions[0].argv,
+        "WhlInstall compile_pyc argument",
+    )
+    if ctx.attr.expect_compile_pyc:
+        argv = actions[0].argv
+        asserts.true(
+            env,
+            argv[0].endswith("/exec-python"),
+            "WhlInstall must execute the exec runtime interpreter",
+        )
+        asserts.equals(
+            env,
+            [
+                "--compile-pyc",
+                "--pyc-invalidation-mode",
+                "checked-hash",
+                "--python",
+                argv[0],
+            ],
+            argv[-5:],
+            "WhlInstall compilation arguments",
+        )
+    else:
+        for arg in ["--compile-pyc", "--pyc-invalidation-mode", "--python"]:
+            asserts.false(
+                env,
+                arg in actions[0].argv,
+                "disabled compilation must omit {}".format(arg),
+            )
+    return analysistest.end(env)
+
+def _make_compatible_runtime_test(scenario, expect_compile_pyc):
+    return analysistest.make(
+        _compatible_runtime_test_impl,
+        attrs = {
+            "expect_compile_pyc": attr.bool(default = expect_compile_pyc),
+        },
+        config_settings = {
+            str(Label("//:scenario")): scenario,
+        },
+    )
+
+compatible_metadata_test = _make_compatible_runtime_test("compatible_metadata", True)
+compile_disabled_test = _make_compatible_runtime_test("compile_disabled", False)
+exec_runtime_only_test = _make_compatible_runtime_test("exec_runtime_only", True)
+ordinary_runtime_pairs_test = _make_compatible_runtime_test("ordinary_runtime_pairs", True)

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -101,6 +101,11 @@ bzl_library(
 )
 
 bzl_library(
+    name = "interpreter_executable",
+    srcs = ["interpreter_executable.bzl"],
+)
+
+bzl_library(
     name = "resolve",
     srcs = ["resolve.bzl"],
 )

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -95,6 +95,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "pbs_runtime_pair",
+    srcs = ["pbs_runtime_pair.bzl"],
+    deps = ["@rules_python//python:py_runtime_info_bzl"],  # keep
+)
+
+bzl_library(
     name = "resolve",
     srcs = ["resolve.bzl"],
 )

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -2,10 +2,14 @@
 
 load(":repository.bzl", "python_interpreter", "python_toolchains")
 load(":version_util.bzl", "is_decimal", "is_pre_release", "version_gt")
-load(":versions.bzl", "BUILD_CONFIGS", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS")
+load(":versions.bzl", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS", "RUNTIME_MODES")
 
 # The GitHub API endpoint for resolving "latest" releases.
 _GITHUB_API_LATEST = "https://api.github.com/repos/{owner}/{repo}/releases/latest"
+
+# Facts can outlive an extension implementation change, so index shape changes
+# must use a new key rather than accepting cached data from the old schema.
+_RELEASE_INDEX_SCHEMA = 1
 
 def _sanitize(s):
     """Replace characters that are invalid in Bazel repo names."""
@@ -14,7 +18,7 @@ def _sanitize(s):
 def _parse_sha256sums(content, release_date):
     """Parse a SHA256SUMS file into a structured index.
 
-    Returns a dict mapping (major_minor, platform, build_config) -> {
+    Returns a dict mapping (major_minor, platform, runtime_mode) -> {
         "sha256": str,
         "filename": str,
         "full_version": str,
@@ -24,6 +28,16 @@ def _parse_sha256sums(content, release_date):
     newest is kept.
     """
     index = {}
+    configured_assets = {}
+
+    for platform, platform_info in PLATFORMS.items():
+        for mode_name, mode_info in RUNTIME_MODES.items():
+            asset = "{}-{}.{}".format(
+                platform,
+                platform_info["asset_suffixes"][mode_name],
+                mode_info["extension"],
+            )
+            configured_assets[asset] = (platform, mode_name)
 
     for line in content.split("\n"):
         line = line.strip()
@@ -53,24 +67,14 @@ def _parse_sha256sums(content, release_date):
             continue
         major_minor = "{}.{}".format(version_parts[0], version_parts[1])
 
-        # Match against known build configs (check suffix + extension)
+        # Match the complete platform, suffix, and extension.
         remainder = filename[plus_idx + 1 + len(release_date) + 1:]  # skip "{date}-"
-        matched_config = None
-        matched_platform = None
-
-        for config_name, config_info in BUILD_CONFIGS.items():
-            expected_tail = "-{}.{}".format(config_info["suffix"], config_info["extension"])
-            if remainder.endswith(expected_tail):
-                platform_str = remainder[:len(remainder) - len(expected_tail)]
-                if platform_str in PLATFORMS:
-                    matched_config = config_name
-                    matched_platform = platform_str
-                    break
-
-        if not matched_config:
+        matched_asset = configured_assets.get(remainder)
+        if not matched_asset:
             continue
+        matched_platform, matched_mode = matched_asset
 
-        key = "{}/{}/{}".format(major_minor, matched_platform, matched_config)
+        key = "{}/{}/{}".format(major_minor, matched_platform, matched_mode)
 
         # Keep the newest patch version
         existing = index.get(key)
@@ -84,6 +88,9 @@ def _parse_sha256sums(content, release_date):
         }
 
     return index
+
+def _release_index_facts_key(release_date, base_url):
+    return "release_index_v{}_{}_{}".format(_RELEASE_INDEX_SCHEMA, release_date, base_url)
 
 def _owner_repo_from_base_url(base_url):
     """Extract GitHub owner/repo from a base URL like https://github.com/{owner}/{repo}/releases/download."""
@@ -126,7 +133,7 @@ def _fetch_release_index(module_ctx, release_date, base_url, facts):
 
     Returns the parsed index dict for this release date.
     """
-    facts_key = "release_index_{}_{}".format(release_date, base_url)
+    facts_key = _release_index_facts_key(release_date, base_url)
     cached = facts.get(facts_key)
     if cached:
         return cached
@@ -270,18 +277,18 @@ def _python_interpreters_impl(module_ctx):
         release_indices[date] = index
 
         # Cache in facts for next run — but never cache under "latest"
-        facts_key = "release_index_{}_{}".format(date, base_url)
+        facts_key = _release_index_facts_key(date, base_url)
         new_facts[facts_key] = index
 
-    # Create per-platform, per-build-config interpreter repos and collect
+    # Create per-platform, per-runtime-mode interpreter repos and collect
     # toolchain entries. Version and freethreaded target settings determine
     # which entries are eligible.
     toolchain_entries = []
 
-    # Keep generated output stable: regular configs, then freethreaded configs.
-    ordered_configs = (
-        [(name, cfg) for name, cfg in BUILD_CONFIGS.items() if not cfg["freethreaded"]] +
-        [(name, cfg) for name, cfg in BUILD_CONFIGS.items() if cfg["freethreaded"]]
+    # Keep generated output stable: regular modes, then freethreaded modes.
+    ordered_modes = (
+        [(name, mode) for name, mode in RUNTIME_MODES.items() if not mode["freethreaded"]] +
+        [(name, mode) for name, mode in RUNTIME_MODES.items() if mode["freethreaded"]]
     )
 
     # Target-pattern registration orders toolchains lexicographically by name,
@@ -294,26 +301,26 @@ def _python_interpreters_impl(module_ctx):
             "exec_compatible_with": [],
             "target_compatible_with": [],
         })
-        for config_name, config_info in ordered_configs:
+        for mode_name, mode_info in ordered_modes:
             for platform_triple, platform_info in PLATFORMS.items():
                 repo_name = "python_{}_{}".format(
                     _sanitize(major_minor),
                     _sanitize(platform_triple),
                 )
-                if config_name != "install_only":
-                    repo_name += "_" + _sanitize(config_name)
+                if mode_name != "install_only":
+                    repo_name += "_" + _sanitize(mode_name)
 
-                # Find the best release for this version/platform/config
+                # Find the best release for this version/platform/mode
                 asset_info = _find_asset(
                     major_minor,
                     platform_triple,
-                    config_name,
+                    mode_name,
                     release_dates,
                     release_indices,
                 )
 
                 if not asset_info:
-                    # Version/platform/config combo doesn't exist — skip it
+                    # Version/platform/mode combo doesn't exist — skip it
                     # rather than registering a stub toolchain.
                     continue
 
@@ -331,20 +338,20 @@ def _python_interpreters_impl(module_ctx):
                 )
                 python_interpreter(
                     name = repo_name,
-                    abi_flags = config_info["abi_flags"],
+                    abi_flags = mode_info["abi_flags"],
                     python_version = asset_info["full_version"],
                     platform = platform_triple,
                     url = url,
                     sha256 = asset_info["sha256"],
-                    strip_prefix = config_info["strip_prefix"],
-                    freethreaded = config_info["freethreaded"],
+                    strip_prefix = mode_info["strip_prefix"],
+                    freethreaded = mode_info["freethreaded"],
                 )
 
                 toolchain_entries.append(json.encode({
                     "name": repo_name,
                     "repo": repo_name,
                     "python_version": major_minor,
-                    "freethreaded": config_info["freethreaded"],
+                    "freethreaded": mode_info["freethreaded"],
                     "compatible_with": platform_info["compatible_with"],
                     "platform_target_settings": platform_info.get("target_settings", {}),
                     "config_settings": settings["config_settings"],
@@ -371,11 +378,11 @@ def _python_interpreters_impl(module_ctx):
 
     return _return_metadata(module_ctx, has_facts, new_facts, is_reproducible, resolved_latest)
 
-def _find_asset(major_minor, platform, build_config, release_dates, release_indices):
+def _find_asset(major_minor, platform, runtime_mode, release_dates, release_indices):
     """Find the best asset across releases, preferring newer releases."""
     for date in release_dates:
         index = release_indices.get(date, {})
-        key = "{}/{}/{}".format(major_minor, platform, build_config)
+        key = "{}/{}/{}".format(major_minor, platform, runtime_mode)
         entry = index.get(key)
         if entry:
             return {

--- a/py/private/interpreter/interpreter_executable.bzl
+++ b/py/private/interpreter/interpreter_executable.bzl
@@ -1,0 +1,43 @@
+"""Expose a supplied Python runtime pair as an executable target."""
+
+def _interpreter_executable_impl(ctx):
+    toolchain = ctx.attr.runtime_pair[platform_common.ToolchainInfo]
+    runtime = toolchain.py3_runtime
+    if runtime.interpreter == None:
+        fail("interpreter_executable requires a hermetic Python runtime")
+
+    # rules_python's default exec_interpreter resolves its Python toolchain in
+    # cfg = "exec". PBS repositories instead need to preserve their supplied
+    # runtime pair while satisfying exec_interpreter's executable contract:
+    # https://github.com/bazel-contrib/rules_python/blob/1.9.0/python/private/py_exec_tools_toolchain.bzl#L61-L106
+    # Keep the executable symlink shape used by rules_python's own adapter:
+    # https://github.com/bazel-contrib/rules_python/blob/1.9.0/python/private/py_exec_tools_toolchain.bzl#L108-L129
+    executable = ctx.actions.declare_file(
+        "{}/{}".format(ctx.label.name, runtime.interpreter.basename),
+    )
+    ctx.actions.symlink(
+        output = executable,
+        target_file = runtime.interpreter,
+        is_executable = True,
+    )
+    return [
+        toolchain,
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.runfiles(
+                files = [executable],
+                transitive_files = runtime.files,
+            ),
+        ),
+    ]
+
+interpreter_executable = rule(
+    implementation = _interpreter_executable_impl,
+    attrs = {
+        "runtime_pair": attr.label(
+            mandatory = True,
+            providers = [platform_common.ToolchainInfo],
+        ),
+    },
+    executable = True,
+)

--- a/py/private/interpreter/pbs_runtime_pair.bzl
+++ b/py/private/interpreter/pbs_runtime_pair.bzl
@@ -1,0 +1,30 @@
+"""Attach CPython bytecode identity to a PBS runtime pair.
+
+The returned ToolchainInfo extends rules_python's public runtime-pair schema
+with `pyc_magic_number`, CPython's 16-bit PYC_MAGIC_NUMBER value:
+https://github.com/bazel-contrib/rules_python/blob/1.9.0/python/py_runtime_pair.bzl#L31-L41
+"""
+
+load("@rules_python//python:py_runtime_info.bzl", "PyRuntimeInfo")
+
+def _pbs_runtime_pair_impl(ctx):
+    runtime = ctx.attr.py3_runtime[PyRuntimeInfo]
+    if runtime.python_version != "PY3":
+        fail("pbs_runtime_pair requires a Python 3 runtime")
+    return [platform_common.ToolchainInfo(
+        py2_runtime = None,
+        py3_runtime = runtime,
+        pyc_magic_number = ctx.attr.pyc_magic_number,
+    )]
+
+pbs_runtime_pair = rule(
+    implementation = _pbs_runtime_pair_impl,
+    attrs = {
+        "pyc_magic_number": attr.int(mandatory = True),
+        "py3_runtime": attr.label(
+            cfg = "target",
+            mandatory = True,
+            providers = [PyRuntimeInfo],
+        ),
+    },
+)

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -198,6 +198,7 @@ def _build_file_content(major, minor, micro, python_bin, pyc_magic_number, is_wi
 """.format(feature = feature_name)
 
     return """\
+load("@aspect_rules_py//py/private/interpreter:interpreter_executable.bzl", "interpreter_executable")
 load("@rules_python//python:py_runtime.bzl", "py_runtime")
 load("@rules_python//python:py_exec_tools_toolchain.bzl", "py_exec_tools_toolchain")
 load("@aspect_rules_py//py/private/interpreter:pbs_runtime_pair.bzl", "pbs_runtime_pair")
@@ -245,8 +246,14 @@ pbs_runtime_pair(
     py3_runtime = ":py3_runtime",
 )
 
+interpreter_executable(
+    name = "exec_interpreter",
+    runtime_pair = ":runtime_pair",
+)
+
 py_exec_tools_toolchain(
     name = "exec_tools_toolchain",
+    exec_interpreter = ":exec_interpreter",
 )
 """.format(
         abi_flags = abi_flags,
@@ -386,13 +393,30 @@ config_setting(
         version_setting = ":" + _version_setting_name(info["python_version"])
         freethreaded_setting = ":" + _freethreaded_setting_name(info.get("freethreaded", False))
 
-        target_settings = [
+        python_target_settings = [
             version_setting,
             freethreaded_setting,
-        ] + [":" + name for name in platform_setting_names] + extra_config_settings
+        ]
+        runtime_target_settings = (
+            python_target_settings +
+            [":" + name for name in platform_setting_names] +
+            extra_config_settings
+        )
 
-        target_compatible_with = info["compatible_with"] + extra_target_compatible
+        # target_settings are evaluated against the target configuration even
+        # for a toolchain whose implementation runs on the execution platform:
+        # https://bazel.build/reference/be/general#toolchain.target_settings
+        # Select the requested Python version and mode, but do not require the
+        # execution interpreter to match target-platform settings such as libc.
+        exec_target_settings = python_target_settings + extra_config_settings
+
+        runtime_target_compatible_with = info["compatible_with"] + extra_target_compatible
         exec_compatible_with = info["compatible_with"] + extra_exec_compatible
+
+        # Root target constraints describe which targets may use the exec
+        # toolchain. PBS OS/CPU constraints describe only its exec platform:
+        # https://bazel.build/reference/be/general#toolchain.target_compatible_with
+        exec_target_compatible_with = extra_target_compatible
 
         content.append("""
 # The Python interpreter toolchain has no exec_compatible_with: the interpreter
@@ -404,25 +428,26 @@ config_setting(
 # sufficient to pick the right interpreter for the target.
 toolchain(
     name = "{name}",
-    target_compatible_with = {target_compatible_with},
-    target_settings = {target_settings},
+    target_compatible_with = {runtime_target_compatible_with},
+    target_settings = {runtime_target_settings},
     toolchain = "@{repo}//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 """.format(
             name = info["name"],
             repo = info["repo"],
-            target_compatible_with = target_compatible_with,
-            target_settings = target_settings,
+            runtime_target_settings = runtime_target_settings,
+            runtime_target_compatible_with = runtime_target_compatible_with,
         ))
 
         if info["register_exec_tools"]:
-            content.append("""# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+            content.append("""# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "{name}_exec_tools",
     exec_compatible_with = {exec_compatible_with},
+    target_compatible_with = {exec_target_compatible_with},
+    target_settings = {exec_target_settings},
     toolchain = "@{repo}//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -430,6 +455,8 @@ toolchain(
                 name = info["name"],
                 repo = info["repo"],
                 exec_compatible_with = exec_compatible_with,
+                exec_target_compatible_with = exec_target_compatible_with,
+                exec_target_settings = exec_target_settings,
             ))
 
     content.append("""

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -8,6 +8,77 @@ _RPY_VERSION_FLAG = "@rules_python//python/config_settings:python_version"
 _FREETHREADING_FLAG = "@aspect_rules_py//py/private/interpreter:freethreaded"
 _EXCLUDE_FEATURE_FLAG = "@aspect_rules_py//py/private/interpreter:exclude_feature"
 
+# CPython through 3.13 defines the bytecode magic in the frozen importlib
+# source. Python 3.14 moved its authoritative value to an internal header:
+# https://github.com/python/cpython/blob/v3.13.2/Lib/importlib/_bootstrap_external.py
+# https://github.com/python/cpython/blob/v3.14.0/Include/internal/pycore_magic_number.h
+def _parse_pyc_magic_number(content, source_kind, description):
+    matches = []
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if source_kind == "header":
+            tokens = [
+                token
+                for token in line.replace("\t", " ").split(" ")
+                if token
+            ]
+            if tokens[:2] == ["#define", "PYC_MAGIC_NUMBER"]:
+                if len(tokens) < 3:
+                    fail("{} has a malformed definition: {}".format(description, repr(raw_line)))
+                matches.append((tokens[2], raw_line))
+        else:
+            source_prefix = "MAGIC_NUMBER = ("
+            if line.startswith(source_prefix):
+                value = line[len(source_prefix):]
+                if ")" not in value:
+                    fail("{} has a malformed assignment: {}".format(description, repr(raw_line)))
+                matches.append((value.split(")")[0], raw_line))
+
+    if len(matches) != 1:
+        fail("{} must contain exactly one PYC_MAGIC_NUMBER, found {}".format(
+            description,
+            len(matches),
+        ))
+
+    value, raw_line = matches[0]
+    if not value or not all([char in "0123456789" for char in value.elems()]):
+        fail("{} has a non-decimal value: {}".format(description, repr(raw_line)))
+
+    magic_number = int(value)
+    if magic_number > 0xffff:
+        fail("{} has a value outside the 16-bit range: {}".format(description, magic_number))
+    return magic_number
+
+def _read_pyc_magic_number(rctx, major, minor, is_windows):
+    abi_suffix = "t" if rctx.attr.freethreaded else ""
+    version = "{}.{}{}".format(major, minor, abi_suffix)
+    if is_windows:
+        paths = [
+            "include/internal/pycore_magic_number.h",
+            "Lib/importlib/_bootstrap_external.py",
+        ]
+    else:
+        paths = [
+            "include/python{}/internal/pycore_magic_number.h".format(version),
+            "lib/python{}/importlib/_bootstrap_external.py".format(version),
+        ]
+
+    mode = "free-threaded" if rctx.attr.freethreaded else "regular"
+    description = "PBS Python {} for {} ({})".format(
+        rctx.attr.python_version,
+        rctx.attr.platform,
+        mode,
+    )
+    for path, source_kind in [(paths[0], "header"), (paths[1], "source")]:
+        if rctx.path(path).exists:
+            return _parse_pyc_magic_number(
+                rctx.read(path),
+                source_kind,
+                "{} {}".format(description, path),
+            )
+
+    fail("{} contains neither {} nor {}".format(description, paths[0], paths[1]))
+
 def _python_interpreter_impl(rctx):
     """Downloads and extracts a Python interpreter from PBS."""
     url = rctx.attr.url
@@ -38,6 +109,7 @@ def _python_interpreter_impl(rctx):
             micro = micro[:marker_index] or "0"
             releaselevel = level
             break
+    pyc_magic_number = _read_pyc_magic_number(rctx, major, minor, is_windows)
 
     # Delete terminfo symlink loops on newer PBS releases (linux only)
     if "linux" in platform:
@@ -49,6 +121,7 @@ def _python_interpreter_impl(rctx):
         minor = minor,
         micro = micro,
         python_bin = python_bin,
+        pyc_magic_number = pyc_magic_number,
         is_windows = is_windows,
         releaselevel = releaselevel,
         serial = serial,
@@ -93,7 +166,7 @@ filegroup(
 
     return "\n".join(lines), all_excludes
 
-def _build_file_content(major, minor, micro, python_bin, is_windows, abi_flags, releaselevel, serial):
+def _build_file_content(major, minor, micro, python_bin, pyc_magic_number, is_windows, abi_flags, releaselevel, serial):
     """Generate the full BUILD.bazel content for an interpreter repo."""
 
     feature_targets, feature_excludes = _feature_filegroups(major, minor, is_windows)
@@ -126,8 +199,8 @@ def _build_file_content(major, minor, micro, python_bin, is_windows, abi_flags, 
 
     return """\
 load("@rules_python//python:py_runtime.bzl", "py_runtime")
-load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
 load("@rules_python//python:py_exec_tools_toolchain.bzl", "py_exec_tools_toolchain")
+load("@aspect_rules_py//py/private/interpreter:pbs_runtime_pair.bzl", "pbs_runtime_pair")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -166,9 +239,9 @@ py_runtime(
     python_version = "PY3",
 )
 
-py_runtime_pair(
+pbs_runtime_pair(
     name = "runtime_pair",
-    py2_runtime = None,
+    pyc_magic_number = {pyc_magic_number},
     py3_runtime = ":py3_runtime",
 )
 
@@ -183,6 +256,7 @@ py_exec_tools_toolchain(
         micro = micro,
         releaselevel = releaselevel,
         serial = serial,
+        pyc_magic_number = pyc_magic_number,
         feature_targets = feature_targets,
         feature_selects = feature_selects,
         core_include = core_include,

--- a/py/private/interpreter/versions.bzl
+++ b/py/private/interpreter/versions.bzl
@@ -1,6 +1,6 @@
 """Python-build-standalone release metadata.
 
-This file contains platform mappings and build config definitions for CPython
+This file contains platform mappings and runtime mode definitions for CPython
 interpreters built by the python-build-standalone project
 (https://github.com/astral-sh/python-build-standalone).
 
@@ -35,7 +35,12 @@ DEFAULT_RELEASE_DATES = [
 # config the host's interpreter is being resolved under.
 
 # Mapping from PBS platform triple to Bazel platform constraints.
+# Optimized free-threaded archives use different suffixes on macOS/GNU Linux,
+# musl Linux, and Windows. These exact mappings are visible in PBS manifests:
+# https://github.com/astral-sh/python-build-standalone/releases/download/20260303/SHA256SUMS
+# https://github.com/astral-sh/python-build-standalone/releases/download/20251031/SHA256SUMS
 #
+# - asset_suffixes: exact PBS filename suffix for each logical runtime mode
 # - compatible_with: constraint_values for exec_compatible_with / target_compatible_with
 # - target_settings: additional config_settings the toolchain must match (optional)
 # - register_exec_tools: whether the hub emits the platform's exec registration
@@ -49,6 +54,10 @@ DEFAULT_RELEASE_DATES = [
 # buildifier: disable=unsorted-dict-items
 PLATFORMS = {
     "aarch64-apple-darwin": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
@@ -56,6 +65,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-unknown-linux-gnu": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
@@ -66,6 +79,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-unknown-linux-musl": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
@@ -76,6 +93,10 @@ PLATFORMS = {
         "register_exec_tools": False,
     },
     "x86_64-apple-darwin": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
@@ -83,6 +104,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "x86_64-unknown-linux-gnu": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
@@ -93,6 +118,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "x86_64-unknown-linux-musl": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+lto-full",
+        },
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
@@ -103,6 +132,10 @@ PLATFORMS = {
         "register_exec_tools": False,
     },
     "x86_64-pc-windows-msvc": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo-full",
+        },
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
@@ -110,6 +143,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-pc-windows-msvc": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo-full",
+        },
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:aarch64",
@@ -117,6 +154,10 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "i686-pc-windows-msvc": {
+        "asset_suffixes": {
+            "install_only": "install_only",
+            "freethreaded": "freethreaded+pgo-full",
+        },
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_32",
@@ -125,39 +166,22 @@ PLATFORMS = {
     },
 }
 
-# Build configurations available from PBS. Each config specifies:
-# - suffix: the build config suffix in the asset filename
+# Logical runtime modes registered by this extension. Each mode specifies:
 # - extension: the archive file extension
 # - strip_prefix: the prefix to strip when extracting
 # - freethreaded: whether this is a free-threaded build
 # - abi_flags: CPython ABI flags for the build
 #
 # buildifier: disable=unsorted-dict-items
-BUILD_CONFIGS = {
+RUNTIME_MODES = {
     "install_only": {
         "abi_flags": "",
-        "suffix": "install_only",
         "extension": "tar.gz",
         "strip_prefix": "python",
         "freethreaded": False,
     },
-    "install_only_stripped": {
-        "abi_flags": "",
-        "suffix": "install_only_stripped",
-        "extension": "tar.gz",
-        "strip_prefix": "python",
-        "freethreaded": False,
-    },
-    "freethreaded+pgo+lto": {
+    "freethreaded": {
         "abi_flags": "t",
-        "suffix": "freethreaded+pgo+lto-full",
-        "extension": "tar.zst",
-        "strip_prefix": "python/install",
-        "freethreaded": True,
-    },
-    "freethreaded+debug": {
-        "abi_flags": "td",
-        "suffix": "freethreaded+debug-full",
         "extension": "tar.zst",
         "strip_prefix": "python/install",
         "freethreaded": True,

--- a/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
@@ -267,10 +267,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_aarch64_apple_darwin_install_only_stripped",
+    name = "python_3_13_aarch64_apple_darwin_freethreaded",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -278,9 +278,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_aarch64_apple_darwin_install_only_stripped_exec_tools",
+    name = "python_3_13_aarch64_apple_darwin_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -293,10 +293,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_install_only_stripped",
+    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded",
     target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
+    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -304,9 +304,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_install_only_stripped_exec_tools",
+    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -319,10 +319,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_aarch64_unknown_linux_musl_install_only_stripped",
+    name = "python_3_13_aarch64_unknown_linux_musl_freethreaded",
     target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_musl"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_musl_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
+    toolchain = "@python_3_13_aarch64_unknown_linux_musl_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -335,10 +335,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_x86_64_apple_darwin_install_only_stripped",
+    name = "python_3_13_x86_64_apple_darwin_freethreaded",
     target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -346,9 +346,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_x86_64_apple_darwin_install_only_stripped_exec_tools",
+    name = "python_3_13_x86_64_apple_darwin_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -361,10 +361,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_install_only_stripped",
+    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded",
     target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
+    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -372,9 +372,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_install_only_stripped_exec_tools",
+    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -387,10 +387,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_x86_64_unknown_linux_musl_install_only_stripped",
+    name = "python_3_13_x86_64_unknown_linux_musl_freethreaded",
     target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false", ":platform_libc_is_musl"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_musl_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
+    toolchain = "@python_3_13_x86_64_unknown_linux_musl_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -403,10 +403,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_x86_64_pc_windows_msvc_install_only_stripped",
+    name = "python_3_13_x86_64_pc_windows_msvc_freethreaded",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_x86_64_pc_windows_msvc_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_x86_64_pc_windows_msvc_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -414,9 +414,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_x86_64_pc_windows_msvc_install_only_stripped_exec_tools",
+    name = "python_3_13_x86_64_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_pc_windows_msvc_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_x86_64_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -429,10 +429,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_aarch64_pc_windows_msvc_install_only_stripped",
+    name = "python_3_13_aarch64_pc_windows_msvc_freethreaded",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_aarch64_pc_windows_msvc_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_aarch64_pc_windows_msvc_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -440,9 +440,9 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_aarch64_pc_windows_msvc_install_only_stripped_exec_tools",
+    name = "python_3_13_aarch64_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_pc_windows_msvc_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_aarch64_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
 
@@ -455,10 +455,10 @@ toolchain(
 # satisfy the arm64 exec constraint.  The target_compatible_with constraint is
 # sufficient to pick the right interpreter for the target.
 toolchain(
-    name = "python_3_13_i686_pc_windows_msvc_install_only_stripped",
+    name = "python_3_13_i686_pc_windows_msvc_freethreaded",
     target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
-    toolchain = "@python_3_13_i686_pc_windows_msvc_install_only_stripped//:runtime_pair",
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
+    toolchain = "@python_3_13_i686_pc_windows_msvc_freethreaded//:runtime_pair",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
@@ -466,250 +466,10 @@ toolchain(
 # that build actions using the interpreter (e.g. compileall) get a runnable
 # binary on the build host regardless of the target platform being built for.
 toolchain(
-    name = "python_3_13_i686_pc_windows_msvc_install_only_stripped_exec_tools",
+    name = "python_3_13_i686_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
-    toolchain = "@python_3_13_i686_pc_windows_msvc_install_only_stripped//:exec_tools_toolchain",
+    toolchain = "@python_3_13_i686_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto",
-    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto_exec_tools",
-    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_pgo_lto//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_pgo_lto",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded_pgo_lto//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_pgo_lto_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded_pgo_lto//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto",
-    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto_exec_tools",
-    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_pgo_lto//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_pgo_lto",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded_pgo_lto//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_pgo_lto_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded_pgo_lto//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_apple_darwin_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_apple_darwin_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_aarch64_unknown_linux_musl_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
-    toolchain = "@python_3_13_aarch64_unknown_linux_musl_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_apple_darwin_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_apple_darwin_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_glibc"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
-)
-
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_debug_exec_tools",
-    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded_debug//:exec_tools_toolchain",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
-)
-
-
-# The Python interpreter toolchain has no exec_compatible_with: the interpreter
-# runs on the TARGET platform (inside the virtualenv), not on the exec host.
-# Setting exec_compatible_with = platform_constraints would prevent this
-# toolchain from being selected during cross-compilation (e.g. building an
-# arm64 image on an amd64 host), because the exec platform (amd64) would not
-# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
-# sufficient to pick the right interpreter for the target.
-toolchain(
-    name = "python_3_13_x86_64_unknown_linux_musl_freethreaded_debug",
-    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-    target_settings = [":python_version_is_3_13", ":freethreaded_is_true", ":platform_libc_is_musl"],
-    toolchain = "@python_3_13_x86_64_unknown_linux_musl_freethreaded_debug//:runtime_pair",
-    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
 

--- a/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
@@ -60,12 +60,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_apple_darwin_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_apple_darwin//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -86,12 +87,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_unknown_linux_gnu_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_unknown_linux_gnu//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -128,12 +130,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_apple_darwin_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_apple_darwin//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -154,12 +157,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_unknown_linux_gnu_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_unknown_linux_gnu//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -196,12 +200,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_pc_windows_msvc_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_x86_64_pc_windows_msvc//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -222,12 +227,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_pc_windows_msvc_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_aarch64_pc_windows_msvc//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -248,12 +254,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_i686_pc_windows_msvc_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_false"],
     toolchain = "@python_3_13_i686_pc_windows_msvc//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -274,12 +281,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_apple_darwin_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_aarch64_apple_darwin_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -300,12 +308,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_unknown_linux_gnu_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_aarch64_unknown_linux_gnu_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -342,12 +351,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_apple_darwin_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_x86_64_apple_darwin_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -368,12 +378,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_unknown_linux_gnu_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_x86_64_unknown_linux_gnu_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -410,12 +421,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_x86_64_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_x86_64_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -436,12 +448,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_aarch64_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_aarch64_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )
@@ -462,12 +475,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 
-# Exec tools toolchain: selected by exec platform (not target platform) so
-# that build actions using the interpreter (e.g. compileall) get a runnable
-# binary on the build host regardless of the target platform being built for.
+# Exec tools run on the selected execution platform for this target's
+# Python mode.
 toolchain(
     name = "python_3_13_i686_pc_windows_msvc_freethreaded_exec_tools",
     exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
+    target_compatible_with = [],
+    target_settings = [":python_version_is_3_13", ":freethreaded_is_true"],
     toolchain = "@python_3_13_i686_pc_windows_msvc_freethreaded//:exec_tools_toolchain",
     toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
 )

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -38,8 +38,10 @@ source_built_wheel = rule(
 )
 
 def _whl_install(ctx):
-    py_toolchain = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
-    exec_runtime = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN].exec_tools.exec_runtime
+    target_toolchain = ctx.toolchains[PY_TOOLCHAIN]
+    py_toolchain = target_toolchain.py3_runtime
+    exec_tools = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN].exec_tools
+    exec_runtime = exec_tools.exec_runtime
 
     # Name the install tree after the target rather than a fixed "install"
     # so several whl_install targets can coexist in one package without
@@ -71,9 +73,34 @@ def _whl_install(ctx):
 
     # Optional .pyc pre-compilation (runs after patching).
     # Use the exec-configured interpreter from EXEC_TOOLS_TOOLCHAIN so cross-arch
-    # builds work (the target interpreter isn't runnable on the build host). This is
-    # safe because .pyc bytecode varies by Python version, not by architecture.
+    # builds work (the target interpreter isn't runnable on the build host).
     if ctx.attr.compile_pyc:
+        target_magic = getattr(target_toolchain, "pyc_magic_number", None)
+        exec_interpreter = exec_tools.exec_interpreter
+        exec_toolchain = None
+        if exec_interpreter != None and platform_common.ToolchainInfo in exec_interpreter:
+            exec_toolchain = exec_interpreter[platform_common.ToolchainInfo]
+        exec_magic = getattr(exec_toolchain, "pyc_magic_number", None) if exec_toolchain != None else None
+
+        if exec_magic != None and getattr(exec_toolchain, "py3_runtime", None) != exec_runtime:
+            fail("{} cannot compile .pyc files: exec_interpreter bytecode identity is not bound to exec_runtime".format(ctx.label))
+
+        # Standard rules_python runtime pairs do not expose bytecode identity:
+        # https://github.com/bazel-contrib/rules_python/blob/1.9.0/python/private/py_runtime_pair_rule.bzl#L43-L51
+        # Preserve that existing path when neither side opts in, but reject
+        # partial metadata rather than treating it as compatible.
+        if target_magic != None or exec_magic != None:
+            if target_magic == None:
+                fail("{} cannot compile .pyc files: target runtime does not declare pyc_magic_number".format(ctx.label))
+            if exec_magic == None:
+                fail("{} cannot compile .pyc files: exec runtime does not declare pyc_magic_number".format(ctx.label))
+            if target_magic != exec_magic:
+                fail("{} cannot compile .pyc files: PYC_MAGIC_NUMBER target={}, exec={}".format(
+                    ctx.label,
+                    target_magic,
+                    exec_magic,
+                ))
+
         arguments.add("--compile-pyc")
         arguments.add("--pyc-invalidation-mode", ctx.attr.pyc_invalidation_mode)
         arguments.add("--python", exec_runtime.interpreter)


### PR DESCRIPTION
`whl_install` compiles wheel bytecode with an execution-platform
interpreter while the target runtime consumes the resulting tree. PBS
toolchains can resolve those runtimes independently, and Python version
metadata is not an exact bytecode identity.

When either runtime pair declares `pyc_magic_number`, require both sides
to declare the same value before enabling compilation. Preserve existing
behavior when neither runtime pair opts in, and bypass the check when
precompilation is disabled.

Read exec identity from `exec_interpreter` only when available, and
require its forwarded `py3_runtime` to match the RBE-safe `exec_runtime`
used by the action. This prevents validating one interpreter while
executing another.

The guard [f6af2403] uses the bytecode-identity producer [e59cd1cc] and
the selected-exec-runtime binding [45619404]; both follow archive
selection [c1cd9499]. GitHub cannot base this cross-repository pull
request on another fork branch, so those prerequisites remain in the
branch until they land upstream.

[f6af2403]:
  https://github.com/tamird/rules_py/commit/f6af2403
[e59cd1cc]:
  https://github.com/tamird/rules_py/commit/e59cd1cc
[45619404]:
  https://github.com/tamird/rules_py/commit/45619404
[c1cd9499]:
  https://github.com/tamird/rules_py/commit/c1cd9499