### PR TITLE
fix(uv): keep JDK paths valid during sdist builds

### DIFF
--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -122,7 +122,7 @@ write_source_files(
         # plumbing for the augment-on-defaults `toolchains = [...]` /
         # `env = {...}`. The override layers a JDK runtime on top of the
         # default CC toolchain; the snapshot pins both toolchain
-        # references and both env families (CC + JAVA_HOME/JAVA/JAR).
+        # references and both env families (CC + JAVA_HOME/JAVA).
         # Pairs with the analysis test at
         # //uv/private/pep517_whl:toolchain_env_test which asserts the
         # rule expands env keys correctly given an explicit fixture.

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
@@ -22,7 +22,6 @@ pep517_native_whl(
         "AR": "$(AR)",
         "CC": "$(CC)",
         "CXX": "$(CC)",
-        "JAR": "$(JAVABASE)/bin/jar",
         "JAVA": "$(JAVA)",
         "JAVA_HOME": "$(JAVABASE)",
         "LD": "$(LD)",

--- a/e2e/cases/uv-sdist-jdk-build/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-jdk-build/setup.MODULE.bazel
@@ -1,7 +1,7 @@
 """Regression for the per-package toolchain plumbing on
 `uv.override_package`. jpype1 is forced to sdist via
 [tool.uv].no-binary-package; the override layers a JDK runtime
-toolchain into the build env so JAVA_HOME / JAVA / JAR are exported.
+toolchain into the build env so JAVA_HOME / JAVA are exported.
 
 Uses its own hub to keep the override and no-binary setting isolated
 from other test cases.
@@ -29,7 +29,6 @@ uv.unstable_annotate_packages(
 uv.override_package(
     name = "jpype1",
     env = {
-        "JAR": "$(JAVABASE)/bin/jar",
         "JAVA": "$(JAVA)",
         "JAVA_HOME": "$(JAVABASE)",
     },

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -158,7 +158,6 @@ pep517_native_whl(
         "STRIP": "$(STRIP)",
         "JAVA_HOME": "$(JAVABASE)",
         "JAVA": "$(JAVA)",
-        "JAR": "$(JAVABASE)/bin/jar",
     },
     tags = ["manual"],
     tool = ":__stub_tool",

--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -97,6 +97,14 @@ def _override_tool(env, key, wrapper):
         env[key] = shlex.join(parts)
 
 
+def _absolutize_java_tool_paths(env):
+    """Keep Bazel's Java toolchain paths valid after the backend cwd change."""
+    for key in ("JAVA_HOME", "JAVA"):
+        value = env.get(key)
+        if value and not path.isabs(value) and path.exists(value):
+            env[key] = path.abspath(value)
+
+
 def _compiler_env(tmpdir):
     env = dict(os.environ)
     # The helper's launcher exports RUNFILES_DIR, RUNFILES_MANIFEST_FILE, and
@@ -120,6 +128,11 @@ def _compiler_env(tmpdir):
     env["TMP"] = tmpdir
     env["TEMP"] = tmpdir
     env["TEMPDIR"] = tmpdir
+
+    # The Java toolchain expands its paths relative to the execroot. Resolve
+    # them while the helper still runs there; the PEP 517 backend later runs
+    # inside the unpacked source tree.
+    _absolutize_java_tool_paths(env)
 
     cc_path = _resolve_compiler_path(env, "CC", "cc")
     cxx_path = _resolve_compiler_path(env, "CXX", "c++")

--- a/uv/private/pep517_whl/test.bzl
+++ b/uv/private/pep517_whl/test.bzl
@@ -54,7 +54,7 @@ hostile_python_env_target = rule(
 _CC_ENV_KEYS = ["CC", "CXX", "AR", "LD", "STRIP"]
 
 # Env vars sourced from the Java runtime toolchain's TemplateVariableInfo.
-_JDK_ENV_KEYS = ["JAVA_HOME", "JAVA", "JAR"]
+_JDK_ENV_KEYS = ["JAVA_HOME", "JAVA"]
 
 _REQUIRED_ENV_KEYS = _CC_ENV_KEYS + _JDK_ENV_KEYS
 
@@ -98,13 +98,6 @@ def _toolchain_env_test_impl(ctx):
         driver_paths.cxx if driver_paths else cc,
         action_env.get("CXX"),
         "CXX should use the declared companion or selected compiler fallback",
-    )
-
-    # JAR is constructed from $(JAVABASE)/bin/jar — sanity-check the suffix.
-    asserts.true(
-        env,
-        action_env.get("JAR", "").endswith("/bin/jar"),
-        "JAR should resolve under JAVA_HOME/bin/jar; got {}".format(action_env.get("JAR")),
     )
 
     return analysistest.end(env)

--- a/uv/private/pep517_whl/tests/explicit_env/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/explicit_env/BUILD.bazel
@@ -7,11 +7,15 @@ pep517_native_whl(
     src = "//uv/private/pep517_whl:__python_env_sdist",
     env = {
         "EXPECTED_PYTHONPATH": "/explicit/path",
+        "EXPECT_JAVA_TOOL_PATHS": "1",
+        "JAVA": "$(JAVA)",
+        "JAVA_HOME": "$(JAVABASE)",
         "PYTHONPATH": "/explicit/path",
     },
     # This must only build through the hostile environment transition below.
     tags = ["manual"],
     tool = "//uv/private/pep517_whl:__build_helper",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
     version = "0.0.1",
 )
 

--- a/uv/private/pep517_whl/tests/python_env_backend/backend.py
+++ b/uv/private/pep517_whl/tests/python_env_backend/backend.py
@@ -37,6 +37,12 @@ def _check_environment() -> None:
     if os.environ.get("PYTHONSAFEPATH") != "1":
         raise RuntimeError("unrelated PYTHONSAFEPATH was not preserved")
 
+    if os.environ.get("EXPECT_JAVA_TOOL_PATHS") == "1":
+        for name in ("JAVA_HOME", "JAVA"):
+            value = os.environ.get(name)
+            if not value or not os.path.isabs(value) or not os.path.exists(value):
+                raise RuntimeError(f"{name} is not an absolute existing path: {value!r}")
+
 
 def get_requires_for_build_wheel(
     config_settings: dict[str, object] | None = None,


### PR DESCRIPTION
PEP 517 backends run from the unpacked sdist worktree, but
JAVABASE and JAVA expand to execroot-relative paths. Native Java
sdists such as pemja therefore see those paths stop resolving after
the cwd change.

Resolve the declared Java runtime paths before invoking the backend.
Remove the stale JAR fixture because current_java_runtime does not
declare that tool. Extend the native-wheel fixture to require
absolute, existing JAVA_HOME and JAVA.