### PR TITLE
refactor(uv): alias cp* python-version constraints to their py* twins

### DIFF
--- a/uv/private/constraints/python/defs.bzl
+++ b/uv/private/constraints/python/defs.bzl
@@ -33,8 +33,7 @@ def supported_python(python_tag):
 _PYTHON_VERSION_MAJOR_MINOR_FLAG = Label("@rules_python//python/config_settings:python_version_major_minor")
 _ARPY_PYTHON_VERSION_FLAG = Label("@aspect_rules_py//py/private/interpreter:python_version")
 
-def is_python_version_at_least(name, version = None, visibility = visibility, **kwargs):
-    version = version or name
+def is_python_version_at_least(name, version, visibility, **kwargs):
     flag_name = "_{}_flag".format(name)
     native.config_setting(
         name = name,

--- a/uv/private/constraints/python/macro.bzl
+++ b/uv/private/constraints/python/macro.bzl
@@ -9,7 +9,6 @@ load(":defs.bzl", "is_python_version_at_least")
 # buildifier: disable=function-docstring
 def generate(
         visibility):
-    # FIXME: Needs to generate a cascade.
     for major in MAJORS:
         is_python_version_at_least(
             name = "py{}".format(major),

--- a/uv/private/constraints/python/macro.bzl
+++ b/uv/private/constraints/python/macro.bzl
@@ -10,17 +10,35 @@ load(":defs.bzl", "is_python_version_at_least")
 def generate(
         visibility):
     # FIXME: Needs to generate a cascade.
-    for interpreter in INTERPRETERS:
-        for major in MAJORS:
+    for major in MAJORS:
+        is_python_version_at_least(
+            name = "py{}".format(major),
+            version = "{}.0".format(major),
+            visibility = visibility,
+        )
+
+        for minor in MINORS:
             is_python_version_at_least(
+                name = "py{}{}".format(major, minor),
+                version = "{}.{}".format(major, minor),
+                visibility = visibility,
+            )
+
+    # The settings check only the interpreter version, so every non-generic
+    # tag (cp312, ...) evaluates identically to its py equivalent.
+    for interpreter in INTERPRETERS:
+        if interpreter == "py":
+            continue
+        for major in MAJORS:
+            native.alias(
                 name = "{}{}".format(interpreter, major),
-                version = "{}.0".format(major),
+                actual = ":py{}".format(major),
                 visibility = visibility,
             )
 
             for minor in MINORS:
-                is_python_version_at_least(
+                native.alias(
                     name = "{}{}{}".format(interpreter, major, minor),
-                    version = "{}.{}".format(major, minor),
+                    actual = ":py{}{}".format(major, minor),
                     visibility = visibility,
                 )


### PR DESCRIPTION
The generated settings check only the interpreter version, so cp312
and py312 were identical config_settings (each with a private flag
rule behind it). Generate real settings for the generic py prefix and
aliases for the rest. Also make is_python_version_at_least's version/
visibility params mandatory: the version-defaults-to-name fallback was
unreachable, and the visibility default was the .bzl builtin function.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
