### PR TITLE
feat(uv): expose group dependency labels

### DIFF
--- a/docs/uv.md
+++ b/docs/uv.md
@@ -153,6 +153,14 @@ py_binary(
 future options (such as PEP 508 package extras) can be added as arguments
 without breaking callers.
 
+Macros that must inspect dependency labels while loading a BUILD file can use
+`group_dep_labels(name)` instead. It returns the frozen membership list for one
+explicit group as sorted `Label` values and fails if the group is unknown.
+These aliases still resolve according to the active `dep_group`, so analyze
+them only under the matching group. Prefer `group_deps()` for ordinary rule
+attributes so the dependency list follows the consuming target's group
+automatically.
+
 `all_requirements` (in `requirements.bzl`) remains the hub-wide union for
 compatibility with `rules_python`. Under a dependency-group transition, that
 union may contain targets which are incompatible with the selected group, so

--- a/e2e/cases/uv-requirements-bzl/BUILD.bazel
+++ b/e2e/cases/uv-requirements-bzl/BUILD.bazel
@@ -13,6 +13,7 @@ load(
     # follows the consuming target's dep_group, so the group name is never
     # repeated in deps.
     "@pypi_requirements_by_dep_group//:defs.bzl",
+    "group_dep_labels",
     multi_group_deps = "group_deps",
 )
 load(
@@ -31,6 +32,21 @@ load(
 # all_data_requirements == all_requirements (rules_python-compat alias);
 # referenced once so buildifier doesn't strip the load.
 _ALL_DATA_REQUIREMENTS_COUNT = len(all_data_requirements)
+
+_EXPLICIT_DEMO_DEPS = group_dep_labels("requirements-bzl-demo")
+
+_EXPECTED_EXPLICIT_DEMO_PACKAGES = [
+    "cowsay",
+    "python_dateutil",
+    "requirements_bzl_demo",
+    "six",
+]
+
+_EXPLICIT_DEMO_PACKAGES = [dep.package for dep in _EXPLICIT_DEMO_DEPS]
+
+_EXPLICIT_DEMO_DEPS_CHECK = None if _EXPLICIT_DEMO_PACKAGES == _EXPECTED_EXPLICIT_DEMO_PACKAGES else fail(
+    "unexpected explicit demo dependencies: {}".format(_EXPLICIT_DEMO_DEPS),
+)
 
 # requirement(name) returns the :pkg alias.
 py_test(
@@ -115,11 +131,9 @@ py_test(
     deps = multi_group_deps(),
 )
 
-# group_deps(): the SAME function used under two different dep_group attrs must
-# resolve to each group's list, with the group name never repeated in deps.
-# demo -> cowsay (shared with group-b) + python-dateutil + six (exclusive to
-# demo). group-b's exclusive wcwidth must NOT appear here, or it is incompatible
-# under this dep_group and analysis fails.
+# group_deps(): the same function resolves to the demo group's dependencies
+# under this target's dep_group. Together with the group-b target below, this
+# pins both populated select arms and their shared cowsay dependency.
 py_test(
     name = "group_deps_demo_test",
     srcs = ["__multi_test__.py"],
@@ -129,10 +143,19 @@ py_test(
     deps = multi_group_deps(),
 )
 
-# group-b -> cowsay (shared) + wcwidth (exclusive). Same function as above; if
-# the select did not track the active dep_group it would resolve to demo's
-# incompatible list and analysis would fail. Together these pin bidirectional
-# exclusion plus the shared-package overlap (cowsay in both groups' lists).
+# group_dep_labels(): macros can inspect one explicit group's membership before
+# target configuration. Analyze these aliases under the matching dep_group.
+py_test(
+    name = "group_dep_labels_demo_test",
+    srcs = ["__multi_test__.py"],
+    dep_group = "requirements-bzl-demo",
+    main = "__multi_test__.py",
+    python_version = "3.12",
+    deps = _EXPLICIT_DEMO_DEPS,
+)
+
+# group-b -> cowsay (shared) + wcwidth (exclusive). Resolving to the demo arm
+# would introduce incompatible python-dateutil and six targets.
 py_test(
     name = "group_deps_group_b_test",
     srcs = ["__group_b_test__.py"],

--- a/e2e/snapshots/pypi_multi.defs.bzl
+++ b/e2e/snapshots/pypi_multi.defs.bzl
@@ -54,5 +54,10 @@ _GROUP_DEPS = select(
     no_match_error = "no dep_group selected; set the dep_group attribute on the consuming target to one of: beta, dev, gamma, unit-tests",
 )
 
+def group_dep_labels(group):
+    if group not in _DEPS_BY_GROUP:
+        fail("unknown dep_group %r; expected one of: %s" % (group, ", ".join(sorted(_DEPS_BY_GROUP))))
+    return [Label(dep) for dep in _DEPS_BY_GROUP[group]]
+
 def group_deps():
     return _GROUP_DEPS

--- a/e2e/snapshots/pypi_single.defs.bzl
+++ b/e2e/snapshots/pypi_single.defs.bzl
@@ -41,5 +41,10 @@ _GROUP_DEPS = select(
     no_match_error = "no dep_group selected; set the dep_group attribute on the consuming target to one of: single_project_hub",
 )
 
+def group_dep_labels(group):
+    if group not in _DEPS_BY_GROUP:
+        fail("unknown dep_group %r; expected one of: %s" % (group, ", ".join(sorted(_DEPS_BY_GROUP))))
+    return [Label(dep) for dep in _DEPS_BY_GROUP[group]]
+
 def group_deps():
     return _GROUP_DEPS

--- a/uv/private/uv_hub/repository.bzl
+++ b/uv/private/uv_hub/repository.bzl
@@ -225,6 +225,11 @@ _GROUP_DEPS = select(
     no_match_error = {no_match_error},
 )
 
+def group_dep_labels(group):
+    if group not in _DEPS_BY_GROUP:
+        fail("unknown dep_group %r; expected one of: %s" % (group, ", ".join(sorted(_DEPS_BY_GROUP))))
+    return [Label(dep) for dep in _DEPS_BY_GROUP[group]]
+
 def group_deps():
     return _GROUP_DEPS
 """.format(
@@ -284,9 +289,9 @@ uv_hub = repository_rule(
 
     Lays down two loadable files:
 
-    - `defs.bzl` (rules_py-native): the `group_deps()` helper plus the
-      `compatible_with` / `incompatible_with` constraint helpers and the
-      `VIRTUALENVS` list.
+    - `defs.bzl` (rules_py-native): the `group_deps()` and
+      `group_dep_labels()` helpers plus the `compatible_with` /
+      `incompatible_with` constraint helpers and the `VIRTUALENVS` list.
     - `requirements.bzl`: a rules_python-compatibility shim (`all_requirements`,
       `requirement()`, and friends).
 
@@ -303,6 +308,11 @@ uv_hub = repository_rule(
     It is a function rather than a value so that future options -- such as
     PEP 508 package extras -- can be added as keyword arguments without breaking
     callers.
+
+    `group_dep_labels(name)` returns the membership list for an explicit group
+    as sorted `Label` values. This supports macros that must inspect normalized
+    package names during package loading. The aliases still resolve under the
+    active `dep_group`, so consuming targets must use the matching group.
     """,
     implementation = _hub_impl,
     attrs = {

--- a/uv/private/uv_hub/snapshots/pypi.defs.bzl
+++ b/uv/private/uv_hub/snapshots/pypi.defs.bzl
@@ -113,5 +113,10 @@ _GROUP_DEPS = select(
     no_match_error = "no dep_group selected; set the dep_group attribute on the consuming target to one of: aspect_rules_py",
 )
 
+def group_dep_labels(group):
+    if group not in _DEPS_BY_GROUP:
+        fail("unknown dep_group %r; expected one of: %s" % (group, ", ".join(sorted(_DEPS_BY_GROUP))))
+    return [Label(dep) for dep in _DEPS_BY_GROUP[group]]
+
 def group_deps():
     return _GROUP_DEPS


### PR DESCRIPTION
`group_deps()` suits configurable dependency attributes, but a macro
cannot iterate its `select()` result. Waiting until analysis also loses
the normalized package name after a hub alias resolves to a project SCC
target.

Expose `group_dep_labels(name)` from native `defs.bzl`. It returns sorted
`Label` values from the existing per-group membership table, so macros
can inspect package names during loading without publishing Bzlmod
canonical repository spellings.

The labels describe membership, not a pinned resolution. Package aliases
still resolve through the active `dep_group` and must be analyzed under
the matching group. Prefer `group_deps()` for ordinary rule attributes,
and keep `requirements.bzl` aligned with the `rules_python` surface.