### PR TITLE
perf(uv): collapse abi tag config_setting_groups into config_settings

### DIFF
--- a/uv/private/constraints/abi/macro.bzl
+++ b/uv/private/constraints/abi/macro.bzl
@@ -2,7 +2,7 @@
 Generate interpreter ABI config_settings for wheel selection.
 
 Each ABI tag from a wheel filename (e.g. cp312, cp312t, cp312dmu) maps to a
-config_setting_group that combines a Python version check with interpreter
+config_setting whose flag_values AND a Python version check with interpreter
 feature flag checks. The feature flags are backed by bool_flags defined in
 //py/private/interpreter:BUILD.bazel and are set by the interpreter toolchain
 provisioning system.
@@ -35,66 +35,24 @@ def generate(
         ],
     )
 
-    # Interpreter feature flag config_settings. Each pair (enabled/disabled)
-    # checks the corresponding bool_flag from //py/private/interpreter.
-    native.config_setting(
-        name = "pydebug_enabled",
-        flag_values = {_PYDEBUG_FLAG: "true"},
-        visibility = visibility,
-    )
-    native.config_setting(
-        name = "pydebug_disabled",
-        flag_values = {_PYDEBUG_FLAG: "false"},
-        visibility = visibility,
-    )
-
-    native.config_setting(
-        name = "pymalloc_enabled",
-        flag_values = {_PYMALLOC_FLAG: "true"},
-        visibility = visibility,
-    )
-    native.config_setting(
-        name = "pymalloc_disabled",
-        flag_values = {_PYMALLOC_FLAG: "false"},
-        visibility = visibility,
-    )
-
-    native.config_setting(
-        name = "freethreading_enabled",
-        flag_values = {_FREETHREADING_FLAG: "true"},
-        visibility = visibility,
-    )
-    native.config_setting(
-        name = "freethreading_disabled",
-        flag_values = {_FREETHREADING_FLAG: "false"},
-        visibility = visibility,
-    )
-
-    native.config_setting(
-        name = "wide_unicode_enabled",
-        flag_values = {_WIDE_UNICODE_FLAG: "true"},
-        visibility = visibility,
-    )
-    native.config_setting(
-        name = "wide_unicode_disabled",
-        flag_values = {_WIDE_UNICODE_FLAG: "false"},
-        visibility = visibility,
-    )
-
     native.alias(
         name = "abi3",
         actual = "//uv/private/constraints/python:py33",
         visibility = visibility,
     )
 
+    # A native config_setting ANDs all of its flag_values entries, so each
+    # abi tag is one target instead of a config_setting_group chain — this
+    # loop emits 1344 tags, so the per-tag target count matters.
     for interpreter in INTERPRETERS:
         for major in MAJORS:
             for minor in MINORS:
+                version_flag = "//uv/private/constraints/python:_py{}{}_flag".format(major, minor)
                 for d in [False, True]:
                     for m in [False, True]:
                         for t in [False, True]:
                             for u in [False, True]:
-                                selects.config_setting_group(
+                                native.config_setting(
                                     name = "{0}{1}{2}{3}{4}{5}{6}".format(
                                         interpreter,
                                         major,
@@ -104,14 +62,12 @@ def generate(
                                         "t" if t else "",
                                         "u" if u else "",
                                     ),
-                                    match_all = (
-                                        [
-                                            "//uv/private/constraints/python:py{}{}".format(major, minor),
-                                        ] +
-                                        ([":pydebug_enabled"] if d else [":pydebug_disabled"]) +
-                                        ([":pymalloc_enabled"] if m else [":pymalloc_disabled"]) +
-                                        ([":freethreading_enabled"] if t else [":freethreading_disabled"]) +
-                                        ([":wide_unicode_enabled"] if u else [":wide_unicode_disabled"])
-                                    ),
+                                    flag_values = {
+                                        version_flag: "yes",
+                                        _PYDEBUG_FLAG: "true" if d else "false",
+                                        _PYMALLOC_FLAG: "true" if m else "false",
+                                        _FREETHREADING_FLAG: "true" if t else "false",
+                                        _WIDE_UNICODE_FLAG: "true" if u else "false",
+                                    },
                                     visibility = visibility,
                                 )

--- a/uv/private/constraints/python/defs.bzl
+++ b/uv/private/constraints/python/defs.bzl
@@ -46,7 +46,9 @@ def is_python_version_at_least(name, version = None, visibility = visibility, **
     _python_version_at_least(
         name = flag_name,
         at_least = version,
-        visibility = ["//visibility:private"],
+        # The abi package's config_settings check this flag directly in
+        # their flag_values, ANDed with the interpreter feature flags.
+        visibility = ["//uv/private/constraints:__subpackages__"],
         **kwargs
     )
 


### PR DESCRIPTION
The abi constraints package generated a skylib config_setting_group for each of its 1344 abi tags, and match_all expands every group into a chain of intermediate targets. All five conditions per tag are flag checks (the _python_version_at_least feature flag plus four interpreter bool_flags), and a native config_setting already ANDs its flag_values — so each tag is now one target checking all five flags directly.

Same labels and match semantics; the python version flag targets gain constraints-subpackage visibility, and the now-unreferenced per-feature enabled/disabled settings are dropped. Loading the abi package falls from 210ms to 20ms in the Starlark CPU profile, paid on every build.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
