### PR TITLE
fix(py): expose POSIX libpython

### DIFF
--- a/e2e/cases/pbs-cc-toolchain/BUILD.bazel
+++ b/e2e/cases/pbs-cc-toolchain/BUILD.bazel
@@ -1,4 +1,19 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load(":toolchain_test.bzl", "pbs_toolchain_check")
+
+cc_test(
+    name = "embed_python_test",
+    srcs = ["embed_python.cc"],
+    tags = ["manual"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "@rules_python//python/cc:current_py_cc_headers",
+        "@rules_python//python/cc:current_py_cc_libs",
+    ],
+)
 
 platform(
     name = "linux_x86_64",

--- a/e2e/cases/pbs-cc-toolchain/BUILD.bazel
+++ b/e2e/cases/pbs-cc-toolchain/BUILD.bazel
@@ -1,18 +1,31 @@
-load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load(":toolchain_test.bzl", "pbs_toolchain_check")
 
-cc_test(
-    name = "embed_python_test",
+_WINDOWS_INCOMPATIBLE = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
+cc_binary(
+    name = "embed_python",
+    testonly = True,
     srcs = ["embed_python.cc"],
-    tags = ["manual"],
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    target_compatible_with = _WINDOWS_INCOMPATIBLE,
     deps = [
         "@rules_python//python/cc:current_py_cc_headers",
         "@rules_python//python/cc:current_py_cc_libs",
     ],
+)
+
+py_test(
+    name = "embed_python_test",
+    srcs = ["embed_python_test.py"],
+    args = ["$(location :embed_python)"],
+    data = [":embed_python"],
+    main = "embed_python_test.py",
+    python_version = "3.13",
+    target_compatible_with = _WINDOWS_INCOMPATIBLE,
 )
 
 platform(

--- a/e2e/cases/pbs-cc-toolchain/embed_python.cc
+++ b/e2e/cases/pbs-cc-toolchain/embed_python.cc
@@ -1,9 +1,14 @@
 #include <Python.h>
 
+#include <cstdio>
 #include <cstring>
 
 int main() {
-  return std::strncmp(Py_GetVersion(), PY_VERSION, sizeof(PY_VERSION) - 1) == 0
-             ? 0
-             : 1;
+  const char* runtime_version = Py_GetVersion();
+  if (std::strncmp(runtime_version, PY_VERSION, sizeof(PY_VERSION) - 1) != 0) {
+    std::fprintf(stderr, "libpython reports %s but headers report %s\n",
+                 runtime_version, PY_VERSION);
+    return 1;
+  }
+  return 0;
 }

--- a/e2e/cases/pbs-cc-toolchain/embed_python.cc
+++ b/e2e/cases/pbs-cc-toolchain/embed_python.cc
@@ -1,0 +1,9 @@
+#include <Python.h>
+
+#include <cstring>
+
+int main() {
+  return std::strncmp(Py_GetVersion(), PY_VERSION, sizeof(PY_VERSION) - 1) == 0
+             ? 0
+             : 1;
+}

--- a/e2e/cases/pbs-cc-toolchain/embed_python_test.py
+++ b/e2e/cases/pbs-cc-toolchain/embed_python_test.py
@@ -1,0 +1,4 @@
+import subprocess
+import sys
+
+subprocess.run([sys.argv[1]], check=True)

--- a/e2e/cases/pbs-cc-toolchain/test.sh
+++ b/e2e/cases/pbs-cc-toolchain/test.sh
@@ -36,6 +36,12 @@ if [[ "$(uname -s)" == "Linux" ]]; then
     host_flags+=(--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc)
 fi
 
+"$BAZEL" test \
+    --lockfile_mode=off \
+    --@rules_python//python/config_settings:python_version=3.13 \
+    "${host_flags[@]}" \
+    -- //cases/pbs-cc-toolchain:embed_python_test
+
 if [[ "$(uname -s)" == "Darwin" ]]; then
     library_target="@aspect_rules_py//py/tests/cc-deps:example_library.so"
     "$BAZEL" build \

--- a/e2e/cases/pbs-cc-toolchain/test.sh
+++ b/e2e/cases/pbs-cc-toolchain/test.sh
@@ -36,12 +36,6 @@ if [[ "$(uname -s)" == "Linux" ]]; then
     host_flags+=(--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc)
 fi
 
-"$BAZEL" test \
-    --lockfile_mode=off \
-    --@rules_python//python/config_settings:python_version=3.13 \
-    "${host_flags[@]}" \
-    -- //cases/pbs-cc-toolchain:embed_python_test
-
 if [[ "$(uname -s)" == "Darwin" ]]; then
     library_target="@aspect_rules_py//py/tests/cc-deps:example_library.so"
     "$BAZEL" build \

--- a/e2e/cases/pbs-cc-toolchain/toolchain_test.bzl
+++ b/e2e/cases/pbs-cc-toolchain/toolchain_test.bzl
@@ -77,8 +77,6 @@ def _check_cc_toolchain(ctx, cc_toolchain):
         if cc_toolchain.headers_abi3 != None:
             _check_windows_libraries(ctx, cc_toolchain.headers_abi3, "stable-ABI headers", stable_abi = True)
     else:
-        if cc_toolchain.libs != None:
-            fail("Python {} POSIX C toolchain unexpectedly exposes link libraries".format(ctx.attr.python_version))
         for description, headers in [
             ("full-ABI headers", cc_toolchain.headers),
             ("stable-ABI headers", cc_toolchain.headers_abi3),

--- a/e2e/cases/pbs-cc-toolchain/toolchain_test.bzl
+++ b/e2e/cases/pbs-cc-toolchain/toolchain_test.bzl
@@ -77,18 +77,8 @@ def _check_cc_toolchain(ctx, cc_toolchain):
         if cc_toolchain.headers_abi3 != None:
             _check_windows_libraries(ctx, cc_toolchain.headers_abi3, "stable-ABI headers", stable_abi = True)
     else:
-        if cc_toolchain.libs == None:
-            fail("Python {} POSIX C toolchain has no libpython".format(ctx.attr.python_version))
-        suffix = "t" if ctx.attr.freethreaded else ""
-        stem = "libpython{}{}".format(ctx.attr.python_version, suffix)
-        is_macos = ctx.target_platform_has_constraint(ctx.attr._macos_constraint[platform_common.ConstraintValueInfo])
-        expected = [stem + ".dylib"] if is_macos else [
-            stem + ".so",
-            stem + ".so.1.0",
-        ]
-        libraries = sorted([artifact.basename for artifact in _link_library_files(cc_toolchain.libs)])
-        if libraries != expected:
-            fail("expected POSIX libpython files {}, got {}".format(expected, libraries))
+        if cc_toolchain.libs != None:
+            fail("Python {} POSIX C toolchain unexpectedly exposes link libraries".format(ctx.attr.python_version))
         for description, headers in [
             ("full-ABI headers", cc_toolchain.headers),
             ("stable-ABI headers", cc_toolchain.headers_abi3),
@@ -134,7 +124,6 @@ _CC_ATTRS = {
     "expected_interpreter": attr.label(allow_single_file = True, mandatory = True),
     "freethreaded": attr.bool(mandatory = True),
     "python_version": attr.string(mandatory = True),
-    "_macos_constraint": attr.label(default = "@platforms//os:macos"),
     "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 

--- a/e2e/cases/pbs-cc-toolchain/toolchain_test.bzl
+++ b/e2e/cases/pbs-cc-toolchain/toolchain_test.bzl
@@ -77,8 +77,18 @@ def _check_cc_toolchain(ctx, cc_toolchain):
         if cc_toolchain.headers_abi3 != None:
             _check_windows_libraries(ctx, cc_toolchain.headers_abi3, "stable-ABI headers", stable_abi = True)
     else:
-        if cc_toolchain.libs != None:
-            fail("Python {} POSIX C toolchain unexpectedly exposes link libraries".format(ctx.attr.python_version))
+        if cc_toolchain.libs == None:
+            fail("Python {} POSIX C toolchain has no libpython".format(ctx.attr.python_version))
+        suffix = "t" if ctx.attr.freethreaded else ""
+        stem = "libpython{}{}".format(ctx.attr.python_version, suffix)
+        is_macos = ctx.target_platform_has_constraint(ctx.attr._macos_constraint[platform_common.ConstraintValueInfo])
+        expected = [stem + ".dylib"] if is_macos else [
+            stem + ".so",
+            stem + ".so.1.0",
+        ]
+        libraries = sorted([artifact.basename for artifact in _link_library_files(cc_toolchain.libs)])
+        if libraries != expected:
+            fail("expected POSIX libpython files {}, got {}".format(expected, libraries))
         for description, headers in [
             ("full-ABI headers", cc_toolchain.headers),
             ("stable-ABI headers", cc_toolchain.headers_abi3),
@@ -124,6 +134,7 @@ _CC_ATTRS = {
     "expected_interpreter": attr.label(allow_single_file = True, mandatory = True),
     "freethreaded": attr.bool(mandatory = True),
     "python_version": attr.string(mandatory = True),
+    "_macos_constraint": attr.label(default = "@platforms//os:macos"),
     "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -23,6 +23,7 @@ def _python_interpreter_impl(rctx):
     )
 
     # Determine the Python binary path
+    is_macos = "apple-darwin" in platform
     is_windows = "windows" in platform
     python_bin = "python.exe" if is_windows else "bin/python3"
     version_parts = python_version.split(".")
@@ -49,6 +50,7 @@ def _python_interpreter_impl(rctx):
         minor = minor,
         micro = micro,
         python_bin = python_bin,
+        is_macos = is_macos,
         is_windows = is_windows,
         releaselevel = releaselevel,
         serial = serial,
@@ -93,7 +95,7 @@ filegroup(
 
     return "\n".join(lines), all_excludes
 
-def _build_file_content(major, minor, micro, python_bin, is_windows, abi_flags, releaselevel, serial):
+def _build_file_content(major, minor, micro, python_bin, is_macos, is_windows, abi_flags, releaselevel, serial):
     """Generate the full BUILD.bazel content for an interpreter repo."""
 
     feature_targets, feature_excludes = _feature_filegroups(major, minor, is_windows)
@@ -102,7 +104,7 @@ def _build_file_content(major, minor, micro, python_bin, is_windows, abi_flags, 
     if not is_windows:
         include_dirs.append("include/python{}.{}{}".format(major, minor, abi_flags))
 
-    interface_targets = ""
+    library_targets = ""
     header_interface_deps = []
     abi3_header_target = ""
     headers_abi3_attr = ""
@@ -117,7 +119,7 @@ def _build_file_content(major, minor, micro, python_bin, is_windows, abi_flags, 
         # Windows extensions link an import library. Regular stable-ABI
         # extensions use python3.lib.
         # https://docs.python.org/3.13/c-api/stable.html#stable-application-binary-interface
-        interface_targets = """\
+        library_targets = """\
 cc_import(
     name = "interface",
     interface_library = "libs/python{major}{minor}{abi_flags}.lib",
@@ -132,7 +134,7 @@ cc_import(
         libs_attr = "    libs = \":interface\",\n"
         header_interface_deps = [":interface"]
         if abi_flags == "":
-            interface_targets += """
+            library_targets += """
 cc_import(
     name = "abi3_interface",
     interface_library = "libs/python3.lib",
@@ -150,8 +152,28 @@ cc_library(
 )
 """.format(include_dirs = repr(include_dirs))
             headers_abi3_attr = "    headers_abi3 = \":python_headers_abi3\",\n"
-    elif abi_flags == "":
-        headers_abi3_attr = "    headers_abi3 = \":python_headers\",\n"
+    else:
+        # rules_python exposes this target through current_py_cc_libs for
+        # embedding consumers. Keep it separate from python_headers so Python
+        # extension modules do not acquire a libpython dependency.
+        # https://rules-python.readthedocs.io/en/latest/toolchains.html#consuming-python-c-headers-and-libraries
+        if is_macos:
+            libpython_srcs = ["lib/libpython{}.{}{}.dylib".format(major, minor, abi_flags)]
+        else:
+            libpython_srcs = [
+                "lib/libpython{}.{}{}.so".format(major, minor, abi_flags),
+                "lib/libpython{}.{}{}.so.1.0".format(major, minor, abi_flags),
+            ]
+        library_targets = """\
+cc_library(
+    name = "libpython",
+    srcs = {libpython_srcs},
+    visibility = ["//visibility:private"],
+)
+""".format(libpython_srcs = repr(libpython_srcs))
+        libs_attr = "    libs = \":libpython\",\n"
+        if abi_flags == "":
+            headers_abi3_attr = "    headers_abi3 = \":python_headers\",\n"
 
     if is_windows:
         core_include = '["**/*.py", "**/*.pyd", "**/*.dll", "**/*.exe", "include/**", "Lib/**"]'
@@ -211,7 +233,7 @@ filegroup(
 
 # --- Python C toolchain ---
 
-{interface_targets}filegroup(
+{library_targets}filegroup(
     name = "includes",
     srcs = glob(["include/**/*.h"], allow_empty = False),
     visibility = ["//visibility:private"],
@@ -261,7 +283,7 @@ py_cc_toolchain(
         header_interface_deps = repr(header_interface_deps),
         headers_abi3_attr = headers_abi3_attr,
         include_dirs = repr(include_dirs),
-        interface_targets = interface_targets,
+        library_targets = library_targets,
         libs_attr = libs_attr,
         python_bin = python_bin,
         major = major,


### PR DESCRIPTION
The PBS C toolchains added by 2ab36be0 register matching headers but leave PyCcToolchainInfo.libs unset on POSIX. This breaks consumers that need embedding libraries rather than ordinary extension headers. In particular, rules_rust_pyo3 0.67.0 dereferences libs to set PYO3_CROSS_LIB_DIR, so selecting a rules_py PBS runtime fails during analysis.

Expose the .dylib or .so files already present in each PBS archive through a separate libpython cc_library. Keeping this target out of python_headers preserves the existing POSIX extension-module model; the macOS end-to-end check still rejects extension modules that link libpython.

A normal e2e py_test carries a small current_py_cc_libs-linked binary as data and executes it. The binary calls Py_GetVersion and compares it with the selected headers, proving the selected library is loadable and matches its headers without requiring the Python standard library.

The rules_rust_pyo3 consumer is visible at https://github.com/bazelbuild/rules_rust/blob/0.67.0/extensions/pyo3/private/pyo3_toolchain.bzl#L32-L67.