### PR TITLE
ci: use 32core for rules-proto-grpc-python e2e test

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -45,7 +45,7 @@ jobs:
                 - { path: "e2e/interpreter-runtime-metadata", slug: "e2e-interpreter-runtime-metadata", runner: "ubuntu-latest" }
                 - { path: "e2e/interpreter-toolchain-settings", slug: "e2e-interpreter-toolchain-settings", runner: "ubuntu-latest" }
                 - { path: "e2e/interpreter-input-validation", slug: "e2e-interpreter-input-validation", runner: "ubuntu-latest" }
-                - { path: "e2e/rules-proto-grpc-python", slug: "e2e-rules-proto-grpc-python", runner: "ubuntu-latest" }
+                - { path: "e2e/rules-proto-grpc-python", slug: "e2e-rules-proto-grpc-python", runner: "ubuntu-22.04-32core" }
                 - { path: "examples/debugger", slug: "examples-debugger", runner: "ubuntu-latest" }
                 - { path: "examples/dev_deps", slug: "examples-dev_deps", runner: "ubuntu-latest" }
                 - { path: "examples/django", slug: "examples-django", runner: "ubuntu-latest" }


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
