### PR TITLE
test: cover py_pex_binary shebang, inherit_path, and constraint attrs

### DIFF
--- a/py/tests/py-pex-binary/BUILD.bazel
+++ b/py/tests/py-pex-binary/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_lib//lib:testing.bzl", "assert_contains")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//py:defs.bzl", "py_binary", "py_pex_binary")
+load("//py:defs.bzl", "py_binary", "py_pex_binary", "py_test")
 
 # Test that both single-file modules (six) and multi-file modules (cowsay) work with py_pex_binary.
 py_binary(
@@ -33,6 +33,54 @@ assert_contains(
     name = "test__print_modules_pex",
     actual = "print_modules_pex.out",
     expected = "Mooo!,cowsay-6.1/cowsay/__init__.py,six-1.16.0/six.py",
+)
+
+# Assert py_pex_binary attrs land in the built artifact: the shebang line,
+# PEX-INFO inherit_path, and interpreter_constraints (including the default
+# constraint's {major}/{minor}/{patch} placeholder substitution from the
+# resolved toolchain version). Uses a dependency-free binary so each pex
+# only carries the entrypoint.
+py_binary(
+    name = "noop_bin",
+    srcs = ["noop.py"],
+)
+
+py_pex_binary(
+    name = "defaults_pex",
+    binary = ":noop_bin",
+)
+
+py_pex_binary(
+    name = "custom_pex",
+    binary = ":noop_bin",
+    inherit_path = "prefer",
+    python_interpreter_constraints = ["CPython=={major}.{minor}.{patch}"],
+    python_shebang = "#!/opt/custom/bin/python3",
+)
+
+py_pex_binary(
+    name = "inherit_fallback_pex",
+    binary = ":noop_bin",
+    inherit_path = "fallback",
+)
+
+py_pex_binary(
+    name = "inherit_false_pex",
+    binary = ":noop_bin",
+    inherit_path = "false",
+)
+
+py_test(
+    name = "pex_info_test",
+    srcs = ["pex_info_test.py"],
+    data = [
+        ":custom_pex",
+        ":defaults_pex",
+        ":inherit_fallback_pex",
+        ":inherit_false_pex",
+    ],
+    main = "pex_info_test.py",
+    deps = ["@pypi//bazel_runfiles"],
 )
 
 # Verify PEX building works under a platform transition. The PEX builder must

--- a/py/tests/py-pex-binary/noop.py
+++ b/py/tests/py-pex-binary/noop.py
@@ -1,0 +1,1 @@
+print("noop")

--- a/py/tests/py-pex-binary/pex_info_test.py
+++ b/py/tests/py-pex-binary/pex_info_test.py
@@ -1,0 +1,62 @@
+"""Asserts py_pex_binary attrs are reflected in the built PEX artifact.
+
+The shebang is the first line of the zipapp; inherit_path and
+interpreter_constraints land in the PEX-INFO json at the zip root.
+The default python_interpreter_constraints resolve {major}/{minor}
+placeholders from the resolved toolchain, which is the same default
+toolchain this test runs under, so expectations come from sys.version_info.
+"""
+
+import json
+import sys
+import zipfile
+
+import runfiles
+
+r = runfiles.Create()
+
+PKG = "_main/py/tests/py-pex-binary"
+
+
+def read_pex(name):
+    path = r.Rlocation("{}/{}.pex".format(PKG, name))
+    with open(path, "rb") as f:
+        shebang = f.readline().rstrip(b"\r\n").decode()
+    with zipfile.ZipFile(path) as zf:
+        info = json.loads(zf.read("PEX-INFO"))
+    return shebang, info
+
+
+major, minor, micro = sys.version_info[:3]
+
+# Defaults: stock shebang, no inherit-path, and the default
+# "CPython=={major}.{minor}.*" constraint with placeholders substituted
+# from the toolchain version.
+shebang, info = read_pex("defaults_pex")
+assert shebang == "#!/usr/bin/env python3", shebang
+assert info.get("inherit_path", "false") == "false", info
+expected = "CPython=={}.{}.*".format(major, minor)
+assert info["interpreter_constraints"] == [expected], (
+    info["interpreter_constraints"],
+    expected,
+)
+
+# Custom values: shebang override, inherit_path=prefer, and full
+# {major}.{minor}.{patch} placeholder substitution.
+shebang, info = read_pex("custom_pex")
+assert shebang == "#!/opt/custom/bin/python3", shebang
+assert info["inherit_path"] == "prefer", info
+expected = "CPython=={}.{}.{}".format(major, minor, micro)
+assert info["interpreter_constraints"] == [expected], (
+    info["interpreter_constraints"],
+    expected,
+)
+
+# Remaining inherit_path attr values.
+_, info = read_pex("inherit_fallback_pex")
+assert info["inherit_path"] == "fallback", info
+
+_, info = read_pex("inherit_false_pex")
+assert info.get("inherit_path", "false") == "false", info
+
+print("PASS")


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
