### PR TITLE
fix(py): Resolve Java toolchain paths before the PEP 517 backend chdirs into the sdist

### DIFF
--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -122,7 +122,7 @@ write_source_files(
         # plumbing for the augment-on-defaults `toolchains = [...]` /
         # `env = {...}`. The override layers a JDK runtime on top of the
         # default CC toolchain; the snapshot pins both toolchain
-        # references and both env families (CC + JAVA_HOME/JAVA/JAR).
+        # references and both env families (CC + JAVA_HOME/JAVA).
         # Pairs with the analysis test at
         # //uv/private/pep517_whl:toolchain_env_test which asserts the
         # rule expands env keys correctly given an explicit fixture.

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
@@ -22,7 +22,6 @@ pep517_native_whl(
         "AR": "$(AR)",
         "CC": "$(CC)",
         "CXX": "$(CC)",
-        "JAR": "$(JAVABASE)/bin/jar",
         "JAVA": "$(JAVA)",
         "JAVA_HOME": "$(JAVABASE)",
         "LD": "$(LD)",

--- a/e2e/cases/uv-sdist-jdk-build/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-jdk-build/setup.MODULE.bazel
@@ -1,7 +1,7 @@
 """Regression for the per-package toolchain plumbing on
 `uv.override_package`. jpype1 is forced to sdist via
 [tool.uv].no-binary-package; the override layers a JDK runtime
-toolchain into the build env so JAVA_HOME / JAVA / JAR are exported.
+toolchain into the build env so JAVA_HOME / JAVA are exported.
 
 Uses its own hub to keep the override and no-binary setting isolated
 from other test cases.
@@ -29,7 +29,6 @@ uv.unstable_annotate_packages(
 uv.override_package(
     name = "jpype1",
     env = {
-        "JAR": "$(JAVABASE)/bin/jar",
         "JAVA": "$(JAVA)",
         "JAVA_HOME": "$(JAVABASE)",
     },

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -158,7 +158,6 @@ pep517_native_whl(
         "STRIP": "$(STRIP)",
         "JAVA_HOME": "$(JAVABASE)",
         "JAVA": "$(JAVA)",
-        "JAR": "$(JAVABASE)/bin/jar",
     },
     tags = ["manual"],
     tool = ":__stub_tool",

--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -97,6 +97,14 @@ def _override_tool(env, key, wrapper):
         env[key] = shlex.join(parts)
 
 
+def _absolutize_java_tool_paths(env):
+    """Keep Bazel's Java toolchain paths valid after the backend cwd change."""
+    for key in ("JAVA_HOME", "JAVA"):
+        value = env.get(key)
+        if value and not path.isabs(value) and path.exists(value):
+            env[key] = path.abspath(value)
+
+
 def _compiler_env(tmpdir):
     env = dict(os.environ)
     # The helper's launcher exports RUNFILES_DIR, RUNFILES_MANIFEST_FILE, and
@@ -120,6 +128,11 @@ def _compiler_env(tmpdir):
     env["TMP"] = tmpdir
     env["TEMP"] = tmpdir
     env["TEMPDIR"] = tmpdir
+
+    # The Java toolchain expands its paths relative to the execroot. Resolve
+    # them while the helper still runs there; the PEP 517 backend later runs
+    # inside the unpacked source tree.
+    _absolutize_java_tool_paths(env)
 
     cc_path = _resolve_compiler_path(env, "CC", "cc")
     cxx_path = _resolve_compiler_path(env, "CXX", "c++")

--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -60,6 +60,18 @@ def _darwin_sysroot():
         return None
 
 
+def _absolutize_path(value):
+    """Resolve a relative path to absolute, leaving absolute/empty values untouched.
+
+    Shared by _resolve_compiler_path (CC/CXX) and _absolutize_java_tool_paths
+    (JAVA_HOME/JAVA): both toolchains expand workspace-relative refs from the
+    action execroot, which break once the PEP 517 backend chdirs into the
+    unpacked sdist. Centralizing the policy keeps the two paths in lockstep
+    and gives future toolchains (FC, RUSTC, ...) a single primitive to call.
+    """
+    return path.abspath(value) if value and not path.isabs(value) else value
+
+
 def _resolve_compiler_path(env, key, default):
     """Extract the real compiler from the environment and resolve it to an absolute path."""
     current = env.get(key)
@@ -68,10 +80,7 @@ def _resolve_compiler_path(env, key, default):
     parts = shlex.split(current)
     if not parts:
         return default
-    compiler = parts[0]
-    if os.path.isabs(compiler):
-        return compiler
-    return os.path.abspath(compiler)
+    return _absolutize_path(parts[0])
 
 
 def _make_compiler_wrapper(tmpdir, name, compiler_path, sysroot=None):
@@ -102,17 +111,15 @@ def _absolutize_java_tool_paths(env):
     the action execroot.
 
     $(JAVA)/$(JAVABASE) expand workspace-relative; the PEP 517 backend later
-    chdirs into the unpacked sdist, which would invalidate those refs.
-    Absolutize unconditionally when the value isn't already absolute,
-    matching _resolve_compiler_path's handling of CC/CXX. The JDK inputs
-    are declared via the rule's `toolchains` attr (see
+    chdirs into the unpacked sdist, which would invalidate those refs. The
+    JDK inputs are declared via the rule's `toolchains` attr (see
     _collect_toolchain_inputs_and_vars), so a missing path fails loudly in
     the backend rather than silently shipping a broken relative env.
     """
     for key in ("JAVA_HOME", "JAVA"):
         value = env.get(key)
-        if value and not path.isabs(value):
-            env[key] = path.abspath(value)
+        if value:
+            env[key] = _absolutize_path(value)
 
 
 def _compiler_env(tmpdir):

--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -98,10 +98,20 @@ def _override_tool(env, key, wrapper):
 
 
 def _absolutize_java_tool_paths(env):
-    """Keep Bazel's Java toolchain paths valid after the backend cwd change."""
+    """Resolve Bazel's Java toolchain paths while the helper still runs from
+    the action execroot.
+
+    $(JAVA)/$(JAVABASE) expand workspace-relative; the PEP 517 backend later
+    chdirs into the unpacked sdist, which would invalidate those refs.
+    Absolutize unconditionally when the value isn't already absolute,
+    matching _resolve_compiler_path's handling of CC/CXX. The JDK inputs
+    are declared via the rule's `toolchains` attr (see
+    _collect_toolchain_inputs_and_vars), so a missing path fails loudly in
+    the backend rather than silently shipping a broken relative env.
+    """
     for key in ("JAVA_HOME", "JAVA"):
         value = env.get(key)
-        if value and not path.isabs(value) and path.exists(value):
+        if value and not path.isabs(value):
             env[key] = path.abspath(value)
 
 

--- a/uv/private/pep517_whl/test.bzl
+++ b/uv/private/pep517_whl/test.bzl
@@ -54,7 +54,7 @@ hostile_python_env_target = rule(
 _CC_ENV_KEYS = ["CC", "CXX", "AR", "LD", "STRIP"]
 
 # Env vars sourced from the Java runtime toolchain's TemplateVariableInfo.
-_JDK_ENV_KEYS = ["JAVA_HOME", "JAVA", "JAR"]
+_JDK_ENV_KEYS = ["JAVA_HOME", "JAVA"]
 
 _REQUIRED_ENV_KEYS = _CC_ENV_KEYS + _JDK_ENV_KEYS
 
@@ -98,13 +98,6 @@ def _toolchain_env_test_impl(ctx):
         driver_paths.cxx if driver_paths else cc,
         action_env.get("CXX"),
         "CXX should use the declared companion or selected compiler fallback",
-    )
-
-    # JAR is constructed from $(JAVABASE)/bin/jar — sanity-check the suffix.
-    asserts.true(
-        env,
-        action_env.get("JAR", "").endswith("/bin/jar"),
-        "JAR should resolve under JAVA_HOME/bin/jar; got {}".format(action_env.get("JAR")),
     )
 
     return analysistest.end(env)

--- a/uv/private/pep517_whl/tests/explicit_env/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/explicit_env/BUILD.bazel
@@ -7,11 +7,15 @@ pep517_native_whl(
     src = "//uv/private/pep517_whl:__python_env_sdist",
     env = {
         "EXPECTED_PYTHONPATH": "/explicit/path",
+        "EXPECT_JAVA_TOOL_PATHS": "1",
+        "JAVA": "$(JAVA)",
+        "JAVA_HOME": "$(JAVABASE)",
         "PYTHONPATH": "/explicit/path",
     },
     # This must only build through the hostile environment transition below.
     tags = ["manual"],
     tool = "//uv/private/pep517_whl:__build_helper",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
     version = "0.0.1",
 )
 

--- a/uv/private/pep517_whl/tests/python_env_backend/backend.py
+++ b/uv/private/pep517_whl/tests/python_env_backend/backend.py
@@ -37,6 +37,12 @@ def _check_environment() -> None:
     if os.environ.get("PYTHONSAFEPATH") != "1":
         raise RuntimeError("unrelated PYTHONSAFEPATH was not preserved")
 
+    if os.environ.get("EXPECT_JAVA_TOOL_PATHS") == "1":
+        for name in ("JAVA_HOME", "JAVA"):
+            value = os.environ.get(name)
+            if not value or not os.path.isabs(value) or not os.path.exists(value):
+                raise RuntimeError(f"{name} is not an absolute existing path: {value!r}")
+
 
 def get_requires_for_build_wheel(
     config_settings: dict[str, object] | None = None,


### PR DESCRIPTION
Bazel expands `$(JAVA)` and `$(JAVABASE)` as workspace-relative paths, but the PEP 517 backend chdirs into the unpacked sdist before building; leaving JAVA_HOME/JAVA pointing at locations that no longer resolve. 

The build helper now resolves them to absolute while it still runs from the action execroot, mirroring `_resolve_compiler_path` for CC/CXX. The initial path.exists guard is dropped (the JDK is a declared action input, so a missing path should fail loudly rather than silently ship a broken env); the shared absolutization is extracted into _absolutize_path so the two toolchain paths can't drift again.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
