### PR TITLE
test(uv): unit-cover parse_whl_name and version_util.is_decimal

### DIFF
--- a/py/private/interpreter/version_util_test.bzl
+++ b/py/private/interpreter/version_util_test.bzl
@@ -1,7 +1,7 @@
 """Tests for version_util.bzl."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//py/private/interpreter:version_util.bzl", "is_pre_release", "version_gt", "version_key")
+load("//py/private/interpreter:version_util.bzl", "is_decimal", "is_pre_release", "version_gt", "version_key")
 
 def _version_key_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -103,6 +103,21 @@ def _is_pre_release_test_impl(ctx):
 
 is_pre_release_test = unittest.make(_is_pre_release_test_impl)
 
+def _is_decimal_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.true(env, is_decimal("0"))
+    asserts.true(env, is_decimal("20260303"))
+
+    asserts.false(env, is_decimal(""))
+    asserts.false(env, is_decimal("3.12"))
+    asserts.false(env, is_decimal("12a"))
+    asserts.false(env, is_decimal("latest"))
+
+    return unittest.end(env)
+
+is_decimal_test = unittest.make(_is_decimal_test_impl)
+
 def version_util_test_suite():
     unittest.suite(
         "version_util_tests",
@@ -110,5 +125,6 @@ def version_util_test_suite():
         version_gt_basic_test,
         version_gt_prerelease_test,
         version_gt_padding_test,
+        is_decimal_test,
         is_pre_release_test,
     )

--- a/uv/private/BUILD.bazel
+++ b/uv/private/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load(":normalize_version_test.bzl", "normalize_version_test_suite")
+load(":parse_whl_name_test.bzl", "parse_whl_name_test_suite")
 
 package(default_visibility = [
     "//docs:__pkg__",
@@ -7,6 +8,8 @@ package(default_visibility = [
 ])
 
 normalize_version_test_suite()
+
+parse_whl_name_test_suite()
 
 bzl_library(
     name = "sha1",

--- a/uv/private/parse_whl_name_test.bzl
+++ b/uv/private/parse_whl_name_test.bzl
@@ -1,0 +1,87 @@
+"""Tests for parse_whl_name.bzl."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":parse_whl_name.bzl", "normalize_abi_tag", "normalize_platform_tag", "parse_whl_name")
+
+def _normalize_platform_tag_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # PEP 600 legacy aliases resolve to their modern equivalents.
+    asserts.equals(env, "manylinux_2_17_x86_64", normalize_platform_tag("manylinux2014_x86_64"))
+    asserts.equals(env, "manylinux_2_12_i686", normalize_platform_tag("manylinux2010_i686"))
+    asserts.equals(env, "manylinux_2_5_x86_64", normalize_platform_tag("manylinux1_x86_64"))
+
+    # A legacy alias alongside its modern spelling dedupes to one tag.
+    asserts.equals(
+        env,
+        "manylinux_2_17_aarch64",
+        normalize_platform_tag("manylinux2014_aarch64.manylinux_2_17_aarch64"),
+    )
+
+    # Non-legacy tags pass through untouched, preserving order.
+    asserts.equals(env, "macosx_11_0_arm64", normalize_platform_tag("macosx_11_0_arm64"))
+    asserts.equals(
+        env,
+        "musllinux_1_2_x86_64.manylinux_2_17_x86_64",
+        normalize_platform_tag("musllinux_1_2_x86_64.manylinux2014_x86_64"),
+    )
+
+    return unittest.end(env)
+
+normalize_platform_tag_test = unittest.make(_normalize_platform_tag_test_impl)
+
+def _normalize_abi_tag_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Tags without trailing feature flags are untouched.
+    asserts.equals(env, "abi3", normalize_abi_tag("abi3"))
+    asserts.equals(env, "none", normalize_abi_tag("none"))
+    asserts.equals(env, "cp310", normalize_abi_tag("cp310"))
+
+    # Feature flags normalize to a stable d/m/t/u order.
+    asserts.equals(env, "cp313t", normalize_abi_tag("cp313t"))
+    asserts.equals(env, "cp39dm", normalize_abi_tag("cp39md"))
+    asserts.equals(env, "cp39dmu", normalize_abi_tag("cp39umd"))
+
+    return unittest.end(env)
+
+normalize_abi_tag_test = unittest.make(_normalize_abi_tag_test_impl)
+
+def _parse_whl_name_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Common pure-python wheel: compound python tag, no build tag.
+    parsed = parse_whl_name("six-1.17.0-py2.py3-none-any.whl")
+    asserts.equals(env, "six", parsed.project)
+    asserts.equals(env, "1.17.0", parsed.version)
+    asserts.equals(env, None, parsed.build)
+    asserts.equals(env, ["py2", "py3"], parsed.python_tags)
+    asserts.equals(env, ["none"], parsed.abi_tags)
+    asserts.equals(env, ["any"], parsed.platform_tags)
+
+    # Build tag between version and python tag.
+    parsed = parse_whl_name("mypkg-1.0-2foo-py3-none-any.whl")
+    asserts.equals(env, "mypkg", parsed.project)
+    asserts.equals(env, "1.0", parsed.version)
+    asserts.equals(env, "2foo", parsed.build)
+
+    # Native wheel with a legacy platform alias and a freethreaded ABI:
+    # the alias normalizes and dedupes against its modern spelling.
+    parsed = parse_whl_name(
+        "regex-2024.11.6-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+    )
+    asserts.equals(env, ["cp313"], parsed.python_tags)
+    asserts.equals(env, ["cp313t"], parsed.abi_tags)
+    asserts.equals(env, ["manylinux_2_17_x86_64"], parsed.platform_tags)
+
+    return unittest.end(env)
+
+parse_whl_name_test = unittest.make(_parse_whl_name_test_impl)
+
+def parse_whl_name_test_suite():
+    unittest.suite(
+        "parse_whl_name_tests",
+        normalize_abi_tag_test,
+        normalize_platform_tag_test,
+        parse_whl_name_test,
+    )


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- New test cases added
