### PR TITLE
fix: correct two broken CLI error paths found in the dead-code audit

### DIFF
--- a/py/private/pytest_shard/pytest_shard.py
+++ b/py/private/pytest_shard/pytest_shard.py
@@ -58,7 +58,7 @@ class ShardPlugin:
         shard_total = config.getoption("num_shards")
         if shard_id >= shard_total:
             raise ValueError(
-                "shard_num = f{shard_num} must be less than shard_total = f{shard_total}"
+                f"shard_id = {shard_id} must be less than num_shards = {shard_total}"
             )
 
         items[:] = filter_items_by_shard(items, shard_id, shard_total)

--- a/py/tools/pex/main.py
+++ b/py/tools/pex/main.py
@@ -39,9 +39,8 @@ parser.add_argument(
     "-o",
     "--output-file",
     dest="pex_name",
-    default=None,
-    help="The name of the generated .pex file: Omitting this will run PEX "
-    "immediately and not save it to a file.",
+    required=True,
+    help="The name of the generated .pex file.",
 )
 
 parser.add_argument(


### PR DESCRIPTION
- pex main.py: -o/--output-file is required in practice (build(None) would crash) — declare it required and drop the help text describing a run-immediately mode that doesn't exist
- pytest_shard: the shard-bounds ValueError printed a literal template (missing f-prefix, nonexistent variable names)

### Changes are visible to end-users: no

### Test plan

- Manual testing
