### PR TITLE
fix(uv): align C++ toolchain platform

### DIFF
--- a/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
+++ b/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
@@ -3,6 +3,9 @@ load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load(":toolchain.bzl", "fake_cc_toolchain")
+
+_CC_TOOLCHAIN = "//cases/pep517-frontend-exec-group:cc_toolchain"
 
 # Keep the host first so the default exec group selects it. The native wheel's
 # `target` exec group requires the transitioned target constraints and selects
@@ -18,6 +21,7 @@ platform(
     flags = [
         "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
         "--extra_execution_platforms=@platforms//host,//cases/pep517-frontend-exec-group:linux_aarch64",
+        "--extra_toolchains=" + _CC_TOOLCHAIN,
     ],
 )
 
@@ -30,6 +34,7 @@ platform(
     flags = [
         "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
         "--extra_execution_platforms=@platforms//host,//cases/pep517-frontend-exec-group:linux_x86_64",
+        "--extra_toolchains=" + _CC_TOOLCHAIN,
     ],
 )
 
@@ -50,6 +55,44 @@ config_setting(
 )
 
 write_file(
+    name = "linux_aarch64_compiler",
+    out = "linux_aarch64_compiler.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "printf '%s\\n' aarch64",
+    ],
+    is_executable = True,
+)
+
+write_file(
+    name = "linux_x86_64_compiler",
+    out = "linux_x86_64_compiler.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "printf '%s\\n' x86_64",
+    ],
+    is_executable = True,
+)
+
+fake_cc_toolchain(
+    name = "cc",
+    compiler = select({
+        ":linux_aarch64_config": ":linux_aarch64_compiler",
+        ":linux_x86_64_config": ":linux_x86_64_compiler",
+        "//conditions:default": ":linux_x86_64_compiler",
+    }),
+)
+
+# The toolchain target is configured for its execution platform. Resolving it
+# in the default group therefore exposes the host compiler, while resolving it
+# in the native wheel's target group exposes the transitioned target compiler.
+toolchain(
+    name = "cc_toolchain",
+    toolchain = ":cc",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+write_file(
     name = "frontend_script",
     out = "frontend.sh",
     content = [
@@ -63,6 +106,11 @@ write_file(
         "expected=\"$1\"",
         "if [[ \"${actual}\" != \"${expected}\" ]]; then",
         "  echo \"frontend used ${actual}; expected ${expected}\" >&2",
+        "  exit 1",
+        "fi",
+        "compiler_actual=\"$(\"${CC}\")\"",
+        "if [[ \"${compiler_actual}\" != \"${expected}\" ]]; then",
+        "  echo \"compiler ${CC} reported ${compiler_actual}; expected ${expected}\" >&2",
         "  exit 1",
         "fi",
         "wheel_dir=\"${!#}\"",

--- a/e2e/cases/pep517-frontend-exec-group/toolchain.bzl
+++ b/e2e/cases/pep517-frontend-exec-group/toolchain.bzl
@@ -1,0 +1,20 @@
+"""Synthetic C++ toolchains for the PEP 517 execution-group test."""
+
+def _fake_cc_toolchain_impl(ctx):
+    compiler = ctx.file.compiler
+    return [
+        platform_common.ToolchainInfo(
+            all_files = depset([compiler]),
+            compiler_executable = compiler.path,
+        ),
+    ]
+
+fake_cc_toolchain = rule(
+    implementation = _fake_cc_toolchain_impl,
+    attrs = {
+        "compiler": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+    },
+)

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -6,8 +6,10 @@ build backend the sdist declares in its `[build-system]` table.
 """
 
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
+
+_CC_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:toolchain_type")
+_TARGET_EXEC_GROUP = "target"
 
 _INHERITED_PYTHON_ENV = (
     "PYTHONHOME",
@@ -84,13 +86,10 @@ def _collect_toolchain_inputs_and_vars(ctx):
 _BAZEL_CC_WRAPPER_BASENAMES = ["gcc", "g++", "clang", "clang++"]
 
 def _cc_toolchain_inputs_and_compiler(ctx):
-    """Return (depset of CcToolchainInfo files, compiler_file_path or None).
-
-    Uses find_cpp_toolchain so the lookup works for both direct cc_toolchain
-    targets and alias wrappers such as current_cc_toolchain, which Bazel 9 no
-    longer exposes CcToolchainInfo on directly through the alias target.
-    """
-    cc_toolchain = find_cpp_toolchain(ctx)
+    """Return the target execution group's C++ files and compiler path."""
+    cc_toolchain = ctx.exec_groups[_TARGET_EXEC_GROUP].toolchains[_CC_TOOLCHAIN_TYPE]
+    if hasattr(cc_toolchain, "cc_provider_in_toolchain") and hasattr(cc_toolchain, "cc"):
+        cc_toolchain = cc_toolchain.cc
     if not cc_toolchain or not hasattr(cc_toolchain, "all_files"):
         return None, None
     files = cc_toolchain.all_files
@@ -138,7 +137,7 @@ def _pep517_whl(ctx):
         tools = [ctx.attr.tool[DefaultInfo].files_to_run],
         outputs = [wheel_dir],
         env = _common_env(ctx),
-        exec_group = "target",
+        exec_group = _TARGET_EXEC_GROUP,
         resource_set = resource_set(ctx.attr),
     )
 
@@ -179,7 +178,7 @@ def _pep517_native_whl(ctx):
         tools = [ctx.attr.tool[DefaultInfo].files_to_run],
         outputs = [wheel_dir],
         env = env,
-        exec_group = "target",
+        exec_group = _TARGET_EXEC_GROUP,
         resource_set = resource_set(ctx.attr),
     )
 
@@ -202,7 +201,7 @@ _pep517_whl_attrs = {
     # The wheel action uses the named group below, so its frontend must use the
     # same execution platform:
     # https://bazel.build/extending/exec-groups#defining-exec-groups
-    "tool": attr.label(executable = True, cfg = config.exec("target")),
+    "tool": attr.label(executable = True, cfg = config.exec(_TARGET_EXEC_GROUP)),
     "version": attr.string(),
     "args": attr.string_list(default = ["--validate-anyarch"]),
     "monitor_memory": attr.bool(
@@ -221,7 +220,7 @@ specified Python dependencies under the configured Python toolchain.
 """,
     attrs = _pep517_whl_attrs,
     exec_groups = {
-        "target": exec_group(
+        _TARGET_EXEC_GROUP: exec_group(
             toolchains = [
                 PY_TOOLCHAIN,
             ],
@@ -257,9 +256,6 @@ constraints of the target platform.
                   "`TemplateVariableInfo`).",
         ),
     },
-    toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
     exec_groups = {
         # Create an exec group which depends on a toolchain which can only be
         # resolved to exec_compatible_with constraints equal to the target. This
@@ -274,11 +270,11 @@ constraints of the target platform.
         # would need to encode the target platform with no upstream tooling
         # support. Packages that need cross-compiled native extensions should
         # publish pre-built wheels for their target platforms instead.
-        "target": exec_group(
+        _TARGET_EXEC_GROUP: exec_group(
             toolchains = [
                 PY_TOOLCHAIN,
                 NATIVE_BUILD_TOOLCHAIN,
-                "@bazel_tools//tools/cpp:toolchain_type",
+                _CC_TOOLCHAIN_TYPE,
             ],
         ),
     },


### PR DESCRIPTION
Extracted from PR 1167. That fix moved the PEP 517 frontend onto the native wheel action target execution group, but cumulative review found that native wheel C++ lookup still read the default group. When the platforms differ, CC and CXX and their files can come from the host toolchain while the action executes on the target-matching platform.

Resolve the C++ toolchain from the named target execution group, unwrap Bazel current-toolchain providers there, and remove the unused default-group C++ registration. Keep frontend configuration, action execution, and toolchain lookup on one shared group constant.

The e2e fixture registers a platform-selected synthetic C++ toolchain, transitions two target platforms, and executes CC inside the real frontend. It fails under the old default lookup and passes only when compiler identity matches the action group.