### PR TITLE
fix(py_venv): keep one fallback metadata owner

### DIFF
--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -91,10 +91,10 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
 
     * **Declared distribution metadata in site-packages.** Metadata discovery
       scans every `sys.path` entry instead of stopping at the first match.
-      Preserve the existing exact-entry collision precedence, but project the
-      selected `*.dist-info` and `*.egg-info` entry only when that wheel needs
-      no whole-wheel fallback. Reject an exact-entry collision when a losing
-      claimant remains on fallback and therefore cannot be suppressed.
+      Apply exact-entry collision policy first. When no claimant remains on
+      whole-wheel fallback, project the normal winner. When exactly one
+      remains, project nothing and let that sole fallback copy own discovery.
+      Reject multiple fallback copies because they cannot be suppressed.
 
     * **Console-script name in bin/.** Apply `package_collisions` directly
       — no namespace equivalent.
@@ -414,12 +414,9 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
         if covered:
             fully_covered[w.site_packages_rfpath] = True
 
-    # Metadata discovery scans every sys.path entry. Resolve duplicate declared
-    # metadata entries with the existing collision precedence, but first reject
-    # a losing claimant that remains on whole-wheel fallback because downgrading
-    # the collision cannot suppress that copy. Project the winner only when its
-    # fallback is gone. Wheels without declared layout metadata remain on the
-    # existing whole-wheel fallback and cannot be classified here.
+    # Metadata discovery scans every sys.path entry. After collision policy,
+    # no fallback projects the normal winner, one fallback owns discovery
+    # without a projection, and multiple fallback copies remain ambiguous.
     for tl, claimants in metadata_claimants.items():
         winner = claimants[0]
         seen = {winner: True}
@@ -428,15 +425,6 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                 continue
             winner = site_packages
             seen[site_packages] = True
-        for site_packages in seen:
-            if site_packages != winner and site_packages not in fully_covered:
-                fail(("{}: distribution metadata entry `{}` selects {}, but " +
-                      "losing claimant {} remains on whole-wheel fallback.").format(
-                    ctx.label,
-                    tl,
-                    winner,
-                    site_packages,
-                ))
         prior = claimants[0]
         complained = {prior: True}
         for site_packages in claimants[1:]:
@@ -445,7 +433,20 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             _complain("distribution metadata entry", tl, prior, site_packages)
             prior = site_packages
             complained[site_packages] = True
-        if winner in fully_covered:
+        fallback_claimants = [
+            site_packages
+            for site_packages in seen
+            if site_packages not in fully_covered
+        ]
+        if len(fallback_claimants) > 1:
+            fail(("{}: distribution metadata entry `{}` selects {}, but " +
+                  "multiple claimants remain on whole-wheel fallback: {}.").format(
+                ctx.label,
+                tl,
+                winner,
+                sorted(fallback_claimants),
+            ))
+        if not fallback_claimants:
             top_level_to_site_pkgs[tl] = winner
 
     return top_level_to_site_pkgs, fully_covered, console_scripts_map, merge_groups

--- a/py/tests/py_venv_conflict/collision_order_test.bzl
+++ b/py/tests/py_venv_conflict/collision_order_test.bzl
@@ -173,10 +173,30 @@ def collision_order_test_suite():
         name = "_metadata_collision_second",
         metadata_name = "collision_first-1.0.dist-info",
         tags = ["manual"],
-        value = "metadata_second",
+        value = "first",
+    )
+    py_test(
+        name = "metadata_collision_single_fallback_test",
+        srcs = ["test_metadata_collision_suppression.py"],
+        args = [
+            "collision-first",
+            "_collision_first",
+        ],
+        main = "test_metadata_collision_suppression.py",
+        package_collisions = "ignore",
+        deps = [
+            ":_collision_first",
+            ":_metadata_collision_second",
+        ],
+    )
+    _wheel(
+        name = "_metadata_collision_third",
+        metadata_name = "collision_first-1.0.dist-info",
+        tags = ["manual"],
+        value = "first",
     )
     py_binary(
-        name = "_metadata_collision_error_binary",
+        name = "_metadata_collision_multi_fallback_error_binary",
         srcs = ["test_namespace_fallback.py"],
         main = "test_namespace_fallback.py",
         package_collisions = "ignore",
@@ -184,12 +204,13 @@ def collision_order_test_suite():
         deps = [
             ":_collision_first",
             ":_metadata_collision_second",
+            ":_metadata_collision_third",
         ],
     )
     _collision_error_test(
-        name = "metadata_collision_error_test",
-        expected_error = "distribution metadata entry `collision_first-1.0.dist-info` selects",
-        target_under_test = ":_metadata_collision_error_binary",
+        name = "metadata_collision_multi_fallback_error_test",
+        expected_error = "multiple claimants remain on whole-wheel fallback",
+        target_under_test = ":_metadata_collision_multi_fallback_error_binary",
     )
 
     _wheel(
@@ -204,9 +225,29 @@ def collision_order_test_suite():
         tags = ["manual"],
         value = "metadata_shared",
     )
+    py_binary(
+        name = "_metadata_collision_policy_error_binary",
+        srcs = ["test_metadata_collision_suppression.py"],
+        main = "test_metadata_collision_suppression.py",
+        package_collisions = "error",
+        tags = ["manual"],
+        deps = [
+            ":_metadata_suppressible_first",
+            ":_metadata_suppressible_second",
+        ],
+    )
+    _collision_error_test(
+        name = "metadata_collision_policy_error_test",
+        expected_error = "distribution metadata entry `collision_metadata_shared-1.0.dist-info`",
+        target_under_test = ":_metadata_collision_policy_error_binary",
+    )
     py_test(
         name = "metadata_collision_suppression_test",
         srcs = ["test_metadata_collision_suppression.py"],
+        args = [
+            "collision-metadata-shared",
+            "_metadata_suppressible_second",
+        ],
         main = "test_metadata_collision_suppression.py",
         package_collisions = "ignore",
         deps = [

--- a/py/tests/py_venv_conflict/test_metadata_collision_suppression.py
+++ b/py/tests/py_venv_conflict/test_metadata_collision_suppression.py
@@ -1,6 +1,8 @@
 from importlib.metadata import distributions
+import sys
 
 
-matches = list(distributions(name="collision-metadata-shared"))
+distribution_name, expected_summary = sys.argv[1:3]
+matches = list(distributions(name=distribution_name))
 assert len(matches) == 1, [str(match.locate_file("")) for match in matches]
-assert matches[0].metadata["Summary"] == "_metadata_suppressible_second"
+assert matches[0].metadata["Summary"] == expected_summary


### PR DESCRIPTION
A native-root collision can leave one wheel on whole-wheel fallback
while another claimant owns the direct package projection. When both
wheels publish the same dist-info entry, the metadata collision path
rejected the venv even though only one fallback copy remains visible.

Apply the metadata collision policy first. Keep the normal projected
winner when no claimant needs fallback. Let a sole fallback copy own
metadata discovery without another projection. Retain the hard failure
when multiple fallback copies cannot be suppressed.

This preserves one importlib.metadata result for a permissive
duplicate-lock case while keeping error policy and the ambiguous case
explicit.