### PR TITLE
perf(uv): name uv_project targets without pure-Starlark sha1

### DIFF
--- a/uv/private/uv_hub/snapshots/project.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/project.BUILD.bazel
@@ -805,7 +805,7 @@ alias(
 alias(
     name = "_package_exceptiongroup_aspect_rules_py",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//private/sccs:ba5e2f6d3abc42ae",
+        "//private/markers:marker_0": "//private/sccs:ba5e2f6d3abc42ae",
         "//conditions:default": "//private/sccs:empty",
     }),
     visibility = ["//visibility:private"],
@@ -815,7 +815,7 @@ alias(
 alias(
     name = "_package_exceptiongroup_aspect_rules_py_whl",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "@whl_install__aspect_rules_py__exceptiongroup__1_3_1//:whl",
+        "//private/markers:marker_0": "@whl_install__aspect_rules_py__exceptiongroup__1_3_1//:whl",
         "//conditions:default": ":empty_whl",
     }),
     visibility = ["//visibility:private"],
@@ -1129,7 +1129,7 @@ alias(
 alias(
     name = "_package_importlib_metadata_aspect_rules_py",
     actual = select({
-        "//private/markers:db384b5a67611795b7cf16442b57a34653387090": "//private/sccs:755a2d8d1d107b02",
+        "//private/markers:marker_1": "//private/sccs:755a2d8d1d107b02",
         "//conditions:default": "//private/sccs:empty",
     }),
     visibility = ["//visibility:private"],
@@ -1139,7 +1139,7 @@ alias(
 alias(
     name = "_package_importlib_metadata_aspect_rules_py_whl",
     actual = select({
-        "//private/markers:db384b5a67611795b7cf16442b57a34653387090": "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:whl",
+        "//private/markers:marker_1": "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:whl",
         "//conditions:default": ":empty_whl",
     }),
     visibility = ["//visibility:private"],
@@ -2971,7 +2971,7 @@ alias(
 alias(
     name = "_package_tomli_aspect_rules_py",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//private/sccs:c586b17b00ce1e93",
+        "//private/markers:marker_0": "//private/sccs:c586b17b00ce1e93",
         "//conditions:default": "//private/sccs:empty",
     }),
     visibility = ["//visibility:private"],
@@ -2981,7 +2981,7 @@ alias(
 alias(
     name = "_package_tomli_aspect_rules_py_whl",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "@whl_install__aspect_rules_py__tomli__2_4_0//:whl",
+        "//private/markers:marker_0": "@whl_install__aspect_rules_py__tomli__2_4_0//:whl",
         "//conditions:default": ":empty_whl",
     }),
     visibility = ["//visibility:private"],
@@ -3389,7 +3389,7 @@ alias(
 alias(
     name = "_package_zipp_aspect_rules_py",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//private/sccs:0dfe8750086323f2",
+        "//private/markers:marker_0": "//private/sccs:0dfe8750086323f2",
         "//conditions:default": "//private/sccs:empty",
     }),
     visibility = ["//visibility:private"],
@@ -3399,7 +3399,7 @@ alias(
 alias(
     name = "_package_zipp_aspect_rules_py_whl",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "@whl_install__aspect_rules_py__zipp__3_23_0//:whl",
+        "//private/markers:marker_0": "@whl_install__aspect_rules_py__zipp__3_23_0//:whl",
         "//conditions:default": ":empty_whl",
     }),
     visibility = ["//visibility:private"],

--- a/uv/private/uv_hub/snapshots/project.private.markers.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/project.private.markers.BUILD.bazel
@@ -4,42 +4,42 @@ load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
 
 
 decide_marker(
-    name = "f1406cfc2f85641e883d3ba9c27a964444fb80b1",
+    name = "marker_0",
     marker = "python_full_version < '3.11'",
     visibility = ["//:__subpackages__"],
 )
 
 
 decide_marker(
-    name = "db384b5a67611795b7cf16442b57a34653387090",
+    name = "marker_1",
     marker = "python_full_version < '3.10.2'",
     visibility = ["//:__subpackages__"],
 )
 
 
 decide_marker(
-    name = "3f86223bfcc789fb321ff9bf716d56b3833c02b4",
+    name = "marker_2",
     marker = "sys_platform == 'win32'",
     visibility = ["//:__subpackages__"],
 )
 
 
 decide_marker(
-    name = "1ad1862a16d6a81b2e261b1afd5b12f09b7d1e6c",
+    name = "marker_3",
     marker = "(python_full_version < '3.10.2') and (python_full_version < '3.11')",
     visibility = ["//:__subpackages__"],
 )
 
 
 decide_marker(
-    name = "12e4bc7c496178f88620c50eccb1bb90c24f7aff",
+    name = "marker_4",
     marker = "os_name == 'nt'",
     visibility = ["//:__subpackages__"],
 )
 
 
 decide_marker(
-    name = "67b1edeb1aa91c0f50e1e49af7775f6d7837e291",
+    name = "marker_5",
     marker = "(python_full_version < '3.11') and (python_full_version < '3.11')",
     visibility = ["//:__subpackages__"],
 )

--- a/uv/private/uv_hub/snapshots/project.private.sccs.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/project.private.sccs.BUILD.bazel
@@ -45,9 +45,9 @@ py_library(
 
 
 alias(
-    name = "_maybe__02c60fe71555dbc6__406189b2fa92c520",
+    name = "_maybe__02c60fe71555dbc6__typing_extensions",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//:typing_extensions",
+        "//private/markers:marker_0": "//:typing_extensions",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -58,7 +58,7 @@ py_library(
     name = "02c60fe71555dbc6",
     deps = [
         "@whl_install__aspect_rules_py__asgiref__3_8_1//:install",
-        ":_maybe__02c60fe71555dbc6__406189b2fa92c520",
+        ":_maybe__02c60fe71555dbc6__typing_extensions",
     ],
     visibility = ["//:__subpackages__"],
 )
@@ -278,9 +278,9 @@ py_library(
 
 
 alias(
-    name = "_maybe__17569fac0688142c__fd9b7770715c779f",
+    name = "_maybe__17569fac0688142c__colorama",
     actual = select({
-        "//private/markers:3f86223bfcc789fb321ff9bf716d56b3833c02b4": "//:colorama",
+        "//private/markers:marker_2": "//:colorama",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -291,7 +291,7 @@ py_library(
     name = "17569fac0688142c",
     deps = [
         "@whl_install__aspect_rules_py__click__8_1_7//:install",
-        ":_maybe__17569fac0688142c__fd9b7770715c779f",
+        ":_maybe__17569fac0688142c__colorama",
     ],
     visibility = ["//:__subpackages__"],
 )
@@ -401,9 +401,9 @@ py_library(
 
 
 alias(
-    name = "_maybe__1e0e56026e400a78__fd9b7770715c779f",
+    name = "_maybe__1e0e56026e400a78__colorama",
     actual = select({
-        "//private/markers:3f86223bfcc789fb321ff9bf716d56b3833c02b4": "//:colorama",
+        "//private/markers:marker_2": "//:colorama",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -411,9 +411,9 @@ alias(
 
 
 alias(
-    name = "_maybe__1e0e56026e400a78__520b4425048c4c29",
+    name = "_maybe__1e0e56026e400a78__exceptiongroup",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//:exceptiongroup",
+        "//private/markers:marker_0": "//:exceptiongroup",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -421,9 +421,9 @@ alias(
 
 
 alias(
-    name = "_maybe__1e0e56026e400a78__b3bca24d7b58766c",
+    name = "_maybe__1e0e56026e400a78__tomli",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//:tomli",
+        "//private/markers:marker_0": "//:tomli",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -434,12 +434,12 @@ py_library(
     name = "1e0e56026e400a78",
     deps = [
         "@whl_install__aspect_rules_py__pytest__8_1_1//:install",
-        ":_maybe__1e0e56026e400a78__fd9b7770715c779f",
-        ":_maybe__1e0e56026e400a78__520b4425048c4c29",
+        ":_maybe__1e0e56026e400a78__colorama",
+        ":_maybe__1e0e56026e400a78__exceptiongroup",
         "//:iniconfig",
         "//:packaging",
         "//:pluggy",
-        ":_maybe__1e0e56026e400a78__b3bca24d7b58766c",
+        ":_maybe__1e0e56026e400a78__tomli",
     ],
     visibility = ["//:__subpackages__"],
 )
@@ -577,9 +577,9 @@ py_library(
 
 
 alias(
-    name = "_maybe__3efdd519ba908a3d__b3bca24d7b58766c",
+    name = "_maybe__3efdd519ba908a3d__tomli",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//:tomli",
+        "//private/markers:marker_0": "//:tomli",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -590,7 +590,7 @@ py_library(
     name = "3efdd519ba908a3d",
     deps = [
         "@whl_install__aspect_rules_py__maturin__1_11_5//:install",
-        ":_maybe__3efdd519ba908a3d__b3bca24d7b58766c",
+        ":_maybe__3efdd519ba908a3d__tomli",
     ],
     visibility = ["//:__subpackages__"],
 )
@@ -909,10 +909,10 @@ py_library(
 
 
 alias(
-    name = "_maybe__755a2d8d1d107b02__f4aa5147405e1f10",
+    name = "_maybe__755a2d8d1d107b02__zipp",
     actual = select({
-        "//private/markers:1ad1862a16d6a81b2e261b1afd5b12f09b7d1e6c": "//:zipp",
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//:zipp",
+        "//private/markers:marker_3": "//:zipp",
+        "//private/markers:marker_0": "//:zipp",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -923,7 +923,7 @@ py_library(
     name = "755a2d8d1d107b02",
     deps = [
         "@whl_install__aspect_rules_py__importlib_metadata__8_7_1//:install",
-        ":_maybe__755a2d8d1d107b02__f4aa5147405e1f10",
+        ":_maybe__755a2d8d1d107b02__zipp",
     ],
     visibility = ["//:__subpackages__"],
 )
@@ -1260,9 +1260,9 @@ py_library(
 
 
 alias(
-    name = "_maybe__a6e543d0278612c3__fd9b7770715c779f",
+    name = "_maybe__a6e543d0278612c3__colorama",
     actual = select({
-        "//private/markers:12e4bc7c496178f88620c50eccb1bb90c24f7aff": "//:colorama",
+        "//private/markers:marker_4": "//:colorama",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -1270,9 +1270,9 @@ alias(
 
 
 alias(
-    name = "_maybe__a6e543d0278612c3__f8dd3b4b139f76a6",
+    name = "_maybe__a6e543d0278612c3__importlib_metadata",
     actual = select({
-        "//private/markers:db384b5a67611795b7cf16442b57a34653387090": "//:importlib_metadata",
+        "//private/markers:marker_1": "//:importlib_metadata",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -1280,9 +1280,9 @@ alias(
 
 
 alias(
-    name = "_maybe__a6e543d0278612c3__b3bca24d7b58766c",
+    name = "_maybe__a6e543d0278612c3__tomli",
     actual = select({
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//:tomli",
+        "//private/markers:marker_0": "//:tomli",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -1293,11 +1293,11 @@ py_library(
     name = "a6e543d0278612c3",
     deps = [
         "@whl_install__aspect_rules_py__build__1_3_0//:install",
-        ":_maybe__a6e543d0278612c3__fd9b7770715c779f",
-        ":_maybe__a6e543d0278612c3__f8dd3b4b139f76a6",
+        ":_maybe__a6e543d0278612c3__colorama",
+        ":_maybe__a6e543d0278612c3__importlib_metadata",
         "//:packaging",
         "//:pyproject_hooks",
-        ":_maybe__a6e543d0278612c3__b3bca24d7b58766c",
+        ":_maybe__a6e543d0278612c3__tomli",
     ],
     visibility = ["//:__subpackages__"],
 )
@@ -1520,10 +1520,10 @@ py_library(
 
 
 alias(
-    name = "_maybe__ba5e2f6d3abc42ae__406189b2fa92c520",
+    name = "_maybe__ba5e2f6d3abc42ae__typing_extensions",
     actual = select({
-        "//private/markers:67b1edeb1aa91c0f50e1e49af7775f6d7837e291": "//:typing_extensions",
-        "//private/markers:f1406cfc2f85641e883d3ba9c27a964444fb80b1": "//:typing_extensions",
+        "//private/markers:marker_5": "//:typing_extensions",
+        "//private/markers:marker_0": "//:typing_extensions",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -1534,7 +1534,7 @@ py_library(
     name = "ba5e2f6d3abc42ae",
     deps = [
         "@whl_install__aspect_rules_py__exceptiongroup__1_3_1//:install",
-        ":_maybe__ba5e2f6d3abc42ae__406189b2fa92c520",
+        ":_maybe__ba5e2f6d3abc42ae__typing_extensions",
     ],
     visibility = ["//:__subpackages__"],
 )
@@ -1582,9 +1582,9 @@ py_library(
 
 
 alias(
-    name = "_maybe__be4598f5093464bc__0542fffb639f09e7",
+    name = "_maybe__be4598f5093464bc__tzdata",
     actual = select({
-        "//private/markers:3f86223bfcc789fb321ff9bf716d56b3833c02b4": "//:tzdata",
+        "//private/markers:marker_2": "//:tzdata",
         "//conditions:default": ":empty",
     }),
     visibility = ["//:__subpackages__"],
@@ -1597,7 +1597,7 @@ py_library(
         "@whl_install__aspect_rules_py__django__4_2_15//:install",
         "//:asgiref",
         "//:sqlparse",
-        ":_maybe__be4598f5093464bc__0542fffb639f09e7",
+        ":_maybe__be4598f5093464bc__tzdata",
     ],
     visibility = ["//:__subpackages__"],
 )

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -3,7 +3,6 @@
 """
 
 load("@bazel_features//:features.bzl", features = "bazel_features")
-load("//uv/private:sha1.bzl", "sha1")
 load("//uv/private/pprint:defs.bzl", "pprint")
 load("//uv/private/uv_project:select_gen.bzl", "build_package_select_arms")
 
@@ -46,11 +45,20 @@ def _project_impl(repository_ctx):
         """
         Given a marker expression, get a label for it.
         Interns the marker expression into the marker table as needed.
+        The id is only referenced within this generated repository, and the
+        decide_marker() it names carries the full expression.
         """
         if expr not in marker_table:
-            marker_table[expr] = sha1(expr)
+            marker_table[expr] = "marker_{}".format(len(marker_table))
         marker_id = marker_table[expr]
         return "//private/markers:" + marker_id
+
+    def _safe_name(s):
+        """Project a label or package string into a target-name-safe string."""
+        acc = []
+        for c in s.elems():
+            acc.append(c if c.isalnum() or c in "._-" else "_")
+        return "".join(acc)
 
     def _conditionalize(it, markers, cond_id_thunk, no_match = None):
         if "" in markers:
@@ -235,7 +243,7 @@ py_library(
             deps.append(_conditionalize(
                 member,
                 markers,
-                lambda: "_maybe__{}__{}".format(scc_id, sha1(member)[:16]),
+                lambda: "_maybe__{}__{}".format(scc_id, _safe_name(member)),
                 no_match = ":empty",
             ))
 
@@ -244,7 +252,7 @@ py_library(
                 # Note that we map these back to surface packages
                 "//:" + dep,
                 markers,
-                lambda: "_maybe__{}__{}".format(scc_id, sha1(dep)[:16]),
+                lambda: "_maybe__{}__{}".format(scc_id, _safe_name(dep)),
                 no_match = ":empty",
             ))
 


### PR DESCRIPTION
The uv_project repo generator hashed every marker-conditioned edge's member label (uncached, per edge) and every unique marker expression with the interpreted SHA-1 to mint target names — 80ms of repo eval on this repo's ~50-package lock, scaling with lockfile size.

Both names are only referenced within the generated repository, so content hashing buys nothing: conditional-dep aliases now embed the sanitized member label (_maybe__<scc>__typing_extensions) and marker targets intern by encounter order (marker_0, marker_1, ...) — the decide_marker() each names already carries the full expression.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
