### PR TITLE
fix(py): preserve wheel metadata through binaries

### DIFF
--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_test", "py_unpacked_wheel")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_test", "py_unpacked_wheel")
 load("//tools:pth_snapshot.bzl", "extract_venv_pth")
 
 # Test namespace package resolution with the symlink-forest venv.
@@ -15,6 +15,31 @@ py_test(
         "@pypi_pth_namespace_547//jaraco_classes",
         "@pypi_pth_namespace_547//jaraco_functools",
     ],
+)
+
+# Regression: a py_binary must forward its sibling venv wheel records when it
+# is a dep of another Python target. Without them, the outer venv loses the
+# concrete jaraco namespace projection pinned by __test__.py.
+py_binary(
+    name = "nested_binary",
+    testonly = True,
+    srcs = ["__test__.py"],
+    dep_group = "pth-namespace-547",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi_pth_namespace_547//jaraco_classes",
+        "@pypi_pth_namespace_547//jaraco_functools",
+    ],
+)
+
+py_test(
+    name = "test_nested_binary",
+    srcs = ["__test__.py"],
+    dep_group = "pth-namespace-547",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [":nested_binary"],
 )
 
 # Gap-1 fixture: hand-written `py_unpacked_wheel` contributing to the

--- a/py/private/py_venv/py_venv_exec.bzl
+++ b/py/private/py_venv/py_venv_exec.bzl
@@ -9,6 +9,7 @@ attrs to the auto-generated sibling.
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@hermetic_launcher//launcher:lib.bzl", "launcher")
 load("@rules_python//python:defs.bzl", "PyInfo")
+load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load(":types.bzl", "VirtualenvInfo", "venv_root")
 
@@ -140,6 +141,12 @@ def _py_venv_exec_impl(ctx):
             has_py2_only_sources = False,
             has_py3_only_sources = True,
             uses_shared_libraries = False,
+        ),
+        PyWheelsInfo(
+            # The launcher owns no deps itself; forward the sibling venv's
+            # wheel records so an outer py_binary / py_test can assemble the
+            # same package overlays when this executable appears in deps.
+            wheels = vinfo.wheels,
         ),
         instrumented_files_info,
         RunEnvironmentInfo(


### PR DESCRIPTION
OpenAI Buildkite 5146797 exposed this through nested Python targets: an outer venv received wheel import paths from a `py_binary` dependency but lost the wheel collision records, so it could not reproduce the inner target's package overlay and `azure.core.tracing.ext.opentelemetry_span` disappeared before OpenAPI generators ran.

`py_binary` and `py_test` split dependencies onto a sibling venv, then return a launcher that previously surfaced only `PyInfo`. Forward that sibling venv's existing `PyWheelsInfo` from the launcher as well. The launcher does not rediscover or own wheel records; it preserves the metadata already owned by the sibling venv so an outer executable can make the same collision and namespace decisions.

The existing `pth-namespace-547` e2e now nests a `py_binary` that owns the jaraco wheels under a `py_test` that depends only on that binary. Without this change, the outer venv keeps only the fallback `.pth` and lacks the concrete `site-packages/jaraco` namespace asserted by the fixture. With the forwarded records, the outer projection matches the inner binary.