### PR TITLE
fix(py_pex_binary): exclude interpreter site-packages

### DIFF
--- a/e2e/cases/pex-interpreter-exclusion/BUILD.bazel
+++ b/e2e/cases/pex-interpreter-exclusion/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_pex_binary", "py_test")
+
+py_binary(
+    name = "app",
+    srcs = ["app.py"],
+)
+
+py_pex_binary(
+    name = "app_pex",
+    binary = ":app",
+    python_interpreter_constraints = [],
+)
+
+py_test(
+    name = "test_pex_excludes_interpreter",
+    srcs = ["test_pex_excludes_interpreter.py"],
+    data = [":app_pex"],
+    main = "test_pex_excludes_interpreter.py",
+)

--- a/e2e/cases/pex-interpreter-exclusion/app.py
+++ b/e2e/cases/pex-interpreter-exclusion/app.py
@@ -1,0 +1,1 @@
+print("hello from pex")

--- a/e2e/cases/pex-interpreter-exclusion/test_pex_excludes_interpreter.py
+++ b/e2e/cases/pex-interpreter-exclusion/test_pex_excludes_interpreter.py
@@ -1,0 +1,19 @@
+import os
+import zipfile
+from pathlib import Path
+
+PEX = "_main/cases/pex-interpreter-exclusion/app_pex.pex"
+INTERPRETER_REPO_MARKERS = (
+    "aspect_rules_py++python_interpreters+",
+    "aspect_rules_py~~python_interpreters~",
+)
+
+pex = Path(os.environ["RUNFILES_DIR"]) / PEX
+with zipfile.ZipFile(pex) as zf:
+    leaked = [
+        name
+        for name in zf.namelist()
+        if any(marker in name for marker in INTERPRETER_REPO_MARKERS)
+    ]
+
+assert not leaked, leaked[:10]

--- a/py/private/py_pex_binary.bzl
+++ b/py/private/py_pex_binary.bzl
@@ -39,6 +39,9 @@ exclude_paths = [
     # these will match in bzlmod setup with --incompatible_use_plus_in_repo_names flag flipped.
     "rules_python++python+",
     "aspect_rules_py+/py/tools/",
+    # The hermetic interpreter repo includes bundled pip/setuptools site-packages.
+    "aspect_rules_py++python_interpreters+",
+    "aspect_rules_py~~python_interpreters~",
     # Skip the sibling py_venv's tree (`.<name>.venv/`) — its `.pth`
     # and pyvenv.cfg are launcher plumbing; pex discovers wheels via
     # `--dep`, not by walking the venv.


### PR DESCRIPTION
## Summary

`py_pex_binary` walks the wrapped binary's runfiles and treats any path containing `site-packages` as a PEX dependency. That is correct for application wheels, but not for the hermetic Python interpreter repository produced by `aspect_rules_py`'s `python_interpreters` extension. Those interpreter runfiles include bundled `pip` and `setuptools` under `lib/python*/site-packages`.

When those interpreter site-packages are passed to PEX as a dependency, PEX sees multiple distributions in the same location and fails with `AmbiguousDistributionError`. The older root PEX test does not catch this because it uses a `rules_python++python+...` interpreter repo, which was already excluded.

This change extends the existing interpreter/tooling exclusion list to skip both plus-style and tilde-style `aspect_rules_py` `python_interpreters` repository paths.

## Regression Test

Adds `e2e/cases/pex-interpreter-exclusion`, which builds a minimal `py_pex_binary` in the e2e workspace where the registered interpreter comes from `@aspect_rules_py//py:extensions.bzl%python_interpreters`.

Before the fix, the target fails while building the PEX:

```text
pex.dist_metadata.AmbiguousDistributionError: Found more than one distribution inside external/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/lib/python3.11/site-packages:
pip-26.0.1.dist-info/METADATA
setuptools-80.9.0.dist-info/METADATA
```

After the fix, the test opens the built `.pex` and asserts no `python_interpreters` repository paths were packaged.

## Testing

- Before the code fix, `(cd e2e && bazel test //cases/pex-interpreter-exclusion:test_pex_excludes_interpreter --test_output=errors)` failed during `PyPex` with the `AmbiguousDistributionError` above.
- `bazel run //:gazelle`
- `pre-commit run buildifier --files py/private/py_pex_binary.bzl e2e/cases/pex-interpreter-exclusion/BUILD.bazel`
- `pre-commit run prettier --files py/private/py_pex_binary.bzl e2e/cases/pex-interpreter-exclusion/BUILD.bazel e2e/cases/pex-interpreter-exclusion/app.py e2e/cases/pex-interpreter-exclusion/test_pex_excludes_interpreter.py`
- `pre-commit run typos --files py/private/py_pex_binary.bzl e2e/cases/pex-interpreter-exclusion/BUILD.bazel e2e/cases/pex-interpreter-exclusion/app.py e2e/cases/pex-interpreter-exclusion/test_pex_excludes_interpreter.py`
- `bazel test //py/tests/py-pex-binary:all --test_output=errors`
- `(cd e2e && bazel test //cases/pex-interpreter-exclusion:test_pex_excludes_interpreter --test_output=errors)`