### PR TITLE
refactor(py): remove dead code and unreachable paths

### DIFF
--- a/py/private/interpreter/exclude_feature.bzl
+++ b/py/private/interpreter/exclude_feature.bzl
@@ -16,23 +16,11 @@ like:
 will match if "headers" is among the accumulated --exclude_feature values.
 """
 
-_VALID_FEATURES = [
-    "headers",
-    "docs",
-    "tkinter",
-    "idle",
-    "ensurepip",
-    "config",
-    "pydoc",
-    "lib2to3",
-    "turtle",
-]
-
 def _exclude_feature_flag_impl(ctx):
     values = ctx.build_setting_value
     for v in values:
-        if v and v not in _VALID_FEATURES:
-            fail("Invalid exclude_feature '{}'. Valid values: {}".format(v, ", ".join(_VALID_FEATURES)))
+        if v and v not in INTERPRETER_FEATURES:
+            fail("Invalid exclude_feature '{}'. Valid values: {}".format(v, ", ".join(INTERPRETER_FEATURES.keys())))
     return []
 
 exclude_feature_flag = rule(

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -441,7 +441,7 @@ def _layer_aspect_impl(target, ctx):
                 # Only skip interpreter paths from the source layer when there
                 # IS a separate interpreter tar to route them to; otherwise the
                 # interpreter belongs in the default layer.
-                if interpreter_layer != None and tc_info.interpreter_files != None:
+                if interpreter_layer != None:
                     for f in tc_info.interpreter_files.to_list():
                         interp_paths[f.path] = True
 
@@ -797,8 +797,9 @@ def _py_image_layer_impl(ctx):
             pkg_by_label[pkg.label] = pkg
     all_pkgs = pkg_by_label.values()
 
-    layer_tier = ctx.attr.layer_tier if ctx.attr.layer_tier else ctx.attr._layer_tier
-    plan = layer_tier[PyLayerTierInfo]
+    # `_platform_cfg` rewrites the `//py:layer_tier` flag from `attr.layer_tier`,
+    # so `_layer_tier` always resolves to the effective tier.
+    plan = ctx.attr._layer_tier[PyLayerTierInfo]
     root = plan.root
     strip_prefix = plan.strip_prefix
 

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -214,7 +214,6 @@ py_library_utils = struct(
     attrs = _attrs,
     implementation = _py_library_impl,
     make_imports_depset = _make_imports_depset,
-    make_instrumented_files_info = _make_instrumented_files_info,
     make_merged_runfiles = _make_merged_runfiles,
     make_srcs_depset = _make_srcs_depset,
     make_wheels_depset = _make_wheels_depset,

--- a/py/private/py_semantics.bzl
+++ b/py/private/py_semantics.bzl
@@ -53,7 +53,6 @@ def _resolve_toolchain(ctx):
 
     py3_toolchain = toolchain_info.py3_runtime
 
-    interpreter = None
     runfiles_interpreter = True
 
     if py3_toolchain.interpreter != None:
@@ -67,14 +66,10 @@ def _resolve_toolchain(ctx):
         files = depset([])
         runfiles_interpreter = False
 
-    # Bazel 7 has this field on the PyRuntimeInfo
-    if hasattr(py3_toolchain, "interpreter_version_info"):
-        for attr in ["major", "minor", "micro"]:
-            if not hasattr(py3_toolchain.interpreter_version_info, attr):
-                fail(_MUST_SET_TOOLCHAIN_INTERPRETER_VERSION_INFO)
-        interpreter_version_info = py3_toolchain.interpreter_version_info
-    else:
-        fail(_MUST_SET_TOOLCHAIN_INTERPRETER_VERSION_INFO)
+    for attr in ["major", "minor", "micro"]:
+        if not hasattr(py3_toolchain.interpreter_version_info, attr):
+            fail(_MUST_SET_TOOLCHAIN_INTERPRETER_VERSION_INFO)
+    interpreter_version_info = py3_toolchain.interpreter_version_info
 
     # Read the freethreaded build setting if the consuming rule exposed
     # the attr. Freethreaded Python uses `lib/python<M>.<m>t/site-packages/`

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -29,7 +29,7 @@ load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variabl
 load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
-load("//py/private:transitions.bzl", "python_version_transition")
+load("//py/private:transitions.bzl", "python_transition")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
 load(":py_venv_exec.bzl", _py_venv_exec = "py_venv_exec")
 load(":types.bzl", "VirtualenvInfo", "venv_root")
@@ -287,7 +287,7 @@ _py_venv = rule(
         config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
     ],
     executable = True,
-    cfg = python_version_transition,
+    cfg = python_transition,
 )
 
 def _py_venv_lib_rule_impl(ctx):
@@ -323,7 +323,7 @@ _py_venv_lib = rule(
         # needs it to run the site_merge action when a package spans wheels.
         config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
     ],
-    cfg = python_version_transition,
+    cfg = python_transition,
 )
 
 def _wrap_with_debug(rule):

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -491,14 +491,14 @@ def assemble_venv(
         py_toolchain,
         imports_depset,
         is_windows,
-        package_collisions = "error",
-        include_system_site_packages = False,
-        include_user_site_packages = False,
-        default_env = {},
+        package_collisions,
+        include_system_site_packages,
+        include_user_site_packages,
+        default_env,
         venv_activate_tmpl,
         virtualenv_shim_py,
-        site_merge_script_py = None,
-        venv_name = None):
+        site_merge_script_py,
+        venv_name):
     """Declare every file + symlink that makes up a venv for a target.
 
     Args:
@@ -523,12 +523,11 @@ def assemble_venv(
       virtualenv_shim_py: File — the `_virtualenv.py` distutils shim
         source (usually `ctx.file._virtualenv_shim`).
       site_merge_script_py: File — the site_merge.py tool source
-        (usually `ctx.file._site_merge_script`). Only needed when the
+        (usually `ctx.file._site_merge_script`). Only used when the
         wheel graph contains a regular package spanning wheels; the
         merge action also requires the rule to declare the (optional)
         EXEC_TOOLS_TOOLCHAIN for an exec-configuration interpreter.
-      venv_name: Optional str — explicit venv dir basename. Defaults to
-        "." + safe_name + ".venv" when unset.
+      venv_name: str — the venv dir basename (e.g. "." + safe_name).
 
     Returns:
       struct with:
@@ -581,23 +580,19 @@ def assemble_venv(
     # From venv root (= sys.prefix at runtime) up to runfiles root.
     venv_to_runfiles_escape = "/".join([".."] * (2 + package_depth))
 
-    # Default basename is `.{name}.venv/` — the Pythonic name that
-    # IDEs auto-detect. The leading dot also keeps this distinct from
-    # a sibling py_venv target at `:<name>.venv` (auto-emitted when
-    # `expose_venv = True` is set): the sibling's launcher file lands
-    # at `bazel-bin/<pkg>/<name>.venv`, while any internal venv tree
-    # lives under `bazel-bin/<pkg>/.<name>.venv/`. Different
-    # filesystem paths, no collision. Callers can override via the
-    # `venv_name` parameter.
-    if venv_name == None:
-        venv_name = ".{}.venv".format(safe_name)
+    # The leading-dot basename (e.g. `.{name}.venv/`) is the Pythonic
+    # name that IDEs auto-detect. The leading dot also keeps this
+    # distinct from a sibling py_venv target at `:<name>.venv`
+    # (auto-emitted when `expose_venv = True` is set): the sibling's
+    # launcher file lands at `bazel-bin/<pkg>/<name>.venv`, while any
+    # internal venv tree lives under `bazel-bin/<pkg>/.<name>.venv/`.
+    # Different filesystem paths, no collision.
     site_packages_rel = "{}/lib/{}/site-packages".format(venv_name, venv_py_ver)
 
     # site_packages_rfpath → install_tree, used only by the regular-package
     # merge action below. The per-top-level symlinks and .pth lines locate
     # each wheel by its runfiles path directly, not through this map.
-    wheels_with_trees = [w for w in wheels if getattr(w, "install_tree", None) != None]
-    tree_by_sp = {w.site_packages_rfpath: w.install_tree for w in wheels_with_trees}
+    tree_by_sp = {w.site_packages_rfpath: w.install_tree for w in wheels}
 
     # site_packages_rfpath → True for wheels whose top-level layout is known
     # (they declare `top_levels`), so the per-top-level symlink loop projects
@@ -633,18 +628,10 @@ def assemble_venv(
     # package's `__path__` to; the per-wheel originals are shadowed.
     #
     # The merge runs as a build action under the exec-configuration
-    # interpreter (same shape as WhlInstall's unpack action). Wheels
-    # without an install_tree (legacy py_unpacked_wheel) can't
-    # contribute — they also never carry the metadata that forms a
-    # merge group, so they can't appear here.
+    # interpreter (same shape as WhlInstall's unpack action). Every
+    # PyWheelsInfo record carries an install_tree (see providers.bzl),
+    # so each contributing wheel resolves in tree_by_sp.
     for group in merge_groups:
-        if site_merge_script_py == None:
-            fail(("{}: wheels {} all contribute to the regular package `{}` — merging it " +
-                  "requires the venv rule to supply the site_merge tool.").format(
-                ctx.label,
-                group.site_packages_list,
-                group.root,
-            ))
         exec_toolchain = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN]
         exec_runtime = exec_toolchain.exec_tools.exec_runtime if exec_toolchain else None
         if exec_runtime == None:
@@ -666,13 +653,7 @@ def assemble_venv(
         arguments.add("--collision-policy", package_collisions)
         trees = []
         for sp in group.site_packages_list:
-            tree = tree_by_sp.get(sp)
-            if tree == None:
-                fail("{}: wheel at {} contributes to merged package `{}` but has no install_tree.".format(
-                    ctx.label,
-                    sp,
-                    group.root,
-                ))
+            tree = tree_by_sp[sp]
             trees.append(tree)
             arguments.add_all(
                 [tree],

--- a/py/private/pytest_shard/BUILD.bazel
+++ b/py/private/pytest_shard/BUILD.bazel
@@ -3,7 +3,6 @@ load("@aspect_rules_py//py:defs.bzl", "py_library")
 py_library(
     name = "pytest_shard",
     srcs = [
-        "__init__.py",
         ":pytest_shard.py",
     ],
     imports = ["."],

--- a/py/private/toolchain/tools.bzl
+++ b/py/private/toolchain/tools.bzl
@@ -2,32 +2,24 @@
 
 TOOLCHAIN_PLATFORMS = {
     "darwin_amd64": struct(
-        arch = "x86_64",
-        vendor_os_abi = "apple_darwin",
         compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
     ),
     "darwin_arm64": struct(
-        arch = "aarch64",
-        vendor_os_abi = "apple_darwin",
         compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
     ),
     "linux_amd64": struct(
-        arch = "x86_64",
-        vendor_os_abi = "unknown_linux_musl",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
     ),
     "linux_arm64": struct(
-        arch = "aarch64",
-        vendor_os_abi = "unknown_linux_musl",
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",

--- a/py/private/transitions.bzl
+++ b/py/private/transitions.bzl
@@ -51,6 +51,3 @@ python_transition = transition(
         _FREETHREADED_FLAG,
     ],
 )
-
-# The old name, FIXME: refactor this out
-python_version_transition = python_transition

--- a/py/private/virtual.bzl
+++ b/py/private/virtual.bzl
@@ -29,7 +29,7 @@ def _make_resolutions(base, requirement_fn = lambda r: r):
 
     return struct(
         resolutions = _resolutions,
-        override = lambda overrides, **kwargs: _make_resolutions(_make_overrides(_resolutions, overrides)),
+        override = lambda overrides: _make_resolutions(_make_overrides(_resolutions, overrides)),
         to_label_keyed_dict = lambda: dict({v.requirement: v.name for k, v in _resolutions.items() if k != _RESOLUTION_SENTINEL_KEY}),
     )
 
@@ -67,5 +67,4 @@ def _from_requirements(base, requirement_fn = lambda r: r):
 
 resolutions = struct(
     from_requirements = _from_requirements,
-    empty = lambda: _make_resolutions({}),
 )

--- a/py/toolchains.bzl
+++ b/py/toolchains.bzl
@@ -5,12 +5,11 @@ load("//py/private/toolchain:repo.bzl", "toolchains_repo")
 
 DEFAULT_TOOLS_REPOSITORY = "rules_py_tools"
 
-def rules_py_toolchains(name = DEFAULT_TOOLS_REPOSITORY, **kwargs):
+def rules_py_toolchains(name = DEFAULT_TOOLS_REPOSITORY):
     """Create toolchain repositories for rules_py.
 
     Args:
         name: prefix used in created repositories
-        **kwargs: unused, retained for backwards compatibility
     """
     toolchains_repo(name = name)
 


### PR DESCRIPTION
- drop the Bazel-6-era interpreter_version_info hasattr guard
- make assemble_venv params required; drop its never-taken branches
- drop always-true conjuncts in py_image_layer
- remove the python_version_transition alias
- derive exclude_feature validation from INTERPRETER_FEATURES
- remove unused resolutions.empty, **kwargs swallows, struct exports, TOOLCHAIN_PLATFORMS fields, and pytest_shard/__init__.py

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
