### PR TITLE
fix: physically merge mixed namespace/regular top-level collisions

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -142,5 +142,6 @@ include("//cases/uv-whl-install-output-group:setup.MODULE.bazel")
 include("//cases/uv-workspace-789:setup.MODULE.bazel")
 include("//cases/venv-bin-scripts-423:setup.MODULE.bazel")
 include("//cases/venv-internal-symlinks:setup.MODULE.bazel")
+include("//cases/xds-otel-namespace-1118:setup.MODULE.bazel")
 
 register_toolchains("@uv//:all")

--- a/e2e/cases/xds-otel-namespace-1118/BUILD.bazel
+++ b/e2e/cases/xds-otel-namespace-1118/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+# Regression: xds-protos ships opentelemetry/__init__.py (0 bytes, legacy
+# namespace stub) while opentelemetry-sdk treats `opentelemetry` as a PEP 420
+# namespace. Rules_py must physically merge the top-level directory so both
+# wheels' content is reachable — matching the behaviour of a flat pip install.
+#
+# test      — verifies runtime imports work
+# test_venv — expose_venv mode; verifies the merged layout in site-packages
+
+py_test(
+    name = "test",
+    srcs = ["test.py"],
+    dep_group = "xds-otel-namespace-1118",
+    main = "test.py",
+    deps = [
+        "@pypi_xds_otel_namespace_1118//opentelemetry_sdk",
+        "@pypi_xds_otel_namespace_1118//xds_protos",
+    ],
+)
+
+py_test(
+    name = "test_venv",
+    srcs = ["test.py"],
+    dep_group = "xds-otel-namespace-1118",
+    expose_venv = True,
+    isolated = False,
+    main = "test.py",
+    package_collisions = "warning",
+    python_version = "3.11",
+    deps = [
+        "@pypi_xds_otel_namespace_1118//opentelemetry_sdk",
+        "@pypi_xds_otel_namespace_1118//xds_protos",
+    ],
+)

--- a/e2e/cases/xds-otel-namespace-1118/BUILD.bazel
+++ b/e2e/cases/xds-otel-namespace-1118/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@aspect_rules_py//py:defs.bzl", "py_test")
 
-# Regression: xds-protos ships opentelemetry/__init__.py (0 bytes, legacy
-# namespace stub) while opentelemetry-sdk treats `opentelemetry` as a PEP 420
-# namespace. Rules_py must physically merge the top-level directory so both
-# wheels' content is reachable — matching the behaviour of a flat pip install.
+# Regression: xds-protos ships opentelemetry/__init__.py while
+# opentelemetry-sdk treats `opentelemetry` as a PEP 420 namespace. Rules_py
+# must physically merge the top-level directory so both wheels' content is
+# reachable — matching the behaviour of a flat pip install.
 #
 # test      — verifies runtime imports work
 # test_venv — expose_venv mode; verifies the merged layout in site-packages

--- a/e2e/cases/xds-otel-namespace-1118/pyproject.toml
+++ b/e2e/cases/xds-otel-namespace-1118/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "xds-otel-namespace-1118"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "opentelemetry-sdk==1.39.0",
+    "xds-protos==1.73.1",
+]

--- a/e2e/cases/xds-otel-namespace-1118/setup.MODULE.bazel
+++ b/e2e/cases/xds-otel-namespace-1118/setup.MODULE.bazel
@@ -1,0 +1,14 @@
+"""Regression: mixed namespace/regular top-level collision (#1118).
+
+xds-protos ships opentelemetry/__init__.py (empty stub) while opentelemetry-sdk
+treats `opentelemetry` as a PEP 420 namespace package.
+"""
+
+uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
+uv.declare_hub(hub_name = "pypi_xds_otel_namespace_1118")
+uv.project(
+    hub_name = "pypi_xds_otel_namespace_1118",
+    lock = "//cases/xds-otel-namespace-1118:uv.lock",
+    pyproject = "//cases/xds-otel-namespace-1118:pyproject.toml",
+)
+use_repo(uv, "pypi_xds_otel_namespace_1118")

--- a/e2e/cases/xds-otel-namespace-1118/setup.MODULE.bazel
+++ b/e2e/cases/xds-otel-namespace-1118/setup.MODULE.bazel
@@ -1,7 +1,7 @@
 """Regression: mixed namespace/regular top-level collision (#1118).
 
-xds-protos ships opentelemetry/__init__.py (empty stub) while opentelemetry-sdk
-treats `opentelemetry` as a PEP 420 namespace package.
+xds-protos ships opentelemetry/__init__.py while opentelemetry-sdk treats
+`opentelemetry` as a PEP 420 namespace package.
 """
 
 uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")

--- a/e2e/cases/xds-otel-namespace-1118/test.py
+++ b/e2e/cases/xds-otel-namespace-1118/test.py
@@ -1,7 +1,7 @@
-"""Regression test for #1118: xds-protos ships opentelemetry/__init__.py
-(empty, legacy namespace stub) while opentelemetry-sdk treats `opentelemetry`
-as a PEP 420 namespace. Without the fix the regular-package claim wins the
-top-level symlink and opentelemetry.sdk.* is unreachable.
+"""Regression test for #1118: xds-protos ships opentelemetry/__init__.py while
+opentelemetry-sdk treats `opentelemetry` as a PEP 420 namespace. Without the
+fix the regular-package claim wins the top-level symlink and
+opentelemetry.sdk.* is unreachable.
 """
 
 import os

--- a/e2e/cases/xds-otel-namespace-1118/test.py
+++ b/e2e/cases/xds-otel-namespace-1118/test.py
@@ -1,0 +1,46 @@
+"""Regression test for #1118: xds-protos ships opentelemetry/__init__.py
+(empty, legacy namespace stub) while opentelemetry-sdk treats `opentelemetry`
+as a PEP 420 namespace. Without the fix the regular-package claim wins the
+top-level symlink and opentelemetry.sdk.* is unreachable.
+"""
+
+import os
+import sysconfig
+
+
+def test_sdk_importable():
+    from opentelemetry.sdk.resources import Resource
+
+    assert Resource is not None
+
+
+def test_merged_layout():
+    site_packages = sysconfig.get_paths()["purelib"]
+    otel_dir = os.path.join(site_packages, "opentelemetry")
+
+    assert os.path.isdir(otel_dir), (
+        f"site-packages has no concrete opentelemetry/ directory at {otel_dir}"
+    )
+
+    # xds-protos ships an empty __init__.py (legacy namespace stub).
+    init_py = os.path.join(otel_dir, "__init__.py")
+    assert os.path.isfile(init_py), (
+        f"opentelemetry/__init__.py missing — xds-protos content not merged"
+    )
+    assert os.path.getsize(init_py) == 0, (
+        f"opentelemetry/__init__.py should be 0 bytes (xds-protos stub), "
+        f"got {os.path.getsize(init_py)}"
+    )
+
+    # opentelemetry-sdk contributes opentelemetry/sdk/ into the merged dir.
+    sdk_dir = os.path.join(otel_dir, "sdk")
+    assert os.path.isdir(sdk_dir), (
+        f"opentelemetry/sdk/ missing — PySiteMerge may not have run. "
+        f"opentelemetry/ holds: {sorted(os.listdir(otel_dir))}"
+    )
+
+
+if __name__ == "__main__":
+    test_sdk_importable()
+    test_merged_layout()
+    print("PASS")

--- a/e2e/cases/xds-otel-namespace-1118/test.py
+++ b/e2e/cases/xds-otel-namespace-1118/test.py
@@ -11,7 +11,7 @@ import sysconfig
 def test_sdk_importable():
     from opentelemetry.sdk.resources import Resource
 
-    assert Resource is not None
+    assert callable(Resource)
 
 
 def test_merged_layout():
@@ -22,14 +22,10 @@ def test_merged_layout():
         f"site-packages has no concrete opentelemetry/ directory at {otel_dir}"
     )
 
-    # xds-protos ships an empty __init__.py (legacy namespace stub).
+    # xds-protos ships an __init__.py (legacy namespace stub).
     init_py = os.path.join(otel_dir, "__init__.py")
     assert os.path.isfile(init_py), (
         f"opentelemetry/__init__.py missing — xds-protos content not merged"
-    )
-    assert os.path.getsize(init_py) == 0, (
-        f"opentelemetry/__init__.py should be 0 bytes (xds-protos stub), "
-        f"got {os.path.getsize(init_py)}"
     )
 
     # opentelemetry-sdk contributes opentelemetry/sdk/ into the merged dir.

--- a/e2e/cases/xds-otel-namespace-1118/uv.lock
+++ b/e2e/cases/xds-otel-namespace-1118/uv.lock
@@ -1,0 +1,167 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/ea/1c2fa386b718ff493225e61cfc052ef400b4d6ffc54cbe261026432624b5/grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f", size = 6093112, upload-time = "2026-06-11T12:44:52.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/18/acf45fa8bd1bc5d7b0c2fd3dc4c209379fbd5bb396b440b68a83342226b7/grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137", size = 12074277, upload-time = "2026-06-11T12:44:55.354Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d7/ee86a60699b7db039f772a2c4a7e4facc7138984ff42c0130933a0063884/grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a", size = 6640348, upload-time = "2026-06-11T12:44:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ee/d2de5e47378ffc207d476c230fea3be4d2601edbce9995f4fe45535d4896/grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49", size = 7331842, upload-time = "2026-06-11T12:45:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d6/abeda5c2b896a0b341584fe5ac411bbf72e197a9a374c355fb90965e08d2/grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2", size = 6842229, upload-time = "2026-06-11T12:45:04.76Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1c/1f0da7d590b4aeee006826ba568d0e419ca14b23e18f901a3da3e9fba613/grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416", size = 7446096, upload-time = "2026-06-11T12:45:07.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/5c505d508f7c887aa7982d21443a4126597c80d34b0bcf40f9cec576d7f3/grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70", size = 8445238, upload-time = "2026-06-11T12:45:10.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b2/524847365122ee509ca17bcc4e092198b700e94af7bfd5bb5e6dd9f3ee66/grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad", size = 7873989, upload-time = "2026-06-11T12:45:13.102Z" },
+    { url = "https://files.pythonhosted.org/packages/18/fa/07c037c50b006909d1d13a5848774f8aa7b242f70dc03a035c64eea0e6db/grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5", size = 4202223, upload-time = "2026-06-11T12:45:16.166Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ed/6bff15376920942fac6b95b9802752b837437172c9e8fc2d3170546b89cc/grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79", size = 4941303, upload-time = "2026-06-11T12:45:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/0b/e5428c009d4d9af0515b0a8371a8aaae695371af291f45e702f7969dce6b/opentelemetry_api-1.39.0.tar.gz", hash = "sha256:6130644268c5ac6bdffaf660ce878f10906b3e789f7e2daa5e169b047a2933b9", size = 65763, upload-time = "2025-12-03T13:19:56.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/85/d831a9bc0a9e0e1a304ff3d12c1489a5fbc9bf6690a15dcbdae372bbca45/opentelemetry_api-1.39.0-py3-none-any.whl", hash = "sha256:3c3b3ca5c5687b1b5b37e5c5027ff68eacea8675241b29f13110a8ffbb8f0459", size = 66357, upload-time = "2025-12-03T13:19:33.043Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/e3/7cd989003e7cde72e0becfe830abff0df55c69d237ee7961a541e0167833/opentelemetry_sdk-1.39.0.tar.gz", hash = "sha256:c22204f12a0529e07aa4d985f1bca9d6b0e7b29fe7f03e923548ae52e0e15dde", size = 171322, upload-time = "2025-12-03T13:20:09.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/b4/2adc8bc83eb1055ecb592708efb6f0c520cc2eb68970b02b0f6ecda149cf/opentelemetry_sdk-1.39.0-py3-none-any.whl", hash = "sha256:90cfb07600dfc0d2de26120cebc0c8f27e69bf77cd80ef96645232372709a514", size = 132413, upload-time = "2025-12-03T13:19:51.364Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/0e/176a7844fe4e3cb5de604212094dffaed4e18b32f1c56b5258bcbcba85c2/opentelemetry_semantic_conventions-0.60b0.tar.gz", hash = "sha256:227d7aa73cbb8a2e418029d6b6465553aa01cf7e78ec9d0bc3255c7b3ac5bf8f", size = 137935, upload-time = "2025-12-03T13:20:12.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/56/af0306666f91bae47db14d620775604688361f0f76a872e0005277311131/opentelemetry_semantic_conventions-0.60b0-py3-none-any.whl", hash = "sha256:069530852691136018087b52688857d97bba61cd641d0f8628d2d92788c4f78a", size = 219981, upload-time = "2025-12-03T13:19:53.585Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "xds-otel-namespace-1118"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "opentelemetry-sdk" },
+    { name = "xds-protos" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "opentelemetry-sdk", specifier = "==1.39.0" },
+    { name = "xds-protos", specifier = "==1.73.1" },
+]
+
+[[package]]
+name = "xds-protos"
+version = "1.73.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/d2/fad746b8fd2bd9c4a785201fb22c42e76714c5264ea9ea3d73200a797f78/xds_protos-1.73.1.tar.gz", hash = "sha256:5e49d917be0b698ebceb4f5edef92fcca5bd98fff992653a1dc73acd7a6bd705", size = 493823, upload-time = "2025-06-26T02:02:54.862Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/89/070a327a1f8b89d843054e18fe1d0fa2c31da9b2b9d99fdbde411397be32/xds_protos-1.73.1-py3-none-any.whl", hash = "sha256:ade8d24c98eb242b067b5a6fbaf0e75b7313ace2552e8768d3e5a12db61264f5", size = 1237430, upload-time = "2025-06-26T02:02:40.969Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -336,7 +336,10 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             # __init__.py here while others treat it as a PEP 420 namespace.
             # pip handles this by physically merging all contributing directories;
             # we do the same via PySiteMerge.
-            unique_claimants = distinct_sp.values()
+            unique_claimants = list(distinct_sp.values())
+            first = unique_claimants[0]
+            for c in unique_claimants[1:]:
+                _complain("top-level", tl, first.site_packages, c.site_packages)
             for c in unique_claimants:
                 skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
             top_level_merges[tl] = [
@@ -394,12 +397,12 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     # Pass 2c: build merge groups for mixed regular/namespace top-levels.
     # The entire top-level directory is merged (root = tl itself). No
     # shallowest-root filtering is needed since top-level names have no "/".
+    # sorted() ensures deterministic merge_groups order across builds.
     for tl, sps in sorted(top_level_merges.items()):
-        if len(sps) >= 2:
-            merge_groups.append(struct(
-                root = tl,
-                site_packages_list = sps,
-            ))
+        merge_groups.append(struct(
+            root = tl,
+            site_packages_list = sps,
+        ))
 
     # Pass 2b: console scripts.
     console_scripts_map = {}

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -179,6 +179,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     ns_covered_per_wheel = {}
     conflicted_roots = {}  # root path -> True (regular package spanning wheels)
     ns_claimant_sps = {}  # sp -> True, wheels in any all-namespace collision
+    top_level_merges = {}  # tl -> [site_packages_rfpath, ...] for mixed regular/namespace
     for tl, claimants in tl_claimants.items():
         distinct_sp = {c.site_packages: c for c in claimants}
         if len(distinct_sp) == 1:
@@ -330,6 +331,21 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                     ns_covered_per_wheel.setdefault(c.site_packages, {})[tl] = True
             continue
 
+        elif any([c.is_ns for c in claimants]):
+            # Mixed regular/namespace at this top-level: some wheels ship
+            # __init__.py here while others treat it as a PEP 420 namespace.
+            # pip handles this by physically merging all contributing directories;
+            # we do the same via PySiteMerge.
+            unique_claimants = distinct_sp.values()
+            for c in unique_claimants:
+                skipped_per_wheel.setdefault(c.site_packages, {})[tl] = True
+            top_level_merges[tl] = [
+                ordered_w.site_packages_rfpath
+                for ordered_w in wheels
+                if ordered_w.site_packages_rfpath in distinct_sp
+            ]
+            continue
+
         winner = claimants[0]
         seen = {winner.site_packages: True}
         for c in claimants[1:]:
@@ -373,6 +389,16 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             merge_groups.append(struct(
                 root = root,
                 site_packages_list = group_sps,
+            ))
+
+    # Pass 2c: build merge groups for mixed regular/namespace top-levels.
+    # The entire top-level directory is merged (root = tl itself). No
+    # shallowest-root filtering is needed since top-level names have no "/".
+    for tl, sps in sorted(top_level_merges.items()):
+        if len(sps) >= 2:
+            merge_groups.append(struct(
+                root = tl,
+                site_packages_list = sps,
             ))
 
     # Pass 2b: console scripts.

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -186,7 +186,9 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             top_level_to_site_pkgs[tl] = claimants[0].site_packages
             continue
 
-        all_namespace = all([c.is_ns for c in claimants])
+        is_ns = [c.is_ns for c in claimants]
+        all_namespace = all(is_ns)
+        any_namespace = any(is_ns)
         if all_namespace:
             # Deep-overlap scan first: a regular root of one claimant
             # appearing in another claimant's namespace skeleton (B
@@ -331,7 +333,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                     ns_covered_per_wheel.setdefault(c.site_packages, {})[tl] = True
             continue
 
-        elif any([c.is_ns for c in claimants]):
+        elif any_namespace:
             # Mixed regular/namespace at this top-level: some wheels ship
             # __init__.py here while others treat it as a PEP 420 namespace.
             # pip handles this by physically merging all contributing directories;

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -397,8 +397,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
     # Pass 2c: build merge groups for mixed regular/namespace top-levels.
     # The entire top-level directory is merged (root = tl itself). No
     # shallowest-root filtering is needed since top-level names have no "/".
-    # sorted() ensures deterministic merge_groups order across builds.
-    for tl, sps in sorted(top_level_merges.items()):
+    for tl, sps in top_level_merges.items():
         merge_groups.append(struct(
             root = tl,
             site_packages_list = sps,

--- a/py/tests/py_venv_conflict/collision_order_test.bzl
+++ b/py/tests/py_venv_conflict/collision_order_test.bzl
@@ -6,6 +6,81 @@ load("//py:defs.bzl", "py_binary", "py_library", "py_test")
 load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
 
+def _mixed_wheel_impl(ctx):
+    py_runtime = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
+    install_tree = ctx.actions.declare_directory(ctx.label.name + ".install")
+    major = py_runtime.interpreter_version_info.major
+    minor = py_runtime.interpreter_version_info.minor
+    if ctx.attr.kind == "regular":
+        command = """
+set -eu
+site="$1/lib/python$2.$3/site-packages"
+mkdir -p "$site/mixed_top"
+printf '' > "$site/mixed_top/__init__.py"
+printf 'VALUE = "regular"\n' > "$site/mixed_top/from_regular.py"
+"""
+        top_levels = ("mixed_top",)
+        namespace_top_levels = ()
+        namespace_entries = ()
+        namespace_dirs = ()
+        regular_roots = ()
+    else:
+        command = """
+set -eu
+site="$1/lib/python$2.$3/site-packages"
+mkdir -p "$site/mixed_top"
+printf 'VALUE = "namespace"\n' > "$site/mixed_top/from_namespace.py"
+"""
+        top_levels = ("mixed_top",)
+        namespace_top_levels = ("mixed_top",)
+        namespace_entries = ("mixed_top/from_namespace.py",)
+        namespace_dirs = ()
+        regular_roots = ()
+    ctx.actions.run_shell(
+        outputs = [install_tree],
+        command = command,
+        arguments = [install_tree.path, str(major), str(minor)],
+    )
+    site_packages = "/".join([
+        segment
+        for segment in [
+            ctx.label.repo_name or ctx.workspace_name,
+            ctx.label.package,
+            install_tree.basename,
+        ]
+        if segment
+    ] + ["lib/python{}.{}/site-packages".format(major, minor)])
+    wheel = struct(
+        top_levels = top_levels,
+        namespace_top_levels = namespace_top_levels,
+        namespace_entries = namespace_entries,
+        namespace_dirs = namespace_dirs,
+        regular_roots = regular_roots,
+        site_packages_rfpath = site_packages,
+        console_scripts = (),
+        install_tree = install_tree,
+    )
+    return [
+        DefaultInfo(
+            files = depset([install_tree]),
+            runfiles = ctx.runfiles(files = [install_tree]),
+        ),
+        PyInfo(
+            imports = depset([site_packages]),
+            transitive_sources = depset([install_tree]),
+            has_py2_only_sources = False,
+            has_py3_only_sources = True,
+            uses_shared_libraries = False,
+        ),
+        PyWheelsInfo(wheels = depset([wheel])),
+    ]
+
+_mixed_wheel = rule(
+    implementation = _mixed_wheel_impl,
+    attrs = {"kind": attr.string(mandatory = True)},
+    toolchains = [PY_TOOLCHAIN],
+)
+
 def _wheel_impl(ctx):
     py_runtime = ctx.toolchains[PY_TOOLCHAIN].py3_runtime
     install_tree = ctx.actions.declare_directory(ctx.label.name + ".install")
@@ -237,5 +312,29 @@ def collision_order_test_suite():
         deps = [
             ":_namespace_first",
             ":_namespace_second",
+        ],
+    )
+
+    # Mixed namespace/regular collision: one wheel ships mixed_top/__init__.py
+    # (regular), another ships mixed_top/from_namespace.py (namespace). Both
+    # sub-modules must be importable after the physical merge.
+    _mixed_wheel(
+        name = "_mixed_regular_wheel",
+        kind = "regular",
+        tags = ["manual"],
+    )
+    _mixed_wheel(
+        name = "_mixed_namespace_wheel",
+        kind = "namespace",
+        tags = ["manual"],
+    )
+    py_test(
+        name = "mixed_ns_regular_test",
+        srcs = ["test_mixed_ns_regular.py"],
+        main = "test_mixed_ns_regular.py",
+        package_collisions = "warning",
+        deps = [
+            ":_mixed_namespace_wheel",
+            ":_mixed_regular_wheel",
         ],
     )

--- a/py/tests/py_venv_conflict/test_mixed_ns_regular.py
+++ b/py/tests/py_venv_conflict/test_mixed_ns_regular.py
@@ -1,0 +1,15 @@
+"""Verify that a namespace package (no __init__.py) and a regular package
+(has __init__.py at the top-level) claiming the same top-level are both
+accessible after a physical merge.
+
+Scenario: xds_protos-like wheel ships `opentelemetry/__init__.py` (regular)
+while opentelemetry-sdk-like wheel ships `opentelemetry/sdk/` (namespace).
+Without the fix, the regular wheel's `opentelemetry/` directory would win the
+symlink and hide the namespace wheel's content.
+"""
+
+from mixed_top.from_namespace import VALUE as NS_VALUE
+from mixed_top.from_regular import VALUE as REG_VALUE
+
+assert NS_VALUE == "namespace", NS_VALUE
+assert REG_VALUE == "regular", REG_VALUE


### PR DESCRIPTION
When one wheel ships `opentelemetry/__init__.py` (marking `opentelemetry` as a regular package) while others treat it as a PEP 420 namespace, the previous "last winner wins" logic routed all traffic to the non-namespace wheel's directory, hiding the namespace wheels' subpackages.

Detect the mixed case (some `is_ns = True`, some `is_ns = False`) and route it to the existing physical-merge mechanism, producing the same layout a flat `pip install` would — one merged directory containing all wheels' contributions.

Fixes #1118.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Physically merge directories when there is disagreement on whether a package is a namespace package.

### Test plan

- Covered by existing test cases
- New test cases added
