### PR TITLE
fix(py_image_layer): wire PY_TOOLCHAIN through py_venv_exec so interpreter layers are emitted

### DIFF
--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_layers_fp_listing.yaml
@@ -6,40 +6,6 @@ files:
 ---
 layer: 1
 files:
-  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
-  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansi.py
-  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansitowin32.py
-  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/initialise.py
-  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/__init__.py
-  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
-  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
-  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
-  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
-  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/utils.py
-  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
-  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/win32.py
-  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/winterm.py
----
-layer: 2
-files:
-  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
-  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
----
-layer: 3
-files:
-  - -rwxr-xr-x  0 0      0       17400 Jan  1  2023 ./app
-  - -rwxr-xr-x  0 0      0        2102 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/bin/activate
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/bin/python -> ../../../../../aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/python3
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/bin/python3 -> python
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/bin/python3.11 -> python
-  - -rwxr-xr-x  0 0      0         295 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_my_app_bin.venv.pth
-  - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
-  - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama
-  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
-  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
-  - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11
   - -rwxr-xr-x  0 0      0         158 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3-3.11
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/idle3 -> idle3.11
@@ -2357,5 +2323,42 @@ files:
   - -rwxr-xr-x  0 0      0       25855 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/lib/tk9.0/xmfbox.tcl
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/share/man/man1/python3.1 -> python3.11.1
   - -rwxr-xr-x  0 0      0       20280 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/share/man/man1/python3.11.1
+---
+layer: 2
+files:
+  - -rwxr-xr-x  0 0      0         266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 0      0        2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 0      0       11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 0      0        3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 0      0          75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 0      0        2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 0      0       10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 0      0        6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 0      0        1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 0      0        1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 0      0        3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 0      0        6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 0      0        7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/winterm.py
+---
+layer: 3
+files:
+  - -rwxr-xr-x  0 0      0       17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 0      0        1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+---
+layer: 4
+files:
+  - -rwxr-xr-x  0 0      0       17400 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0        2102 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/bin/activate
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/bin/python -> ../../../../../aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/python3
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/bin/python3 -> python
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/bin/python3.11 -> python
+  - -rwxr-xr-x  0 0      0         295 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_my_app_bin.venv.pth
+  - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
+  - -rwxr-xr-x  0 0      0        4745 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/_virtualenv.py
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
+  - -rwxr-xr-x  0 0      0         153 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0         276 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/__main__.py
+  - -rwxr-xr-x  0 0      0        6570 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - -rwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py+/py/tests/internal-deps/adder/__init__.py
   - -rwxr-xr-x  0 0      0          32 Jan  1  2023 ./app.runfiles/aspect_rules_py+/py/tests/internal-deps/adder/add.py

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -177,11 +177,11 @@ _LayerInfo = provider(
         "pip_packages": "depset[struct] — fully transitive pip packages with per-package layers.",
         "first_party_layers": "depset[struct(label, files, group)] — first-party PyInfo targets matched by py_layer_tier.groups.",
         "interpreter_files": "depset[File] — interpreter runfiles, populated only on the py toolchain pass for the binary-branch skip filter.",
-        "interpreter_layer": "struct(tar, group) | None — prebuilt interpreter layer tar + its group name, declared at the toolchain target's namespace so the tar action-shares across every py_image_layer using that toolchain config.",
+        "interpreter_layer": "struct(tar, group, interpreter_files) | None — prebuilt interpreter layer tar + its group name + the files used to build it, declared at the toolchain target's namespace so the tar action-shares across every py_image_layer using that toolchain config.",
     },
 )
 
-_PY_VENV_KINDS = ("py_venv", "_py_venv")
+_PY_VENV_KINDS = ("py_venv", "_py_venv", "_py_venv_lib")
 
 def _collect_from_deps(ctx, provider):
     """Walk deps/data/actual/venv and return a list of provider values from each matching dep."""
@@ -331,7 +331,7 @@ def _layer_aspect_impl(target, ctx):
                 "PyImagePkgLayer",
                 "Creating interpreter layer %s" % target.label,
             )
-            interp_layer = struct(tar = interp_tar, group = interp_group)
+            interp_layer = struct(tar = interp_tar, group = interp_group, interpreter_files = interp_depset)
         return [_LayerInfo(
             source_files = depset(),
             pip_packages = depset(),
@@ -344,6 +344,7 @@ def _layer_aspect_impl(target, ctx):
     transitive_source = [info.source_files for info in dep_infos]
     transitive_pkgs = [info.pip_packages for info in dep_infos]
     transitive_fp = [info.first_party_layers for info in dep_infos]
+    transitive_interp = [info.interpreter_layer for info in dep_infos if info.interpreter_layer != None]
 
     if PyWheelsInfo in target and ctx.rule.kind in ("whl_install", "py_unpacked_wheel"):
         plan = ctx.attr._layer_tier[PyLayerTierInfo]
@@ -363,11 +364,14 @@ def _layer_aspect_impl(target, ctx):
                 transitive = transitive_pkgs,
             ),
             first_party_layers = depset(transitive = transitive_fp),
+            interpreter_files = depset(),
+            interpreter_layer = None,
         )]
 
     own_source = []
     own_fp = []
     interpreter_layer = None
+    interpreter_files = None
     kind = ctx.rule.kind
     is_binary = (
         PyInfo in target and
@@ -384,6 +388,8 @@ def _layer_aspect_impl(target, ctx):
             source_files = depset(transitive = transitive_source),
             pip_packages = depset(transitive = transitive_pkgs),
             first_party_layers = depset(transitive = transitive_fp),
+            interpreter_files = depset(),
+            interpreter_layer = None,
         )]
 
     # Skip PyInfo deps (including wheel-leaf targets, which also emit PyInfo) —
@@ -413,6 +419,15 @@ def _layer_aspect_impl(target, ctx):
         else:
             own_source.append(own_depset)
 
+    if kind in _PY_VENV_KINDS:
+        if PY_TOOLCHAIN in ctx.rule.toolchains:
+            py_tc = ctx.rule.toolchains[PY_TOOLCHAIN]
+            if _LayerInfo in py_tc:
+                tc_info = py_tc[_LayerInfo]
+                if tc_info.interpreter_layer != None:
+                    interpreter_layer = tc_info.interpreter_layer
+                    interpreter_files = tc_info.interpreter_files
+
     # Binaries walk their runfiles for the source layer, filtering out bytes already
     # shipping in their own pip / fp-group / interpreter layers.
     if is_binary:
@@ -427,23 +442,17 @@ def _layer_aspect_impl(target, ctx):
                     skip_paths[f.path] = True
 
         # Opt-in interpreter layer. The aspect fires on the py toolchain via
-        # `toolchains_aspects` and declares the tar there; we just read the
-        # pre-built File out of the toolchain's _LayerInfo via ctx.rule.toolchains
-        # (NOT ctx.toolchains, which would pick the exec interpreter under
-        # cross-platform transitions) and propagate it up to the rule impl.
+        # `toolchains_aspects` and declares the tar there; the venv propagates
+        # that layer (and its file list) so the binary uses the exact interpreter
+        # that built the venv rather than relying on its own toolchain resolution.
         interp_paths = {}
-        if PY_TOOLCHAIN in ctx.rule.toolchains:
-            py_tc = ctx.rule.toolchains[PY_TOOLCHAIN]
-            if _LayerInfo in py_tc:
-                tc_info = py_tc[_LayerInfo]
-                interpreter_layer = tc_info.interpreter_layer
-
-                # Only skip interpreter paths from the source layer when there
-                # IS a separate interpreter tar to route them to; otherwise the
-                # interpreter belongs in the default layer.
-                if interpreter_layer != None:
-                    for f in tc_info.interpreter_files.to_list():
-                        interp_paths[f.path] = True
+        for interp_layer in transitive_interp:
+            if interp_layer.interpreter_files != None:
+                for f in interp_layer.interpreter_files.to_list():
+                    interp_paths[f.path] = True
+        if transitive_interp:
+            interpreter_layer = transitive_interp[0]
+            interpreter_files = transitive_interp[0].interpreter_files
 
         runfiles_files = target[DefaultInfo].default_runfiles.files.to_list()
         filtered = [f for f in runfiles_files if f.path not in skip_paths and f.path not in interp_paths]
@@ -465,6 +474,7 @@ def _layer_aspect_impl(target, ctx):
         source_files = depset(transitive = transitive_source + own_source),
         pip_packages = depset(transitive = transitive_pkgs),
         first_party_layers = depset(direct = own_fp, transitive = transitive_fp),
+        interpreter_files = interpreter_files,
         interpreter_layer = interpreter_layer,
     )]
 


### PR DESCRIPTION
`py_image_layer` builds the interpreter tar from the Python toolchain aspect, but it reads that tar back from ctx.rule.toolchains on the binary target. py_venv_exec is the rule that the py_binary macro ultimately attaches the layer aspect to, yet it only declared the launcher toolchains, not `PY_TOOLCHAIN`. Because the toolchain was invisible to the aspect, the interpreter was silently dropped into the default source layer instead of a dedicated layer. Adding `PY_TOOLCHAIN` to `py_venv_exec` and `py_venv_exec_test` exposes the toolchain info so the aspect can route interpreter files to their own layer as intended.

Fix #1217 

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
