### PR TITLE
docs: correct broken anchor link in py_test docstring for Bazel registry docs

### DIFF
--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -143,7 +143,7 @@ def py_binary(name, srcs = [], main = None, **kwargs):
     )
 
 def py_test(name, srcs = [], main = None, pytest_main = False, **kwargs):
-    """Identical to [py_binary](./py_binary.md), but produces a target that can be used with `bazel test`.
+    """Identical to [py_binary](#function-py_binary), but produces a target that can be used with `bazel test`.
 
     Args:
         name: Name of the rule.


### PR DESCRIPTION
## Summary
The Bazel registry (registry.bazel.build) renders function/macro definition anchors with a `function-` prefix (e.g. `id="function-py_binary"`), but the `py_test` docstring linked to `./py_binary.md` (a relative file path), which resolves to a 404 on the registry.

- `./py_binary.md` -> `#function-py_binary` in `py_test` macro docstring

> **Note:** The same broken anchor pattern also exists for `py_venv_exec` and `py_venv_exec_test` in `py/private/py_venv/py_venv_exec.bzl` (`#py_binary` and `#py_test`), but those are not currently rendered on the registry docs page so they are not fixed here.


### Test plan
Manual testing:
1. Visit https://registry.bazel.build/docs/aspect_rules_py
2. In the `py_test` macro description, click the "py_binary" link — currently leads to a broken `./py_binary.md` path (404)
3. After this fix, the link navigates to the `py_binary` macro section on the same page