### PR TITLE
perf(py_venv): precompute per-wheel collision claims in the wheel record

### DIFF
--- a/py/private/providers.bzl
+++ b/py/private/providers.bzl
@@ -36,9 +36,95 @@ Duplicate dependency edges do not create another precedence position. Fields:
   * `site_packages_rfpath`: str — runfiles-root-relative path to the wheel's site-packages.
   * `console_scripts`: tuple[str] — entry points encoded as `"name=module:func"`.
   * `install_tree`: File — complete installed wheel tree.
+  * `tl_claims`, `metadata_top_levels`, `cs_claims`: derived fields
+    precomputed by `make_wheel_record` so venv assembly's collision
+    resolution does per-wheel parsing once instead of per consuming binary.
+
+Records must be built with `make_wheel_record` so the derived fields are
+present and consistent with the raw ones.
 """,
     },
 )
+
+def make_wheel_record(
+        *,
+        site_packages_rfpath,
+        install_tree = None,
+        top_levels = (),
+        namespace_top_levels = (),
+        namespace_entries = (),
+        namespace_dirs = (),
+        regular_roots = (),
+        console_scripts = ()):
+    """Build one PyWheelsInfo wheel record.
+
+    Precomputes the collision-resolution claim structs that venv assembly
+    consumes, so parsing happens once per wheel rather than per consuming
+    binary. See the PyWheelsInfo field docs for the raw fields' semantics.
+
+    Args:
+        site_packages_rfpath: runfiles-root-relative path to the wheel's site-packages.
+        install_tree: File holding the complete installed wheel tree.
+        top_levels: immediate site-packages entry names; empty means unknown layout.
+        namespace_top_levels: subset of top_levels that are PEP 420 namespaces.
+        namespace_entries: concrete `/`-joined entries beneath the namespace top-levels.
+        namespace_dirs: implicit-namespace directory skeleton under the top-levels.
+        regular_roots: minimal `__init__.py`-carrying directories under the top-levels.
+        console_scripts: entry points encoded as `"name=module:func"`.
+
+    Returns:
+        A struct for PyWheelsInfo.wheels.
+    """
+    ns_set = {tl: True for tl in namespace_top_levels}
+    ns_entries_by_tl = {}
+    for entry in namespace_entries:
+        ns_entries_by_tl.setdefault(entry.split("/")[0], []).append(entry)
+
+    tl_claims = []
+    metadata_top_levels = []
+    for tl in top_levels:
+        if tl.endswith(".dist-info") or tl.endswith(".egg-info"):
+            metadata_top_levels.append(tl)
+            continue
+        tl_claims.append((tl, struct(
+            site_packages = site_packages_rfpath,
+            is_ns = tl in ns_set,
+            ns_entries = tuple(ns_entries_by_tl.get(tl, [])),
+        )))
+
+    cs_claims = []
+    for entry in console_scripts:
+        # Entry encoding: "name=module:func".
+        if "=" not in entry:
+            continue
+        name, _, target = entry.partition("=")
+        if ":" not in target:
+            continue
+        module, _, func = target.partition(":")
+        name = name.strip()
+        module = module.strip()
+        func = func.strip()
+        if not name or not module or not func:
+            continue
+        cs_claims.append((name, struct(
+            site_packages = site_packages_rfpath,
+            module = module,
+            func = func,
+        )))
+
+    return struct(
+        top_levels = tuple(top_levels),
+        namespace_top_levels = tuple(namespace_top_levels),
+        namespace_entries = tuple(namespace_entries),
+        namespace_dirs = tuple(namespace_dirs),
+        regular_roots = tuple(regular_roots),
+        site_packages_rfpath = site_packages_rfpath,
+        console_scripts = tuple(console_scripts),
+        install_tree = install_tree,
+        tl_claims = tuple(tl_claims),
+        metadata_top_levels = tuple(metadata_top_levels),
+        cs_claims = tuple(cs_claims),
+    )
 
 PyVirtualInfo = provider(
     doc = "FIXME",

--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -1,7 +1,7 @@
 """Unpacks a Python wheel into a directory and returns a PyInfo provider that represents that wheel"""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//py/private:providers.bzl", "PyWheelsInfo")
+load("//py/private:providers.bzl", "PyWheelsInfo", "make_wheel_record")
 load("//py/private:pth.bzl", "make_imports_depset")
 load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
@@ -80,12 +80,12 @@ def _py_unpacked_wheel_impl(ctx):
     ]
 
     providers.append(PyWheelsInfo(
-        wheels = depset(direct = [struct(
-            top_levels = tuple(ctx.attr.top_levels),
-            namespace_top_levels = tuple(ctx.attr.namespace_top_levels),
-            namespace_entries = tuple(ctx.attr.namespace_entries),
+        wheels = depset(direct = [make_wheel_record(
+            top_levels = ctx.attr.top_levels,
+            namespace_top_levels = ctx.attr.namespace_top_levels,
+            namespace_entries = ctx.attr.namespace_entries,
             site_packages_rfpath = site_packages_rfpath,
-            console_scripts = tuple(ctx.attr.console_scripts),
+            console_scripts = ctx.attr.console_scripts,
             # See whl_install rule for the rationale.
             install_tree = unpack_directory,
         )]),

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -148,44 +148,20 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             _complain(what, name, distinct[i - 1], distinct[i])
 
     # Pass 1: bucket claimants per import root, distribution metadata entry,
-    # and console-script name.
+    # and console-script name. The per-wheel claim structs are precomputed
+    # by make_wheel_record, so this pass only merges them per closure.
     tl_claimants = {}  # tl -> list of struct(site_packages, is_ns, ns_entries)
     metadata_claimants = {}  # metadata entry -> ordered site_packages paths
     cs_claimants = {}  # name -> list of struct(site_packages, module, func)
     wheel_by_sp = {}  # site_packages_rfpath -> wheel struct
     for w in wheels:
         wheel_by_sp[w.site_packages_rfpath] = w
-        ns_set = {tl: True for tl in getattr(w, "namespace_top_levels", ())}
-        ns_entries_by_tl = {}
-        for entry in getattr(w, "namespace_entries", ()):
-            ns_entries_by_tl.setdefault(entry.split("/")[0], []).append(entry)
-        for tl in w.top_levels:
-            if tl.endswith(".dist-info") or tl.endswith(".egg-info"):
-                metadata_claimants.setdefault(tl, []).append(w.site_packages_rfpath)
-                continue
-            tl_claimants.setdefault(tl, []).append(struct(
-                site_packages = w.site_packages_rfpath,
-                is_ns = tl in ns_set,
-                ns_entries = tuple(ns_entries_by_tl.get(tl, [])),
-            ))
-        for entry in getattr(w, "console_scripts", ()):
-            # Entry encoding from the repo rule: "name=module:func".
-            if "=" not in entry:
-                continue
-            name, _, target = entry.partition("=")
-            if ":" not in target:
-                continue
-            module, _, func = target.partition(":")
-            name = name.strip()
-            module = module.strip()
-            func = func.strip()
-            if not name or not module or not func:
-                continue
-            cs_claimants.setdefault(name, []).append(struct(
-                site_packages = w.site_packages_rfpath,
-                module = module,
-                func = func,
-            ))
+        for tl in w.metadata_top_levels:
+            metadata_claimants.setdefault(tl, []).append(w.site_packages_rfpath)
+        for tl, claim in w.tl_claims:
+            tl_claimants.setdefault(tl, []).append(claim)
+        for name, claim in w.cs_claims:
+            cs_claimants.setdefault(name, []).append(claim)
 
     # Pass 2: resolve top-levels. Track which (site_packages, tl) pairs
     # we SKIPPED (left to the .pth fallback) and which namespace claims
@@ -221,15 +197,15 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
             for sp_a in distinct_sp.keys():
                 ns_claimant_sps[sp_a] = True
                 w_a = wheel_by_sp[sp_a]
-                for root in getattr(w_a, "regular_roots", ()):
+                for root in w_a.regular_roots:
                     if not root.startswith(tl_prefix):
                         continue
                     for sp_b in distinct_sp.keys():
                         if sp_b == sp_a:
                             continue
                         w_b = wheel_by_sp[sp_b]
-                        if (root in getattr(w_b, "namespace_dirs", ()) or
-                            root in getattr(w_b, "regular_roots", ())):
+                        if (root in w_b.namespace_dirs or
+                            root in w_b.regular_roots):
                             conflicted_roots[root] = True
                             tl_conflicted = True
 
@@ -399,8 +375,7 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
                 continue
             group_sps_seen[sp] = True
             w = wheel_by_sp[sp]
-            if (root in getattr(w, "regular_roots", ()) or
-                root in getattr(w, "namespace_dirs", ())):
+            if root in w.regular_roots or root in w.namespace_dirs:
                 group_sps.append(sp)
         if len(group_sps) >= 2:
             merge_groups.append(struct(
@@ -439,9 +414,9 @@ def _resolve_wheel_collisions(ctx, wheels, package_collisions):
         skipped = skipped_per_wheel.get(w.site_packages_rfpath, {})
         ns_covered = ns_covered_per_wheel.get(w.site_packages_rfpath, {})
         covered = True
-        for tl in w.top_levels:
-            if tl in metadata_claimants:
-                continue
+
+        # tl_claims carries exactly the non-metadata top-levels.
+        for tl, _ in w.tl_claims:
             if tl in skipped:
                 covered = False
                 break

--- a/py/tests/py_venv_conflict/collision_order_test.bzl
+++ b/py/tests/py_venv_conflict/collision_order_test.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//py:defs.bzl", "py_binary", "py_library", "py_test")
-load("//py/private:providers.bzl", "PyWheelsInfo")
+load("//py/private:providers.bzl", "PyWheelsInfo", "make_wheel_record")
 load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
 
@@ -50,14 +50,13 @@ printf 'VALUE = "namespace"\n' > "$site/mixed_top/from_namespace.py"
         ]
         if segment
     ] + ["lib/python{}.{}/site-packages".format(major, minor)])
-    wheel = struct(
+    wheel = make_wheel_record(
         top_levels = top_levels,
         namespace_top_levels = namespace_top_levels,
         namespace_entries = namespace_entries,
         namespace_dirs = namespace_dirs,
         regular_roots = regular_roots,
         site_packages_rfpath = site_packages,
-        console_scripts = (),
         install_tree = install_tree,
     )
     return [
@@ -138,12 +137,10 @@ printf 'VALUE = %s\n' "$4" > "$site/collision_order.py"
         ]
         if segment
     ] + ["lib/python{}.{}/site-packages".format(major, minor)])
-    wheel = struct(
+    wheel = make_wheel_record(
         top_levels = top_levels,
         namespace_top_levels = namespace_top_levels,
         namespace_entries = namespace_entries,
-        namespace_dirs = (),
-        regular_roots = (),
         site_packages_rfpath = site_packages,
         console_scripts = console_scripts,
         install_tree = install_tree,

--- a/py/tests/py_venv_conflict/site_merge_order_test.bzl
+++ b/py/tests/py_venv_conflict/site_merge_order_test.bzl
@@ -1,7 +1,7 @@
 """End-to-end coverage for regular-package physical merge order."""
 
 load("//py:defs.bzl", "py_test")
-load("//py/private:providers.bzl", "PyWheelsInfo")
+load("//py/private:providers.bzl", "PyWheelsInfo", "make_wheel_record")
 load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
 
@@ -104,14 +104,13 @@ printf 'VALUE = %s\n' "$4" > "$site/other/from_final.py"
         ] + ["lib/python{}.{}/site-packages".format(major, minor)])
         install_trees.append(install_tree)
         site_packages_paths.append(site_packages)
-        wheels.append(struct(
+        wheels.append(make_wheel_record(
             top_levels = top_levels,
             namespace_top_levels = top_levels,
             namespace_entries = namespace_entries,
             namespace_dirs = namespace_dirs,
             regular_roots = regular_roots,
             site_packages_rfpath = site_packages,
-            console_scripts = (),
             install_tree = install_tree,
         ))
 

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -1,7 +1,7 @@
 """
 """
 
-load("//py/private:providers.bzl", "PyWheelsInfo")
+load("//py/private:providers.bzl", "PyWheelsInfo", "make_wheel_record")
 load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
 
@@ -164,44 +164,19 @@ def _whl_install(ctx):
     ]
 
     providers.append(PyWheelsInfo(
-        wheels = depset(direct = [struct(
-            top_levels = tuple(top_levels),
-            # PEP 420 namespace packages this wheel contributes to.
-            # When multiple wheels claim the same top-level and ALL of
-            # them flag it as namespace, py_binary merges the namespace
-            # CONCRETELY from `namespace_entries` per-entry symlinks
-            # (so tools that inspect site-packages directly — mypy,
-            # pyright — see the packages and their py.typed markers),
-            # unless a regular package spans the wheels (detected via
-            # `regular_roots` × `namespace_dirs`), which needs a
-            # physical merge instead. Falls back to .pth-based
-            # resolution when entry metadata is missing.
-            namespace_top_levels = tuple(namespace_top_levels),
-            # Concrete per-wheel paths beneath namespace top-levels
-            # (e.g. `jaraco/functools`) that venv assembly symlinks
-            # individually to materialise a merged namespace directory.
-            namespace_entries = tuple(namespace_entries),
-            # Directory skeleton under namespace top-levels: which dirs
-            # are implicit-namespace portions (`namespace_dirs`) and
-            # which are the minimal regular-package roots
-            # (`regular_roots`). venv assembly cross-references these
-            # across wheels to detect a regular package spanning wheels
-            # (Python can't merge a regular package's __path__ at
-            # runtime, so the subtree is physically merged).
-            namespace_dirs = tuple(namespace_dirs),
-            regular_roots = tuple(regular_roots),
+        # See make_wheel_record / the PyWheelsInfo field docs for each
+        # field's semantics. `install_tree` holds the installed file tree
+        # (`install/`, internally `lib/python<M>.<m>/site-packages/...`);
+        # venv assembly's per-top-level symlinks reference each wheel by
+        # its natural runfiles path rather than through this File.
+        wheels = depset(direct = [make_wheel_record(
+            top_levels = top_levels,
+            namespace_top_levels = namespace_top_levels,
+            namespace_entries = namespace_entries,
+            namespace_dirs = namespace_dirs,
+            regular_roots = regular_roots,
             site_packages_rfpath = site_packages_rfpath,
-            # Each entry is "name=module:func"; py_binary parses into
-            # wrapper scripts at <venv>/bin/<name> at analysis time.
-            console_scripts = tuple(console_scripts),
-            # Tree artifact holding this wheel's installed file tree
-            # (`install/`, whose internal shape is
-            # `lib/python<M>.<m>/site-packages/...`). Consumed by
-            # venv assembly's physical merge action (regular packages
-            # spanning wheels) and by py_image_layer's pip-package
-            # layer; the per-top-level venv symlinks reference each
-            # wheel by its natural runfiles path rather than through
-            # this File.
+            console_scripts = console_scripts,
             install_tree = install_dir,
         )]),
     ))


### PR DESCRIPTION
Collision resolution re-derived per-wheel-invariant data for every consuming binary: namespace-entry splits, dist-info classification of every top_level, and console-script parsing, allocating fresh claim structs each time. On a 200-binary x 240-wheel fixture this was 25% of all analysis-phase Starlark CPU; precomputing cuts _resolve_wheel_collisions from 0.98s to 0.63s there.

PyWheelsInfo wheel records are now built by make_wheel_record, which derives tl_claims, metadata_top_levels, and cs_claims once per wheel. The record contract requires the derived fields, so venv assembly drops its getattr fallbacks for optional fields.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
