### PR TITLE
perf(uv): use index cursors in PEP 508 tokenizer and parser

### DIFF
--- a/uv/private/markers/pep508_evaluate.bzl
+++ b/uv/private/markers/pep508_evaluate.bzl
@@ -81,20 +81,22 @@ def tokenize(marker):
     token = ""
     state = _STATE.NONE
     char = ""
+    n = len(marker)
+    pos = 0
 
     # Due to the `continue` in the loop, we will be processing chars at a slower pace
-    for _ in range(2 * len(marker)):
-        if token and (state == _STATE.NONE or not marker):
+    for _ in range(2 * n):
+        if token and (state == _STATE.NONE or pos >= n):
             if tokens and token == "in" and tokens[-1] == _NOT:
                 tokens[-1] += " " + token
             else:
                 tokens.append(token)
             token = ""
 
-        if not marker:
+        if pos >= n:
             return tokens
 
-        char = marker[0]
+        char = marker[pos]
         if state == _STATE.STRING and char in _QUOTES:
             state = _STATE.NONE
             token = '"{}"'.format(token)
@@ -125,9 +127,9 @@ def tokenize(marker):
             token += char
 
         # Consume the char
-        marker = marker[1:]
+        pos += 1
 
-    return fail("BUG: failed to process the marker in allocated cycles: {}".format(marker))
+    return fail("BUG: failed to process the marker in allocated cycles: {}".format(marker[pos:]))
 
 def evaluate(marker, *, env, strict = True, **kwargs):
     """Evaluate the marker against a given env.
@@ -143,13 +145,14 @@ def evaluate(marker, *, env, strict = True, **kwargs):
     """
     tokens = tokenize(marker)
     ast = _new_expr(**kwargs)
+    pos = 0
     for _ in range(len(tokens) * 2):
-        if not tokens:
+        if pos >= len(tokens):
             break
 
-        tokens = ast.parse(env = env, tokens = tokens, strict = strict)
+        pos = ast.parse(env = env, tokens = tokens, pos = pos, strict = strict)
 
-    if not tokens:
+    if pos >= len(tokens):
         return ast.value()
 
     fail("Could not evaluate: {}".format(marker))
@@ -241,26 +244,31 @@ def _new_expr(
     )
     return self
 
-def _parse(self, *, env, tokens, strict = False):
-    """The parse function takes the consumed tokens and returns the remaining."""
-    token, remaining = tokens[0], tokens[1:]
+def _parse(self, *, env, tokens, pos, strict = False):
+    """The parse function takes the token cursor and returns the new position."""
+    token = tokens[pos]
 
     if token == "(":
         expr = _open_parenthesis(self)
+        pos += 1
     elif token == ")":
         expr = _close_parenthesis(self)
+        pos += 1
     elif token == _AND:
         expr = _and_expr(self)
+        pos += 1
     elif token == _OR:
         expr = _or_expr(self)
+        pos += 1
     elif token == _NOT:
         expr = _not_expr(self)
+        pos += 1
     else:
-        expr = marker_expr(env = env, strict = strict, *tokens[:3])
-        remaining = tokens[3:]
+        expr = marker_expr(env = env, strict = strict, *tokens[pos:pos + 3])
+        pos += 3
 
     _append(self, expr)
-    return remaining
+    return pos
 
 def _value(self):
     """Evaluate the expression tree"""

--- a/uv/private/markers/pep508_evaluate_test.bzl
+++ b/uv/private/markers/pep508_evaluate_test.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load(":defs.bzl", "MARKER_ENV_ALIASES")
-load(":pep508_evaluate.bzl", "evaluate")
+load(":pep508_evaluate.bzl", "evaluate", "tokenize")
 
 _LINUX_ENV = {
     "implementation_name": "cpython",
@@ -44,6 +44,65 @@ _X86_64_ENV = {
     "sys_platform": "linux",
     "_aliases": MARKER_ENV_ALIASES,
 }
+
+def _tokenize_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Empty / whitespace-only input
+    asserts.equals(env, [], tokenize(""))
+    asserts.equals(env, [], tokenize(" \t "))
+
+    # Quoting is normalized to double quotes, for single- and double-quoted
+    # values alike.
+    asserts.equals(
+        env,
+        ["sys_platform", "==", "\"linux\""],
+        tokenize("sys_platform == 'linux'"),
+    )
+    asserts.equals(
+        env,
+        ["os_name", "==", "\"nt\""],
+        tokenize("os_name == \"nt\""),
+    )
+
+    # 'not' followed by 'in' fuses into a single "not in" token, regardless
+    # of the whitespace between them.
+    asserts.equals(
+        env,
+        ["\"win32\"", "not in", "sys_platform"],
+        tokenize("'win32' not in sys_platform"),
+    )
+    asserts.equals(
+        env,
+        ["\"win32\"", "not in", "sys_platform"],
+        tokenize("'win32'  not \t in  sys_platform"),
+    )
+
+    # Whitespace is trimmed: tabs, runs of spaces, and no spaces at all
+    # around operators tokenize identically.
+    expected = ["python_version", ">=", "\"3.10\""]
+    asserts.equals(env, expected, tokenize("python_version >= '3.10'"))
+    asserts.equals(env, expected, tokenize("python_version\t>=  '3.10'"))
+    asserts.equals(env, expected, tokenize("python_version>='3.10'"))
+
+    # Parentheses are standalone tokens, including when adjacent to
+    # identifiers and quoted values.
+    asserts.equals(
+        env,
+        ["(", "sys_platform", "==", "\"linux\"", ")"],
+        tokenize("(sys_platform == 'linux')"),
+    )
+    asserts.equals(
+        env,
+        ["(", "(", "sys_platform", "==", "\"linux\"", ")", "and", "(", "os_name", "==", "\"posix\"", ")", ")"],
+        tokenize("((sys_platform == 'linux') and (os_name == 'posix'))"),
+    )
+
+    return unittest.end(env)
+
+tokenize_test = unittest.make(
+    _tokenize_test_impl,
+)
 
 def _evaluate_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -109,6 +168,36 @@ def _evaluate_test_impl(ctx):
     asserts.true(env, evaluate("sys_platform != 'emscripten' and sys_platform != 'win32'", env = _LINUX_ENV))
     asserts.false(env, evaluate("sys_platform != 'emscripten' and sys_platform != 'win32'", env = _WINDOWS_ENV))
 
+    # Double-quoted values (PEP 508 allows both quote styles; uv locks
+    # typically emit single quotes, so pin the other style explicitly).
+    asserts.true(env, evaluate("os_name == \"nt\"", env = _WINDOWS_ENV))
+    asserts.false(env, evaluate("os_name == \"nt\"", env = _LINUX_ENV))
+
+    # Precedence: 'and' binds tighter than 'or'. Each pair distinguishes
+    # correct grouping from the flat left-to-right reading.
+    #
+    # true or (false and false) == true; ((true or false) and false) == false.
+    asserts.true(env, evaluate("sys_platform == 'linux' or sys_platform == 'win32' and python_version >= '3.12'", env = _LINUX_ENV))
+
+    # (false and true) or true == true; (false and (true or true)) == false.
+    asserts.true(env, evaluate("sys_platform == 'win32' and os_name == 'posix' or sys_platform == 'linux'", env = _LINUX_ENV))
+
+    # Parentheses override the default precedence.
+    asserts.false(env, evaluate("(sys_platform == 'linux' or sys_platform == 'win32') and python_version >= '3.12'", env = _LINUX_ENV))
+    asserts.true(env, evaluate("sys_platform == 'linux' or (sys_platform == 'win32' and python_version >= '3.12')", env = _LINUX_ENV))
+
+    # Unary 'not'
+    asserts.true(env, evaluate("not sys_platform == 'win32'", env = _LINUX_ENV))
+    asserts.false(env, evaluate("not sys_platform == 'linux'", env = _LINUX_ENV))
+    asserts.true(env, evaluate("not not sys_platform == 'linux'", env = _LINUX_ENV))
+    asserts.true(env, evaluate("not (sys_platform == 'win32' or sys_platform == 'darwin')", env = _LINUX_ENV))
+    asserts.false(env, evaluate("not (sys_platform == 'win32' or sys_platform == 'linux')", env = _LINUX_ENV))
+
+    # 'not' binds tighter than 'and'/'or'.
+    asserts.true(env, evaluate("not sys_platform == 'win32' and python_version >= '3.10'", env = _LINUX_ENV))
+    asserts.false(env, evaluate("not sys_platform == 'linux' and python_version >= '3.10'", env = _LINUX_ENV))
+    asserts.true(env, evaluate("not sys_platform == 'linux' or python_version >= '3.10'", env = _LINUX_ENV))
+
     # Empty marker evaluates to True
     asserts.true(env, evaluate("", env = _LINUX_ENV))
 
@@ -144,4 +233,5 @@ def pep508_evaluate_test_suite():
     unittest.suite(
         "pep508_evaluate_tests",
         evaluate_test,
+        tokenize_test,
     )


### PR DESCRIPTION
The tokenizer consumed its input via `marker = marker[1:]`, copying the remaining string for every character (O(n²)), and the expression parser re-sliced the token list (`tokens[1:]` / `tokens[3:]`) on every step. Both now walk their input with a position cursor instead, making tokenization O(n).

This runs at analysis time in every `_decide_marker` target — one per marker-conditioned dependency edge, per configuration — so the cost scales with lockfile size. No behavior or API change; `evaluate`'s signature is untouched.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
