### PR TITLE
fix(py_image_layer): don't rename source files that share the binary name

### DIFF
--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -206,3 +206,40 @@ container_structure_test(
         "skip-on-bazel9",
     ],
 )
+
+# Regression test for https://github.com/aspect-build/rules_py/issues/1120
+# When the binary name matches the source file name (e.g. "server" / "server.py"),
+# py_image_layer used to incorrectly rename the source file.
+py_binary(
+    name = "server",
+    srcs = ["server.py"],
+)
+
+py_image_layer(
+    name = "server_layers",
+    binary = ":server",
+)
+
+oci_image(
+    name = "server_image",
+    base = "@ubuntu",
+    entrypoint = ["/app"],
+    tars = [":server_layers"],
+)
+
+platform_transition_filegroup(
+    name = "amd64_server_image",
+    srcs = [":server_image"],
+    target_platform = ":x86_64_linux",
+)
+
+container_structure_test(
+    name = "server_image_command_test",
+    args = ["--verbosity=debug"],
+    configs = ["server_image_command_test.yaml"],
+    image = ":amd64_server_image",
+    platform = "linux/amd64",
+    tags = [
+        "requires-docker",
+    ],
+)

--- a/e2e/cases/oci/py_image_layer/server.py
+++ b/e2e/cases/oci/py_image_layer/server.py
@@ -1,0 +1,2 @@
+if __name__ == "__main__":
+    print("server ok")

--- a/e2e/cases/oci/py_image_layer/server_image_command_test.yaml
+++ b/e2e/cases/oci/py_image_layer/server_image_command_test.yaml
@@ -1,0 +1,7 @@
+schemaVersion: 2.0.0
+
+commandTests:
+  - name: server binary runs correctly (issue #1120 regression)
+    exitCode: 0
+    command: /app
+    expectedOutput: ["server ok"]

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
@@ -65,6 +65,7 @@ files:
   - -rwxr-xr-x  0 0      0         327 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0         246 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0        1278 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/my_app_bin.venv
   - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3-3.11
@@ -2383,4 +2384,3 @@ files:
   - -rwxr-xr-x  0 0      0       20280 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/share/man/man1/python3.11.1
   - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py+/py/tests/internal-deps/adder/__init__.py
   - -rwxr-xr-x  0 0      0          32 Jan  1  2023 ./app.runfiles/aspect_rules_py+/py/tests/internal-deps/adder/add.py
-  - -rwxr-xr-x  0 0      0        1278 Jan  1  2023 ./app.venv

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
@@ -65,6 +65,7 @@ files:
   - -rwxr-xr-x  0 0      0         327 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0         247 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0        1278 Jan  1  2023 ./app.runfiles/_main/cases/oci/py_venv_image_layer/my_app_bin.venv
   - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_aarch64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_aarch64_unknown_linux_gnu/bin/2to3-3.11
@@ -2383,4 +2384,3 @@ files:
   - -rwxr-xr-x  0 0      0       20280 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_aarch64_unknown_linux_gnu/share/man/man1/python3.11.1
   - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py+/py/tests/internal-deps/adder/__init__.py
   - -rwxr-xr-x  0 0      0          32 Jan  1  2023 ./app.runfiles/aspect_rules_py+/py/tests/internal-deps/adder/add.py
-  - -rwxr-xr-x  0 0      0        1278 Jan  1  2023 ./app.venv

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -568,9 +568,7 @@ def _apply_strip_prefix(sp, strip_prefix, root):
     if sp == prefix:
         return "." + root
 
-    # `prefix + "."` catches the binary's own `*.runfiles/...` tree; `prefix + "/"`
-    # catches files actually under a directory named `prefix`.
-    if sp.startswith(prefix + ".") or sp.startswith(prefix + "/"):
+    if sp.startswith(prefix + ".runfiles/") or sp.startswith(prefix + "/"):
         return "." + root + sp[len(prefix):]
     return "./app.runfiles/_main/" + sp
 


### PR DESCRIPTION
_apply_strip_prefix used `prefix + "."` to catch the binary's own runfiles tree (e.g. `server.runfiles/...`), but this also matched source files whose name starts with the binary name followed by a dot (e.g. `server.py`), causing them to be placed at `./app.py` instead of their correct runfiles path.

Tighten the check to `prefix + ".runfiles/"` so only the actual runfiles directory is matched.

Adds a container_structure_test that reproduces the failure: a py_binary named "server" with source "server.py" — the bootstrap script crashes at runtime when the file is misplaced.

Fixes https://github.com/aspect-build/rules_py/issues/1120

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fix py_image_layer to avoid accidentally renaming source files that have the same name as the py_binary

### Test plan

- Covered by existing test cases
- New test cases added
