### PR TITLE
fix(py_venv): preserve PBS base for nested venvs

### DIFF
--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -173,5 +173,11 @@ write_source_files(
         "snapshots/firebase_admin.test_tool.venv.pth": "//firebase-admin-import:test_tool.venv.pth",
         "snapshots/wheel_root_pth.venv.pth": "//uv-include-group:wheel_root_pth_test.venv.pth",
         "snapshots/pth_install_tree_fallback.venv.pth": "//pth-install-tree-fallback:test.venv.pth",
+
+        # PBS pyvenv.cfg home handling (cases/pbs-symlink-prefix-1048).
+        # 3.11 is inside the narrow empty-home gate; 3.13 proves the normal
+        # retained-home line stays intact outside it.
+        "snapshots/pbs_symlink_prefix_1048.python311.pyvenv.cfg": "//pbs-symlink-prefix-1048:action_probe_311.venv.cfg",
+        "snapshots/pbs_symlink_prefix_1048.python313.pyvenv.cfg": "//pbs-symlink-prefix-1048:action_probe_313.venv.cfg",
     },
 )

--- a/e2e/cases/interpreter-local-pyvenv-home/BUILD.bazel
+++ b/e2e/cases/interpreter-local-pyvenv-home/BUILD.bazel
@@ -18,7 +18,8 @@ load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
 
 py_runtime(
     name = "system_py3_runtime",
-    interpreter_path = "/opt/fake-python/bin/python3",
+    # Braces make sure the generated home line is not formatted a second time.
+    interpreter_path = "/opt/{fake-python}/bin/python3",
     interpreter_version_info = {
         "major": "3",
         "minor": "94",

--- a/e2e/cases/interpreter-local-pyvenv-home/test_pyvenv_home.py
+++ b/e2e/cases/interpreter-local-pyvenv-home/test_pyvenv_home.py
@@ -13,5 +13,5 @@ cfg = os.path.join(
 with open(cfg) as f:
     content = f.read()
 
-assert "home = /opt/fake-python/bin\n" in content, content
+assert "home = /opt/{fake-python}/bin\n" in content, content
 print("OK")

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
@@ -37,7 +37,7 @@ files:
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
-  - -rwxr-xr-x  0 0      0         243 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_listing.yaml
@@ -29,7 +29,7 @@ files:
   - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
-  - -rwxr-xr-x  0 0      0         243 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0          42 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/branding/__init__.py
   - -rwxr-xr-x  0 0      0          31 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/branding/palette.txt

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_multi_listing.yaml
@@ -38,7 +38,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks -> ../../../../../../../aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_multi_bin.venv/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info
-  - -rwxr-xr-x  0 0      0         243 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_multi_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_multi_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/__main__.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3-3.11

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
@@ -31,7 +31,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../../../../../aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         300 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
-  - -rwxr-xr-x  0 0      0         243 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1272 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/my_app_bin.venv
   - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
@@ -31,7 +31,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../../../../../aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__venv_images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
   - -rwxr-xr-x  0 0      0         300 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
-  - -rwxr-xr-x  0 0      0         244 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/__main__.py
   - -rwxr-xr-x  0 0      0        1272 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/my_app_bin.venv
   - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py

--- a/e2e/cases/pbs-symlink-prefix-1048/BUILD.bazel
+++ b/e2e/cases/pbs-symlink-prefix-1048/BUILD.bazel
@@ -1,22 +1,54 @@
-"""Regression tests for issue #1048.
+"""Regression tests for issue #1048."""
 
-Verify that sys.base_prefix correctly resolves to the PBS installation
-directory in the runfiles tree, not the PBS compile-time /install sentinel.
-Affected: Python 3.11 and 3.12 with python-build-standalone.
-"""
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load(":action_probe.bzl", "pbs_action_probe", "pbs_pyvenv_cfg_snapshot")
 
-load("@aspect_rules_py//py:defs.bzl", "py_test")
+pbs_action_probe(
+    name = "action_probe_39",
+    python_version = "3.9",
+)
 
-[
-    py_test(
-        name = "test_{}".format(version.replace(".", "")),
-        srcs = ["test_pbs_prefix.py"],
-        main = "test_pbs_prefix.py",
-        python_version = version,
-        deps = ["//tools/verify_venv"],
-    )
-    for version in [
-        "3.11",
-        "3.12",
-    ]
-]
+pbs_action_probe(
+    name = "action_probe_310",
+    python_version = "3.10",
+)
+
+pbs_action_probe(
+    name = "action_probe_311",
+    python_version = "3.11",
+)
+
+pbs_action_probe(
+    name = "action_probe_312",
+    python_version = "3.12",
+)
+
+pbs_action_probe(
+    name = "action_probe_313",
+    python_version = "3.13",
+)
+
+# Snapshot one runtime on each side of the CPython 3.11/3.12 gate so a
+# generated-code diff shows the intentional empty 'home' value and the
+# unchanged retained-home shape. The extractor normalizes platform-dependent
+# PBS interpreter repository names without hiding a retained line.
+pbs_pyvenv_cfg_snapshot(
+    name = "action_probe_311.venv.cfg",
+    venv = ":action_probe_311.venv",
+)
+
+pbs_pyvenv_cfg_snapshot(
+    name = "action_probe_313.venv.cfg",
+    venv = ":action_probe_313.venv",
+)
+
+build_test(
+    name = "action_test",
+    targets = [
+        ":action_probe_39_output",
+        ":action_probe_310_output",
+        ":action_probe_311_output",
+        ":action_probe_312_output",
+        ":action_probe_313_output",
+    ],
+)

--- a/e2e/cases/pbs-symlink-prefix-1048/action_probe.bzl
+++ b/e2e/cases/pbs-symlink-prefix-1048/action_probe.bzl
@@ -1,0 +1,65 @@
+"""Action-level PBS venv regression target."""
+
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+
+def pbs_action_probe(name, python_version):
+    """Run a PBS-backed binary from a non-runfiles action cwd."""
+    py_binary(
+        name = name,
+        srcs = ["test_pbs_prefix.py"],
+        expose_venv = True,
+        main = "test_pbs_prefix.py",
+        python_version = python_version,
+    )
+
+    commands = [
+        "root=$$(pwd)",
+        "mkdir -p $(@D)/cwd",
+        "cd $(@D)/cwd",
+        (
+            "\"$$root/$(execpath :{name})\" " +
+            "--expected-cwd \"$$PWD\" --test-children"
+        ).format(name = name),
+        (
+            "\"$$root/$(execpath :{name}.venv)\" " +
+            "\"$$root/$(location test_pbs_prefix.py)\" " +
+            "--expected-cwd \"$$PWD\""
+        ).format(name = name),
+        "touch \"$$root/$@\"",
+    ]
+
+    native.genrule(
+        name = name + "_output",
+        srcs = ["test_pbs_prefix.py"],
+        outs = [name + ".stamp"],
+        cmd = "\n".join(commands),
+        tools = [
+            ":" + name,
+            ":" + name + ".venv",
+        ],
+    )
+
+def pbs_pyvenv_cfg_snapshot(name, venv):
+    """Copy a PBS-backed py_venv's generated pyvenv.cfg from its runfiles."""
+    native.genrule(
+        name = name,
+        testonly = True,
+        outs = [name],
+        cmd = """
+            launcher=$(execpath {venv})
+            runfiles="$$launcher".runfiles
+            pkg=$$(dirname "$$launcher" | sed 's|^bazel-out/[^/]*/bin/||')
+            vname=$$(basename "$$launcher")
+            cfg="$$runfiles/_main/$$pkg/.$$vname/pyvenv.cfg"
+            if [ ! -f "$$cfg" ]; then
+                echo "expected pyvenv.cfg at $$cfg, not found" >&2
+                ls -la "$$runfiles/_main/$$pkg/" 2>&1 >&2
+                exit 1
+            fi
+            # PBS interpreter repository names include the host OS and CPU.
+            # Keep the `home` line while removing only that volatile value.
+            sed -E 's|^home = .+|home = <PBS_INTERPRETER_HOME>|' "$$cfg" > $@
+        """.format(venv = venv),
+        tools = [venv],
+        visibility = ["//:__pkg__"],
+    )

--- a/e2e/cases/pbs-symlink-prefix-1048/test_pbs_prefix.py
+++ b/e2e/cases/pbs-symlink-prefix-1048/test_pbs_prefix.py
@@ -1,48 +1,121 @@
-"""Regression test for issue #1048: PBS symlink chain breaks sys.base_prefix.
+"""Exercise a PBS-backed venv from a Bazel action working directory."""
 
-Python 3.11/3.12 reimplemented prefix discovery in pure Python (getpath.py).
-Its resolvedpath() has a bug with multi-hop relative symlinks that traverse
-.. components across repo boundaries — the exact shape of the venv's
-bin/python → ../../../../interpreter_repo/bin/python3.11 chain.
-
-When resolution fails, Python falls back to the compiled-in /install prefix
-(absent at runtime), causing:
-    ModuleNotFoundError: No module named 'encodings'
-
-The fix: pyvenv.cfg's home= key now points directly to the PBS bin/ directory,
-so Python only resolves the local python → python3.11 symlink (one hop).
-"""
-
+import argparse
 import os
+import subprocess
 import sys
+import tempfile
 
-from verify_venv import verify_all, verify_base_prefix, verify_in_venv
 
+def _verify_prefixes(expected_cwd: str) -> None:
+    assert os.path.samefile(os.getcwd(), expected_cwd), (os.getcwd(), expected_cwd)
+    assert os.path.isabs(sys.base_prefix), sys.base_prefix
+    assert os.path.isdir(sys.base_prefix), sys.base_prefix
+    assert sys.base_prefix != "/install", sys.path
 
-def test_base_prefix_not_install():
-    assert sys.base_prefix != "/install", (
-        f"sys.base_prefix is '/install' (the PBS compile-time prefix). "
-        f"Python {sys.version_info.major}.{sys.version_info.minor} failed to "
-        f"resolve the pyvenv.cfg home= symlink chain."
+    pyvenv_cfg = os.path.join(os.path.dirname(sys.executable), "..", "pyvenv.cfg")
+    with open(pyvenv_cfg, encoding="utf-8") as cfg:
+        config = cfg.read().splitlines()
+    assert "relocatable = true" in config, config
+    home = next(
+        (line.partition("=")[2].strip() for line in config if line.startswith("home =")),
+        None,
     )
 
+    expect_empty_home = os.name != "nt" and sys.version_info[:2] in {
+        (3, 11),
+        (3, 12),
+    }
+    assert (home == "") == expect_empty_home, (home, sys.version_info)
+    if expect_empty_home:
+        assert sys._base_executable != sys.executable, sys.executable
+        assert os.path.samefile(
+            os.path.dirname(os.path.dirname(sys._base_executable)),
+            sys.base_prefix,
+        ), (
+            sys._base_executable,
+            sys.base_prefix,
+        )
 
-def test_base_prefix_has_stdlib():
+    if not sys.flags.no_site:
+        assert os.path.isabs(sys.prefix), sys.prefix
+        assert os.path.isdir(sys.prefix), sys.prefix
+        assert sys.prefix != sys.base_prefix, (sys.prefix, sys.base_prefix)
+
     stdlib = os.path.join(
         sys.base_prefix,
         "lib",
         f"python{sys.version_info.major}.{sys.version_info.minor}",
     )
-    assert os.path.isdir(stdlib), (
-        f"stdlib missing: {stdlib!r} (sys.base_prefix={sys.base_prefix!r})"
+    assert os.path.isdir(stdlib), (stdlib, sys.path)
+
+
+def _verify_child(options: list[str], expected_cwd: str) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            *options,
+            __file__,
+            "--expected-cwd",
+            expected_cwd,
+        ],
+        check=True,
     )
+
+
+def _verify_nested_venv(expected_cwd: str) -> None:
+    with tempfile.TemporaryDirectory(dir=expected_cwd) as root:
+        child_venv = os.path.join(root, "child")
+        subprocess.run(
+            [sys.executable, "-m", "venv", "--without-pip", child_venv],
+            cwd=expected_cwd,
+            check=True,
+        )
+
+        with open(os.path.join(child_venv, "pyvenv.cfg"), encoding="utf-8") as cfg:
+            child_config = cfg.read().splitlines()
+        child_home = next(
+            (
+                line.partition("=")[2].strip()
+                for line in child_config
+                if line.startswith("home =")
+            ),
+            None,
+        )
+        assert child_home == os.path.dirname(os.path.abspath(sys._base_executable)), (
+            child_home,
+            sys._base_executable,
+        )
+
+        child_python = os.path.join(
+            child_venv,
+            "Scripts" if os.name == "nt" else "bin",
+            "python.exe" if os.name == "nt" else "python",
+        )
+        subprocess.run(
+            [
+                child_python,
+                "-c",
+                "import encodings, os, sys; "
+                "assert sys.base_prefix != '/install', sys.path; "
+                "assert os.path.isdir(sys.base_prefix), sys.base_prefix; "
+                "assert sys.prefix != sys.base_prefix, "
+                "(sys.prefix, sys.base_prefix)",
+            ],
+            cwd=expected_cwd,
+            check=True,
+        )
 
 
 if __name__ == "__main__":
-    verify_all()
-    test_base_prefix_not_install()
-    test_base_prefix_has_stdlib()
-    print(
-        f"OK: sys.base_prefix={sys.base_prefix!r}, "
-        f"Python {sys.version_info.major}.{sys.version_info.minor}"
-    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-cwd", required=True)
+    parser.add_argument("--test-children", action="store_true")
+    args = parser.parse_args()
+
+    _verify_prefixes(args.expected_cwd)
+    if args.test_children:
+        _verify_child([], args.expected_cwd)
+        _verify_child(["-S"], args.expected_cwd)
+        _verify_child(["-BS"], args.expected_cwd)
+        _verify_nested_venv(args.expected_cwd)

--- a/e2e/cases/snapshots/pbs_symlink_prefix_1048.python311.pyvenv.cfg
+++ b/e2e/cases/snapshots/pbs_symlink_prefix_1048.python311.pyvenv.cfg
@@ -1,0 +1,6 @@
+home =
+implementation = CPython
+version_info = 3.11.15
+include-system-site-packages = false
+aspect-include-user-site-packages = false
+relocatable = true

--- a/e2e/cases/snapshots/pbs_symlink_prefix_1048.python313.pyvenv.cfg
+++ b/e2e/cases/snapshots/pbs_symlink_prefix_1048.python313.pyvenv.cfg
@@ -1,0 +1,6 @@
+home = <PBS_INTERPRETER_HOME>
+implementation = CPython
+version_info = 3.13.12
+include-system-site-packages = false
+aspect-include-user-site-packages = false
+relocatable = true

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_amd64_layers_listing.yaml
@@ -44,7 +44,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2 -> ../../../../../../../aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../../../../../aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs
-  - -rwxr-xr-x  0 0      0         243 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0          66 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/__main__.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.12
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_x86_64_unknown_linux_gnu/bin/2to3-3.12

--- a/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
+++ b/e2e/cases/uv-deps-650/crossbuild/snapshots/app_arm64_layers_listing.yaml
@@ -44,7 +44,7 @@ files:
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2 -> ../../../../../../../aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary-2.9.11.dist-info
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/lib/python3.12/site-packages/psycopg2_binary.libs -> ../../../../../../../aspect_rules_py++uv+whl_install__crossbuild__psycopg2_binary__2_9_11/actual_install.install/lib/python3.12/site-packages/psycopg2_binary.libs
-  - -rwxr-xr-x  0 0      0         244 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/._app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0          66 Jan  1  2023 ./app.runfiles/_main/uv-deps-650/crossbuild/__main__.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_aarch64_unknown_linux_gnu/bin/2to3 -> 2to3-3.12
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_12_aarch64_unknown_linux_gnu/bin/2to3-3.12

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -75,6 +75,9 @@ def _assemble_shared(ctx):
         safe_name = safe_name,
         py_toolchain = py_toolchain,
         imports_depset = imports_depset,
+        is_windows = ctx.target_platform_has_constraint(
+            ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
+        ),
         package_collisions = ctx.attr.package_collisions,
         include_system_site_packages = ctx.attr.include_system_site_packages,
         include_user_site_packages = ctx.attr.include_user_site_packages,
@@ -236,6 +239,9 @@ not reinsert a wheel.
     "_virtualenv_shim": attr.label(
         allow_single_file = True,
         default = ":_virtualenv.py",
+    ),
+    "_windows_constraint": attr.label(
+        default = "@platforms//os:windows",
     ),
     # Tool for physically merging a regular package that spans wheels
     # (e.g. azure-core + azure-core-tracing-opentelemetry both

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -490,6 +490,7 @@ def assemble_venv(
         safe_name,
         py_toolchain,
         imports_depset,
+        is_windows,
         package_collisions = "error",
         include_system_site_packages = False,
         include_user_site_packages = False,
@@ -507,6 +508,7 @@ def assemble_venv(
       py_toolchain: Resolved Python toolchain struct from py_semantics.
       imports_depset: Depset of first-party + transitive wheel import
         paths (as returned by py_library_utils.make_imports_depset).
+      is_windows: Bool — whether the venv targets Windows.
       package_collisions: "error" / "warning" / "ignore" — policy applied
         when two wheels claim the same top-level (non-namespace case),
         distribution metadata entry, or console-script name.
@@ -739,15 +741,30 @@ def assemble_venv(
     )
     declared.append(site_packages_pth_file)
 
-    # pyvenv.cfg. `home` must name the BASE interpreter's bin/ — never the
-    # venv's own bin/ (./bin), or CPython is left chasing the venv's python
-    # symlinks and can fall back to the compile-time prefix (PBS: /install) →
-    # ModuleNotFoundError: 'encodings'. Hermetic interpreters: point directly
-    # at the PBS bin/, since 3.11/3.12's getpath.py resolvedpath() fails on
-    # multi-hop relative symlinks across repo boundaries. System interpreters
-    # (py_runtime(interpreter_path)): the dirname of the absolute interpreter
-    # path — the same value `python -m venv` writes.
-    if py_toolchain.runfiles_interpreter:
+    # `relocatable = true` below is a rules_py extension: for an in-build
+    # CPython 3.11/3.12 runtime that supports build-time venvs, keep `home`
+    # empty so getpath resolves the relocatable bin/python symlink into the
+    # base executable without forcing prefix discovery from a relative path.
+    # Omitting the key leaves sys._base_executable at the outer venv symlink,
+    # so a stdlib-created nested venv writes the outer venv's bin/ as home.
+    # A relative `home` instead resolves from the startup cwd:
+    # https://github.com/python/cpython/blob/3bb231a6/Modules/getpath.py#L362-L365
+    # https://github.com/python/cpython/blob/3bb231a6/Modules/getpath.py#L431-L432
+    # https://github.com/python/cpython/blob/3bb231a6/Lib/venv/__init__.py#L158-L166
+    # Direct runtimes use that symlink. The capability also permits wrappers
+    # that set PYTHONEXECUTABLE to preserve the underlying base executable:
+    # https://github.com/bazel-contrib/rules_python/blob/bac54949/python/private/py_runtime_info.bzl#L316-L337
+    use_empty_venv_home = (
+        py_toolchain.runfiles_interpreter and
+        not is_windows and
+        getattr(py_toolchain.toolchain, "implementation_name", None) == "cpython" and
+        getattr(py_toolchain.toolchain, "supports_build_time_venv", False) and
+        py_toolchain.interpreter_version_info.major == 3 and
+        py_toolchain.interpreter_version_info.minor in [11, 12]
+    )
+    if use_empty_venv_home:
+        pyvenv_home = ""
+    elif py_toolchain.runfiles_interpreter:
         pbs_rlocation = to_rlocation_path(ctx, py_toolchain.python)
         pbs_bin_dir = "/".join(pbs_rlocation.split("/")[:-1])
         pyvenv_home = "{}/{}".format(venv_to_runfiles_escape, pbs_bin_dir)
@@ -755,15 +772,16 @@ def assemble_venv(
         pyvenv_home = py_toolchain.python.path.rsplit("/", 1)[0]
 
     pyvenv_cfg = ctx.actions.declare_file("{}/pyvenv.cfg".format(venv_name))
+    home_line = "home =\n" if pyvenv_home == "" else "home = {}\n".format(pyvenv_home)
     ctx.actions.write(
         output = pyvenv_cfg,
-        content = ("home = {home}\n" +
-                   "implementation = CPython\n" +
-                   "version_info = {major}.{minor}.{micro}\n" +
-                   "include-system-site-packages = {include_system}\n" +
-                   "aspect-include-user-site-packages = {include_user}\n" +
-                   "relocatable = true\n").format(
-            home = pyvenv_home,
+        content = home_line + (
+            "implementation = CPython\n" +
+            "version_info = {major}.{minor}.{micro}\n" +
+            "include-system-site-packages = {include_system}\n" +
+            "aspect-include-user-site-packages = {include_user}\n" +
+            "relocatable = true\n"
+        ).format(
             major = py_toolchain.interpreter_version_info.major,
             minor = py_toolchain.interpreter_version_info.minor,
             micro = py_toolchain.interpreter_version_info.micro,


### PR DESCRIPTION
CPython 3.11 and 3.12 interpret a relative pyvenv.cfg home from the process working directory. rules_py 2 writes a runfiles-relative value. When a py_binary runs as a Bazel action tool, that directory is the action sandbox, so prefix discovery can fall back to the PBS build-time /install prefix before Python can import encodings.

py_venv owns both the generated pyvenv.cfg and the relocatable bin/python link. For non-Windows in-build CPython 3.11 and 3.12 runtimes that declare supports_build_time_venv, write home with an empty value. getpath sees the key and resolves bin/python to the real PBS base executable, while the empty value does not force cwd-relative prefix discovery. That keeps outer startup relocatable and lets stdlib-created child venvs inherit PBS rather than the outer venv bin directory. System interpreters, unsupported runtimes, Windows, and other Python versions retain their current home.

The e2e matrix runs PBS 3.9 through 3.13 from an unrelated action cwd. It exercises the launcher, child interpreters with and without site initialization, the exposed venv, and a nested stdlib venv. The nested child starts from that unrelated cwd, imports encodings, and rejects /install as its base prefix. Two checked-in pyvenv.cfg snapshots make the generated metadata delta reviewable: 3.11 keeps an empty home line, while 3.13 retains a normalized nonempty home line.

Fix #1048.