### PR TITLE
fix(py): avoid dirname in console scripts

### DIFF
--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -50,7 +50,11 @@ load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
 # https://packaging.python.org/en/latest/specifications/entry-points/#data-model
 _CONSOLE_SCRIPT_TEMPLATE = """\
 #!/bin/sh
-exec "$(dirname "$0")/python" -c 'import sys; from importlib import import_module; from operator import attrgetter; sys.argv[0] = "{name}"; sys.exit(attrgetter("{func}")(import_module("{module}"))())' "$@"
+case $0 in
+    */*) script_dir=${{0%/*}} ;;
+    *) script_dir=. ;;
+esac
+exec "${{script_dir}}/python" -c 'import sys; from importlib import import_module; from operator import attrgetter; sys.argv[0] = "{name}"; sys.exit(attrgetter("{func}")(import_module("{module}"))())' "$@"
 """
 
 def _dict_to_exports(env):

--- a/py/tests/console-scripts/BUILD.bazel
+++ b/py/tests/console-scripts/BUILD.bazel
@@ -38,7 +38,7 @@ py_unpacked_wheel(
 # Failure modes this test catches:
 #   - Wrapper file not written (PyWheelInfo plumbing broken)
 #   - Wrapper not on $PATH (launcher doesn't prepend <venv>/bin/)
-#   - Wrapper's `$(dirname "$0")/python` can't find the venv's python
+#   - Wrapper can't find the sibling venv interpreter without ambient tools
 #   - Module resolution inside the wrapper fails (site-packages not set up)
 py_test(
     name = "test_console_scripts",

--- a/py/tests/console-scripts/test_console_scripts.py
+++ b/py/tests/console-scripts/test_console_scripts.py
@@ -44,6 +44,19 @@ class ConsoleScriptsTest(unittest.TestCase):
         )
         self.assertIn("subprocess-invocation-worked", result.stdout)
 
+    def test_wrapper_needs_only_venv_bin_on_path(self):
+        wrapper = shutil.which("cowsay")
+        self.assertIsNotNone(wrapper)
+        result = subprocess.run(
+            [wrapper, "-t", "restricted-path-worked"],
+            capture_output=True,
+            env={**os.environ, "PATH": os.path.dirname(wrapper)},
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("restricted-path-worked", result.stdout)
+
     def test_wrapper_invokes_dotted_entry_point(self):
         result = subprocess.run(
             ["Dotted-Entry"],


### PR DESCRIPTION
Generated console-script wrappers resolve their sibling interpreter by running dirname. A caller can find the wrapper through a PATH containing only the venv bin directory, but the wrapper cannot find dirname, expands its interpreter path to /python, and fails before the entry point runs.

Resolve the sibling interpreter with POSIX shell parameter expansion. The wrapper stays relocatable and keeps the existing dotted-entry-point dispatch without an ambient tool dependency.

The console-script runtime test now invokes a generated cowsay wrapper with PATH limited to its venv bin directory. It fails on the previous wrapper with dirname not found and /python missing, and passes with this change.