### PR TITLE
fix(uv): honor native sdist annotations

### DIFF
--- a/docs/uv.md
+++ b/docs/uv.md
@@ -488,6 +488,8 @@ support this.
 some key information. Such as what requirements apply when performing sdist
 builds. Annotations are the current workaround for how to associate such
 required but nonstandardized and missing dependency data with requirements.
+Set `native = true|false` on a package annotation to override automatic sdist
+native detection and select the native or pure-Python wheel build path.
 
 **Why aren't entrypoints automatically created?** Downloaded-wheel entrypoints
 are discovered while repositories are generated. Source-built wheels do not

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -128,12 +128,14 @@ write_source_files(
         # rule expands env keys correctly given an explicit fixture.
         "snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel": "@sdist_build__uv_sdist_jdk_build__jpype1__1_7_1//:BUILD.bazel",
 
-        # @sdist_build for cowsay with uv.override_package(monitor_memory)
-        # ----------------------------------------------------------------
-        # Covers the override_package -> repo-rule -> BUILD-template plumbing
-        # for a monitor-only source build. The runtime
-        # //cases/uv-sdist-fallback:test proves that the generated build tool
-        # can load the conditional monitor dependency and complete the wheel.
+        # @sdist_build for cowsay with native annotation and monitor_memory
+        # ------------------------------------------------------------------
+        # cowsay is pure Python, so only `native = true` can select
+        # pep517_native_whl. Its build and native annotations are split so the
+        # snapshot also pins that a native-only annotation preserves explicit
+        # and configure-discovered build deps. This retains the monitor-only
+        # source-build coverage. The runtime //cases/uv-sdist-fallback:test
+        # proves that the forced-native build produces a working wheel.
         "snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel": "@sdist_build__uv_sdist_fallback__cowsay__6_0//:BUILD.bazel",
 
         # @sdist_build for python-geohash with uv.override_package(resource_set)

--- a/e2e/cases/uv-sdist-fallback/annotations.toml
+++ b/e2e/cases/uv-sdist-fallback/annotations.toml
@@ -1,0 +1,7 @@
+version = "0.0.0"
+
+[[package]]
+name = "cowsay"
+build-dependencies = [
+    { name = "packaging" },
+]

--- a/e2e/cases/uv-sdist-fallback/native_annotations.toml
+++ b/e2e/cases/uv-sdist-fallback/native_annotations.toml
@@ -1,0 +1,5 @@
+version = "0.0.0"
+
+[[package]]
+name = "cowsay"
+native = true

--- a/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
@@ -16,6 +16,14 @@ uv.project(
     lock = "//cases/uv-sdist-fallback:uv.lock",
     pyproject = "//cases/uv-sdist-fallback:pyproject.toml",
 )
+uv.unstable_annotate_packages(
+    src = "//cases/uv-sdist-fallback:annotations.toml",
+    lock = "//cases/uv-sdist-fallback:uv.lock",
+)
+uv.unstable_annotate_packages(
+    src = "//cases/uv-sdist-fallback:native_annotations.toml",
+    lock = "//cases/uv-sdist-fallback:uv.lock",
+)
 uv.override_package(
     name = "cowsay",
     console_scripts = {"cowsay": "cowsay.__main__:cli"},

--- a/e2e/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
+++ b/e2e/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
@@ -1,20 +1,30 @@
 
-load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
-    deps = ["@aspect_rules_py//uv/private/pep517_whl:memory_monitor", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"],
+    deps = ["@aspect_rules_py//uv/private/pep517_whl:memory_monitor", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"],
 )
 
-pep517_whl(
+pep517_native_whl(
     name = "whl",
     src = "@@aspect_rules_py++uv+sdist__cowsay__47445cb273684618//file:file",
     tool = ":build_tool",
     version = "6.0",
     monitor_memory = True,
+    toolchains = [
+        "@bazel_tools//tools/cpp:current_cc_toolchain",
+    ],
+    env = {
+        "AR": "$(AR)",
+        "CC": "$(CC)",
+        "CXX": "$(CC)",
+        "LD": "$(LD)",
+        "STRIP": "$(STRIP)",
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -245,6 +245,7 @@ def _parse_projects(module_ctx, hub_specs):
                     return None
 
             lock_build_dep_anns = {}
+            lock_native_anns = {}
             for ann in mod.tags.unstable_annotate_packages:
                 if ann.lock == project.lock:
                     annotations = toml.decode_file(module_ctx, ann.src)
@@ -253,16 +254,21 @@ def _parse_projects(module_ctx, hub_specs):
                         if k == None:
                             # Allow a shared annotation file to include entries for other locks.
                             continue
-                        deps = []
-                        skip = False
-                        for dep in package.get("build-dependencies", []):
-                            resolved = _resolve(dep, fail_if_missing = False)
-                            if resolved == None:
-                                skip = True
-                                break
-                            deps.append(resolved)
-                        if not skip:
-                            lock_build_dep_anns[k] = deps
+                        if "native" in package:
+                            if type(package["native"]) != "bool":
+                                fail("Annotation `native` for package {} in {} must be a boolean, got {}".format(package["name"], ann.src, repr(package["native"])))
+                            lock_native_anns[k] = package["native"]
+                        if "build-dependencies" in package:
+                            deps = []
+                            skip = False
+                            for dep in package["build-dependencies"]:
+                                resolved = _resolve(dep, fail_if_missing = False)
+                                if resolved == None:
+                                    skip = True
+                                    break
+                                deps.append(resolved)
+                            if not skip:
+                                lock_build_dep_anns[k] = deps
 
             # Collect package overrides, validating no duplicates per (lock, name, version).
             package_overrides = {}
@@ -467,6 +473,9 @@ def _parse_projects(module_ctx, hub_specs):
                     # could do pyproject.toml introspection.
                     ann_key = (project_id, normalize_name(package["name"]), package["version"], "__base__")
                     build_deps = lock_build_dep_anns.get(ann_key) or []
+                    is_native = "auto"
+                    if ann_key in lock_native_anns:
+                        is_native = "true" if lock_native_anns[ann_key] else "false"
                     if lock_build_deps == None:
                         # For optional sdist fallbacks (sdist present but a
                         # wheel will be picked at install time), tolerate a
@@ -510,7 +519,7 @@ def _parse_projects(module_ctx, hub_specs):
                     sbuild_specs[sbuild_id] = struct(
                         src = sdist,
                         deps = ["@{0}//:{1}".format(*it) for it in build_deps],
-                        is_native = "auto",
+                        is_native = is_native,
                         version = package["version"],
                         pre_build_patches = pre_build_patches,
                         pre_build_patch_strip = pre_build_patch_strip,

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -150,11 +150,14 @@ def _resolve_archive_path(repository_ctx):
 def _sdist_build_impl(repository_ctx):
     """Prepares a repository for building a wheel from a source distribution (sdist).
 
-    When `is_native` is "auto" (the default), a configure tool is run to
-    inspect the sdist archive. The tool may return:
+    A configure tool may inspect the sdist archive and return:
     - `build_file_content`: used verbatim as the BUILD.bazel
     - `is_native` + `extra_deps`: used to generate a standard build file
       with the appropriate rule and resolved dependencies
+
+    An explicit `is_native` selects the generated rule while preserving
+    configure-discovered deps. It conflicts with complete `build_file_content`,
+    which is otherwise used verbatim.
 
     See //uv/private/sdist_configure:defs.bzl for the tool contract.
 
@@ -163,15 +166,16 @@ def _sdist_build_impl(repository_ctx):
     """
 
     is_native_override = repository_ctx.attr.is_native
-    inspection = None
+    archive_path = _resolve_archive_path(repository_ctx)
+    inspection = _run_configure_tool(repository_ctx, archive_path) if archive_path else None
+    build_file_content = inspection.get("build_file_content") if inspection else None
+
+    if build_file_content and is_native_override != "auto":
+        fail("sdist_build for '{}': explicit `is_native = \"{}\"` requests a generated `pep517_*whl(...)` call, but the configure tool returned complete `build_file_content`; remove the native annotation, or have the configure tool select the build rule.".format(repository_ctx.name, is_native_override))
 
     if is_native_override == "auto":
-        archive_path = _resolve_archive_path(repository_ctx)
-        inspection = _run_configure_tool(repository_ctx, archive_path) if archive_path else None
-
         if inspection != None:
             # If the tool provided complete build file content, use it directly.
-            build_file_content = inspection.get("build_file_content")
             if build_file_content:
                 validate_build_attrs(
                     console_scripts = [],


### PR DESCRIPTION
Package annotations already accept native = true or false, but the uv extension only reads build-dependencies and hard-codes every sdist spec to auto. Explicit native overrides are therefore inert before the repository rule can choose its existing native or pure wheel path.

Parse an optional boolean native field by the resolved lock key, reject non-boolean values early, and merge annotation fields independently so a native-only entry cannot erase build dependencies from another annotation. Map present true or false values into the existing is_native contract while retaining auto for unannotated packages.

Keep configure inspection active when native selection is explicit so discovered build requirements still reach the generated wheel target. The annotation owns only native or pure generated-rule selection. Reject a configure result that also supplies complete build_file_content instead of silently discarding either owner.

Reuse the cowsay sdist fallback fixture with split annotations to snapshot the native rule plus explicit and discovered build dependencies while retaining monitor-memory coverage.