### PR TITLE
refactor(uv): remove dead code and unreachable paths

### DIFF
--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -28,7 +28,6 @@ bzl_library(
         "//uv/private:normalize_version",
         "//uv/private/constraints:repository",
         "//uv/private/git_archive:repository",
-        "//uv/private/pprint:defs",
         "//uv/private/sdist_build:attrs",
         "//uv/private/sdist_build:repository",
         "//uv/private/sdist_configure:defs",

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -149,18 +149,15 @@ def _parse_hubs(module_ctx):
         module_ctx: The Bazel module context.
 
     Returns:
-        A dictionary of hub specifications, where the keys are hub names and the
-        values are dictionaries of module names that declared the hub.
+        A dictionary of hub specifications, keyed by hub name.
     """
 
     # As with `rules_python` hub names have to be globally unique :/
     hub_specs = {}
 
-    # Collect all hubs, ensure we have no dupes
     for mod in module_ctx.modules:
         for hub in mod.tags.declare_hub:
-            hub_specs.setdefault(hub.hub_name, {})
-            hub_specs[hub.hub_name][mod.name] = 1
+            hub_specs[hub.hub_name] = True
 
     # Note that we ARE NOT validating that the same hub name is registered by
     # one and only one repository. This allows `@pypi` which we think should be

--- a/uv/private/gazelle_manifest/generate.py
+++ b/uv/private/gazelle_manifest/generate.py
@@ -6,8 +6,6 @@
 #
 # The strategy is simple.
 # - Accept an args file containing paths to wheel (.whl) files or directories containing .whl files
-# - A path to a lockfile
-# - A path to a file containing an integrity shasum
 #
 # - For each whl file
 #   - open it with a zip reader, extract the .dist-info/METADATA` file and use that to grab the package name
@@ -15,7 +13,7 @@
 #   - strip out `_` prefixed modules and packages
 #   - enter each module into a mapping from module name to requirement name
 #
-# - Write a YAML format manifest file {manifest: {modules_mapping: <mapping>, pip_repository: <hub name>}, integrity: <integrity>}
+# - Write a YAML format manifest file {manifest: {modules_mapping: <mapping>, pip_repository: <hub name>}}
 
 import argparse
 import sys
@@ -174,7 +172,7 @@ def identify_modules(whl_path: Path, package_name: str) -> dict[str, str]:
 
 def write_manifest(module_mapping: dict[str, str],
                    output_path: Path,
-                   pip_repository_name: str = "pypi") -> None:
+                   pip_repository_name: str) -> None:
     """
     Formats the module mapping into a YAML-like string and
     writes it to the specified output path. No pyyaml is used.

--- a/uv/private/markers/pep508_evaluate.bzl
+++ b/uv/private/markers/pep508_evaluate.bzl
@@ -157,26 +157,6 @@ def evaluate(marker, *, env, strict = True, **kwargs):
 
     fail("Could not evaluate: {}".format(marker))
 
-_STRING_REPLACEMENTS = {
-    "!=": "neq",
-    "(": "_",
-    ")": "_",
-    "<": "lt",
-    "<=": "lteq",
-    "==": "eq",
-    "===": "eeq",
-    ">": "gt",
-    ">=": "gteq",
-    "not in": "not_in",
-    "~==": "cmp",
-}
-
-def to_string(marker):
-    return "_".join([
-        _STRING_REPLACEMENTS.get(t, t)
-        for t in tokenize(marker)
-    ]).replace("\"", "")
-
 def _and_fn(x, y):
     """Our custom `and` evaluation function.
 

--- a/uv/private/markers/semver.bzl
+++ b/uv/private/markers/semver.bzl
@@ -39,15 +39,6 @@ def _key(version):
         version.build,
     )
 
-def _to_dict(self):
-    return {
-        "build": self.build,
-        "major": self.major,
-        "minor": self.minor,
-        "patch": self.patch,
-        "pre_release": self.pre_release,
-    }
-
 def _upper(self):
     major = self.major
     minor = self.minor
@@ -62,7 +53,7 @@ def _upper(self):
     elif minor != None:
         major = major + 1
         minor = 0
-    elif minor == None:
+    else:
         major = major + 1
 
     return _new(
@@ -86,7 +77,6 @@ def _new(*, major, minor, patch, pre_release, build, version = None):
         # buildifier: disable=uninitialized
         key = lambda: _key(self),
         str = lambda: version,
-        to_dict = lambda: _to_dict(self),
         upper = lambda: _upper(self),
     )
     return self


### PR DESCRIPTION
- stop emitting the unused py_library load in generated hub BUILDs
- drop unused to_string/_STRING_REPLACEMENTS and semver.to_dict
- simplify _parse_hubs, the select_arms disjunct, and an exact-else elif
- remove the stale pprint bzl_library dep and generate.py's stale header/unused default

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
