### PR TITLE
chore: remove debug logs in py_console_script_binary

### DIFF
--- a/uv/private/py_entrypoint_binary/search.py
+++ b/uv/private/py_entrypoint_binary/search.py
@@ -20,21 +20,17 @@ PARSER.add_argument("--template")
 PARSER.add_argument("--script")
 opts, args = PARSER.parse_known_args()
 
-print(repr(opts), file=sys.stderr)
-
 entrypoint = None
 for e in sys.path:
     if entrypoint:
         break
     
-    print("{}:".format(e), file=sys.stderr)
     for entrypoints in Path(e).glob("*.dist-info/entry_points.txt"):        
         cp = CaseSensitiveConfigParser(delimiters=('=',))
         cp.read([entrypoints])
 
         if "console_scripts" in cp:
             for e in cp["console_scripts"]:
-                print(entrypoints, e, cp["console_scripts"][e], file=sys.stderr)
                 if e == opts.script:
                     entrypoint = cp["console_scripts"][e]
                     break


### PR DESCRIPTION
The search tool used for `py_console_script_binary` produces a lot of logspam to stderr. This PR removes it.

### Changes are visible to end-users:

yes

- Searched for relevant documentation and updated as needed: n/a
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases