### PR TITLE
fix(py_venv): avoid duplicate wheel metadata

### DIFF
--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -26,7 +26,8 @@ distutils, etc.) treat it as a real venv:
         <ns_pkg>/<entry>                        merged PEP 420 namespace: real
                                                 <ns_pkg>/ dir, per-entry symlinks
                                                 into each contributing wheel
-        <dist>-<ver>.dist-info                  symlink to a wheel's dist-info
+        <dist>-<ver>.dist-info                  symlink when the wheel needs no
+                                                whole-wheel fallback
 
 The whole tree is declared at analysis time as individual
 `ctx.actions.declare_file` / `ctx.actions.declare_symlink` outputs so
@@ -58,7 +59,7 @@ def _dict_to_exports(env):
 def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     """Walk PyWheelsInfo.wheels and produce merge plans for site-packages + bin/.
 
-    Two kinds of collision get checked:
+    Three kinds of collision get checked:
 
     * **Top-level in site-packages.** Multiple wheels claiming the same
       top-level name. When ALL contributing wheels flag the name as a
@@ -88,15 +89,23 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
       caller physically merges those subtrees (what a flat
       `pip install` would have produced).
 
+    * **Declared distribution metadata in site-packages.** Metadata discovery
+      scans every `sys.path` entry instead of stopping at the first match.
+      Preserve the existing exact-entry collision precedence, but project the
+      selected `*.dist-info` and `*.egg-info` entry only when that wheel needs
+      no whole-wheel fallback. Reject an exact-entry collision when a losing
+      claimant remains on fallback and therefore cannot be suppressed.
+
     * **Console-script name in bin/.** Apply `package_collisions` directly
       — no namespace equivalent.
 
     Returns:
       top_level_to_site_pkgs: dict {site_packages_relative_path: site_packages_rfpath}
-          — keys are top-level names, plus `/`-joined deeper paths (e.g.
-          `jaraco/functools`) for merged namespace packages.
+          — keys are import roots, `/`-joined deeper paths (e.g.
+          `jaraco/functools`) for merged namespace packages, and distribution
+          metadata entries owned by fully covered wheels.
       fully_covered_site_pkgs: dict[str, True] — site-packages paths whose
-          declared top-levels ALL ended up claimed by them (directly or
+          declared import roots ALL ended up claimed by them (directly or
           via a complete namespace merge) — safe to drop from the .pth
           fallback.
       console_scripts_map: dict {script_name: struct(module, func)} after
@@ -121,8 +130,10 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             # buildifier: disable=print
             print(msg)
 
-    # Pass 1: bucket claimants per top-level / per console-script name.
+    # Pass 1: bucket claimants per import root, distribution metadata entry,
+    # and console-script name.
     tl_claimants = {}  # tl -> list of struct(site_packages, is_ns, ns_entries)
+    metadata_claimants = {}  # metadata entry -> ordered site_packages paths
     cs_claimants = {}  # name -> list of struct(site_packages, module, func)
     wheel_by_sp = {}  # site_packages_rfpath -> wheel struct
     for w in wheels:
@@ -132,6 +143,9 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
         for entry in getattr(w, "namespace_entries", ()):
             ns_entries_by_tl.setdefault(entry.split("/")[0], []).append(entry)
         for tl in w.top_levels:
+            if tl.endswith(".dist-info") or tl.endswith(".egg-info"):
+                metadata_claimants.setdefault(tl, []).append(w.site_packages_rfpath)
+                continue
             tl_claimants.setdefault(tl, []).append(struct(
                 site_packages = w.site_packages_rfpath,
                 is_ns = tl in ns_set,
@@ -389,6 +403,8 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
         ns_covered = ns_covered_per_wheel.get(w.site_packages_rfpath, {})
         covered = True
         for tl in w.top_levels:
+            if tl in metadata_claimants:
+                continue
             if tl in skipped:
                 covered = False
                 break
@@ -397,6 +413,40 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                 break
         if covered:
             fully_covered[w.site_packages_rfpath] = True
+
+    # Metadata discovery scans every sys.path entry. Resolve duplicate declared
+    # metadata entries with the existing collision precedence, but first reject
+    # a losing claimant that remains on whole-wheel fallback because downgrading
+    # the collision cannot suppress that copy. Project the winner only when its
+    # fallback is gone. Wheels without declared layout metadata remain on the
+    # existing whole-wheel fallback and cannot be classified here.
+    for tl, claimants in metadata_claimants.items():
+        winner = claimants[0]
+        seen = {winner: True}
+        for site_packages in claimants[1:]:
+            if site_packages in seen:
+                continue
+            winner = site_packages
+            seen[site_packages] = True
+        for site_packages in seen:
+            if site_packages != winner and site_packages not in fully_covered:
+                fail(("{}: distribution metadata entry `{}` selects {}, but " +
+                      "losing claimant {} remains on whole-wheel fallback.").format(
+                    ctx.label,
+                    tl,
+                    winner,
+                    site_packages,
+                ))
+        prior = claimants[0]
+        complained = {prior: True}
+        for site_packages in claimants[1:]:
+            if site_packages in complained:
+                continue
+            _complain("distribution metadata entry", tl, prior, site_packages)
+            prior = site_packages
+            complained[site_packages] = True
+        if winner in fully_covered:
+            top_level_to_site_pkgs[tl] = winner
 
     return top_level_to_site_pkgs, fully_covered, console_scripts_map, merge_groups
 
@@ -432,8 +482,8 @@ def assemble_venv(
       imports_depset: Depset of first-party + transitive wheel import
         paths (as returned by py_library_utils.make_imports_depset).
       package_collisions: "error" / "warning" / "ignore" — policy applied
-        when two wheels claim the same top-level (non-namespace case) or
-        the same console-script name.
+        when two wheels claim the same top-level (non-namespace case),
+        distribution metadata entry, or console-script name.
       include_system_site_packages: Value for pyvenv.cfg's
         `include-system-site-packages` key.
       include_user_site_packages: Value for the Aspect extension

--- a/py/tests/py_venv_conflict/collision_order_test.bzl
+++ b/py/tests/py_venv_conflict/collision_order_test.bzl
@@ -14,12 +14,27 @@ def _wheel_impl(ctx):
     command = """
 set -eu
 site="$1/lib/python$2.$3/site-packages"
+metadata="$site/$6"
+mkdir -p "$metadata"
+printf 'Metadata-Version: 2.1\nName: collision-%s\nVersion: 1.0\nSummary: %s\n' "$5" "$7" > "$metadata/METADATA"
+"""
+    metadata_name = ctx.attr.metadata_name or "collision_{}-1.0.dist-info".format(ctx.attr.value)
+    top_levels = (metadata_name,)
+    namespace_top_levels = ()
+    namespace_entries = ()
+    console_scripts = ()
+    if not ctx.attr.metadata_only:
+        command += """
 mkdir -p "$site/collision_namespace"
 printf 'VALUE = %s\n' "$4" > "$site/collision_namespace/shared.py"
 printf 'VALUE = %s\n\ndef main():\n    print(VALUE)\n' "$4" > "$site/collision_namespace/$5.py"
 """
-    top_levels = ("collision_namespace",)
-    console_scripts = ()
+        top_levels = ("collision_namespace", metadata_name)
+        namespace_top_levels = ("collision_namespace",)
+        namespace_entries = (
+            "collision_namespace/shared.py",
+            "collision_namespace/{}.py".format(ctx.attr.value),
+        )
     if ctx.attr.ordinary:
         command += """
 printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
@@ -35,6 +50,8 @@ printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
             str(minor),
             json.encode(ctx.attr.value),
             ctx.attr.value,
+            metadata_name,
+            ctx.label.name,
         ],
     )
     site_packages = "/".join([
@@ -48,11 +65,8 @@ printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
     ] + ["lib/python{}.{}/site-packages".format(major, minor)])
     wheel = struct(
         top_levels = top_levels,
-        namespace_top_levels = ("collision_namespace",),
-        namespace_entries = (
-            "collision_namespace/shared.py",
-            "collision_namespace/{}.py".format(ctx.attr.value),
-        ),
+        namespace_top_levels = namespace_top_levels,
+        namespace_entries = namespace_entries,
         namespace_dirs = (),
         regular_roots = (),
         site_packages_rfpath = site_packages,
@@ -77,6 +91,8 @@ printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
 _wheel = rule(
     implementation = _wheel_impl,
     attrs = {
+        "metadata_name": attr.string(),
+        "metadata_only": attr.bool(),
         "ordinary": attr.bool(),
         "value": attr.string(mandatory = True),
     },
@@ -85,11 +101,14 @@ _wheel = rule(
 
 def _collision_error_test_impl(ctx):
     env = analysistest.begin(ctx)
-    asserts.expect_failure(env, "namespace entry `collision_namespace/shared.py`")
+    asserts.expect_failure(env, ctx.attr.expected_error)
     return analysistest.end(env)
 
 _collision_error_test = analysistest.make(
     _collision_error_test_impl,
+    attrs = {
+        "expected_error": attr.string(mandatory = True),
+    },
     expect_failure = True,
 )
 
@@ -146,7 +165,54 @@ def collision_order_test_suite():
     )
     _collision_error_test(
         name = "collision_error_test",
+        expected_error = "namespace entry `collision_namespace/shared.py`",
         target_under_test = ":_collision_error_binary",
+    )
+
+    _wheel(
+        name = "_metadata_collision_second",
+        metadata_name = "collision_first-1.0.dist-info",
+        tags = ["manual"],
+        value = "metadata_second",
+    )
+    py_binary(
+        name = "_metadata_collision_error_binary",
+        srcs = ["test_namespace_fallback.py"],
+        main = "test_namespace_fallback.py",
+        package_collisions = "ignore",
+        tags = ["manual"],
+        deps = [
+            ":_collision_first",
+            ":_metadata_collision_second",
+        ],
+    )
+    _collision_error_test(
+        name = "metadata_collision_error_test",
+        expected_error = "distribution metadata entry `collision_first-1.0.dist-info` selects",
+        target_under_test = ":_metadata_collision_error_binary",
+    )
+
+    _wheel(
+        name = "_metadata_suppressible_first",
+        metadata_only = True,
+        tags = ["manual"],
+        value = "metadata_shared",
+    )
+    _wheel(
+        name = "_metadata_suppressible_second",
+        metadata_only = True,
+        tags = ["manual"],
+        value = "metadata_shared",
+    )
+    py_test(
+        name = "metadata_collision_suppression_test",
+        srcs = ["test_metadata_collision_suppression.py"],
+        main = "test_metadata_collision_suppression.py",
+        package_collisions = "ignore",
+        deps = [
+            ":_metadata_suppressible_first",
+            ":_metadata_suppressible_second",
+        ],
     )
 
     _wheel(

--- a/py/tests/py_venv_conflict/test_collision_order.py
+++ b/py/tests/py_venv_conflict/test_collision_order.py
@@ -1,6 +1,7 @@
 import importlib
 import subprocess
 import sys
+from importlib.metadata import distributions
 
 import collision_order
 from collision_namespace import shared
@@ -12,6 +13,8 @@ assert shared.VALUE == expected, (shared.VALUE, expected)
 for unique in ("first", "second"):
     module = importlib.import_module(f"collision_namespace.{unique}")
     assert module.VALUE == unique, (module.VALUE, unique)
+    metadata = list(distributions(name=f"collision-{unique}"))
+    assert len(metadata) == 1, [str(item.locate_file("")) for item in metadata]
 result = subprocess.run(
     [sys.prefix + "/bin/collision-order"],
     check=True,

--- a/py/tests/py_venv_conflict/test_metadata_collision_suppression.py
+++ b/py/tests/py_venv_conflict/test_metadata_collision_suppression.py
@@ -1,0 +1,6 @@
+from importlib.metadata import distributions
+
+
+matches = list(distributions(name="collision-metadata-shared"))
+assert len(matches) == 1, [str(match.locate_file("")) for match in matches]
+assert matches[0].metadata["Summary"] == "_metadata_suppressible_second"


### PR DESCRIPTION
An import-root collision can leave a declared-layout wheel on
whole-wheel fallback. The downstream rules_py 2 upgrade exposed that
`py_venv` still projected the same wheel metadata entry, so
`importlib.metadata` discovered it through both paths.

Classify declared `*.dist-info` and `*.egg-info` entries separately from
import roots when deciding whether a wheel needs fallback. Preserve the
existing exact-entry collision policy, but project selected metadata only
when the owning wheel no longer needs fallback. Reject an exact-entry
collision when an unselected claimant remains visible through fallback
because downgrading cannot suppress that copy.

Metadata-unknown wheel layouts remain on whole-wheel fallback. Their
contents cannot participate in analysis-time ownership, so this does not
attempt to resolve different metadata directory names for the same
normalized project.