### PR TITLE
chore: replace bazel_tools//tools/python/runfiles with pip bazel-runfiles

### DIFF
--- a/examples/py_pex_binary/BUILD.bazel
+++ b/examples/py_pex_binary/BUILD.bazel
@@ -8,7 +8,7 @@ py_binary(
         "TEST": "1",
     },
     deps = [
-        "@bazel_tools//tools/python/runfiles",
+        "@pypi//bazel_runfiles",
         "@pypi//cowsay",
     ],
 )

--- a/examples/py_pex_binary/say.py
+++ b/examples/py_pex_binary/say.py
@@ -1,7 +1,7 @@
 import cowsay
 import sys
 import os
-from bazel_tools.tools.python.runfiles import runfiles
+import runfiles
 
 print("sys.path entries:")
 for p in sys.path:

--- a/py/private/pth.bzl
+++ b/py/private/pth.bzl
@@ -96,7 +96,7 @@ def write_pth_file(ctx, name, imports_depset, escape = None):
     The `escape` value is the relative path from `site-packages` back to the
     runfiles root (e.g. `../../../../..`). By writing it as the first line, the
     runfiles root itself becomes importable, which is required by a few targets
-    (notably `@rules_python//python/runfiles`) that rely on the root being on
+    (notably `@bazel_tools//tools/python/runfiles`) that rely on the root being on
     `sys.path` but have no `imports` attribute to hint that they need it.
 
     Args:

--- a/py/tests/external-deps/BUILD.bazel
+++ b/py/tests/external-deps/BUILD.bazel
@@ -49,6 +49,6 @@ py_test(
     name = "test_can_import_runfiles_helper",
     srcs = ["test_can_import_runfiles_helper.py"],
     deps = [
-        "@bazel_tools//tools/python/runfiles",
+        "@pypi//bazel_runfiles",
     ],
 )

--- a/py/tests/external-deps/test_can_import_runfiles_helper.py
+++ b/py/tests/external-deps/test_can_import_runfiles_helper.py
@@ -1,4 +1,4 @@
 try:
-    from bazel_tools.tools.python.runfiles import runfiles
+    import runfiles
 except ModuleNotFoundError as err:
     assert False, "Expected to be able to import runfiles helper"

--- a/py/tests/py-pex-binary/BUILD.bazel
+++ b/py/tests/py-pex-binary/BUILD.bazel
@@ -9,9 +9,9 @@ py_binary(
     srcs = ["print_modules.py"],
     data = ["data.txt"],
     deps = [
+        "@pypi//bazel_runfiles",
         "@pypi//cowsay",
         "@pypi//six",
-        "@rules_python//python/runfiles",
     ],
 )
 

--- a/py/tests/py-pex-binary/print_modules.py
+++ b/py/tests/py-pex-binary/print_modules.py
@@ -1,7 +1,7 @@
 import sys
 import cowsay
 import six
-from python.runfiles import runfiles
+import runfiles
 
 
 r = runfiles.Create()


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
