### PR TITLE
test(e2e): replace file-path assertions in airflow test with import checks

### DIFF
--- a/e2e/cases/uv-deps-650/airflow/BUILD.bazel
+++ b/e2e/cases/uv-deps-650/airflow/BUILD.bazel
@@ -10,6 +10,7 @@ py_test(
     python_version = "3.13",
     deps = [
         "@pypi_uv_deps_650//apache_airflow",
+        "@pypi_uv_deps_650//apache_airflow_providers_common_sql",
     ],
 )
 
@@ -25,5 +26,6 @@ py_test(
     python_version = "3.13",
     deps = [
         "@pypi_uv_deps_650//apache_airflow",
+        "@pypi_uv_deps_650//apache_airflow_providers_common_sql",
     ],
 )

--- a/e2e/cases/uv-deps-650/airflow/__test__.py
+++ b/e2e/cases/uv-deps-650/airflow/__test__.py
@@ -1,16 +1,26 @@
 #!/usr/bin/env python3
 
-# TODO: Deprecated API, need an alternative
-import pkgutil
+# airflow is a top-level collision across many apache-airflow-* wheels.
+# apache-airflow-core owns airflow/__init__.py (non-namespace); provider wheels
+# contribute content under airflow/ without an __init__.py.
 
-# `airflow` resolves to the providing wheel's natural runfiles path; the venv
-# references wheels there rather than copying them into its own tree. `airflow`
-# is a top-level collision across many apache-airflow-* wheels, so resolution
-# must pick airflow-core (the wheel that owns `airflow/__init__.py`), not a
-# provider.
-_airflow_file = pkgutil.get_loader("airflow").get_filename()
-assert _airflow_file.endswith("/site-packages/airflow/__init__.py"), _airflow_file
-assert "apache_airflow_core" in _airflow_file, _airflow_file
+import os
+
+# Airflow's initialization tries to create $AIRFLOW_HOME (default ~/airflow).
+# Point it at Bazel's writable scratch dir so sandbox runs don't fail.
+os.environ.setdefault("AIRFLOW_HOME", os.environ.get("TEST_TMPDIR", "/tmp"))
+
+# apache-airflow-core: the wheel that owns airflow/__init__.py
+from airflow.models import DAG
+
+assert DAG is not None
+
+# apache-airflow-providers-common-sql is a transitive dep of core.
+# Importing from it exercises that provider content is accessible alongside
+# core's airflow/__init__.py under the mixed regular/namespace topology.
+from airflow.providers.common.sql.hooks.sql import DbApiHook
+
+assert DbApiHook is not None
 
 import sys
 assert sys.version_info.major == 3


### PR DESCRIPTION
Drop the deprecated pkgutil.get_loader() file-path assertions and assert instead that DAG (from core) and DbApiHook (from a provider transitive dep) are importable.

This way we are not making any fragile assumptions about the file layout, which is likely going to change soon as we try to accommodate certain collisions by doing physical merges.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases