### PR TITLE
fix(uv): describe installed wheel topology

### DIFF
--- a/e2e/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
+++ b/e2e/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
@@ -115,6 +115,44 @@ whl_install(
             "cffi-2.0.0.dist-info",
         ],
     },
+    regular_directory_top_levels = {
+        "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-win32.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-win_amd64.whl": [
+            "cffi",
+        ],
+        "cffi-2.0.0-cp312-cp312-win_arm64.whl": [
+            "cffi",
+        ],
+    },
     namespace_top_levels = {},
     console_scripts = {},
     visibility = ["//visibility:private"],

--- a/e2e/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
+++ b/e2e/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
@@ -340,6 +340,92 @@ whl_install(
             "cryptography-46.0.5.dist-info",
         ],
     },
+    regular_directory_top_levels = {
+        "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-win32.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp311-abi3-win_amd64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-win32.whl": [
+            "cryptography",
+        ],
+        "cryptography-46.0.5-cp38-abi3-win_amd64.whl": [
+            "cryptography",
+        ],
+    },
     namespace_top_levels = {
         "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl": [
             "cryptography.libs",

--- a/e2e/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
+++ b/e2e/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
@@ -242,6 +242,128 @@ whl_install(
             "grpcio-1.80.0.dist-info",
         ],
     },
+    regular_directory_top_levels = {
+        "grpcio-1.80.0-cp311-cp311-linux_armv7l.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-win32.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp311-cp311-win_amd64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-linux_armv7l.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-win32.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp312-cp312-win_amd64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-linux_armv7l.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-win32.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp313-cp313-win_amd64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-linux_armv7l.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-win32.whl": [
+            "grpc",
+        ],
+        "grpcio-1.80.0-cp314-cp314-win_amd64.whl": [
+            "grpc",
+        ],
+    },
     namespace_top_levels = {},
     console_scripts = {},
     visibility = ["//visibility:private"],

--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -20,6 +20,9 @@ handling gives the later distinct element in the flattened sequence precedence.
 Duplicate dependency edges do not create another precedence position. Fields:
   * `top_levels`: tuple[str] — complete set of immediate `site-packages`
     entry names when nonempty; an empty tuple means the layout is unknown.
+  * `regular_directory_top_levels`: tuple[str] — regular top-level packages
+    positively known to be directories in the inspected wheel archive. An
+    unlisted name or absent field is unknown, not evidence of a file.
   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.
   * `namespace_entries`: tuple[str] — `/`-joined paths of the concrete entries beneath
     the namespace top-levels (e.g. `jaraco/functools`), used to materialise a merged

--- a/uv/private/uv_hub/snapshots/whl_install.attrs.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/whl_install.attrs.BUILD.bazel
@@ -48,6 +48,12 @@ whl_install(
             "attrs-23.2.0.dist-info",
         ],
     },
+    regular_directory_top_levels = {
+        "attrs-23.2.0-py3-none-any.whl": [
+            "attr",
+            "attrs",
+        ],
+    },
     namespace_top_levels = {},
     console_scripts = {},
     visibility = ["//visibility:private"],

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -685,6 +685,7 @@ filegroup(
         whl_file_index += 1
 
     top_levels_by_whl = {}
+    regular_directory_top_levels_by_whl = {}
     namespace_top_levels_by_whl = {}
     namespace_entries_by_whl = {}
     namespace_dirs_by_whl = {}
@@ -699,6 +700,13 @@ filegroup(
         )
         if tls:
             top_levels_by_whl[whl_name] = sorted(tls.keys())
+            regular_directories = sorted([
+                tl
+                for tl in tls
+                if tl in regular and tl in dirs_set
+            ])
+            if regular_directories:
+                regular_directory_top_levels_by_whl[whl_name] = regular_directories
 
             # A top-level counts as a PEP 420 namespace for this wheel if
             # its RECORD shows no `<toplevel>/__init__.py` at depth 1.
@@ -734,16 +742,24 @@ filegroup(
         if css:
             console_scripts_by_whl[whl_name] = sorted(css.values())
 
+    regular_directory_top_levels_attr = ""
+    if regular_directory_top_levels_by_whl:
+        regular_directory_top_levels_attr = """
+    regular_directory_top_levels = {regular_directory_top_levels},""".format(
+            regular_directory_top_levels = indent(pprint(regular_directory_top_levels_by_whl), " " * 4).lstrip(),
+        )
+
     install_attrs = """
     src = ":whl",
     compile_pyc = {compile_pyc},
     pyc_invalidation_mode = {pyc_invalidation_mode},
-    top_levels = {top_levels},
+    top_levels = {top_levels},{regular_directory_top_levels_attr}
     namespace_top_levels = {namespace_top_levels},
     console_scripts = {console_scripts},""".format(
         compile_pyc = compile_pyc_select,
         pyc_invalidation_mode = pyc_invalidation_mode_select,
         top_levels = indent(pprint(top_levels_by_whl), " " * 4).lstrip(),
+        regular_directory_top_levels_attr = regular_directory_top_levels_attr,
         namespace_top_levels = indent(pprint(namespace_top_levels_by_whl), " " * 4).lstrip(),
         console_scripts = indent(pprint(console_scripts_by_whl), " " * 4).lstrip(),
     )

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -147,6 +147,7 @@ def _whl_install(ctx):
     # consumers retain the wheel.
     if SourceBuiltWheelInfo in ctx.attr.src:
         top_levels = []
+        regular_directory_top_levels = []
         namespace_top_levels = []
         namespace_entries = []
         namespace_dirs = []
@@ -155,6 +156,9 @@ def _whl_install(ctx):
     else:
         whl_basename = ctx.file.src.basename
         top_levels = ctx.attr.top_levels.get(whl_basename, [])
+        regular_directory_top_levels = (
+            [] if patch_files else ctx.attr.regular_directory_top_levels.get(whl_basename, [])
+        )
         namespace_top_levels = ctx.attr.namespace_top_levels.get(whl_basename, [])
         namespace_entries = ctx.attr.namespace_entries.get(whl_basename, [])
         namespace_dirs = ctx.attr.namespace_dirs.get(whl_basename, [])
@@ -164,6 +168,7 @@ def _whl_install(ctx):
     providers.append(PyWheelsInfo(
         wheels = depset(direct = [struct(
             top_levels = tuple(top_levels),
+            regular_directory_top_levels = tuple(regular_directory_top_levels),
             # PEP 420 namespace packages this wheel contributes to.
             # When multiple wheels claim the same top-level and ALL of
             # them flag it as namespace, py_binary merges the namespace
@@ -262,6 +267,16 @@ consumers such as image layering.
 
 Typically populated automatically by the `whl_install` repo rule from each
 wheel's `*.dist-info/RECORD` at repo-fetch time.
+""",
+            default = {},
+        ),
+        "regular_directory_top_levels": attr.string_list_dict(
+            doc = """Per-wheel regular top-level packages that are directories, keyed by wheel file basename.
+
+The repository rule derives this positive evidence from each wheel archive's
+`RECORD`. It is discarded when post-install patches may invalidate the
+archive topology. Only the entry matching the selected wheel (see `top_levels`)
+is used.
 """,
             default = {},
         ),

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -222,6 +222,11 @@ _TOP_LEVELS = {
     ],
 }
 
+_REGULAR_DIRECTORY_TOP_LEVELS = {
+    _LINUX_WHL: ["demo"],
+    _MACOS_WHL: ["demo"],
+}
+
 _NAMESPACE_TOP_LEVELS = {
     _MACOS_WHL: ["demo_ns"],
 }
@@ -244,6 +249,11 @@ def _metadata_selection_test_impl(ctx):
     wheel = wheels[0]
     asserts.true(env, wheel.install_tree != None, "wheel record must retain its install tree")
     asserts.equals(env, tuple(ctx.attr.expected_top_levels), wheel.top_levels)
+    asserts.equals(
+        env,
+        tuple(ctx.attr.expected_regular_directory_top_levels),
+        wheel.regular_directory_top_levels,
+    )
     asserts.equals(env, tuple(ctx.attr.expected_namespace_top_levels), wheel.namespace_top_levels)
     asserts.equals(env, tuple(ctx.attr.expected_console_scripts), wheel.console_scripts)
 
@@ -267,6 +277,7 @@ def _metadata_selection_test_impl(ctx):
 _metadata_selection_test = analysistest.make(
     _metadata_selection_test_impl,
     attrs = {
+        "expected_regular_directory_top_levels": attr.string_list(),
         "expected_top_levels": attr.string_list(),
         "expected_namespace_top_levels": attr.string_list(),
         "expected_console_scripts": attr.string_list(),
@@ -300,6 +311,13 @@ def metadata_selection_test_suite(name):
         tags = ["manual"],
     )
 
+    write_file(
+        name = "__metadata_noop_patch",
+        out = "metadata_noop.patch",
+        content = [""],
+        tags = ["manual"],
+    )
+
     source_built_wheel(
         name = "__metadata_declared_sbuild_wheel",
         testonly = True,
@@ -317,6 +335,7 @@ def metadata_selection_test_suite(name):
             name = fixture_name,
             testonly = True,
             src = src,
+            regular_directory_top_levels = _REGULAR_DIRECTORY_TOP_LEVELS,
             top_levels = _TOP_LEVELS,
             namespace_top_levels = _NAMESPACE_TOP_LEVELS,
             console_scripts = _CONSOLE_SCRIPTS,
@@ -324,9 +343,20 @@ def metadata_selection_test_suite(name):
         )
 
     whl_install(
+        name = "__metadata_patched_fixture",
+        testonly = True,
+        src = _MACOS_WHL,
+        patches = [":__metadata_noop_patch"],
+        regular_directory_top_levels = _REGULAR_DIRECTORY_TOP_LEVELS,
+        top_levels = _TOP_LEVELS,
+        tags = ["manual"],
+    )
+
+    whl_install(
         name = "__metadata_declared_sbuild_fixture",
         testonly = True,
         src = ":__metadata_declared_sbuild_wheel",
+        regular_directory_top_levels = _REGULAR_DIRECTORY_TOP_LEVELS,
         top_levels = _TOP_LEVELS,
         namespace_top_levels = _NAMESPACE_TOP_LEVELS,
         console_scripts = _CONSOLE_SCRIPTS,
@@ -336,6 +366,7 @@ def metadata_selection_test_suite(name):
     _metadata_selection_test(
         name = name + "_linux_test",
         target_under_test = ":__metadata_linux_fixture",
+        expected_regular_directory_top_levels = _REGULAR_DIRECTORY_TOP_LEVELS[_LINUX_WHL],
         expected_top_levels = _TOP_LEVELS[_LINUX_WHL],
         expected_namespace_top_levels = [],
         expected_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
@@ -349,6 +380,7 @@ def metadata_selection_test_suite(name):
     _metadata_selection_test(
         name = name + "_macos_test",
         target_under_test = ":__metadata_macos_fixture",
+        expected_regular_directory_top_levels = _REGULAR_DIRECTORY_TOP_LEVELS[_MACOS_WHL],
         expected_top_levels = _TOP_LEVELS[_MACOS_WHL],
         expected_namespace_top_levels = _NAMESPACE_TOP_LEVELS[_MACOS_WHL],
         expected_console_scripts = _CONSOLE_SCRIPTS[_MACOS_WHL],
@@ -359,6 +391,7 @@ def metadata_selection_test_suite(name):
     _metadata_selection_test(
         name = name + "_sbuild_fallback_test",
         target_under_test = ":__metadata_sbuild_fixture",
+        expected_regular_directory_top_levels = [],
         expected_top_levels = [],
         expected_namespace_top_levels = [],
         expected_console_scripts = [],
@@ -369,11 +402,23 @@ def metadata_selection_test_suite(name):
     _metadata_selection_test(
         name = name + "_declared_sbuild_test",
         target_under_test = ":__metadata_declared_sbuild_fixture",
+        expected_regular_directory_top_levels = [],
         expected_top_levels = [],
         expected_namespace_top_levels = [],
         expected_console_scripts = _DECLARED_SBUILD_CONSOLE_SCRIPTS,
         leaked_top_levels = _TOP_LEVELS[_LINUX_WHL],
         leaked_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
+    )
+
+    _metadata_selection_test(
+        name = name + "_patched_test",
+        target_under_test = ":__metadata_patched_fixture",
+        expected_regular_directory_top_levels = [],
+        expected_top_levels = _TOP_LEVELS[_MACOS_WHL],
+        expected_namespace_top_levels = [],
+        expected_console_scripts = [],
+        leaked_top_levels = [],
+        leaked_console_scripts = [],
     )
 
 def whl_install_suite():


### PR DESCRIPTION
Wheel repository analysis records every immediate `site-packages`
entry, but `PyWheelsInfo` does not preserve which regular packages are
directories. Venv analysis must choose between a symlink and a tree
artifact before an action runs, so it cannot safely merge colliding
package directories from names alone.

PEP 420 namespaces already have dedicated directory metadata. Carry only
regular top-level directories as positive pre-patch evidence for the
selected wheel. Source-built and patched wheels, absent fields, and
unlisted names remain unknown.

This lets consumers distinguish mergeable directory collisions without
classifying modules such as `CHANGELOG.md` as tree artifacts or
expanding the public `py_unpacked_wheel` API.