### PR TITLE
fix(uv): validate patched wheel topology

### DIFF
--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -48,6 +48,10 @@ Where `patches/nvidia-strip-init.patch` might look like:
 +# Stripped by aspect_rules_py override
 ```
 
+The file remains in place, so `nvidia` stays a regular package. Post-install
+patches may not remove package roots or change regular packages into namespace
+packages; use full replacement when the installed topology itself must change.
+
 ### Applying the same patch to multiple packages
 
 Use a Starlark list comprehension:
@@ -183,6 +187,23 @@ uv.override_package(
 - `console_scripts` applies only when the lock record has a source
   distribution. Prebuilt wheels use their inspected metadata.
 - Pre-build patches only apply to packages that have a source distribution in the lockfile. If a package only has pre-built wheels, `pre_build_patches` has no effect.
+- For prebuilt wheels, post-install patches may add paths but must preserve
+  every original path used for collision and regular-package merge planning,
+  including its file-or-directory kind and package classification. Patched
+  wheels retain whole-wheel import fallback while that original topology
+  participates in analysis. Added paths are not visible during analysis; do
+  not add paths that collide with another wheel. Original root `.pth` files
+  execute through the fallback rather than through projected copies. The
+  fallback also owns original `*.dist-info` and `*.egg-info` entries, so
+  metadata scanners observe each distribution once. Collision resolution can
+  suppress complete-layout losers, but rejects a losing root `.pth` or
+  distribution-metadata claimant that remains on whole-wheel fallback.
+  Source-built wheel topology is unknown during analysis, so it remains on
+  whole-wheel fallback and topology changes are not validated.
+- Prebuilt console-script declarations are extracted before post-install
+  patches run; source-built wrappers use the override's `console_scripts`.
+  Post-install changes to `.dist-info/entry_points.txt` do not affect generated
+  wrappers in either case.
 
 ## Future work
 

--- a/e2e/cases/azure-core-tracing-overlap/BUILD.bazel
+++ b/e2e/cases/azure-core-tracing-overlap/BUILD.bazel
@@ -18,12 +18,15 @@ load("@aspect_rules_py//py:defs.bzl", "py_test")
 # Variants:
 #   :test       — py_test default (.pth strategy)
 #   :test_tool  — py_venv_test variant (symlink-forest venv)
+# Both use Python 3.11 because post_install.patch names the interpreter-specific
+# lib/python3.11/site-packages install path.
 
 py_test(
     name = "test",
     srcs = ["test.py"],
     dep_group = "azure-core-tracing-import",
     main = "test.py",
+    python_version = "3.11",
     deps = [
         "@pypi_azure_core_tracing//azure_core",
         "@pypi_azure_core_tracing//azure_core_tracing_opentelemetry",

--- a/e2e/cases/azure-core-tracing-overlap/patches/BUILD.bazel
+++ b/e2e/cases/azure-core-tracing-overlap/patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["post_install.patch"])

--- a/e2e/cases/azure-core-tracing-overlap/patches/post_install.patch
+++ b/e2e/cases/azure-core-tracing-overlap/patches/post_install.patch
@@ -1,0 +1,4 @@
+--- /dev/null
++++ b/lib/python3.11/site-packages/azure/core/patched_marker.py
+@@ -0,0 +1 @@
++PATCHED = True

--- a/e2e/cases/azure-core-tracing-overlap/setup.MODULE.bazel
+++ b/e2e/cases/azure-core-tracing-overlap/setup.MODULE.bazel
@@ -12,6 +12,12 @@ uv.project(
     lock = "//cases/azure-core-tracing-overlap:uv.lock",
     pyproject = "//cases/azure-core-tracing-overlap:pyproject.toml",
 )
+uv.override_package(
+    name = "azure-core",
+    lock = "//cases/azure-core-tracing-overlap:uv.lock",
+    post_install_patch_strip = 1,
+    post_install_patches = ["//cases/azure-core-tracing-overlap/patches:post_install.patch"],
+)
 use_repo(uv, "pypi_azure_core_tracing")
 
 # Exposed so e2e/BUILD.bazel can snapshot the namespace_dirs / regular_roots

--- a/e2e/cases/azure-core-tracing-overlap/test.py
+++ b/e2e/cases/azure-core-tracing-overlap/test.py
@@ -21,6 +21,7 @@ exact Azure package pair.
 """
 
 import sys
+from importlib.metadata import distributions
 
 
 def test_azure_core_tracing_ext_import():
@@ -42,6 +43,19 @@ def test_azure_core_still_intact():
     assert SpanKind is not None
 
 
+def test_patched_azure_core_still_merges():
+    from azure.core.patched_marker import PATCHED
+    from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+
+    assert PATCHED is True
+    assert OpenTelemetrySpan is not None
+
+
+def test_patched_azure_core_metadata_is_not_duplicated():
+    matches = list(distributions(name="azure-core"))
+    assert len(matches) == 1, [str(match.locate_file("")) for match in matches]
+
+
 def test_azure_core_tracing_is_regular_package():
     """Guard the premise of this test case.
 
@@ -60,6 +74,8 @@ def test_azure_core_tracing_is_regular_package():
 if __name__ == "__main__":
     test_azure_core_tracing_ext_import()
     test_azure_core_still_intact()
+    test_patched_azure_core_still_merges()
+    test_patched_azure_core_metadata_is_not_duplicated()
     test_azure_core_tracing_is_regular_package()
     print("PASS: azure.core.tracing.ext imports correctly")
     sys.exit(0)

--- a/e2e/cases/uv-patching-829/__test__.py
+++ b/e2e/cases/uv-patching-829/__test__.py
@@ -2,7 +2,13 @@
 
 """Test that post-install patches are applied to cowsay."""
 
+import subprocess
+import sys
+from pathlib import Path
+
 import cowsay
+import patched_top_level
+import patched_via_pth
 
 # Verify the post-install patch added PATCHED_POST_INSTALL to __init__.py
 assert hasattr(cowsay, "PATCHED_POST_INSTALL"), (
@@ -11,9 +17,24 @@ assert hasattr(cowsay, "PATCHED_POST_INSTALL"), (
 assert cowsay.PATCHED_POST_INSTALL is True
 print("post_install patch: OK")
 
+# Verify a top-level module added after wheel metadata extraction remains
+# importable through the unknown-layout fallback.
+assert patched_top_level.PATCHED is True
+print("post_install top-level addition: OK")
+
+# Verify the unknown-layout fallback processes root .pth files added by the
+# post-install patch.
+assert patched_via_pth.PATCHED is True
+print("post_install root .pth addition: OK")
+
 # Verify cowsay still works after patching
 output = cowsay.get_output_string("cow", "patches work!")
 assert "patches work!" in output
 print("cowsay functional: OK")
+
+# Console-script metadata remains valid when only package files are patched.
+console_script = Path(sys.executable).with_name("cowsay")
+subprocess.run([console_script, "--help"], check=True, capture_output=True, text=True)
+print("original console script: OK")
 
 print("All patching tests passed.")

--- a/e2e/cases/uv-patching-829/patches/post_install.patch
+++ b/e2e/cases/uv-patching-829/patches/post_install.patch
@@ -6,3 +6,15 @@
  from .main import (
 
      __version__,
+--- /dev/null
++++ b/lib/python3.11/site-packages/patched_top_level.py
+@@ -0,0 +1 @@
++PATCHED = True
+--- /dev/null
++++ b/lib/python3.11/site-packages/patched_path.pth
+@@ -0,0 +1 @@
++cowsay
+--- /dev/null
++++ b/lib/python3.11/site-packages/cowsay/patched_via_pth.py
+@@ -0,0 +1 @@
++PATCHED = True

--- a/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
+++ b/e2e/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
@@ -64,6 +64,8 @@ whl_install(
             "azure/core",
         ],
     },
+    patches = ["@@//cases/azure-core-tracing-overlap/patches:post_install.patch"],
+    patch_strip = 1,
     visibility = ["//visibility:private"],
 )
 

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -18,8 +18,11 @@ postorder. Producers must use `default` or `postorder`, the orders Bazel permits
 in that aggregate. For collision classes that select one claimant, permissive
 handling gives the later distinct element in the flattened sequence precedence.
 Duplicate dependency edges do not create another precedence position. Fields:
-  * `top_levels`: tuple[str] — complete set of immediate `site-packages`
-    entry names when nonempty; an empty tuple means the layout is unknown.
+  * `top_levels`: tuple[str] — immediate `site-packages` entry names observed
+    during repository analysis.
+  * `layout_complete`: bool — whether the layout fields completely describe
+    the installed tree. False retains observed topology for collision planning
+    while requiring whole-wheel fallback for imports.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
   * `namespace_entries`: tuple[str] — `/`-joined paths of the concrete entries beneath
     the namespace top-levels (e.g. `jaraco/functools`), used to materialise a merged

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -82,6 +82,7 @@ def _py_unpacked_wheel_impl(ctx):
     providers.append(PyWheelsInfo(
         wheels = depset(direct = [struct(
             top_levels = tuple(ctx.attr.top_levels),
+            layout_complete = bool(ctx.attr.top_levels),
             namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
             namespace_entries = tuple(ctx.attr.namespace_entries),
             site_packages_rfpath = site_packages_rfpath,

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -132,7 +132,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
 
     # Pass 1: bucket claimants per import root, distribution metadata entry,
     # and console-script name.
-    tl_claimants = {}  # tl -> list of struct(site_packages, is_ns, ns_entries)
+    tl_claimants = {}  # tl -> list of struct(site_packages, layout_complete, is_ns, ns_entries)
     metadata_claimants = {}  # metadata entry -> ordered site_packages paths
     cs_claimants = {}  # name -> list of struct(site_packages, module, func)
     wheel_by_sp = {}  # site_packages_rfpath -> wheel struct
@@ -148,6 +148,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                 continue
             tl_claimants.setdefault(tl, []).append(struct(
                 site_packages = w.site_packages_rfpath,
+                layout_complete = w.layout_complete,
                 is_ns = tl in ns_set,
                 ns_entries = tuple(ns_entries_by_tl.get(tl, [])),
             ))
@@ -181,8 +182,14 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     ns_claimant_sps = {}  # sp -> True, wheels in any all-namespace collision
     for tl, claimants in tl_claimants.items():
         distinct_sp = {c.site_packages: c for c in claimants}
+
+        # site.addsitedir processes only non-hidden names ending in `.pth`:
+        # https://github.com/python/cpython/blob/v3.11.9/Lib/site.py#L233-L236
+        site_processed_pth = tl.endswith(".pth") and not tl.startswith(".")
         if len(distinct_sp) == 1:
-            top_level_to_site_pkgs[tl] = claimants[0].site_packages
+            claimant = claimants[0]
+            if not site_processed_pth or claimant.layout_complete:
+                top_level_to_site_pkgs[tl] = claimant.site_packages
             continue
 
         all_namespace = all([c.is_ns for c in claimants])
@@ -330,16 +337,34 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                     ns_covered_per_wheel.setdefault(c.site_packages, {})[tl] = True
             continue
 
-        winner = claimants[0]
-        seen = {winner.site_packages: True}
-        for c in claimants[1:]:
+        ordered_claimants = []
+        seen = {}
+        for c in claimants:
             if c.site_packages in seen:
                 continue
+            ordered_claimants.append(c)
+            seen[c.site_packages] = True
+
+        if site_processed_pth:
+            final_winner = ordered_claimants[-1]
+            for c in ordered_claimants[:-1]:
+                if not c.layout_complete:
+                    fail(("{}: root `.pth` file `{}` selects {}, but losing " +
+                          "claimant {} has an incomplete layout and remains on " +
+                          "whole-wheel fallback.").format(
+                        ctx.label,
+                        tl,
+                        final_winner.site_packages,
+                        c.site_packages,
+                    ))
+
+        winner = ordered_claimants[0]
+        for c in ordered_claimants[1:]:
             _complain("top-level", tl, winner.site_packages, c.site_packages)
             skipped_per_wheel.setdefault(winner.site_packages, {})[tl] = True
             winner = c
-            seen[c.site_packages] = True
-        top_level_to_site_pkgs[tl] = winner.site_packages
+        if not site_processed_pth or winner.layout_complete:
+            top_level_to_site_pkgs[tl] = winner.site_packages
 
     # Pass 2a: fold conflicted roots into merge groups. Keep only the
     # minimal (shallowest) roots — a conflicted root nested inside
@@ -393,11 +418,13 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             seen[c.site_packages] = True
         console_scripts_map[name] = struct(module = winner.module, func = winner.func)
 
-    # Pass 3: wheels fully covered by direct (or complete per-entry
-    # namespace) symlinks.
+    # Pass 3: complete wheel layouts fully covered by direct (or complete
+    # per-entry namespace) symlinks. Incomplete layouts retain their observed
+    # claims for collision and merge planning but always keep whole-wheel
+    # fallback.
     fully_covered = {}
     for w in wheels:
-        if not w.top_levels:
+        if not w.layout_complete:
             continue
         skipped = skipped_per_wheel.get(w.site_packages_rfpath, {})
         ns_covered = ns_covered_per_wheel.get(w.site_packages_rfpath, {})
@@ -566,14 +593,11 @@ def assemble_venv(
     # each wheel by its runfiles path directly, not through this map.
     wheels_with_trees = [w for w in wheels if getattr(w, "install_tree", None) != None]
     tree_by_sp = {w.site_packages_rfpath: w.install_tree for w in wheels_with_trees}
-
-    # site_packages_rfpath → True for wheels whose top-level layout is known
-    # (they declare `top_levels`), so the per-top-level symlink loop projects
-    # their root entries — including any root `.pth` files — into the venv
-    # site-packages. Wheels that carry only `console_scripts` (e.g. source-built
-    # scripts) leave `top_levels` empty: nothing is projected for them, so their
-    # `.pth` line must use `site.addsitedir` (see `_format_imp`).
-    known_layout_site_pkgs = {w.site_packages_rfpath: True for w in wheels if w.top_levels}
+    known_layout_site_pkgs = {
+        w.site_packages_rfpath: True
+        for w in wheels
+        if w.layout_complete
+    }
 
     declared = []  # accumulator for all outputs
 
@@ -582,7 +606,10 @@ def assemble_venv(
     # wheel's `site_packages_rfpath`/<tl>. Works for both install_tree and
     # rules_python pip wheels (both stage content at their rfpath).
     # `/`-joined top-levels (merged namespace packages, e.g.
-    # `jaraco/functools`) need one extra `..` per segment.
+    # `jaraco/functools`) need one extra `..` per segment. Collision planning
+    # omits observed root `.pth` files from incomplete layouts so whole-wheel
+    # fallback is their only runtime owner and can also discover added `.pth`
+    # files.
     for tl, wheel_site_pkgs in top_level_to_site_pkgs.items():
         out = ctx.actions.declare_symlink("{}/{}".format(site_packages_rel, tl))
         extra_up = "../" * tl.count("/")
@@ -664,16 +691,10 @@ def assemble_venv(
         )
         declared.append(merged_dir)
 
-    # A wheel-root `.pth` shim only fires when its file sits in the venv's own
-    # site-packages. Wheels that declare `top_levels` (known layout) had their
-    # root entries — including any root `.pth` files — projected there by the
-    # per-top-level symlink loop above, so they emit a plain path line;
-    # `site.addsitedir` would re-scan the wheel root and run the shim a second
-    # time. Wheels with no projected layout (console-script-only, e.g.
-    # source-built scripts, or metadata-free `py_unpacked_wheel`s) fall back to
-    # `site.addsitedir` so their site-packages joins sys.path and root `.pth`
-    # shims run at all; the path is sys.prefix-relative to survive RBE sandbox
-    # layouts.
+    # Incomplete layouts use `site.addsitedir` so patch-added root `.pth` files
+    # are processed. Complete layouts use a plain path because their observed
+    # root `.pth` files were projected or deliberately suppressed by collision
+    # resolution.
     def _format_imp(imp):
         if imp in fully_covered_site_pkgs:
             return None

--- a/py/tests/py_venv_conflict/collision_order_test.bzl
+++ b/py/tests/py_venv_conflict/collision_order_test.bzl
@@ -41,6 +41,11 @@ printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
 """
         top_levels += ("collision_order.py",)
         console_scripts = ("collision-order=collision_namespace.{}:main".format(ctx.attr.value),)
+    if ctx.attr.root_pth_name:
+        command += """
+printf 'import sys; sys.path.append("rules_py_pth_%s")\n' "$5" > "$site/$8.pth"
+"""
+        top_levels += (ctx.attr.root_pth_name + ".pth",)
     ctx.actions.run_shell(
         outputs = [install_tree],
         command = command,
@@ -52,6 +57,7 @@ printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
             ctx.attr.value,
             metadata_name,
             ctx.label.name,
+            ctx.attr.root_pth_name,
         ],
     )
     site_packages = "/".join([
@@ -65,6 +71,7 @@ printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
     ] + ["lib/python{}.{}/site-packages".format(major, minor)])
     wheel = struct(
         top_levels = top_levels,
+        layout_complete = ctx.attr.layout_complete,
         namespace_top_levels = namespace_top_levels,
         namespace_entries = namespace_entries,
         namespace_dirs = (),
@@ -91,9 +98,11 @@ printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
 _wheel = rule(
     implementation = _wheel_impl,
     attrs = {
+        "layout_complete": attr.bool(default = True),
         "metadata_name": attr.string(),
         "metadata_only": attr.bool(),
         "ordinary": attr.bool(),
+        "root_pth_name": attr.string(),
         "value": attr.string(mandatory = True),
     },
     toolchains = [PY_TOOLCHAIN],
@@ -212,6 +221,90 @@ def collision_order_test_suite():
         deps = [
             ":_metadata_suppressible_first",
             ":_metadata_suppressible_second",
+        ],
+    )
+
+    _wheel(
+        name = "_collision_incomplete",
+        layout_complete = False,
+        ordinary = True,
+        tags = ["manual"],
+        value = "incomplete",
+    )
+    py_binary(
+        name = "_incomplete_collision_error_binary",
+        srcs = ["test_collision_order.py"],
+        main = "test_collision_order.py",
+        package_collisions = "error",
+        tags = ["manual"],
+        deps = [
+            ":_collision_first",
+            ":_collision_incomplete",
+        ],
+    )
+    _collision_error_test(
+        name = "incomplete_collision_error_test",
+        expected_error = "namespace entry `collision_namespace/shared.py`",
+        target_under_test = ":_incomplete_collision_error_binary",
+    )
+
+    _wheel(
+        name = "_pth_collision_complete",
+        metadata_only = True,
+        root_pth_name = "collision_marker",
+        tags = ["manual"],
+        value = "complete",
+    )
+    _wheel(
+        name = "_pth_collision_incomplete",
+        layout_complete = False,
+        metadata_only = True,
+        root_pth_name = "collision_marker",
+        tags = ["manual"],
+        value = "pth_incomplete",
+    )
+    py_binary(
+        name = "_incomplete_pth_collision_error_binary",
+        srcs = ["test_namespace_fallback.py"],
+        main = "test_namespace_fallback.py",
+        package_collisions = "error",
+        tags = ["manual"],
+        deps = [
+            ":_pth_collision_incomplete",
+            ":_pth_collision_complete",
+        ],
+    )
+    _collision_error_test(
+        name = "incomplete_pth_collision_error_test",
+        expected_error = "root `.pth` file `collision_marker.pth` selects",
+        target_under_test = ":_incomplete_pth_collision_error_binary",
+    )
+
+    _wheel(
+        name = "_pth_runtime_complete_loser",
+        metadata_only = True,
+        root_pth_name = "runtime_collision_marker",
+        tags = ["manual"],
+        value = "suppressed",
+    )
+    _wheel(
+        name = "_pth_runtime_incomplete",
+        layout_complete = False,
+        metadata_only = True,
+        root_pth_name = "runtime_collision_marker",
+        tags = ["manual"],
+        value = "incomplete",
+    )
+    py_test(
+        name = "incomplete_layout_pth_test",
+        srcs = ["test_incomplete_layout_pth.py"],
+        isolated = False,
+        main = "test_incomplete_layout_pth.py",
+        package_collisions = "ignore",
+        deps = [
+            ":_pth_collision_complete",
+            ":_pth_runtime_complete_loser",
+            ":_pth_runtime_incomplete",
         ],
     )
 

--- a/py/tests/py_venv_conflict/site_merge_order_test.bzl
+++ b/py/tests/py_venv_conflict/site_merge_order_test.bzl
@@ -106,6 +106,7 @@ printf 'VALUE = %s\n' "$4" > "$site/other/from_final.py"
         site_packages_paths.append(site_packages)
         wheels.append(struct(
             top_levels = top_levels,
+            layout_complete = True,
             namespace_top_levels = top_levels,
             namespace_entries = namespace_entries,
             namespace_dirs = namespace_dirs,

--- a/py/tests/py_venv_conflict/test_incomplete_layout_pth.py
+++ b/py/tests/py_venv_conflict/test_incomplete_layout_pth.py
@@ -1,0 +1,17 @@
+import sys
+
+
+complete_count = sys.path.count("rules_py_pth_complete")
+incomplete_count = sys.path.count("rules_py_pth_incomplete")
+suppressed_count = sys.path.count("rules_py_pth_suppressed")
+
+assert complete_count > 0, "complete-layout root .pth did not execute"
+assert suppressed_count == 0, (
+    "losing complete-layout root .pth was not suppressed",
+    suppressed_count,
+)
+assert incomplete_count == complete_count, (
+    "incomplete layout added root .pth executions",
+    complete_count,
+    incomplete_count,
+)

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -176,6 +176,7 @@ def main():
     ap.add_argument("--patch", dest="patches", action="append", default=[], type=Path)
     ap.add_argument("--patch-strip", type=int, default=0)
     ap.add_argument("--patch-tool", type=Path, default=Path("patch"))
+    ap.add_argument("--preserve-path", action="append", default=[])
     ap.add_argument("--compile-pyc", action="store_true")
     ap.add_argument("--pyc-invalidation-mode", default="checked-hash",
                     choices=["checked-hash", "unchecked-hash", "timestamp"])
@@ -188,6 +189,27 @@ def main():
         args.into,
         args.wheel,
     )
+
+    site_packages = (
+        args.into / "lib"
+        / "python{}.{}".format(args.python_version_major, args.python_version_minor)
+        / "site-packages"
+    )
+    # Analysis uses these paths for collision and merge planning. Snapshot their
+    # installed shape here, where both the before and after states are available.
+    observed_files = []
+    observed_directory_init = {}
+    for relative_string in args.preserve_path:
+        relative = Path(relative_string)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise SystemExit("Invalid preserved wheel path: {}".format(relative))
+        path = site_packages / relative
+        if path.is_dir():
+            observed_directory_init[relative] = (path / "__init__.py").is_file()
+        elif path.is_file():
+            observed_files.append(relative)
+        else:
+            raise SystemExit("Preserved wheel path does not exist: {}".format(relative))
 
     for patch_file in args.patches:
         # --no-backup-if-mismatch: a fuzz/offset apply otherwise drops a
@@ -210,14 +232,25 @@ def main():
                 "Error: failed to apply patch {} (patch exited {}).".format(patch_file, r.returncode)
             )
 
+    for relative in observed_files:
+        if not (site_packages / relative).is_file():
+            raise SystemExit(
+                "Post-install patch changed observed wheel file: {}".format(relative)
+            )
+    for relative, had_init in observed_directory_init.items():
+        directory = site_packages / relative
+        if not directory.is_dir():
+            raise SystemExit(
+                "Post-install patch changed observed wheel directory: {}".format(relative)
+            )
+        if (directory / "__init__.py").is_file() != had_init:
+            raise SystemExit(
+                "Post-install patch changed observed package classification: {}".format(relative)
+            )
+
     if args.compile_pyc:
         if not args.python:
             raise SystemExit("--python is required when --compile-pyc is set")
-        site_packages = (
-            args.into / "lib"
-            / "python{}.{}".format(args.python_version_major, args.python_version_minor)
-            / "site-packages"
-        )
         # Wheels may retain source for older Python versions. Match pip by
         # retaining compileall's diagnostics while ignoring its aggregate
         # false result; check=True still rejects abnormal interpreter exits.

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -62,23 +62,26 @@ def _run_unpack(
     wheel: Path,
     output: Path,
     python: Path,
+    extra_args: tuple[str, ...] = (),
 ) -> subprocess.CompletedProcess:
+    command = [
+        sys.executable,
+        str(unpack),
+        "--into",
+        str(output),
+        "--wheel",
+        str(wheel),
+        "--python-version-major",
+        str(sys.version_info.major),
+        "--python-version-minor",
+        str(sys.version_info.minor),
+        "--compile-pyc",
+        "--python",
+        str(python),
+        *extra_args,
+    ]
     return subprocess.run(
-        [
-            sys.executable,
-            str(unpack),
-            "--into",
-            str(output),
-            "--wheel",
-            str(wheel),
-            "--python-version-major",
-            str(sys.version_info.major),
-            "--python-version-minor",
-            str(sys.version_info.minor),
-            "--compile-pyc",
-            "--python",
-            str(python),
-        ],
+        command,
         capture_output=True,
         text=True,
     )
@@ -103,6 +106,118 @@ def main() -> None:
             / "site-packages"
         )
         assert next((site_packages / "fixture" / "__pycache__").glob("*.pyc"))
+
+        site_packages_relative = (
+            f"lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages"
+        )
+        namespace_wheel = root / "namespace_fixture-1.0-py3-none-any.whl"
+        _write_wheel(
+            namespace_wheel,
+            "namespace_fixture",
+            {"fixture_ns/mod.py": b"VALUE = 1\n"},
+        )
+        add_init_patch = root / "add-init.patch"
+        add_init_patch.write_text(
+            f"""\
+--- /dev/null
++++ b/{site_packages_relative}/fixture_ns/__init__.py
+@@ -0,0 +1 @@
++VALUE = 1
+"""
+        )
+        reclassified = _run_unpack(
+            unpack,
+            namespace_wheel,
+            root / "reclassified-layout",
+            Path(sys.executable),
+            (
+                "--patch",
+                str(add_init_patch),
+                "--patch-strip",
+                "1",
+                "--preserve-path",
+                "fixture_ns",
+            ),
+        )
+        assert reclassified.returncode != 0, reclassified.stdout + reclassified.stderr
+        assert "changed observed package classification: fixture_ns" in reclassified.stderr
+
+        # BSD and GNU patch differ in whether a deletion diff removes the empty
+        # file. Use a controlled patch executable for topology transitions that
+        # must behave identically on every test host.
+        mutation_tool = root / "mutate_tree.py"
+        mutation_tool.write_text(
+            f"""#!{sys.executable}
+import shutil
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[sys.argv.index("-d") + 1])
+operation, relative = sys.stdin.read().splitlines()
+target = root / relative
+if operation == "unlink":
+    target.unlink()
+elif operation == "file-to-directory":
+    target.unlink()
+    target.mkdir()
+elif operation == "directory-to-file":
+    shutil.rmtree(target)
+    target.write_text("replacement\\n")
+else:
+    raise SystemExit(f"unknown operation: {{operation}}")
+"""
+        )
+        mutation_tool.chmod(0o755)
+        for name, operation, changed_path, preserved_path, expected_error in [
+            (
+                "removed-file",
+                "unlink",
+                "fixture/mod.py",
+                "fixture/mod.py",
+                "changed observed wheel file: fixture/mod.py",
+            ),
+            (
+                "file-to-directory",
+                "file-to-directory",
+                "fixture/mod.py",
+                "fixture/mod.py",
+                "changed observed wheel file: fixture/mod.py",
+            ),
+            (
+                "regular-to-namespace",
+                "unlink",
+                "fixture/__init__.py",
+                "fixture",
+                "changed observed package classification: fixture",
+            ),
+            (
+                "directory-to-file",
+                "directory-to-file",
+                "fixture",
+                "fixture",
+                "changed observed wheel directory: fixture",
+            ),
+        ]:
+            mutation = root / f"{name}.patch"
+            mutation.write_text(
+                f"{operation}\n{site_packages_relative}/{changed_path}\n"
+            )
+            rejected = _run_unpack(
+                unpack,
+                good_wheel,
+                root / name,
+                Path(sys.executable),
+                (
+                    "--patch",
+                    str(mutation),
+                    "--patch-tool",
+                    str(mutation_tool),
+                    "--preserve-path",
+                    preserved_path,
+                ),
+            )
+            assert rejected.returncode != 0, rejected.stdout + rejected.stderr
+            assert expected_error in rejected.stderr
 
         # Wheels may retain source for older interpreters. Compatible modules
         # still compile, while the incompatible file remains diagnostic.

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -50,6 +50,26 @@ def _whl_install(ctx):
 
     archive = ctx.file.src
     unpack_script = ctx.file._unpack_script
+
+    # Source-built wheels cannot be inspected during repository evaluation.
+    # Prebuilt wheel metadata is keyed by basename and selected for the active
+    # configuration; metadata from inactive platform wheels must not leak in.
+    if SourceBuiltWheelInfo in ctx.attr.src:
+        top_levels = []
+        namespace_top_levels = []
+        namespace_entries = []
+        namespace_dirs = []
+        regular_roots = []
+        console_scripts = ctx.attr.src[SourceBuiltWheelInfo].console_scripts
+    else:
+        whl_basename = archive.basename
+        top_levels = ctx.attr.top_levels.get(whl_basename, [])
+        namespace_top_levels = ctx.attr.namespace_top_levels.get(whl_basename, [])
+        namespace_entries = ctx.attr.namespace_entries.get(whl_basename, [])
+        namespace_dirs = ctx.attr.namespace_dirs.get(whl_basename, [])
+        regular_roots = ctx.attr.regular_roots.get(whl_basename, [])
+        console_scripts = ctx.attr.console_scripts.get(whl_basename, [])
+
     arguments = ctx.actions.args()
     arguments.add(unpack_script)
     arguments.add_all([install_dir], expand_directories = False, before_each = "--into")
@@ -67,6 +87,13 @@ def _whl_install(ctx):
     if patch_files:
         arguments.add("--patch-strip", str(ctx.attr.patch_strip))
         arguments.add_all(patch_files, before_each = "--patch")
+        arguments.add_all(
+            sorted({
+                path: None
+                for path in top_levels + namespace_entries + namespace_dirs + regular_roots
+            }),
+            before_each = "--preserve-path",
+        )
         transitive_inputs.append(depset(patch_files))
 
     # Optional .pyc pre-compilation (runs after patching).
@@ -132,38 +159,17 @@ def _whl_install(ctx):
         ),
     ]
 
-    # Per-configuration metadata selection: `src` resolves (through the
-    # repo rule's select_chain) to exactly one wheel for the active
-    # configuration, and the metadata attrs are dicts keyed by wheel file
-    # basename. Looking up the resolved wheel at analysis time limits the
-    # advertised package surface (top-levels, console scripts) to the
-    # wheel that is actually installed — metadata from inactive platform
-    # wheels must not leak in (e.g. another platform's C-extension
-    # suffix, or a console script shipped only by the win32 wheel).
-    # Source-built wheels cannot be inspected during repository evaluation.
-    # Check their provenance before using the output basename: a custom source
-    # producer may reuse a locked bdist's filename, but its topology is still
-    # unknown. PyWheelsInfo always carries the install tree so venv and image
-    # consumers retain the wheel.
-    if SourceBuiltWheelInfo in ctx.attr.src:
-        top_levels = []
-        namespace_top_levels = []
-        namespace_entries = []
-        namespace_dirs = []
-        regular_roots = []
-        console_scripts = ctx.attr.src[SourceBuiltWheelInfo].console_scripts
-    else:
-        whl_basename = ctx.file.src.basename
-        top_levels = ctx.attr.top_levels.get(whl_basename, [])
-        namespace_top_levels = ctx.attr.namespace_top_levels.get(whl_basename, [])
-        namespace_entries = ctx.attr.namespace_entries.get(whl_basename, [])
-        namespace_dirs = ctx.attr.namespace_dirs.get(whl_basename, [])
-        regular_roots = ctx.attr.regular_roots.get(whl_basename, [])
-        console_scripts = ctx.attr.console_scripts.get(whl_basename, [])
+    # Repository metadata describes the wheel before post-install patches run.
+    # Patches may add paths, but the install action preserves every original
+    # path used for collision and merge planning, including its kind and package
+    # classification. Mark the layout incomplete so venv assembly also keeps
+    # the whole-wheel fallback for additions.
+    layout_complete = bool(top_levels) and not patch_files
 
     providers.append(PyWheelsInfo(
         wheels = depset(direct = [struct(
             top_levels = tuple(top_levels),
+            layout_complete = layout_complete,
             # PEP 420 namespace packages this wheel contributes to.
             # When multiple wheels claim the same top-level and ALL of
             # them flag it as namespace, py_binary merges the namespace

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -234,6 +234,33 @@ _CONSOLE_SCRIPTS = {
     ],
 }
 
+_NAMESPACE_ENTRIES = {
+    _MACOS_WHL: [
+        "demo_ns/part",
+        "demo_ns/plain.py",
+    ],
+}
+
+_NAMESPACE_DIRS = {
+    _MACOS_WHL: ["demo_ns/nested"],
+}
+
+_REGULAR_ROOTS = {
+    # Deliberately duplicates a namespace entry; the action should preserve
+    # each analysis-visible path exactly once.
+    _MACOS_WHL: ["demo_ns/part"],
+}
+
+_PATCHED_PRESERVE_PATHS = [
+    "_demo_backend.cpython-311-darwin.so",
+    "demo",
+    "demo-1.0.0.dist-info",
+    "demo_ns",
+    "demo_ns/nested",
+    "demo_ns/part",
+    "demo_ns/plain.py",
+]
+
 def _metadata_selection_test_impl(ctx):
     env = analysistest.begin(ctx)
     target = analysistest.target_under_test(env)
@@ -243,6 +270,7 @@ def _metadata_selection_test_impl(ctx):
 
     wheel = wheels[0]
     asserts.true(env, wheel.install_tree != None, "wheel record must retain its install tree")
+    asserts.equals(env, ctx.attr.expected_layout_complete, wheel.layout_complete)
     asserts.equals(env, tuple(ctx.attr.expected_top_levels), wheel.top_levels)
     asserts.equals(env, tuple(ctx.attr.expected_namespace_top_levels), wheel.namespace_top_levels)
     asserts.equals(env, tuple(ctx.attr.expected_console_scripts), wheel.console_scripts)
@@ -262,16 +290,29 @@ def _metadata_selection_test_impl(ctx):
             "console script '{}' from an inactive platform wheel leaked into the selected wheel's surface".format(leaked),
         )
 
+    if ctx.attr.expected_preserve_paths:
+        build_actions = [a for a in target.actions if a.mnemonic == "WhlInstall"]
+        asserts.equals(env, 1, len(build_actions), "expected exactly one WhlInstall action")
+        argv = build_actions[0].argv
+        preserve_paths = [
+            argv[i + 1]
+            for i in range(len(argv) - 1)
+            if argv[i] == "--preserve-path"
+        ]
+        asserts.equals(env, ctx.attr.expected_preserve_paths, preserve_paths)
+
     return analysistest.end(env)
 
 _metadata_selection_test = analysistest.make(
     _metadata_selection_test_impl,
     attrs = {
+        "expected_layout_complete": attr.bool(),
         "expected_top_levels": attr.string_list(),
         "expected_namespace_top_levels": attr.string_list(),
         "expected_console_scripts": attr.string_list(),
         "leaked_top_levels": attr.string_list(),
         "leaked_console_scripts": attr.string_list(),
+        "expected_preserve_paths": attr.string_list(),
     },
 )
 
@@ -308,6 +349,25 @@ def metadata_selection_test_suite(name):
         tags = ["manual"],
     )
 
+    write_file(
+        name = "__metadata_noop_patch",
+        out = "metadata_noop.patch",
+        content = [""],
+        tags = ["manual"],
+    )
+    whl_install(
+        name = "__metadata_patched_fixture",
+        src = _MACOS_WHL,
+        console_scripts = _CONSOLE_SCRIPTS,
+        namespace_dirs = _NAMESPACE_DIRS,
+        namespace_entries = _NAMESPACE_ENTRIES,
+        namespace_top_levels = _NAMESPACE_TOP_LEVELS,
+        patches = [":__metadata_noop_patch"],
+        regular_roots = _REGULAR_ROOTS,
+        tags = ["manual"],
+        top_levels = _TOP_LEVELS,
+    )
+
     for fixture_name, src in [
         ("__metadata_linux_fixture", _LINUX_WHL),
         ("__metadata_macos_fixture", _MACOS_WHL),
@@ -336,6 +396,7 @@ def metadata_selection_test_suite(name):
     _metadata_selection_test(
         name = name + "_linux_test",
         target_under_test = ":__metadata_linux_fixture",
+        expected_layout_complete = True,
         expected_top_levels = _TOP_LEVELS[_LINUX_WHL],
         expected_namespace_top_levels = [],
         expected_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
@@ -349,6 +410,7 @@ def metadata_selection_test_suite(name):
     _metadata_selection_test(
         name = name + "_macos_test",
         target_under_test = ":__metadata_macos_fixture",
+        expected_layout_complete = True,
         expected_top_levels = _TOP_LEVELS[_MACOS_WHL],
         expected_namespace_top_levels = _NAMESPACE_TOP_LEVELS[_MACOS_WHL],
         expected_console_scripts = _CONSOLE_SCRIPTS[_MACOS_WHL],
@@ -359,6 +421,7 @@ def metadata_selection_test_suite(name):
     _metadata_selection_test(
         name = name + "_sbuild_fallback_test",
         target_under_test = ":__metadata_sbuild_fixture",
+        expected_layout_complete = False,
         expected_top_levels = [],
         expected_namespace_top_levels = [],
         expected_console_scripts = [],
@@ -369,11 +432,24 @@ def metadata_selection_test_suite(name):
     _metadata_selection_test(
         name = name + "_declared_sbuild_test",
         target_under_test = ":__metadata_declared_sbuild_fixture",
+        expected_layout_complete = False,
         expected_top_levels = [],
         expected_namespace_top_levels = [],
         expected_console_scripts = _DECLARED_SBUILD_CONSOLE_SCRIPTS,
         leaked_top_levels = _TOP_LEVELS[_LINUX_WHL],
         leaked_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
+    )
+
+    _metadata_selection_test(
+        name = name + "_patched_test",
+        target_under_test = ":__metadata_patched_fixture",
+        expected_console_scripts = _CONSOLE_SCRIPTS[_MACOS_WHL],
+        expected_layout_complete = False,
+        expected_namespace_top_levels = _NAMESPACE_TOP_LEVELS[_MACOS_WHL],
+        expected_preserve_paths = _PATCHED_PRESERVE_PATHS,
+        expected_top_levels = _TOP_LEVELS[_MACOS_WHL],
+        leaked_console_scripts = [],
+        leaked_top_levels = [],
     )
 
 def whl_install_suite():


### PR DESCRIPTION
Post-install patches run after repository analysis records a wheel's
layout. A downstream rules_py 2 upgrade patched a wheel that also
participates in package merges. Treating the pre-patch snapshot as
complete hides added paths; discarding it loses collision checks and
package merges for unchanged paths.

Mark patched layouts incomplete and retain whole-wheel fallback for
patch-added paths. Preserve observed topology for collision and merge
planning. Reject patches that change an observed path's file or
directory kind or package classification.

Keep original root `.pth` files and distribution metadata under one
runtime owner. Reject only collisions that leave unsuppressible fallback
copies. Console-script declarations remain pre-patch metadata.
