### PR TITLE
perf(uv): derive SCC ids without hashing full SCC content

### DIFF
--- a/e2e/cases/snapshots/project_single.BUILD.bazel
+++ b/e2e/cases/snapshots/project_single.BUILD.bazel
@@ -11,7 +11,7 @@ filegroup(
 # cowsay
 # {
 #     "single_project_hub": {
-#         "aee49c8f5bedac06": {
+#         "cowsay__6_1": {
 #             "": 1,
 #         },
 #     },
@@ -21,7 +21,7 @@ filegroup(
 alias(
     name = "_package_cowsay_single_project_hub",
     actual = select({
-        "//conditions:default": "//private/sccs:aee49c8f5bedac06",
+        "//conditions:default": "//private/sccs:cowsay__6_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -57,7 +57,7 @@ alias(
 # single_project_hub
 # {
 #     "single_project_hub": {
-#         "b3c9a68bcea9c616": {
+#         "single_project_hub__0_0_0": {
 #             "": 1,
 #         },
 #     },
@@ -67,7 +67,7 @@ alias(
 alias(
     name = "_package_single_project_hub_single_project_hub",
     actual = select({
-        "//conditions:default": "//private/sccs:b3c9a68bcea9c616",
+        "//conditions:default": "//private/sccs:single_project_hub__0_0_0",
     }),
     visibility = ["//visibility:private"],
 )

--- a/e2e/cases/snapshots/project_single.private.sccs.BUILD.bazel
+++ b/e2e/cases/snapshots/project_single.private.sccs.BUILD.bazel
@@ -9,7 +9,7 @@ py_library(
 )
 
 
-# scc: aee49c8f5bedac06
+# scc: cowsay__6_1
 # members:
 # {
 #     "@whl_install__single_project_hub__cowsay__6_1//:install": {
@@ -21,7 +21,7 @@ py_library(
 
 
 py_library(
-    name = "aee49c8f5bedac06",
+    name = "cowsay__6_1",
     deps = [
         "@whl_install__single_project_hub__cowsay__6_1//:install",
     ],
@@ -29,7 +29,7 @@ py_library(
 )
 
 
-# scc: b3c9a68bcea9c616
+# scc: single_project_hub__0_0_0
 # members:
 # {}
 # deps:
@@ -41,7 +41,7 @@ py_library(
 
 
 py_library(
-    name = "b3c9a68bcea9c616",
+    name = "single_project_hub__0_0_0",
     deps = [
         "//:cowsay",
     ],

--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -47,7 +47,7 @@ bzl_library(
     srcs = ["graph_utils.bzl"],
     visibility = ["//uv:__subpackages__"],
     deps = [
-        "//uv/private:sha1",
+        "//uv/private:normalize_version",
         "//uv/private/graph:sccs",
     ],
 )

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -372,9 +372,13 @@ def _parse_projects(module_ctx, hub_specs):
 
             # Mapping from package to cfg to the SCC for that package in that cfg
             package_cfg_sccs = {}
+
+            # Shared across configurations so identical SCC content keeps one
+            # id while content differing only in deps/markers stays distinct.
+            scc_id_state = {}
             for cfg in configuration_names:
                 cfgd_marker_graph = activate_extras(marker_graph, activated_extras, cfg)
-                cfgd_dep_to_scc, cfgd_scc_graph, cfgd_scc_deps = collect_sccs(cfgd_marker_graph)
+                cfgd_dep_to_scc, cfgd_scc_graph, cfgd_scc_deps = collect_sccs(cfgd_marker_graph, scc_id_state)
 
                 # Aggregate the dependency graphs Note that this may be overly
                 # simplistic, since markers COULD vary per configured graph;

--- a/uv/private/extension/graph_utils.bzl
+++ b/uv/private/extension/graph_utils.bzl
@@ -1,7 +1,26 @@
-load("//uv/private:sha1.bzl", "sha1")
+load("//uv/private:normalize_version.bzl", "normalize_version")
 load("//uv/private/graph:sccs.bzl", "sccs")
 
-def collect_sccs(marker_graph):
+def _derive_scc_id(scc_members, stems):
+    """Derive a deterministic, readable SCC id from the SCC's members.
+
+    A lone base package (the overwhelmingly common case) gets
+    `<name>__<version>`; a genuine cycle is named by its member packages.
+    `stems` disambiguates repeat stems with a `__v<n>` suffix.
+    """
+    if len(scc_members) == 1 and scc_members[0][3] == "__base__":
+        member = scc_members[0]
+        stem = "{}__{}".format(member[1], normalize_version(member[2]))
+    else:
+        names = sorted([m[1] for m in scc_members])
+        if len(names) > 4:
+            names = names[:4] + ["and_{}_more".format(len(scc_members) - 4)]
+        stem = "cycle__" + "__".join(names)
+    n = stems.get(stem, 0)
+    stems[stem] = n + 1
+    return stem if n == 0 else "{}__v{}".format(stem, n)
+
+def collect_sccs(marker_graph, id_state = None):
     """Computes Strongly Connected Components (SCCs) for a dependency marker_graph.
 
     This function takes a dependency marker_graph and identifies all the SCCs, which
@@ -10,6 +29,10 @@ def collect_sccs(marker_graph):
     Args:
         marker_graph: The dependency marker_graph, as returned by `_build_marker_graph`.
         {pkg: {dep: {marker: 1}}}
+        id_state: dict carrying SCC id intern state. Pass the same dict for
+        every configuration of one project: identical SCC content reuses one
+        id (the caller aggregates by id), while an SCC with the same members
+        but different external deps/markers gets a distinct id.
 
     Returns:
         A tuple containing:
@@ -49,11 +72,19 @@ def collect_sccs(marker_graph):
     dep_to_scc = {}
     final_scc_deps = {}  # This will store the scc_deps with the new keys
 
+    if id_state == None:
+        id_state = {}
+    interned_ids = id_state.setdefault("ids", {})
+    id_stems = id_state.setdefault("stems", {})
+
     for scc_members, raw_scc_deps in scc_info_list:
-        # Generate the new scc_id
-        # We need to sort the raw_scc_deps.items() to ensure consistent hashing
-        sorted_raw_scc_deps_repr = repr(sorted(raw_scc_deps.items()))
-        new_scc_id = sha1(repr(sorted(scc_members)) + ";" + sorted_raw_scc_deps_repr)[:16]
+        # Intern the scc_id by full content: distinct (members, deps, markers)
+        # content must map to distinct ids, identical content to one id.
+        content_key = repr(sorted(scc_members)) + ";" + repr(sorted(raw_scc_deps.items()))
+        new_scc_id = interned_ids.get(content_key)
+        if new_scc_id == None:
+            new_scc_id = _derive_scc_id(scc_members, id_stems)
+            interned_ids[content_key] = new_scc_id
 
         # Build the new scc_graph entry
         new_scc_graph[new_scc_id] = {m: {} for m in scc_members}

--- a/uv/private/extension/test_graph_utils.bzl
+++ b/uv/private/extension/test_graph_utils.bzl
@@ -195,6 +195,37 @@ collect_sccs_empty_graph_test = unittest.make(
     _collect_sccs_empty_graph_test_impl,
 )
 
+def _collect_sccs_id_state_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    pkg = ("lock", "cowsay", "6.1", "__base__")
+    dep_a = ("lock", "requests", "2.0", "__base__")
+    dep_b = ("lock", "urllib3", "1.26", "__base__")
+
+    id_state = {}
+    ids_cfg1, _, _ = collect_sccs({pkg: {dep_a: {"": 1}}, dep_a: {}}, id_state)
+    ids_cfg2, _, _ = collect_sccs({pkg: {dep_a: {"": 1}}, dep_a: {}}, id_state)
+
+    # A lone base package gets a readable name__version id
+    asserts.equals(env, "cowsay__6_1", ids_cfg1[pkg])
+
+    # Identical SCC content across configurations reuses the same id
+    asserts.equals(env, ids_cfg1[pkg], ids_cfg2[pkg])
+
+    # Same members but different external deps/markers gets a distinct id
+    ids_cfg3, _, _ = collect_sccs({pkg: {dep_b: {"sys_platform == 'linux'": 1}}, dep_b: {}}, id_state)
+    asserts.equals(env, "cowsay__6_1__v1", ids_cfg3[pkg])
+
+    # A genuine cycle is named by its member packages
+    cycle_ids, _, _ = collect_sccs({pkg: {dep_a: {"": 1}}, dep_a: {pkg: {"": 1}}}, {})
+    asserts.equals(env, "cycle__cowsay__requests", cycle_ids[pkg])
+
+    return unittest.end(env)
+
+collect_sccs_id_state_test = unittest.make(
+    _collect_sccs_id_state_test_impl,
+)
+
 def _collect_sccs_linear_graph_test_impl(ctx):
     env = unittest.begin(ctx)
     marker_graph = {
@@ -374,6 +405,7 @@ def graph_utils_test_suite():
         "collect_sccs_tests",
         collect_sccs_test,
         collect_sccs_empty_graph_test,
+        collect_sccs_id_state_test,
         collect_sccs_linear_graph_test,
         collect_sccs_disconnected_graph_test,
         collect_sccs_single_node_graph_test,

--- a/uv/private/uv_hub/snapshots/project.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/project.BUILD.bazel
@@ -11,7 +11,7 @@ filegroup(
 # arrow
 # {
 #     "aspect_rules_py": {
-#         "66db1ee5578c91b3": {
+#         "arrow__1_3_0": {
 #             "": 1,
 #         },
 #     },
@@ -21,7 +21,7 @@ filegroup(
 alias(
     name = "_package_arrow_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:66db1ee5578c91b3",
+        "//conditions:default": "//private/sccs:arrow__1_3_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -57,7 +57,7 @@ alias(
 # asgiref
 # {
 #     "aspect_rules_py": {
-#         "02c60fe71555dbc6": {
+#         "asgiref__3_8_1": {
 #             "": 1,
 #         },
 #     },
@@ -67,7 +67,7 @@ alias(
 alias(
     name = "_package_asgiref_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:02c60fe71555dbc6",
+        "//conditions:default": "//private/sccs:asgiref__3_8_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -103,7 +103,7 @@ alias(
 # aspect_rules_py
 # {
 #     "aspect_rules_py": {
-#         "3bf90d5a8d65a96f": {
+#         "aspect_rules_py__0_0_0": {
 #             "": 1,
 #         },
 #     },
@@ -113,7 +113,7 @@ alias(
 alias(
     name = "_package_aspect_rules_py_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:3bf90d5a8d65a96f",
+        "//conditions:default": "//private/sccs:aspect_rules_py__0_0_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -149,7 +149,7 @@ alias(
 # attrs
 # {
 #     "aspect_rules_py": {
-#         "7dc7776b98af97fb": {
+#         "attrs__23_2_0": {
 #             "": 1,
 #         },
 #     },
@@ -159,7 +159,7 @@ alias(
 alias(
     name = "_package_attrs_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:7dc7776b98af97fb",
+        "//conditions:default": "//private/sccs:attrs__23_2_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -195,7 +195,7 @@ alias(
 # bazel_runfiles
 # {
 #     "aspect_rules_py": {
-#         "36263f2e745aec68": {
+#         "bazel_runfiles__1_1_0": {
 #             "": 1,
 #         },
 #     },
@@ -205,7 +205,7 @@ alias(
 alias(
     name = "_package_bazel_runfiles_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:36263f2e745aec68",
+        "//conditions:default": "//private/sccs:bazel_runfiles__1_1_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -241,7 +241,7 @@ alias(
 # boto3
 # {
 #     "aspect_rules_py": {
-#         "d062f9c8da4486d0": {
+#         "boto3__1_34_93": {
 #             "": 1,
 #         },
 #     },
@@ -251,7 +251,7 @@ alias(
 alias(
     name = "_package_boto3_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:d062f9c8da4486d0",
+        "//conditions:default": "//private/sccs:boto3__1_34_93",
     }),
     visibility = ["//visibility:private"],
 )
@@ -287,7 +287,7 @@ alias(
 # botocore
 # {
 #     "aspect_rules_py": {
-#         "1a9692ca440d40f6": {
+#         "botocore__1_34_93": {
 #             "": 1,
 #         },
 #     },
@@ -297,7 +297,7 @@ alias(
 alias(
     name = "_package_botocore_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:1a9692ca440d40f6",
+        "//conditions:default": "//private/sccs:botocore__1_34_93",
     }),
     visibility = ["//visibility:private"],
 )
@@ -333,7 +333,7 @@ alias(
 # bravado
 # {
 #     "aspect_rules_py": {
-#         "5ad4c33225a6c315": {
+#         "bravado__11_0_3": {
 #             "": 1,
 #         },
 #     },
@@ -343,7 +343,7 @@ alias(
 alias(
     name = "_package_bravado_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:5ad4c33225a6c315",
+        "//conditions:default": "//private/sccs:bravado__11_0_3",
     }),
     visibility = ["//visibility:private"],
 )
@@ -379,7 +379,7 @@ alias(
 # bravado_core
 # {
 #     "aspect_rules_py": {
-#         "b852273138dfaef1": {
+#         "bravado_core__6_1_1": {
 #             "": 1,
 #         },
 #     },
@@ -389,7 +389,7 @@ alias(
 alias(
     name = "_package_bravado_core_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:b852273138dfaef1",
+        "//conditions:default": "//private/sccs:bravado_core__6_1_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -425,7 +425,7 @@ alias(
 # build
 # {
 #     "aspect_rules_py": {
-#         "a6e543d0278612c3": {
+#         "build__1_3_0": {
 #             "": 1,
 #         },
 #     },
@@ -435,7 +435,7 @@ alias(
 alias(
     name = "_package_build_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:a6e543d0278612c3",
+        "//conditions:default": "//private/sccs:build__1_3_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -471,7 +471,7 @@ alias(
 # certifi
 # {
 #     "aspect_rules_py": {
-#         "3d28b6e946c58648": {
+#         "certifi__2024_7_4": {
 #             "": 1,
 #         },
 #     },
@@ -481,7 +481,7 @@ alias(
 alias(
     name = "_package_certifi_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:3d28b6e946c58648",
+        "//conditions:default": "//private/sccs:certifi__2024_7_4",
     }),
     visibility = ["//visibility:private"],
 )
@@ -517,7 +517,7 @@ alias(
 # charset_normalizer
 # {
 #     "aspect_rules_py": {
-#         "7a5508482ee7c7ef": {
+#         "charset_normalizer__3_3_2": {
 #             "": 1,
 #         },
 #     },
@@ -527,7 +527,7 @@ alias(
 alias(
     name = "_package_charset_normalizer_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:7a5508482ee7c7ef",
+        "//conditions:default": "//private/sccs:charset_normalizer__3_3_2",
     }),
     visibility = ["//visibility:private"],
 )
@@ -563,7 +563,7 @@ alias(
 # click
 # {
 #     "aspect_rules_py": {
-#         "17569fac0688142c": {
+#         "click__8_1_7": {
 #             "": 1,
 #         },
 #     },
@@ -573,7 +573,7 @@ alias(
 alias(
     name = "_package_click_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:17569fac0688142c",
+        "//conditions:default": "//private/sccs:click__8_1_7",
     }),
     visibility = ["//visibility:private"],
 )
@@ -609,7 +609,7 @@ alias(
 # colorama
 # {
 #     "aspect_rules_py": {
-#         "da61d1b3f896ca29": {
+#         "colorama__0_4_6": {
 #             "": 1,
 #             "os_name == 'nt'": 1,
 #             "sys_platform == 'win32'": 1,
@@ -621,7 +621,7 @@ alias(
 alias(
     name = "_package_colorama_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:da61d1b3f896ca29",
+        "//conditions:default": "//private/sccs:colorama__0_4_6",
     }),
     visibility = ["//visibility:private"],
 )
@@ -657,7 +657,7 @@ alias(
 # coverage
 # {
 #     "aspect_rules_py": {
-#         "75d05c99d874710d": {
+#         "coverage__7_6_10": {
 #             "": 1,
 #         },
 #     },
@@ -667,7 +667,7 @@ alias(
 alias(
     name = "_package_coverage_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:75d05c99d874710d",
+        "//conditions:default": "//private/sccs:coverage__7_6_10",
     }),
     visibility = ["//visibility:private"],
 )
@@ -703,7 +703,7 @@ alias(
 # cowsay
 # {
 #     "aspect_rules_py": {
-#         "47a07453022c3f00": {
+#         "cowsay__6_1": {
 #             "": 1,
 #         },
 #     },
@@ -713,7 +713,7 @@ alias(
 alias(
     name = "_package_cowsay_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:47a07453022c3f00",
+        "//conditions:default": "//private/sccs:cowsay__6_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -749,7 +749,7 @@ alias(
 # django
 # {
 #     "aspect_rules_py": {
-#         "be4598f5093464bc": {
+#         "django__4_2_15": {
 #             "": 1,
 #         },
 #     },
@@ -759,7 +759,7 @@ alias(
 alias(
     name = "_package_django_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:be4598f5093464bc",
+        "//conditions:default": "//private/sccs:django__4_2_15",
     }),
     visibility = ["//visibility:private"],
 )
@@ -795,7 +795,7 @@ alias(
 # exceptiongroup
 # {
 #     "aspect_rules_py": {
-#         "ba5e2f6d3abc42ae": {
+#         "exceptiongroup__1_3_1": {
 #             "python_full_version < '3.11'": 1,
 #         },
 #     },
@@ -805,7 +805,7 @@ alias(
 alias(
     name = "_package_exceptiongroup_aspect_rules_py",
     actual = select({
-        "//private/markers:marker_0": "//private/sccs:ba5e2f6d3abc42ae",
+        "//private/markers:marker_0": "//private/sccs:exceptiongroup__1_3_1",
         "//conditions:default": "//private/sccs:empty",
     }),
     visibility = ["//visibility:private"],
@@ -843,7 +843,7 @@ alias(
 # fqdn
 # {
 #     "aspect_rules_py": {
-#         "be422b5bb805eb81": {
+#         "fqdn__1_5_1": {
 #             "": 1,
 #         },
 #     },
@@ -853,7 +853,7 @@ alias(
 alias(
     name = "_package_fqdn_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:be422b5bb805eb81",
+        "//conditions:default": "//private/sccs:fqdn__1_5_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -889,7 +889,7 @@ alias(
 # ftfy
 # {
 #     "aspect_rules_py": {
-#         "f3fc9e72edf46a94": {
+#         "ftfy__6_2_0": {
 #             "": 1,
 #         },
 #     },
@@ -899,7 +899,7 @@ alias(
 alias(
     name = "_package_ftfy_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:f3fc9e72edf46a94",
+        "//conditions:default": "//private/sccs:ftfy__6_2_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -935,7 +935,7 @@ alias(
 # future
 # {
 #     "aspect_rules_py": {
-#         "0bf957689dc8a17a": {
+#         "future__1_0_0": {
 #             "": 1,
 #         },
 #     },
@@ -945,7 +945,7 @@ alias(
 alias(
     name = "_package_future_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:0bf957689dc8a17a",
+        "//conditions:default": "//private/sccs:future__1_0_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -981,7 +981,7 @@ alias(
 # gitdb
 # {
 #     "aspect_rules_py": {
-#         "57bbb1e13328c57d": {
+#         "gitdb__4_0_12": {
 #             "": 1,
 #         },
 #     },
@@ -991,7 +991,7 @@ alias(
 alias(
     name = "_package_gitdb_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:57bbb1e13328c57d",
+        "//conditions:default": "//private/sccs:gitdb__4_0_12",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1027,7 +1027,7 @@ alias(
 # gitpython
 # {
 #     "aspect_rules_py": {
-#         "0b3eac9fa46ed553": {
+#         "gitpython__3_1_43": {
 #             "": 1,
 #         },
 #     },
@@ -1037,7 +1037,7 @@ alias(
 alias(
     name = "_package_gitpython_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:0b3eac9fa46ed553",
+        "//conditions:default": "//private/sccs:gitpython__3_1_43",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1073,7 +1073,7 @@ alias(
 # idna
 # {
 #     "aspect_rules_py": {
-#         "e32f72aa83d0aa19": {
+#         "idna__3_7": {
 #             "": 1,
 #         },
 #     },
@@ -1083,7 +1083,7 @@ alias(
 alias(
     name = "_package_idna_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:e32f72aa83d0aa19",
+        "//conditions:default": "//private/sccs:idna__3_7",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1119,7 +1119,7 @@ alias(
 # importlib_metadata
 # {
 #     "aspect_rules_py": {
-#         "755a2d8d1d107b02": {
+#         "importlib_metadata__8_7_1": {
 #             "python_full_version < '3.10.2'": 1,
 #         },
 #     },
@@ -1129,7 +1129,7 @@ alias(
 alias(
     name = "_package_importlib_metadata_aspect_rules_py",
     actual = select({
-        "//private/markers:marker_1": "//private/sccs:755a2d8d1d107b02",
+        "//private/markers:marker_1": "//private/sccs:importlib_metadata__8_7_1",
         "//conditions:default": "//private/sccs:empty",
     }),
     visibility = ["//visibility:private"],
@@ -1167,7 +1167,7 @@ alias(
 # iniconfig
 # {
 #     "aspect_rules_py": {
-#         "a645893aac936c2f": {
+#         "iniconfig__2_0_0": {
 #             "": 1,
 #         },
 #     },
@@ -1177,7 +1177,7 @@ alias(
 alias(
     name = "_package_iniconfig_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:a645893aac936c2f",
+        "//conditions:default": "//private/sccs:iniconfig__2_0_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1213,7 +1213,7 @@ alias(
 # isoduration
 # {
 #     "aspect_rules_py": {
-#         "b614323508da0659": {
+#         "isoduration__20_11_0": {
 #             "": 1,
 #         },
 #     },
@@ -1223,7 +1223,7 @@ alias(
 alias(
     name = "_package_isoduration_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:b614323508da0659",
+        "//conditions:default": "//private/sccs:isoduration__20_11_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1259,7 +1259,7 @@ alias(
 # jmespath
 # {
 #     "aspect_rules_py": {
-#         "0122121f49196a45": {
+#         "jmespath__1_0_1": {
 #             "": 1,
 #         },
 #     },
@@ -1269,7 +1269,7 @@ alias(
 alias(
     name = "_package_jmespath_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:0122121f49196a45",
+        "//conditions:default": "//private/sccs:jmespath__1_0_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1305,7 +1305,7 @@ alias(
 # jsonpointer
 # {
 #     "aspect_rules_py": {
-#         "f562ebd179f2bb77": {
+#         "jsonpointer__2_4": {
 #             "": 1,
 #         },
 #     },
@@ -1315,7 +1315,7 @@ alias(
 alias(
     name = "_package_jsonpointer_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:f562ebd179f2bb77",
+        "//conditions:default": "//private/sccs:jsonpointer__2_4",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1351,7 +1351,7 @@ alias(
 # jsonref
 # {
 #     "aspect_rules_py": {
-#         "c9bd99220bf6a1cc": {
+#         "jsonref__1_1_0": {
 #             "": 1,
 #         },
 #     },
@@ -1361,7 +1361,7 @@ alias(
 alias(
     name = "_package_jsonref_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:c9bd99220bf6a1cc",
+        "//conditions:default": "//private/sccs:jsonref__1_1_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1397,7 +1397,7 @@ alias(
 # jsonschema
 # {
 #     "aspect_rules_py": {
-#         "83c2335691aac8c7": {
+#         "jsonschema__4_21_1": {
 #             "": 1,
 #         },
 #     },
@@ -1407,7 +1407,7 @@ alias(
 alias(
     name = "_package_jsonschema_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:83c2335691aac8c7",
+        "//conditions:default": "//private/sccs:jsonschema__4_21_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1443,7 +1443,7 @@ alias(
 # jsonschema_specifications
 # {
 #     "aspect_rules_py": {
-#         "7b750f6dabe77708": {
+#         "jsonschema_specifications__2023_12_1": {
 #             "": 1,
 #         },
 #     },
@@ -1453,7 +1453,7 @@ alias(
 alias(
     name = "_package_jsonschema_specifications_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:7b750f6dabe77708",
+        "//conditions:default": "//private/sccs:jsonschema_specifications__2023_12_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1489,7 +1489,7 @@ alias(
 # maturin
 # {
 #     "aspect_rules_py": {
-#         "3efdd519ba908a3d": {
+#         "maturin__1_11_5": {
 #             "": 1,
 #         },
 #     },
@@ -1499,7 +1499,7 @@ alias(
 alias(
     name = "_package_maturin_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:3efdd519ba908a3d",
+        "//conditions:default": "//private/sccs:maturin__1_11_5",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1535,7 +1535,7 @@ alias(
 # monotonic
 # {
 #     "aspect_rules_py": {
-#         "645e8b10704343f3": {
+#         "monotonic__1_6": {
 #             "": 1,
 #         },
 #     },
@@ -1545,7 +1545,7 @@ alias(
 alias(
     name = "_package_monotonic_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:645e8b10704343f3",
+        "//conditions:default": "//private/sccs:monotonic__1_6",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1581,7 +1581,7 @@ alias(
 # msgpack
 # {
 #     "aspect_rules_py": {
-#         "57db4c17774c1aff": {
+#         "msgpack__1_0_8": {
 #             "": 1,
 #         },
 #     },
@@ -1591,7 +1591,7 @@ alias(
 alias(
     name = "_package_msgpack_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:57db4c17774c1aff",
+        "//conditions:default": "//private/sccs:msgpack__1_0_8",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1627,7 +1627,7 @@ alias(
 # neptune
 # {
 #     "aspect_rules_py": {
-#         "0c448469fc42e513": {
+#         "neptune__1_10_2": {
 #             "": 1,
 #         },
 #     },
@@ -1637,7 +1637,7 @@ alias(
 alias(
     name = "_package_neptune_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:0c448469fc42e513",
+        "//conditions:default": "//private/sccs:neptune__1_10_2",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1673,7 +1673,7 @@ alias(
 # numpy
 # {
 #     "aspect_rules_py": {
-#         "f729005acfb43d98": {
+#         "numpy__1_26_4": {
 #             "": 1,
 #         },
 #     },
@@ -1683,7 +1683,7 @@ alias(
 alias(
     name = "_package_numpy_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:f729005acfb43d98",
+        "//conditions:default": "//private/sccs:numpy__1_26_4",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1719,7 +1719,7 @@ alias(
 # oauthlib
 # {
 #     "aspect_rules_py": {
-#         "abf028a68f5c5ef2": {
+#         "oauthlib__3_2_2": {
 #             "": 1,
 #         },
 #     },
@@ -1729,7 +1729,7 @@ alias(
 alias(
     name = "_package_oauthlib_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:abf028a68f5c5ef2",
+        "//conditions:default": "//private/sccs:oauthlib__3_2_2",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1765,7 +1765,7 @@ alias(
 # packaging
 # {
 #     "aspect_rules_py": {
-#         "faab7792fab0e0c3": {
+#         "packaging__24_0": {
 #             "": 1,
 #         },
 #     },
@@ -1775,7 +1775,7 @@ alias(
 alias(
     name = "_package_packaging_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:faab7792fab0e0c3",
+        "//conditions:default": "//private/sccs:packaging__24_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1811,7 +1811,7 @@ alias(
 # pandas
 # {
 #     "aspect_rules_py": {
-#         "e585531523a85c06": {
+#         "pandas__2_2_2": {
 #             "": 1,
 #         },
 #     },
@@ -1821,7 +1821,7 @@ alias(
 alias(
     name = "_package_pandas_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:e585531523a85c06",
+        "//conditions:default": "//private/sccs:pandas__2_2_2",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1857,7 +1857,7 @@ alias(
 # pillow
 # {
 #     "aspect_rules_py": {
-#         "1ab32a29e45cda88": {
+#         "pillow__10_3_0": {
 #             "": 1,
 #         },
 #     },
@@ -1867,7 +1867,7 @@ alias(
 alias(
     name = "_package_pillow_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:1ab32a29e45cda88",
+        "//conditions:default": "//private/sccs:pillow__10_3_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1903,7 +1903,7 @@ alias(
 # pkg
 # {
 #     "aspect_rules_py": {
-#         "b441bfc3c3fbed87": {
+#         "pkg__0_2": {
 #             "": 1,
 #         },
 #     },
@@ -1913,7 +1913,7 @@ alias(
 alias(
     name = "_package_pkg_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:b441bfc3c3fbed87",
+        "//conditions:default": "//private/sccs:pkg__0_2",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1949,7 +1949,7 @@ alias(
 # pluggy
 # {
 #     "aspect_rules_py": {
-#         "94204164e2a95885": {
+#         "pluggy__1_4_0": {
 #             "": 1,
 #         },
 #     },
@@ -1959,7 +1959,7 @@ alias(
 alias(
     name = "_package_pluggy_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:94204164e2a95885",
+        "//conditions:default": "//private/sccs:pluggy__1_4_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -1995,7 +1995,7 @@ alias(
 # psutil
 # {
 #     "aspect_rules_py": {
-#         "605ce566dcea5c6e": {
+#         "psutil__5_9_8": {
 #             "": 1,
 #         },
 #     },
@@ -2005,7 +2005,7 @@ alias(
 alias(
     name = "_package_psutil_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:605ce566dcea5c6e",
+        "//conditions:default": "//private/sccs:psutil__5_9_8",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2041,7 +2041,7 @@ alias(
 # pyjwt
 # {
 #     "aspect_rules_py": {
-#         "188d1bae875e01c5": {
+#         "pyjwt__2_8_0": {
 #             "": 1,
 #         },
 #     },
@@ -2051,7 +2051,7 @@ alias(
 alias(
     name = "_package_pyjwt_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:188d1bae875e01c5",
+        "//conditions:default": "//private/sccs:pyjwt__2_8_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2087,7 +2087,7 @@ alias(
 # pyproject_hooks
 # {
 #     "aspect_rules_py": {
-#         "ee63e8df8d3acccd": {
+#         "pyproject_hooks__1_2_0": {
 #             "": 1,
 #         },
 #     },
@@ -2097,7 +2097,7 @@ alias(
 alias(
     name = "_package_pyproject_hooks_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:ee63e8df8d3acccd",
+        "//conditions:default": "//private/sccs:pyproject_hooks__1_2_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2133,7 +2133,7 @@ alias(
 # pytest
 # {
 #     "aspect_rules_py": {
-#         "1e0e56026e400a78": {
+#         "pytest__8_1_1": {
 #             "": 1,
 #         },
 #     },
@@ -2143,7 +2143,7 @@ alias(
 alias(
     name = "_package_pytest_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:1e0e56026e400a78",
+        "//conditions:default": "//private/sccs:pytest__8_1_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2179,7 +2179,7 @@ alias(
 # python_dateutil
 # {
 #     "aspect_rules_py": {
-#         "fe2c2ebbba7146e6": {
+#         "python_dateutil__2_9_0_post0": {
 #             "": 1,
 #         },
 #     },
@@ -2189,7 +2189,7 @@ alias(
 alias(
     name = "_package_python_dateutil_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:fe2c2ebbba7146e6",
+        "//conditions:default": "//private/sccs:python_dateutil__2_9_0_post0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2225,7 +2225,7 @@ alias(
 # pytz
 # {
 #     "aspect_rules_py": {
-#         "e676cae8276d8ac5": {
+#         "pytz__2024_1": {
 #             "": 1,
 #         },
 #     },
@@ -2235,7 +2235,7 @@ alias(
 alias(
     name = "_package_pytz_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:e676cae8276d8ac5",
+        "//conditions:default": "//private/sccs:pytz__2024_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2271,7 +2271,7 @@ alias(
 # pyyaml
 # {
 #     "aspect_rules_py": {
-#         "0d90a0107911e2ee": {
+#         "pyyaml__6_0_1": {
 #             "": 1,
 #         },
 #     },
@@ -2281,7 +2281,7 @@ alias(
 alias(
     name = "_package_pyyaml_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:0d90a0107911e2ee",
+        "//conditions:default": "//private/sccs:pyyaml__6_0_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2317,7 +2317,7 @@ alias(
 # referencing
 # {
 #     "aspect_rules_py": {
-#         "79d80fb738204348": {
+#         "referencing__0_35_0": {
 #             "": 1,
 #         },
 #     },
@@ -2327,7 +2327,7 @@ alias(
 alias(
     name = "_package_referencing_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:79d80fb738204348",
+        "//conditions:default": "//private/sccs:referencing__0_35_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2363,7 +2363,7 @@ alias(
 # requests
 # {
 #     "aspect_rules_py": {
-#         "e5244e9a2665fdb2": {
+#         "requests__2_31_0": {
 #             "": 1,
 #         },
 #     },
@@ -2373,7 +2373,7 @@ alias(
 alias(
     name = "_package_requests_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:e5244e9a2665fdb2",
+        "//conditions:default": "//private/sccs:requests__2_31_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2409,7 +2409,7 @@ alias(
 # requests_oauthlib
 # {
 #     "aspect_rules_py": {
-#         "ad22749935bebfb1": {
+#         "requests_oauthlib__2_0_0": {
 #             "": 1,
 #         },
 #     },
@@ -2419,7 +2419,7 @@ alias(
 alias(
     name = "_package_requests_oauthlib_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:ad22749935bebfb1",
+        "//conditions:default": "//private/sccs:requests_oauthlib__2_0_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2455,7 +2455,7 @@ alias(
 # rfc3339_validator
 # {
 #     "aspect_rules_py": {
-#         "501678eadc2406c8": {
+#         "rfc3339_validator__0_1_4": {
 #             "": 1,
 #         },
 #     },
@@ -2465,7 +2465,7 @@ alias(
 alias(
     name = "_package_rfc3339_validator_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:501678eadc2406c8",
+        "//conditions:default": "//private/sccs:rfc3339_validator__0_1_4",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2501,7 +2501,7 @@ alias(
 # rfc3986_validator
 # {
 #     "aspect_rules_py": {
-#         "7e2655fa19c9381e": {
+#         "rfc3986_validator__0_1_1": {
 #             "": 1,
 #         },
 #     },
@@ -2511,7 +2511,7 @@ alias(
 alias(
     name = "_package_rfc3986_validator_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:7e2655fa19c9381e",
+        "//conditions:default": "//private/sccs:rfc3986_validator__0_1_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2547,7 +2547,7 @@ alias(
 # rpds_py
 # {
 #     "aspect_rules_py": {
-#         "daf8d376b4a8df52": {
+#         "rpds_py__0_18_0": {
 #             "": 1,
 #         },
 #     },
@@ -2557,7 +2557,7 @@ alias(
 alias(
     name = "_package_rpds_py_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:daf8d376b4a8df52",
+        "//conditions:default": "//private/sccs:rpds_py__0_18_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2593,7 +2593,7 @@ alias(
 # s3transfer
 # {
 #     "aspect_rules_py": {
-#         "b21aa6f0da345f65": {
+#         "s3transfer__0_10_1": {
 #             "": 1,
 #         },
 #     },
@@ -2603,7 +2603,7 @@ alias(
 alias(
     name = "_package_s3transfer_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:b21aa6f0da345f65",
+        "//conditions:default": "//private/sccs:s3transfer__0_10_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2639,7 +2639,7 @@ alias(
 # setuptools
 # {
 #     "aspect_rules_py": {
-#         "f16968e1474c15d5": {
+#         "setuptools__80_9_0": {
 #             "": 1,
 #         },
 #     },
@@ -2649,7 +2649,7 @@ alias(
 alias(
     name = "_package_setuptools_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:f16968e1474c15d5",
+        "//conditions:default": "//private/sccs:setuptools__80_9_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2685,7 +2685,7 @@ alias(
 # simplejson
 # {
 #     "aspect_rules_py": {
-#         "64670a6ca059db08": {
+#         "simplejson__3_19_2": {
 #             "": 1,
 #         },
 #     },
@@ -2695,7 +2695,7 @@ alias(
 alias(
     name = "_package_simplejson_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:64670a6ca059db08",
+        "//conditions:default": "//private/sccs:simplejson__3_19_2",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2731,7 +2731,7 @@ alias(
 # six
 # {
 #     "aspect_rules_py": {
-#         "4e0c8fcba708bfaa": {
+#         "six__1_16_0": {
 #             "": 1,
 #         },
 #     },
@@ -2741,7 +2741,7 @@ alias(
 alias(
     name = "_package_six_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:4e0c8fcba708bfaa",
+        "//conditions:default": "//private/sccs:six__1_16_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2777,7 +2777,7 @@ alias(
 # smmap
 # {
 #     "aspect_rules_py": {
-#         "d2e5aa217f8d6e1c": {
+#         "smmap__5_0_1": {
 #             "": 1,
 #         },
 #     },
@@ -2787,7 +2787,7 @@ alias(
 alias(
     name = "_package_smmap_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:d2e5aa217f8d6e1c",
+        "//conditions:default": "//private/sccs:smmap__5_0_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2823,7 +2823,7 @@ alias(
 # snakesay
 # {
 #     "aspect_rules_py": {
-#         "813a1389613cfa27": {
+#         "snakesay__0_10_3": {
 #             "": 1,
 #         },
 #     },
@@ -2833,7 +2833,7 @@ alias(
 alias(
     name = "_package_snakesay_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:813a1389613cfa27",
+        "//conditions:default": "//private/sccs:snakesay__0_10_3",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2869,7 +2869,7 @@ alias(
 # sqlparse
 # {
 #     "aspect_rules_py": {
-#         "f4309313f08dd20b": {
+#         "sqlparse__0_5_1": {
 #             "": 1,
 #         },
 #     },
@@ -2879,7 +2879,7 @@ alias(
 alias(
     name = "_package_sqlparse_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:f4309313f08dd20b",
+        "//conditions:default": "//private/sccs:sqlparse__0_5_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2915,7 +2915,7 @@ alias(
 # swagger_spec_validator
 # {
 #     "aspect_rules_py": {
-#         "cf43c11aa7568cfc": {
+#         "swagger_spec_validator__3_0_3": {
 #             "": 1,
 #         },
 #     },
@@ -2925,7 +2925,7 @@ alias(
 alias(
     name = "_package_swagger_spec_validator_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:cf43c11aa7568cfc",
+        "//conditions:default": "//private/sccs:swagger_spec_validator__3_0_3",
     }),
     visibility = ["//visibility:private"],
 )
@@ -2961,7 +2961,7 @@ alias(
 # tomli
 # {
 #     "aspect_rules_py": {
-#         "c586b17b00ce1e93": {
+#         "tomli__2_4_0": {
 #             "python_full_version < '3.11'": 1,
 #         },
 #     },
@@ -2971,7 +2971,7 @@ alias(
 alias(
     name = "_package_tomli_aspect_rules_py",
     actual = select({
-        "//private/markers:marker_0": "//private/sccs:c586b17b00ce1e93",
+        "//private/markers:marker_0": "//private/sccs:tomli__2_4_0",
         "//conditions:default": "//private/sccs:empty",
     }),
     visibility = ["//visibility:private"],
@@ -3009,7 +3009,7 @@ alias(
 # types_python_dateutil
 # {
 #     "aspect_rules_py": {
-#         "1126c4a05de455bd": {
+#         "types_python_dateutil__2_9_0_20240316": {
 #             "": 1,
 #         },
 #     },
@@ -3019,7 +3019,7 @@ alias(
 alias(
     name = "_package_types_python_dateutil_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:1126c4a05de455bd",
+        "//conditions:default": "//private/sccs:types_python_dateutil__2_9_0_20240316",
     }),
     visibility = ["//visibility:private"],
 )
@@ -3055,7 +3055,7 @@ alias(
 # typing_extensions
 # {
 #     "aspect_rules_py": {
-#         "532dae902462bf54": {
+#         "typing_extensions__4_12_2": {
 #             "": 1,
 #             "python_full_version < '3.11'": 1,
 #         },
@@ -3066,7 +3066,7 @@ alias(
 alias(
     name = "_package_typing_extensions_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:532dae902462bf54",
+        "//conditions:default": "//private/sccs:typing_extensions__4_12_2",
     }),
     visibility = ["//visibility:private"],
 )
@@ -3102,7 +3102,7 @@ alias(
 # tzdata
 # {
 #     "aspect_rules_py": {
-#         "e75ced7ea0bca451": {
+#         "tzdata__2024_1": {
 #             "": 1,
 #             "sys_platform == 'win32'": 1,
 #         },
@@ -3113,7 +3113,7 @@ alias(
 alias(
     name = "_package_tzdata_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:e75ced7ea0bca451",
+        "//conditions:default": "//private/sccs:tzdata__2024_1",
     }),
     visibility = ["//visibility:private"],
 )
@@ -3149,7 +3149,7 @@ alias(
 # uri_template
 # {
 #     "aspect_rules_py": {
-#         "8c7876aa6947b426": {
+#         "uri_template__1_3_0": {
 #             "": 1,
 #         },
 #     },
@@ -3159,7 +3159,7 @@ alias(
 alias(
     name = "_package_uri_template_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:8c7876aa6947b426",
+        "//conditions:default": "//private/sccs:uri_template__1_3_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -3195,7 +3195,7 @@ alias(
 # urllib3
 # {
 #     "aspect_rules_py": {
-#         "5fc6ecd45601013d": {
+#         "urllib3__1_26_19": {
 #             "": 1,
 #         },
 #     },
@@ -3205,7 +3205,7 @@ alias(
 alias(
     name = "_package_urllib3_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:5fc6ecd45601013d",
+        "//conditions:default": "//private/sccs:urllib3__1_26_19",
     }),
     visibility = ["//visibility:private"],
 )
@@ -3241,7 +3241,7 @@ alias(
 # wcwidth
 # {
 #     "aspect_rules_py": {
-#         "a42101321901faea": {
+#         "wcwidth__0_2_13": {
 #             "": 1,
 #         },
 #     },
@@ -3251,7 +3251,7 @@ alias(
 alias(
     name = "_package_wcwidth_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:a42101321901faea",
+        "//conditions:default": "//private/sccs:wcwidth__0_2_13",
     }),
     visibility = ["//visibility:private"],
 )
@@ -3287,7 +3287,7 @@ alias(
 # webcolors
 # {
 #     "aspect_rules_py": {
-#         "b2c4b8d6df4d741c": {
+#         "webcolors__1_13": {
 #             "": 1,
 #         },
 #     },
@@ -3297,7 +3297,7 @@ alias(
 alias(
     name = "_package_webcolors_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:b2c4b8d6df4d741c",
+        "//conditions:default": "//private/sccs:webcolors__1_13",
     }),
     visibility = ["//visibility:private"],
 )
@@ -3333,7 +3333,7 @@ alias(
 # websocket_client
 # {
 #     "aspect_rules_py": {
-#         "c8fdcb8672c8c446": {
+#         "websocket_client__1_8_0": {
 #             "": 1,
 #         },
 #     },
@@ -3343,7 +3343,7 @@ alias(
 alias(
     name = "_package_websocket_client_aspect_rules_py",
     actual = select({
-        "//conditions:default": "//private/sccs:c8fdcb8672c8c446",
+        "//conditions:default": "//private/sccs:websocket_client__1_8_0",
     }),
     visibility = ["//visibility:private"],
 )
@@ -3379,7 +3379,7 @@ alias(
 # zipp
 # {
 #     "aspect_rules_py": {
-#         "0dfe8750086323f2": {
+#         "zipp__3_23_0": {
 #             "python_full_version < '3.11'": 1,
 #         },
 #     },
@@ -3389,7 +3389,7 @@ alias(
 alias(
     name = "_package_zipp_aspect_rules_py",
     actual = select({
-        "//private/markers:marker_0": "//private/sccs:0dfe8750086323f2",
+        "//private/markers:marker_0": "//private/sccs:zipp__3_23_0",
         "//conditions:default": "//private/sccs:empty",
     }),
     visibility = ["//visibility:private"],
@@ -3509,79 +3509,79 @@ filegroup(
 filegroup(
     name = "gazelle_index_whls",
     srcs = [
-        "@whl_install__aspect_rules_py__jmespath__1_0_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__asgiref__3_8_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__gitpython__3_1_43//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__future__1_0_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__neptune__1_10_2//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pyyaml__6_0_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__zipp__3_23_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__types_python_dateutil__2_9_0_20240316//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__click__8_1_7//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pyjwt__2_8_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__botocore__1_34_93//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pillow__10_3_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pytest__8_1_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__bazel_runfiles__1_1_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__certifi__2024_7_4//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__maturin__1_11_5//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__cowsay__6_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__six__1_16_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__rfc3339_validator__0_1_4//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__typing_extensions__4_12_2//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__gitdb__4_0_12//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__msgpack__1_0_8//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__bravado__11_0_3//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__urllib3__1_26_19//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__psutil__5_9_8//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__monotonic__1_6//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__simplejson__3_19_2//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__arrow__1_3_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__coverage__7_6_10//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__referencing__0_35_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__charset_normalizer__3_3_2//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__jsonschema_specifications__2023_12_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__asgiref__3_8_1//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__attrs__23_2_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__rfc3986_validator__0_1_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__snakesay__0_10_3//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__jsonschema__4_21_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__uri_template__1_3_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pluggy__1_4_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__wcwidth__0_2_13//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__iniconfig__2_0_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__build__1_3_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__oauthlib__3_2_2//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__requests_oauthlib__2_0_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__s3transfer__0_10_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__webcolors__1_13//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pkg__0_2//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__isoduration__20_11_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__bazel_runfiles__1_1_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__boto3__1_34_93//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__botocore__1_34_93//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__bravado__11_0_3//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__bravado_core__6_1_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__build__1_3_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__certifi__2024_7_4//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__charset_normalizer__3_3_2//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__click__8_1_7//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__colorama__0_4_6//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__coverage__7_6_10//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__cowsay__6_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__django__4_2_15//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__exceptiongroup__1_3_1//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__fqdn__1_5_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__django__4_2_15//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__tomli__2_4_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__websocket_client__1_8_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__jsonref__1_1_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__swagger_spec_validator__3_0_3//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__boto3__1_34_93//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__smmap__5_0_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__colorama__0_4_6//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__rpds_py__0_18_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__idna__3_7//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__requests__2_31_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pandas__2_2_2//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pytz__2024_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__tzdata__2024_1//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__pyproject_hooks__1_2_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__setuptools__80_9_0//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__ftfy__6_2_0//:gazelle_index_whl",
-        "@whl_install__aspect_rules_py__sqlparse__0_5_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__future__1_0_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__gitdb__4_0_12//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__gitpython__3_1_43//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__idna__3_7//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__iniconfig__2_0_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__isoduration__20_11_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__jmespath__1_0_1//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__jsonpointer__2_4//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__jsonref__1_1_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__jsonschema__4_21_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__jsonschema_specifications__2023_12_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__maturin__1_11_5//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__monotonic__1_6//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__msgpack__1_0_8//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__neptune__1_10_2//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__numpy__1_26_4//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__oauthlib__3_2_2//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__packaging__24_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pandas__2_2_2//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pillow__10_3_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pkg__0_2//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pluggy__1_4_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__psutil__5_9_8//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pyjwt__2_8_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pyproject_hooks__1_2_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pytest__8_1_1//:gazelle_index_whl",
         "@whl_install__aspect_rules_py__python_dateutil__2_9_0_post0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pytz__2024_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__pyyaml__6_0_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__referencing__0_35_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__requests__2_31_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__requests_oauthlib__2_0_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__rfc3339_validator__0_1_4//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__rfc3986_validator__0_1_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__rpds_py__0_18_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__s3transfer__0_10_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__setuptools__80_9_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__simplejson__3_19_2//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__six__1_16_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__smmap__5_0_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__snakesay__0_10_3//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__sqlparse__0_5_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__swagger_spec_validator__3_0_3//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__tomli__2_4_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__types_python_dateutil__2_9_0_20240316//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__typing_extensions__4_12_2//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__tzdata__2024_1//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__uri_template__1_3_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__urllib3__1_26_19//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__wcwidth__0_2_13//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__webcolors__1_13//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__websocket_client__1_8_0//:gazelle_index_whl",
+        "@whl_install__aspect_rules_py__zipp__3_23_0//:gazelle_index_whl",
     ],
     visibility = ["//visibility:public"],
 )

--- a/uv/private/uv_hub/snapshots/project.private.markers.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/project.private.markers.BUILD.bazel
@@ -19,28 +19,28 @@ decide_marker(
 
 decide_marker(
     name = "marker_2",
-    marker = "sys_platform == 'win32'",
-    visibility = ["//:__subpackages__"],
-)
-
-
-decide_marker(
-    name = "marker_3",
-    marker = "(python_full_version < '3.10.2') and (python_full_version < '3.11')",
-    visibility = ["//:__subpackages__"],
-)
-
-
-decide_marker(
-    name = "marker_4",
     marker = "os_name == 'nt'",
     visibility = ["//:__subpackages__"],
 )
 
 
 decide_marker(
-    name = "marker_5",
+    name = "marker_3",
+    marker = "sys_platform == 'win32'",
+    visibility = ["//:__subpackages__"],
+)
+
+
+decide_marker(
+    name = "marker_4",
     marker = "(python_full_version < '3.11') and (python_full_version < '3.11')",
+    visibility = ["//:__subpackages__"],
+)
+
+
+decide_marker(
+    name = "marker_5",
+    marker = "(python_full_version < '3.10.2') and (python_full_version < '3.11')",
     visibility = ["//:__subpackages__"],
 )
 

--- a/uv/private/uv_hub/snapshots/project.private.sccs.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/project.private.sccs.BUILD.bazel
@@ -9,27 +9,36 @@ py_library(
 )
 
 
-# scc: 0122121f49196a45
+# scc: arrow__1_3_0
 # members:
 # {
-#     "@whl_install__aspect_rules_py__jmespath__1_0_1//:install": {
+#     "@whl_install__aspect_rules_py__arrow__1_3_0//:install": {
 #         "": 1,
 #     },
 # }
 # deps:
-# {}
+# {
+#     "python_dateutil": {
+#         "": 1,
+#     },
+#     "types_python_dateutil": {
+#         "": 1,
+#     },
+# }
 
 
 py_library(
-    name = "0122121f49196a45",
+    name = "arrow__1_3_0",
     deps = [
-        "@whl_install__aspect_rules_py__jmespath__1_0_1//:install",
+        "@whl_install__aspect_rules_py__arrow__1_3_0//:install",
+        "//:python_dateutil",
+        "//:types_python_dateutil",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 02c60fe71555dbc6
+# scc: asgiref__3_8_1
 # members:
 # {
 #     "@whl_install__aspect_rules_py__asgiref__3_8_1//:install": {
@@ -45,7 +54,7 @@ py_library(
 
 
 alias(
-    name = "_maybe__02c60fe71555dbc6__typing_extensions",
+    name = "_maybe__asgiref__3_8_1__typing_extensions",
     actual = select({
         "//private/markers:marker_0": "//:typing_extensions",
         "//conditions:default": ":empty",
@@ -55,16 +64,692 @@ alias(
 
 
 py_library(
-    name = "02c60fe71555dbc6",
+    name = "asgiref__3_8_1",
     deps = [
         "@whl_install__aspect_rules_py__asgiref__3_8_1//:install",
-        ":_maybe__02c60fe71555dbc6__typing_extensions",
+        ":_maybe__asgiref__3_8_1__typing_extensions",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 0b3eac9fa46ed553
+# scc: aspect_rules_py__0_0_0
+# members:
+# {}
+# deps:
+# {
+#     "bazel_runfiles": {
+#         "": 1,
+#     },
+#     "build": {
+#         "": 1,
+#     },
+#     "click": {
+#         "": 1,
+#     },
+#     "colorama": {
+#         "": 1,
+#     },
+#     "coverage": {
+#         "": 1,
+#     },
+#     "cowsay": {
+#         "": 1,
+#     },
+#     "django": {
+#         "": 1,
+#     },
+#     "ftfy": {
+#         "": 1,
+#     },
+#     "maturin": {
+#         "": 1,
+#     },
+#     "neptune": {
+#         "": 1,
+#     },
+#     "pkg": {
+#         "": 1,
+#     },
+#     "pytest": {
+#         "": 1,
+#     },
+#     "setuptools": {
+#         "": 1,
+#     },
+#     "six": {
+#         "": 1,
+#     },
+#     "snakesay": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "aspect_rules_py__0_0_0",
+    deps = [
+        "//:bazel_runfiles",
+        "//:build",
+        "//:click",
+        "//:colorama",
+        "//:coverage",
+        "//:cowsay",
+        "//:django",
+        "//:ftfy",
+        "//:maturin",
+        "//:neptune",
+        "//:pkg",
+        "//:pytest",
+        "//:setuptools",
+        "//:six",
+        "//:snakesay",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: attrs__23_2_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__attrs__23_2_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "attrs__23_2_0",
+    deps = [
+        "@whl_install__aspect_rules_py__attrs__23_2_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: bazel_runfiles__1_1_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__bazel_runfiles__1_1_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "bazel_runfiles__1_1_0",
+    deps = [
+        "@whl_install__aspect_rules_py__bazel_runfiles__1_1_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: boto3__1_34_93
+# members:
+# {
+#     "@whl_install__aspect_rules_py__boto3__1_34_93//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "botocore": {
+#         "": 1,
+#     },
+#     "jmespath": {
+#         "": 1,
+#     },
+#     "s3transfer": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "boto3__1_34_93",
+    deps = [
+        "@whl_install__aspect_rules_py__boto3__1_34_93//:install",
+        "//:botocore",
+        "//:jmespath",
+        "//:s3transfer",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: botocore__1_34_93
+# members:
+# {
+#     "@whl_install__aspect_rules_py__botocore__1_34_93//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "jmespath": {
+#         "": 1,
+#     },
+#     "python_dateutil": {
+#         "": 1,
+#     },
+#     "urllib3": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "botocore__1_34_93",
+    deps = [
+        "@whl_install__aspect_rules_py__botocore__1_34_93//:install",
+        "//:jmespath",
+        "//:python_dateutil",
+        "//:urllib3",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: bravado__11_0_3
+# members:
+# {
+#     "@whl_install__aspect_rules_py__bravado__11_0_3//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "bravado_core": {
+#         "": 1,
+#     },
+#     "monotonic": {
+#         "": 1,
+#     },
+#     "msgpack": {
+#         "": 1,
+#     },
+#     "python_dateutil": {
+#         "": 1,
+#     },
+#     "pyyaml": {
+#         "": 1,
+#     },
+#     "requests": {
+#         "": 1,
+#     },
+#     "simplejson": {
+#         "": 1,
+#     },
+#     "six": {
+#         "": 1,
+#     },
+#     "typing_extensions": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "bravado__11_0_3",
+    deps = [
+        "@whl_install__aspect_rules_py__bravado__11_0_3//:install",
+        "//:bravado_core",
+        "//:monotonic",
+        "//:msgpack",
+        "//:python_dateutil",
+        "//:pyyaml",
+        "//:requests",
+        "//:simplejson",
+        "//:six",
+        "//:typing_extensions",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: bravado_core__6_1_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__bravado_core__6_1_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "jsonref": {
+#         "": 1,
+#     },
+#     "jsonschema": {
+#         "": 1,
+#     },
+#     "msgpack": {
+#         "": 1,
+#     },
+#     "python_dateutil": {
+#         "": 1,
+#     },
+#     "pytz": {
+#         "": 1,
+#     },
+#     "pyyaml": {
+#         "": 1,
+#     },
+#     "requests": {
+#         "": 1,
+#     },
+#     "simplejson": {
+#         "": 1,
+#     },
+#     "six": {
+#         "": 1,
+#     },
+#     "swagger_spec_validator": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "bravado_core__6_1_1",
+    deps = [
+        "@whl_install__aspect_rules_py__bravado_core__6_1_1//:install",
+        "//:jsonref",
+        "//:jsonschema",
+        "//:msgpack",
+        "//:python_dateutil",
+        "//:pytz",
+        "//:pyyaml",
+        "//:requests",
+        "//:simplejson",
+        "//:six",
+        "//:swagger_spec_validator",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: build__1_3_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__build__1_3_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "colorama": {
+#         "os_name == 'nt'": 1,
+#     },
+#     "importlib_metadata": {
+#         "python_full_version < '3.10.2'": 1,
+#     },
+#     "packaging": {
+#         "": 1,
+#     },
+#     "pyproject_hooks": {
+#         "": 1,
+#     },
+#     "tomli": {
+#         "python_full_version < '3.11'": 1,
+#     },
+# }
+
+
+alias(
+    name = "_maybe__build__1_3_0__colorama",
+    actual = select({
+        "//private/markers:marker_2": "//:colorama",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+
+alias(
+    name = "_maybe__build__1_3_0__importlib_metadata",
+    actual = select({
+        "//private/markers:marker_1": "//:importlib_metadata",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+
+alias(
+    name = "_maybe__build__1_3_0__tomli",
+    actual = select({
+        "//private/markers:marker_0": "//:tomli",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+
+py_library(
+    name = "build__1_3_0",
+    deps = [
+        "@whl_install__aspect_rules_py__build__1_3_0//:install",
+        ":_maybe__build__1_3_0__colorama",
+        ":_maybe__build__1_3_0__importlib_metadata",
+        "//:packaging",
+        "//:pyproject_hooks",
+        ":_maybe__build__1_3_0__tomli",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: certifi__2024_7_4
+# members:
+# {
+#     "@whl_install__aspect_rules_py__certifi__2024_7_4//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "certifi__2024_7_4",
+    deps = [
+        "@whl_install__aspect_rules_py__certifi__2024_7_4//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: charset_normalizer__3_3_2
+# members:
+# {
+#     "@whl_install__aspect_rules_py__charset_normalizer__3_3_2//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "charset_normalizer__3_3_2",
+    deps = [
+        "@whl_install__aspect_rules_py__charset_normalizer__3_3_2//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: click__8_1_7
+# members:
+# {
+#     "@whl_install__aspect_rules_py__click__8_1_7//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "colorama": {
+#         "sys_platform == 'win32'": 1,
+#     },
+# }
+
+
+alias(
+    name = "_maybe__click__8_1_7__colorama",
+    actual = select({
+        "//private/markers:marker_3": "//:colorama",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+
+py_library(
+    name = "click__8_1_7",
+    deps = [
+        "@whl_install__aspect_rules_py__click__8_1_7//:install",
+        ":_maybe__click__8_1_7__colorama",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: colorama__0_4_6
+# members:
+# {
+#     "@whl_install__aspect_rules_py__colorama__0_4_6//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "colorama__0_4_6",
+    deps = [
+        "@whl_install__aspect_rules_py__colorama__0_4_6//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: coverage__7_6_10
+# members:
+# {
+#     "@whl_install__aspect_rules_py__coverage__7_6_10//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "coverage__7_6_10",
+    deps = [
+        "@whl_install__aspect_rules_py__coverage__7_6_10//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: cowsay__6_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__cowsay__6_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "cowsay__6_1",
+    deps = [
+        "@whl_install__aspect_rules_py__cowsay__6_1//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: django__4_2_15
+# members:
+# {
+#     "@whl_install__aspect_rules_py__django__4_2_15//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "asgiref": {
+#         "": 1,
+#     },
+#     "sqlparse": {
+#         "": 1,
+#     },
+#     "tzdata": {
+#         "sys_platform == 'win32'": 1,
+#     },
+# }
+
+
+alias(
+    name = "_maybe__django__4_2_15__tzdata",
+    actual = select({
+        "//private/markers:marker_3": "//:tzdata",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+
+py_library(
+    name = "django__4_2_15",
+    deps = [
+        "@whl_install__aspect_rules_py__django__4_2_15//:install",
+        "//:asgiref",
+        "//:sqlparse",
+        ":_maybe__django__4_2_15__tzdata",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: exceptiongroup__1_3_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__exceptiongroup__1_3_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "typing_extensions": {
+#         "(python_full_version < '3.11') and (python_full_version < '3.11')": 1,
+#         "python_full_version < '3.11'": 1,
+#     },
+# }
+
+
+alias(
+    name = "_maybe__exceptiongroup__1_3_1__typing_extensions",
+    actual = select({
+        "//private/markers:marker_4": "//:typing_extensions",
+        "//private/markers:marker_0": "//:typing_extensions",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+
+py_library(
+    name = "exceptiongroup__1_3_1",
+    deps = [
+        "@whl_install__aspect_rules_py__exceptiongroup__1_3_1//:install",
+        ":_maybe__exceptiongroup__1_3_1__typing_extensions",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: fqdn__1_5_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__fqdn__1_5_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "fqdn__1_5_1",
+    deps = [
+        "@whl_install__aspect_rules_py__fqdn__1_5_1//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: ftfy__6_2_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__ftfy__6_2_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "wcwidth": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "ftfy__6_2_0",
+    deps = [
+        "@whl_install__aspect_rules_py__ftfy__6_2_0//:install",
+        "//:wcwidth",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: future__1_0_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__future__1_0_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "future__1_0_0",
+    deps = [
+        "@whl_install__aspect_rules_py__future__1_0_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: gitdb__4_0_12
+# members:
+# {
+#     "@whl_install__aspect_rules_py__gitdb__4_0_12//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "smmap": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "gitdb__4_0_12",
+    deps = [
+        "@whl_install__aspect_rules_py__gitdb__4_0_12//:install",
+        "//:smmap",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: gitpython__3_1_43
 # members:
 # {
 #     "@whl_install__aspect_rules_py__gitpython__3_1_43//:install": {
@@ -80,7 +765,7 @@ py_library(
 
 
 py_library(
-    name = "0b3eac9fa46ed553",
+    name = "gitpython__3_1_43",
     deps = [
         "@whl_install__aspect_rules_py__gitpython__3_1_43//:install",
         "//:gitdb",
@@ -89,10 +774,10 @@ py_library(
 )
 
 
-# scc: 0bf957689dc8a17a
+# scc: idna__3_7
 # members:
 # {
-#     "@whl_install__aspect_rules_py__future__1_0_0//:install": {
+#     "@whl_install__aspect_rules_py__idna__3_7//:install": {
 #         "": 1,
 #     },
 # }
@@ -101,15 +786,326 @@ py_library(
 
 
 py_library(
-    name = "0bf957689dc8a17a",
+    name = "idna__3_7",
     deps = [
-        "@whl_install__aspect_rules_py__future__1_0_0//:install",
+        "@whl_install__aspect_rules_py__idna__3_7//:install",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 0c448469fc42e513
+# scc: importlib_metadata__8_7_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "zipp": {
+#         "(python_full_version < '3.10.2') and (python_full_version < '3.11')": 1,
+#         "python_full_version < '3.11'": 1,
+#     },
+# }
+
+
+alias(
+    name = "_maybe__importlib_metadata__8_7_1__zipp",
+    actual = select({
+        "//private/markers:marker_5": "//:zipp",
+        "//private/markers:marker_0": "//:zipp",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+
+py_library(
+    name = "importlib_metadata__8_7_1",
+    deps = [
+        "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:install",
+        ":_maybe__importlib_metadata__8_7_1__zipp",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: iniconfig__2_0_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__iniconfig__2_0_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "iniconfig__2_0_0",
+    deps = [
+        "@whl_install__aspect_rules_py__iniconfig__2_0_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: isoduration__20_11_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__isoduration__20_11_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "arrow": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "isoduration__20_11_0",
+    deps = [
+        "@whl_install__aspect_rules_py__isoduration__20_11_0//:install",
+        "//:arrow",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: jmespath__1_0_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__jmespath__1_0_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "jmespath__1_0_1",
+    deps = [
+        "@whl_install__aspect_rules_py__jmespath__1_0_1//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: jsonpointer__2_4
+# members:
+# {
+#     "@whl_install__aspect_rules_py__jsonpointer__2_4//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "jsonpointer__2_4",
+    deps = [
+        "@whl_install__aspect_rules_py__jsonpointer__2_4//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: jsonref__1_1_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__jsonref__1_1_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "jsonref__1_1_0",
+    deps = [
+        "@whl_install__aspect_rules_py__jsonref__1_1_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: jsonschema__4_21_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__jsonschema__4_21_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "attrs": {
+#         "": 1,
+#     },
+#     "fqdn": {
+#         "": 1,
+#     },
+#     "idna": {
+#         "": 1,
+#     },
+#     "isoduration": {
+#         "": 1,
+#     },
+#     "jsonpointer": {
+#         "": 1,
+#     },
+#     "jsonschema_specifications": {
+#         "": 1,
+#     },
+#     "referencing": {
+#         "": 1,
+#     },
+#     "rfc3339_validator": {
+#         "": 1,
+#     },
+#     "rfc3986_validator": {
+#         "": 1,
+#     },
+#     "rpds_py": {
+#         "": 1,
+#     },
+#     "uri_template": {
+#         "": 1,
+#     },
+#     "webcolors": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "jsonschema__4_21_1",
+    deps = [
+        "@whl_install__aspect_rules_py__jsonschema__4_21_1//:install",
+        "//:attrs",
+        "//:fqdn",
+        "//:idna",
+        "//:isoduration",
+        "//:jsonpointer",
+        "//:jsonschema_specifications",
+        "//:referencing",
+        "//:rfc3339_validator",
+        "//:rfc3986_validator",
+        "//:rpds_py",
+        "//:uri_template",
+        "//:webcolors",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: jsonschema_specifications__2023_12_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__jsonschema_specifications__2023_12_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "referencing": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "jsonschema_specifications__2023_12_1",
+    deps = [
+        "@whl_install__aspect_rules_py__jsonschema_specifications__2023_12_1//:install",
+        "//:referencing",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: maturin__1_11_5
+# members:
+# {
+#     "@whl_install__aspect_rules_py__maturin__1_11_5//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "tomli": {
+#         "python_full_version < '3.11'": 1,
+#     },
+# }
+
+
+alias(
+    name = "_maybe__maturin__1_11_5__tomli",
+    actual = select({
+        "//private/markers:marker_0": "//:tomli",
+        "//conditions:default": ":empty",
+    }),
+    visibility = ["//:__subpackages__"],
+)
+
+
+py_library(
+    name = "maturin__1_11_5",
+    deps = [
+        "@whl_install__aspect_rules_py__maturin__1_11_5//:install",
+        ":_maybe__maturin__1_11_5__tomli",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: monotonic__1_6
+# members:
+# {
+#     "@whl_install__aspect_rules_py__monotonic__1_6//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "monotonic__1_6",
+    deps = [
+        "@whl_install__aspect_rules_py__monotonic__1_6//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: msgpack__1_0_8
+# members:
+# {
+#     "@whl_install__aspect_rules_py__msgpack__1_0_8//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "msgpack__1_0_8",
+    deps = [
+        "@whl_install__aspect_rules_py__msgpack__1_0_8//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: neptune__1_10_2
 # members:
 # {
 #     "@whl_install__aspect_rules_py__neptune__1_10_2//:install": {
@@ -176,7 +1172,7 @@ py_library(
 
 
 py_library(
-    name = "0c448469fc42e513",
+    name = "neptune__1_10_2",
     deps = [
         "@whl_install__aspect_rules_py__neptune__1_10_2//:install",
         "//:boto3",
@@ -202,10 +1198,10 @@ py_library(
 )
 
 
-# scc: 0d90a0107911e2ee
+# scc: numpy__1_26_4
 # members:
 # {
-#     "@whl_install__aspect_rules_py__pyyaml__6_0_1//:install": {
+#     "@whl_install__aspect_rules_py__numpy__1_26_4//:install": {
 #         "": 1,
 #     },
 # }
@@ -214,18 +1210,18 @@ py_library(
 
 
 py_library(
-    name = "0d90a0107911e2ee",
+    name = "numpy__1_26_4",
     deps = [
-        "@whl_install__aspect_rules_py__pyyaml__6_0_1//:install",
+        "@whl_install__aspect_rules_py__numpy__1_26_4//:install",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 0dfe8750086323f2
+# scc: oauthlib__3_2_2
 # members:
 # {
-#     "@whl_install__aspect_rules_py__zipp__3_23_0//:install": {
+#     "@whl_install__aspect_rules_py__oauthlib__3_2_2//:install": {
 #         "": 1,
 #     },
 # }
@@ -234,18 +1230,18 @@ py_library(
 
 
 py_library(
-    name = "0dfe8750086323f2",
+    name = "oauthlib__3_2_2",
     deps = [
-        "@whl_install__aspect_rules_py__zipp__3_23_0//:install",
+        "@whl_install__aspect_rules_py__oauthlib__3_2_2//:install",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 1126c4a05de455bd
+# scc: packaging__24_0
 # members:
 # {
-#     "@whl_install__aspect_rules_py__types_python_dateutil__2_9_0_20240316//:install": {
+#     "@whl_install__aspect_rules_py__packaging__24_0//:install": {
 #         "": 1,
 #     },
 # }
@@ -254,103 +1250,52 @@ py_library(
 
 
 py_library(
-    name = "1126c4a05de455bd",
+    name = "packaging__24_0",
     deps = [
-        "@whl_install__aspect_rules_py__types_python_dateutil__2_9_0_20240316//:install",
+        "@whl_install__aspect_rules_py__packaging__24_0//:install",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 17569fac0688142c
+# scc: pandas__2_2_2
 # members:
 # {
-#     "@whl_install__aspect_rules_py__click__8_1_7//:install": {
+#     "@whl_install__aspect_rules_py__pandas__2_2_2//:install": {
 #         "": 1,
 #     },
 # }
 # deps:
 # {
-#     "colorama": {
-#         "sys_platform == 'win32'": 1,
-#     },
-# }
-
-
-alias(
-    name = "_maybe__17569fac0688142c__colorama",
-    actual = select({
-        "//private/markers:marker_2": "//:colorama",
-        "//conditions:default": ":empty",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-
-py_library(
-    name = "17569fac0688142c",
-    deps = [
-        "@whl_install__aspect_rules_py__click__8_1_7//:install",
-        ":_maybe__17569fac0688142c__colorama",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 188d1bae875e01c5
-# members:
-# {
-#     "@whl_install__aspect_rules_py__pyjwt__2_8_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "188d1bae875e01c5",
-    deps = [
-        "@whl_install__aspect_rules_py__pyjwt__2_8_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 1a9692ca440d40f6
-# members:
-# {
-#     "@whl_install__aspect_rules_py__botocore__1_34_93//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "jmespath": {
+#     "numpy": {
 #         "": 1,
 #     },
 #     "python_dateutil": {
 #         "": 1,
 #     },
-#     "urllib3": {
+#     "pytz": {
+#         "": 1,
+#     },
+#     "tzdata": {
 #         "": 1,
 #     },
 # }
 
 
 py_library(
-    name = "1a9692ca440d40f6",
+    name = "pandas__2_2_2",
     deps = [
-        "@whl_install__aspect_rules_py__botocore__1_34_93//:install",
-        "//:jmespath",
+        "@whl_install__aspect_rules_py__pandas__2_2_2//:install",
+        "//:numpy",
         "//:python_dateutil",
-        "//:urllib3",
+        "//:pytz",
+        "//:tzdata",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 1ab32a29e45cda88
+# scc: pillow__10_3_0
 # members:
 # {
 #     "@whl_install__aspect_rules_py__pillow__10_3_0//:install": {
@@ -362,7 +1307,7 @@ py_library(
 
 
 py_library(
-    name = "1ab32a29e45cda88",
+    name = "pillow__10_3_0",
     deps = [
         "@whl_install__aspect_rules_py__pillow__10_3_0//:install",
     ],
@@ -370,7 +1315,107 @@ py_library(
 )
 
 
-# scc: 1e0e56026e400a78
+# scc: pkg__0_2
+# members:
+# {
+#     "@whl_install__aspect_rules_py__pkg__0_2//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "pkg__0_2",
+    deps = [
+        "@whl_install__aspect_rules_py__pkg__0_2//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: pluggy__1_4_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__pluggy__1_4_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "pluggy__1_4_0",
+    deps = [
+        "@whl_install__aspect_rules_py__pluggy__1_4_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: psutil__5_9_8
+# members:
+# {
+#     "@whl_install__aspect_rules_py__psutil__5_9_8//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "psutil__5_9_8",
+    deps = [
+        "@whl_install__aspect_rules_py__psutil__5_9_8//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: pyjwt__2_8_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__pyjwt__2_8_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "pyjwt__2_8_0",
+    deps = [
+        "@whl_install__aspect_rules_py__pyjwt__2_8_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: pyproject_hooks__1_2_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__pyproject_hooks__1_2_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "pyproject_hooks__1_2_0",
+    deps = [
+        "@whl_install__aspect_rules_py__pyproject_hooks__1_2_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: pytest__8_1_1
 # members:
 # {
 #     "@whl_install__aspect_rules_py__pytest__8_1_1//:install": {
@@ -401,9 +1446,9 @@ py_library(
 
 
 alias(
-    name = "_maybe__1e0e56026e400a78__colorama",
+    name = "_maybe__pytest__8_1_1__colorama",
     actual = select({
-        "//private/markers:marker_2": "//:colorama",
+        "//private/markers:marker_3": "//:colorama",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -411,7 +1456,7 @@ alias(
 
 
 alias(
-    name = "_maybe__1e0e56026e400a78__exceptiongroup",
+    name = "_maybe__pytest__8_1_1__exceptiongroup",
     actual = select({
         "//private/markers:marker_0": "//:exceptiongroup",
         "//conditions:default": ":empty",
@@ -421,7 +1466,7 @@ alias(
 
 
 alias(
-    name = "_maybe__1e0e56026e400a78__tomli",
+    name = "_maybe__pytest__8_1_1__tomli",
     actual = select({
         "//private/markers:marker_0": "//:tomli",
         "//conditions:default": ":empty",
@@ -431,215 +1476,24 @@ alias(
 
 
 py_library(
-    name = "1e0e56026e400a78",
+    name = "pytest__8_1_1",
     deps = [
         "@whl_install__aspect_rules_py__pytest__8_1_1//:install",
-        ":_maybe__1e0e56026e400a78__colorama",
-        ":_maybe__1e0e56026e400a78__exceptiongroup",
+        ":_maybe__pytest__8_1_1__colorama",
+        ":_maybe__pytest__8_1_1__exceptiongroup",
         "//:iniconfig",
         "//:packaging",
         "//:pluggy",
-        ":_maybe__1e0e56026e400a78__tomli",
+        ":_maybe__pytest__8_1_1__tomli",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 36263f2e745aec68
+# scc: python_dateutil__2_9_0_post0
 # members:
 # {
-#     "@whl_install__aspect_rules_py__bazel_runfiles__1_1_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "36263f2e745aec68",
-    deps = [
-        "@whl_install__aspect_rules_py__bazel_runfiles__1_1_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 3bf90d5a8d65a96f
-# members:
-# {}
-# deps:
-# {
-#     "bazel_runfiles": {
-#         "": 1,
-#     },
-#     "build": {
-#         "": 1,
-#     },
-#     "click": {
-#         "": 1,
-#     },
-#     "colorama": {
-#         "": 1,
-#     },
-#     "coverage": {
-#         "": 1,
-#     },
-#     "cowsay": {
-#         "": 1,
-#     },
-#     "django": {
-#         "": 1,
-#     },
-#     "ftfy": {
-#         "": 1,
-#     },
-#     "maturin": {
-#         "": 1,
-#     },
-#     "neptune": {
-#         "": 1,
-#     },
-#     "pkg": {
-#         "": 1,
-#     },
-#     "pytest": {
-#         "": 1,
-#     },
-#     "setuptools": {
-#         "": 1,
-#     },
-#     "six": {
-#         "": 1,
-#     },
-#     "snakesay": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "3bf90d5a8d65a96f",
-    deps = [
-        "//:bazel_runfiles",
-        "//:build",
-        "//:click",
-        "//:colorama",
-        "//:coverage",
-        "//:cowsay",
-        "//:django",
-        "//:ftfy",
-        "//:maturin",
-        "//:neptune",
-        "//:pkg",
-        "//:pytest",
-        "//:setuptools",
-        "//:six",
-        "//:snakesay",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 3d28b6e946c58648
-# members:
-# {
-#     "@whl_install__aspect_rules_py__certifi__2024_7_4//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "3d28b6e946c58648",
-    deps = [
-        "@whl_install__aspect_rules_py__certifi__2024_7_4//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 3efdd519ba908a3d
-# members:
-# {
-#     "@whl_install__aspect_rules_py__maturin__1_11_5//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "tomli": {
-#         "python_full_version < '3.11'": 1,
-#     },
-# }
-
-
-alias(
-    name = "_maybe__3efdd519ba908a3d__tomli",
-    actual = select({
-        "//private/markers:marker_0": "//:tomli",
-        "//conditions:default": ":empty",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-
-py_library(
-    name = "3efdd519ba908a3d",
-    deps = [
-        "@whl_install__aspect_rules_py__maturin__1_11_5//:install",
-        ":_maybe__3efdd519ba908a3d__tomli",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 47a07453022c3f00
-# members:
-# {
-#     "@whl_install__aspect_rules_py__cowsay__6_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "47a07453022c3f00",
-    deps = [
-        "@whl_install__aspect_rules_py__cowsay__6_1//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 4e0c8fcba708bfaa
-# members:
-# {
-#     "@whl_install__aspect_rules_py__six__1_16_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "4e0c8fcba708bfaa",
-    deps = [
-        "@whl_install__aspect_rules_py__six__1_16_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 501678eadc2406c8
-# members:
-# {
-#     "@whl_install__aspect_rules_py__rfc3339_validator__0_1_4//:install": {
+#     "@whl_install__aspect_rules_py__python_dateutil__2_9_0_post0//:install": {
 #         "": 1,
 #     },
 # }
@@ -652,19 +1506,19 @@ py_library(
 
 
 py_library(
-    name = "501678eadc2406c8",
+    name = "python_dateutil__2_9_0_post0",
     deps = [
-        "@whl_install__aspect_rules_py__rfc3339_validator__0_1_4//:install",
+        "@whl_install__aspect_rules_py__python_dateutil__2_9_0_post0//:install",
         "//:six",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 532dae902462bf54
+# scc: pytz__2024_1
 # members:
 # {
-#     "@whl_install__aspect_rules_py__typing_extensions__4_12_2//:install": {
+#     "@whl_install__aspect_rules_py__pytz__2024_1//:install": {
 #         "": 1,
 #     },
 # }
@@ -673,43 +1527,18 @@ py_library(
 
 
 py_library(
-    name = "532dae902462bf54",
+    name = "pytz__2024_1",
     deps = [
-        "@whl_install__aspect_rules_py__typing_extensions__4_12_2//:install",
+        "@whl_install__aspect_rules_py__pytz__2024_1//:install",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 57bbb1e13328c57d
+# scc: pyyaml__6_0_1
 # members:
 # {
-#     "@whl_install__aspect_rules_py__gitdb__4_0_12//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "smmap": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "57bbb1e13328c57d",
-    deps = [
-        "@whl_install__aspect_rules_py__gitdb__4_0_12//:install",
-        "//:smmap",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 57db4c17774c1aff
-# members:
-# {
-#     "@whl_install__aspect_rules_py__msgpack__1_0_8//:install": {
+#     "@whl_install__aspect_rules_py__pyyaml__6_0_1//:install": {
 #         "": 1,
 #     },
 # }
@@ -718,238 +1547,15 @@ py_library(
 
 
 py_library(
-    name = "57db4c17774c1aff",
+    name = "pyyaml__6_0_1",
     deps = [
-        "@whl_install__aspect_rules_py__msgpack__1_0_8//:install",
+        "@whl_install__aspect_rules_py__pyyaml__6_0_1//:install",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: 5ad4c33225a6c315
-# members:
-# {
-#     "@whl_install__aspect_rules_py__bravado__11_0_3//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "bravado_core": {
-#         "": 1,
-#     },
-#     "monotonic": {
-#         "": 1,
-#     },
-#     "msgpack": {
-#         "": 1,
-#     },
-#     "python_dateutil": {
-#         "": 1,
-#     },
-#     "pyyaml": {
-#         "": 1,
-#     },
-#     "requests": {
-#         "": 1,
-#     },
-#     "simplejson": {
-#         "": 1,
-#     },
-#     "six": {
-#         "": 1,
-#     },
-#     "typing_extensions": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "5ad4c33225a6c315",
-    deps = [
-        "@whl_install__aspect_rules_py__bravado__11_0_3//:install",
-        "//:bravado_core",
-        "//:monotonic",
-        "//:msgpack",
-        "//:python_dateutil",
-        "//:pyyaml",
-        "//:requests",
-        "//:simplejson",
-        "//:six",
-        "//:typing_extensions",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 5fc6ecd45601013d
-# members:
-# {
-#     "@whl_install__aspect_rules_py__urllib3__1_26_19//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "5fc6ecd45601013d",
-    deps = [
-        "@whl_install__aspect_rules_py__urllib3__1_26_19//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 605ce566dcea5c6e
-# members:
-# {
-#     "@whl_install__aspect_rules_py__psutil__5_9_8//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "605ce566dcea5c6e",
-    deps = [
-        "@whl_install__aspect_rules_py__psutil__5_9_8//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 645e8b10704343f3
-# members:
-# {
-#     "@whl_install__aspect_rules_py__monotonic__1_6//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "645e8b10704343f3",
-    deps = [
-        "@whl_install__aspect_rules_py__monotonic__1_6//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 64670a6ca059db08
-# members:
-# {
-#     "@whl_install__aspect_rules_py__simplejson__3_19_2//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "64670a6ca059db08",
-    deps = [
-        "@whl_install__aspect_rules_py__simplejson__3_19_2//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 66db1ee5578c91b3
-# members:
-# {
-#     "@whl_install__aspect_rules_py__arrow__1_3_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "python_dateutil": {
-#         "": 1,
-#     },
-#     "types_python_dateutil": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "66db1ee5578c91b3",
-    deps = [
-        "@whl_install__aspect_rules_py__arrow__1_3_0//:install",
-        "//:python_dateutil",
-        "//:types_python_dateutil",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 755a2d8d1d107b02
-# members:
-# {
-#     "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "zipp": {
-#         "(python_full_version < '3.10.2') and (python_full_version < '3.11')": 1,
-#         "python_full_version < '3.11'": 1,
-#     },
-# }
-
-
-alias(
-    name = "_maybe__755a2d8d1d107b02__zipp",
-    actual = select({
-        "//private/markers:marker_3": "//:zipp",
-        "//private/markers:marker_0": "//:zipp",
-        "//conditions:default": ":empty",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-
-py_library(
-    name = "755a2d8d1d107b02",
-    deps = [
-        "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:install",
-        ":_maybe__755a2d8d1d107b02__zipp",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 75d05c99d874710d
-# members:
-# {
-#     "@whl_install__aspect_rules_py__coverage__7_6_10//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "75d05c99d874710d",
-    deps = [
-        "@whl_install__aspect_rules_py__coverage__7_6_10//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 79d80fb738204348
+# scc: referencing__0_35_0
 # members:
 # {
 #     "@whl_install__aspect_rules_py__referencing__0_35_0//:install": {
@@ -968,7 +1574,7 @@ py_library(
 
 
 py_library(
-    name = "79d80fb738204348",
+    name = "referencing__0_35_0",
     deps = [
         "@whl_install__aspect_rules_py__referencing__0_35_0//:install",
         "//:attrs",
@@ -978,838 +1584,7 @@ py_library(
 )
 
 
-# scc: 7a5508482ee7c7ef
-# members:
-# {
-#     "@whl_install__aspect_rules_py__charset_normalizer__3_3_2//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "7a5508482ee7c7ef",
-    deps = [
-        "@whl_install__aspect_rules_py__charset_normalizer__3_3_2//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 7b750f6dabe77708
-# members:
-# {
-#     "@whl_install__aspect_rules_py__jsonschema_specifications__2023_12_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "referencing": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "7b750f6dabe77708",
-    deps = [
-        "@whl_install__aspect_rules_py__jsonschema_specifications__2023_12_1//:install",
-        "//:referencing",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 7dc7776b98af97fb
-# members:
-# {
-#     "@whl_install__aspect_rules_py__attrs__23_2_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "7dc7776b98af97fb",
-    deps = [
-        "@whl_install__aspect_rules_py__attrs__23_2_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 7e2655fa19c9381e
-# members:
-# {
-#     "@whl_install__aspect_rules_py__rfc3986_validator__0_1_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "7e2655fa19c9381e",
-    deps = [
-        "@whl_install__aspect_rules_py__rfc3986_validator__0_1_1//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 813a1389613cfa27
-# members:
-# {
-#     "@whl_install__aspect_rules_py__snakesay__0_10_3//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "813a1389613cfa27",
-    deps = [
-        "@whl_install__aspect_rules_py__snakesay__0_10_3//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 83c2335691aac8c7
-# members:
-# {
-#     "@whl_install__aspect_rules_py__jsonschema__4_21_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "attrs": {
-#         "": 1,
-#     },
-#     "fqdn": {
-#         "": 1,
-#     },
-#     "idna": {
-#         "": 1,
-#     },
-#     "isoduration": {
-#         "": 1,
-#     },
-#     "jsonpointer": {
-#         "": 1,
-#     },
-#     "jsonschema_specifications": {
-#         "": 1,
-#     },
-#     "referencing": {
-#         "": 1,
-#     },
-#     "rfc3339_validator": {
-#         "": 1,
-#     },
-#     "rfc3986_validator": {
-#         "": 1,
-#     },
-#     "rpds_py": {
-#         "": 1,
-#     },
-#     "uri_template": {
-#         "": 1,
-#     },
-#     "webcolors": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "83c2335691aac8c7",
-    deps = [
-        "@whl_install__aspect_rules_py__jsonschema__4_21_1//:install",
-        "//:attrs",
-        "//:fqdn",
-        "//:idna",
-        "//:isoduration",
-        "//:jsonpointer",
-        "//:jsonschema_specifications",
-        "//:referencing",
-        "//:rfc3339_validator",
-        "//:rfc3986_validator",
-        "//:rpds_py",
-        "//:uri_template",
-        "//:webcolors",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 8c7876aa6947b426
-# members:
-# {
-#     "@whl_install__aspect_rules_py__uri_template__1_3_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "8c7876aa6947b426",
-    deps = [
-        "@whl_install__aspect_rules_py__uri_template__1_3_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: 94204164e2a95885
-# members:
-# {
-#     "@whl_install__aspect_rules_py__pluggy__1_4_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "94204164e2a95885",
-    deps = [
-        "@whl_install__aspect_rules_py__pluggy__1_4_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: a42101321901faea
-# members:
-# {
-#     "@whl_install__aspect_rules_py__wcwidth__0_2_13//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "a42101321901faea",
-    deps = [
-        "@whl_install__aspect_rules_py__wcwidth__0_2_13//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: a645893aac936c2f
-# members:
-# {
-#     "@whl_install__aspect_rules_py__iniconfig__2_0_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "a645893aac936c2f",
-    deps = [
-        "@whl_install__aspect_rules_py__iniconfig__2_0_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: a6e543d0278612c3
-# members:
-# {
-#     "@whl_install__aspect_rules_py__build__1_3_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "colorama": {
-#         "os_name == 'nt'": 1,
-#     },
-#     "importlib_metadata": {
-#         "python_full_version < '3.10.2'": 1,
-#     },
-#     "packaging": {
-#         "": 1,
-#     },
-#     "pyproject_hooks": {
-#         "": 1,
-#     },
-#     "tomli": {
-#         "python_full_version < '3.11'": 1,
-#     },
-# }
-
-
-alias(
-    name = "_maybe__a6e543d0278612c3__colorama",
-    actual = select({
-        "//private/markers:marker_4": "//:colorama",
-        "//conditions:default": ":empty",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-
-alias(
-    name = "_maybe__a6e543d0278612c3__importlib_metadata",
-    actual = select({
-        "//private/markers:marker_1": "//:importlib_metadata",
-        "//conditions:default": ":empty",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-
-alias(
-    name = "_maybe__a6e543d0278612c3__tomli",
-    actual = select({
-        "//private/markers:marker_0": "//:tomli",
-        "//conditions:default": ":empty",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-
-py_library(
-    name = "a6e543d0278612c3",
-    deps = [
-        "@whl_install__aspect_rules_py__build__1_3_0//:install",
-        ":_maybe__a6e543d0278612c3__colorama",
-        ":_maybe__a6e543d0278612c3__importlib_metadata",
-        "//:packaging",
-        "//:pyproject_hooks",
-        ":_maybe__a6e543d0278612c3__tomli",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: abf028a68f5c5ef2
-# members:
-# {
-#     "@whl_install__aspect_rules_py__oauthlib__3_2_2//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "abf028a68f5c5ef2",
-    deps = [
-        "@whl_install__aspect_rules_py__oauthlib__3_2_2//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: ad22749935bebfb1
-# members:
-# {
-#     "@whl_install__aspect_rules_py__requests_oauthlib__2_0_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "oauthlib": {
-#         "": 1,
-#     },
-#     "requests": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "ad22749935bebfb1",
-    deps = [
-        "@whl_install__aspect_rules_py__requests_oauthlib__2_0_0//:install",
-        "//:oauthlib",
-        "//:requests",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: b21aa6f0da345f65
-# members:
-# {
-#     "@whl_install__aspect_rules_py__s3transfer__0_10_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "botocore": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "b21aa6f0da345f65",
-    deps = [
-        "@whl_install__aspect_rules_py__s3transfer__0_10_1//:install",
-        "//:botocore",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: b2c4b8d6df4d741c
-# members:
-# {
-#     "@whl_install__aspect_rules_py__webcolors__1_13//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "b2c4b8d6df4d741c",
-    deps = [
-        "@whl_install__aspect_rules_py__webcolors__1_13//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: b441bfc3c3fbed87
-# members:
-# {
-#     "@whl_install__aspect_rules_py__pkg__0_2//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "b441bfc3c3fbed87",
-    deps = [
-        "@whl_install__aspect_rules_py__pkg__0_2//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: b614323508da0659
-# members:
-# {
-#     "@whl_install__aspect_rules_py__isoduration__20_11_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "arrow": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "b614323508da0659",
-    deps = [
-        "@whl_install__aspect_rules_py__isoduration__20_11_0//:install",
-        "//:arrow",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: b852273138dfaef1
-# members:
-# {
-#     "@whl_install__aspect_rules_py__bravado_core__6_1_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "jsonref": {
-#         "": 1,
-#     },
-#     "jsonschema": {
-#         "": 1,
-#     },
-#     "msgpack": {
-#         "": 1,
-#     },
-#     "python_dateutil": {
-#         "": 1,
-#     },
-#     "pytz": {
-#         "": 1,
-#     },
-#     "pyyaml": {
-#         "": 1,
-#     },
-#     "requests": {
-#         "": 1,
-#     },
-#     "simplejson": {
-#         "": 1,
-#     },
-#     "six": {
-#         "": 1,
-#     },
-#     "swagger_spec_validator": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "b852273138dfaef1",
-    deps = [
-        "@whl_install__aspect_rules_py__bravado_core__6_1_1//:install",
-        "//:jsonref",
-        "//:jsonschema",
-        "//:msgpack",
-        "//:python_dateutil",
-        "//:pytz",
-        "//:pyyaml",
-        "//:requests",
-        "//:simplejson",
-        "//:six",
-        "//:swagger_spec_validator",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: ba5e2f6d3abc42ae
-# members:
-# {
-#     "@whl_install__aspect_rules_py__exceptiongroup__1_3_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "typing_extensions": {
-#         "(python_full_version < '3.11') and (python_full_version < '3.11')": 1,
-#         "python_full_version < '3.11'": 1,
-#     },
-# }
-
-
-alias(
-    name = "_maybe__ba5e2f6d3abc42ae__typing_extensions",
-    actual = select({
-        "//private/markers:marker_5": "//:typing_extensions",
-        "//private/markers:marker_0": "//:typing_extensions",
-        "//conditions:default": ":empty",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-
-py_library(
-    name = "ba5e2f6d3abc42ae",
-    deps = [
-        "@whl_install__aspect_rules_py__exceptiongroup__1_3_1//:install",
-        ":_maybe__ba5e2f6d3abc42ae__typing_extensions",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: be422b5bb805eb81
-# members:
-# {
-#     "@whl_install__aspect_rules_py__fqdn__1_5_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "be422b5bb805eb81",
-    deps = [
-        "@whl_install__aspect_rules_py__fqdn__1_5_1//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: be4598f5093464bc
-# members:
-# {
-#     "@whl_install__aspect_rules_py__django__4_2_15//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "asgiref": {
-#         "": 1,
-#     },
-#     "sqlparse": {
-#         "": 1,
-#     },
-#     "tzdata": {
-#         "sys_platform == 'win32'": 1,
-#     },
-# }
-
-
-alias(
-    name = "_maybe__be4598f5093464bc__tzdata",
-    actual = select({
-        "//private/markers:marker_2": "//:tzdata",
-        "//conditions:default": ":empty",
-    }),
-    visibility = ["//:__subpackages__"],
-)
-
-
-py_library(
-    name = "be4598f5093464bc",
-    deps = [
-        "@whl_install__aspect_rules_py__django__4_2_15//:install",
-        "//:asgiref",
-        "//:sqlparse",
-        ":_maybe__be4598f5093464bc__tzdata",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: c586b17b00ce1e93
-# members:
-# {
-#     "@whl_install__aspect_rules_py__tomli__2_4_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "c586b17b00ce1e93",
-    deps = [
-        "@whl_install__aspect_rules_py__tomli__2_4_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: c8fdcb8672c8c446
-# members:
-# {
-#     "@whl_install__aspect_rules_py__websocket_client__1_8_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "c8fdcb8672c8c446",
-    deps = [
-        "@whl_install__aspect_rules_py__websocket_client__1_8_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: c9bd99220bf6a1cc
-# members:
-# {
-#     "@whl_install__aspect_rules_py__jsonref__1_1_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "c9bd99220bf6a1cc",
-    deps = [
-        "@whl_install__aspect_rules_py__jsonref__1_1_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: cf43c11aa7568cfc
-# members:
-# {
-#     "@whl_install__aspect_rules_py__swagger_spec_validator__3_0_3//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "jsonschema": {
-#         "": 1,
-#     },
-#     "pyyaml": {
-#         "": 1,
-#     },
-#     "typing_extensions": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "cf43c11aa7568cfc",
-    deps = [
-        "@whl_install__aspect_rules_py__swagger_spec_validator__3_0_3//:install",
-        "//:jsonschema",
-        "//:pyyaml",
-        "//:typing_extensions",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: d062f9c8da4486d0
-# members:
-# {
-#     "@whl_install__aspect_rules_py__boto3__1_34_93//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "botocore": {
-#         "": 1,
-#     },
-#     "jmespath": {
-#         "": 1,
-#     },
-#     "s3transfer": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "d062f9c8da4486d0",
-    deps = [
-        "@whl_install__aspect_rules_py__boto3__1_34_93//:install",
-        "//:botocore",
-        "//:jmespath",
-        "//:s3transfer",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: d2e5aa217f8d6e1c
-# members:
-# {
-#     "@whl_install__aspect_rules_py__smmap__5_0_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "d2e5aa217f8d6e1c",
-    deps = [
-        "@whl_install__aspect_rules_py__smmap__5_0_1//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: da61d1b3f896ca29
-# members:
-# {
-#     "@whl_install__aspect_rules_py__colorama__0_4_6//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "da61d1b3f896ca29",
-    deps = [
-        "@whl_install__aspect_rules_py__colorama__0_4_6//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: daf8d376b4a8df52
-# members:
-# {
-#     "@whl_install__aspect_rules_py__rpds_py__0_18_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "daf8d376b4a8df52",
-    deps = [
-        "@whl_install__aspect_rules_py__rpds_py__0_18_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: e32f72aa83d0aa19
-# members:
-# {
-#     "@whl_install__aspect_rules_py__idna__3_7//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "e32f72aa83d0aa19",
-    deps = [
-        "@whl_install__aspect_rules_py__idna__3_7//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: e5244e9a2665fdb2
+# scc: requests__2_31_0
 # members:
 # {
 #     "@whl_install__aspect_rules_py__requests__2_31_0//:install": {
@@ -1834,7 +1609,7 @@ py_library(
 
 
 py_library(
-    name = "e5244e9a2665fdb2",
+    name = "requests__2_31_0",
     deps = [
         "@whl_install__aspect_rules_py__requests__2_31_0//:install",
         "//:certifi",
@@ -1846,232 +1621,39 @@ py_library(
 )
 
 
-# scc: e585531523a85c06
+# scc: requests_oauthlib__2_0_0
 # members:
 # {
-#     "@whl_install__aspect_rules_py__pandas__2_2_2//:install": {
+#     "@whl_install__aspect_rules_py__requests_oauthlib__2_0_0//:install": {
 #         "": 1,
 #     },
 # }
 # deps:
 # {
-#     "numpy": {
+#     "oauthlib": {
 #         "": 1,
 #     },
-#     "python_dateutil": {
-#         "": 1,
-#     },
-#     "pytz": {
-#         "": 1,
-#     },
-#     "tzdata": {
+#     "requests": {
 #         "": 1,
 #     },
 # }
 
 
 py_library(
-    name = "e585531523a85c06",
+    name = "requests_oauthlib__2_0_0",
     deps = [
-        "@whl_install__aspect_rules_py__pandas__2_2_2//:install",
-        "//:numpy",
-        "//:python_dateutil",
-        "//:pytz",
-        "//:tzdata",
+        "@whl_install__aspect_rules_py__requests_oauthlib__2_0_0//:install",
+        "//:oauthlib",
+        "//:requests",
     ],
     visibility = ["//:__subpackages__"],
 )
 
 
-# scc: e676cae8276d8ac5
+# scc: rfc3339_validator__0_1_4
 # members:
 # {
-#     "@whl_install__aspect_rules_py__pytz__2024_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "e676cae8276d8ac5",
-    deps = [
-        "@whl_install__aspect_rules_py__pytz__2024_1//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: e75ced7ea0bca451
-# members:
-# {
-#     "@whl_install__aspect_rules_py__tzdata__2024_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "e75ced7ea0bca451",
-    deps = [
-        "@whl_install__aspect_rules_py__tzdata__2024_1//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: ee63e8df8d3acccd
-# members:
-# {
-#     "@whl_install__aspect_rules_py__pyproject_hooks__1_2_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "ee63e8df8d3acccd",
-    deps = [
-        "@whl_install__aspect_rules_py__pyproject_hooks__1_2_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: f16968e1474c15d5
-# members:
-# {
-#     "@whl_install__aspect_rules_py__setuptools__80_9_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "f16968e1474c15d5",
-    deps = [
-        "@whl_install__aspect_rules_py__setuptools__80_9_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: f3fc9e72edf46a94
-# members:
-# {
-#     "@whl_install__aspect_rules_py__ftfy__6_2_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {
-#     "wcwidth": {
-#         "": 1,
-#     },
-# }
-
-
-py_library(
-    name = "f3fc9e72edf46a94",
-    deps = [
-        "@whl_install__aspect_rules_py__ftfy__6_2_0//:install",
-        "//:wcwidth",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: f4309313f08dd20b
-# members:
-# {
-#     "@whl_install__aspect_rules_py__sqlparse__0_5_1//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "f4309313f08dd20b",
-    deps = [
-        "@whl_install__aspect_rules_py__sqlparse__0_5_1//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: f562ebd179f2bb77
-# members:
-# {
-#     "@whl_install__aspect_rules_py__jsonpointer__2_4//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "f562ebd179f2bb77",
-    deps = [
-        "@whl_install__aspect_rules_py__jsonpointer__2_4//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: f729005acfb43d98
-# members:
-# {
-#     "@whl_install__aspect_rules_py__numpy__1_26_4//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "f729005acfb43d98",
-    deps = [
-        "@whl_install__aspect_rules_py__numpy__1_26_4//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: faab7792fab0e0c3
-# members:
-# {
-#     "@whl_install__aspect_rules_py__packaging__24_0//:install": {
-#         "": 1,
-#     },
-# }
-# deps:
-# {}
-
-
-py_library(
-    name = "faab7792fab0e0c3",
-    deps = [
-        "@whl_install__aspect_rules_py__packaging__24_0//:install",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-
-# scc: fe2c2ebbba7146e6
-# members:
-# {
-#     "@whl_install__aspect_rules_py__python_dateutil__2_9_0_post0//:install": {
+#     "@whl_install__aspect_rules_py__rfc3339_validator__0_1_4//:install": {
 #         "": 1,
 #     },
 # }
@@ -2084,10 +1666,428 @@ py_library(
 
 
 py_library(
-    name = "fe2c2ebbba7146e6",
+    name = "rfc3339_validator__0_1_4",
     deps = [
-        "@whl_install__aspect_rules_py__python_dateutil__2_9_0_post0//:install",
+        "@whl_install__aspect_rules_py__rfc3339_validator__0_1_4//:install",
         "//:six",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: rfc3986_validator__0_1_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__rfc3986_validator__0_1_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "rfc3986_validator__0_1_1",
+    deps = [
+        "@whl_install__aspect_rules_py__rfc3986_validator__0_1_1//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: rpds_py__0_18_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__rpds_py__0_18_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "rpds_py__0_18_0",
+    deps = [
+        "@whl_install__aspect_rules_py__rpds_py__0_18_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: s3transfer__0_10_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__s3transfer__0_10_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "botocore": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "s3transfer__0_10_1",
+    deps = [
+        "@whl_install__aspect_rules_py__s3transfer__0_10_1//:install",
+        "//:botocore",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: setuptools__80_9_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__setuptools__80_9_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "setuptools__80_9_0",
+    deps = [
+        "@whl_install__aspect_rules_py__setuptools__80_9_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: simplejson__3_19_2
+# members:
+# {
+#     "@whl_install__aspect_rules_py__simplejson__3_19_2//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "simplejson__3_19_2",
+    deps = [
+        "@whl_install__aspect_rules_py__simplejson__3_19_2//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: six__1_16_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__six__1_16_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "six__1_16_0",
+    deps = [
+        "@whl_install__aspect_rules_py__six__1_16_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: smmap__5_0_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__smmap__5_0_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "smmap__5_0_1",
+    deps = [
+        "@whl_install__aspect_rules_py__smmap__5_0_1//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: snakesay__0_10_3
+# members:
+# {
+#     "@whl_install__aspect_rules_py__snakesay__0_10_3//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "snakesay__0_10_3",
+    deps = [
+        "@whl_install__aspect_rules_py__snakesay__0_10_3//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: sqlparse__0_5_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__sqlparse__0_5_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "sqlparse__0_5_1",
+    deps = [
+        "@whl_install__aspect_rules_py__sqlparse__0_5_1//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: swagger_spec_validator__3_0_3
+# members:
+# {
+#     "@whl_install__aspect_rules_py__swagger_spec_validator__3_0_3//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {
+#     "jsonschema": {
+#         "": 1,
+#     },
+#     "pyyaml": {
+#         "": 1,
+#     },
+#     "typing_extensions": {
+#         "": 1,
+#     },
+# }
+
+
+py_library(
+    name = "swagger_spec_validator__3_0_3",
+    deps = [
+        "@whl_install__aspect_rules_py__swagger_spec_validator__3_0_3//:install",
+        "//:jsonschema",
+        "//:pyyaml",
+        "//:typing_extensions",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: tomli__2_4_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__tomli__2_4_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "tomli__2_4_0",
+    deps = [
+        "@whl_install__aspect_rules_py__tomli__2_4_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: types_python_dateutil__2_9_0_20240316
+# members:
+# {
+#     "@whl_install__aspect_rules_py__types_python_dateutil__2_9_0_20240316//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "types_python_dateutil__2_9_0_20240316",
+    deps = [
+        "@whl_install__aspect_rules_py__types_python_dateutil__2_9_0_20240316//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: typing_extensions__4_12_2
+# members:
+# {
+#     "@whl_install__aspect_rules_py__typing_extensions__4_12_2//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "typing_extensions__4_12_2",
+    deps = [
+        "@whl_install__aspect_rules_py__typing_extensions__4_12_2//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: tzdata__2024_1
+# members:
+# {
+#     "@whl_install__aspect_rules_py__tzdata__2024_1//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "tzdata__2024_1",
+    deps = [
+        "@whl_install__aspect_rules_py__tzdata__2024_1//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: uri_template__1_3_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__uri_template__1_3_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "uri_template__1_3_0",
+    deps = [
+        "@whl_install__aspect_rules_py__uri_template__1_3_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: urllib3__1_26_19
+# members:
+# {
+#     "@whl_install__aspect_rules_py__urllib3__1_26_19//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "urllib3__1_26_19",
+    deps = [
+        "@whl_install__aspect_rules_py__urllib3__1_26_19//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: wcwidth__0_2_13
+# members:
+# {
+#     "@whl_install__aspect_rules_py__wcwidth__0_2_13//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "wcwidth__0_2_13",
+    deps = [
+        "@whl_install__aspect_rules_py__wcwidth__0_2_13//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: webcolors__1_13
+# members:
+# {
+#     "@whl_install__aspect_rules_py__webcolors__1_13//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "webcolors__1_13",
+    deps = [
+        "@whl_install__aspect_rules_py__webcolors__1_13//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: websocket_client__1_8_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__websocket_client__1_8_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "websocket_client__1_8_0",
+    deps = [
+        "@whl_install__aspect_rules_py__websocket_client__1_8_0//:install",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+
+# scc: zipp__3_23_0
+# members:
+# {
+#     "@whl_install__aspect_rules_py__zipp__3_23_0//:install": {
+#         "": 1,
+#     },
+# }
+# deps:
+# {}
+
+
+py_library(
+    name = "zipp__3_23_0",
+    deps = [
+        "@whl_install__aspect_rules_py__zipp__3_23_0//:install",
     ],
     visibility = ["//:__subpackages__"],
 )


### PR DESCRIPTION
collect_sccs() computed each SCC's id as a pure-Starlark SHA-1 over the
repr of its members plus all external deps and markers — often
multi-KB per package, ~94% of the function's CPU (830ms -> 70ms on a
500-package graph).

A lone base package (the common case; dependency graphs are DAGs) now
gets the readable `<name>__<version>`; a real cycle hashes only its
member list. An id_state dict shared across a project's dependency
groups interns ids by full content, so identical SCCs keep one id and
SCCs differing only in deps/markers stay distinct — the property the
content hash previously provided for the cross-group aggregation.

SCC ids only name targets inside the generated project repos, so the
new spelling (visible in the regenerated snapshots) is not a breaking
change — and makes the generated BUILD files debuggable.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
