### PR TITLE
fix: select native compilers from C++ for sdist wheel builds

### DIFF
--- a/.github/workflows/startup-benchmark-comment.yml
+++ b/.github/workflows/startup-benchmark-comment.yml
@@ -1,0 +1,54 @@
+name: Post Benchmark Comment
+
+on:
+  workflow_run:
+    workflows: ["Startup Benchmark"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = parseInt(fs.readFileSync('pr-number.txt', 'utf8').trim());
+            const table = fs.readFileSync('benchmark-table.txt', 'utf8').trim();
+            const header = '<!-- startup-benchmark -->';
+            const body = `${header}\n${table}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(header));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+              console.log(`Updated comment ${existing.id}`);
+            } else {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+              console.log(`Created comment ${created.id}`);
+            }

--- a/.github/workflows/startup-benchmark.yml
+++ b/.github/workflows/startup-benchmark.yml
@@ -15,7 +15,6 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       contents: read
 
     steps:
@@ -122,6 +121,7 @@ jobs:
       # ── Compare & gate ──────────────────────────────────────────────────────
       - name: Compare results
         id: compare
+        continue-on-error: true
         run: |
           set -euo pipefail
           for f in bcr.json main.json pr.json; do
@@ -130,37 +130,31 @@ jobs:
               exit 1
             fi
           done
-          python3 rules_py_pr/benchmark/startup/compare.py bcr.json main.json pr.json
+          python3 rules_py_pr/benchmark/startup/compare.py bcr.json main.json pr.json | tee benchmark-table.txt
 
-      - name: Post PR comment
-        if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload benchmark artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const header = '<!-- startup-benchmark -->';
-            const body = `${header}\n${process.env.TABLE}`;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(header));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body,
-              });
-              console.log(`Updated comment ${existing.id}`);
-            } else {
-              const { data: created } = await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body,
-              });
-              console.log(`Created comment ${created.id}`);
-            }
-        env:
-          TABLE: ${{ steps.compare.outputs.table }}
+          name: benchmark-results
+          path: |
+            bcr.json
+            main.json
+            pr.json
+            bcr-build.json
+            main-build.json
+            pr-build.json
+            bcr-syspath.json
+            main-syspath.json
+            pr-syspath.json
+            benchmark-table.txt
+            pr-number.txt
+          if-no-files-found: warn
+
+      - name: Fail on regression
+        if: steps.compare.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
The startup benchmark workflow is split into two to support pull requests from forks. The main benchmark job now runs in the untrusted fork context with only contents: read, saves its results and PR number as artifacts, and a new Post Benchmark Comment workflow triggers on workflow_run completion to post or update the comment from the trusted base repository context where pull-requests: write is available. This is the standard GitHub pattern for safely interacting with PRs opened by external contributors

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
