### PR TITLE
feat: Support `tool.uv.extra-build-dependencies` in annotation loading

### DIFF
--- a/annotations.toml
+++ b/annotations.toml
@@ -1,12 +1,13 @@
 ## Annotations.toml
 #
 # This is an aspect_rules_py//uv specific configuration file which allows
-# packages to be annotated with their build time dependencies. This fills a gap in
-# both the pylock and uv lockfile formats, neither of which allow for build
-# requirements to be specified.
+# packages to be annotated extra information such as entrypoint.
 #
-# For instance if a package requires cython be available, this is how you can
-# configure it to be delivered.
+# This file allows specifying additional build time dependencies, however
+# <https://docs.astral.sh/uv/reference/settings/#extra-build-dependencies>
+# should be preferred, which is loaded by `uv.project`. For instance if a
+# package requires setuptools be available, this is how you can configure#
+# it to be delivered.
 #
 # Takes the place of giant MODULE.bazel annotation tables.
 #
@@ -17,15 +18,15 @@
 # We version lockfiles and support semver semantics here
 version = "0.0.0"
 
-# Bravado doesn't have bdists, need to build it. Mark explicitly that we need
-# wheel setuptools and build in order to do so; build being the standard build
-# tool driver.
-[[package]]
-name = "bravado-core"
-build-dependencies = [
-   { name = "build" },
-   { name = "setuptools" },
-]
+# This format is supported, but
+# <https://docs.astral.sh/uv/reference/settings/#extra-build-dependencies>
+# is now recommended.
+#[[package]]
+#name = "bravado-core"
+#build-dependencies = [
+#   { name = "build" },
+#   { name = "setuptools" },
+#]
 
 # We can also annotate packages as providing console scripts we care about.
 # Declared console scripts will have Bazel targets generated for them.

--- a/annotations.toml
+++ b/annotations.toml
@@ -1,12 +1,12 @@
 ## Annotations.toml
 #
 # This is an aspect_rules_py//uv specific configuration file which allows
-# packages to be annotated extra information such as entrypoint.
+# packages to be annotated with extra information such as entrypoints.
 #
 # This file allows specifying additional build time dependencies, however
 # <https://docs.astral.sh/uv/reference/settings/#extra-build-dependencies>
 # should be preferred, which is loaded by `uv.project`. For instance if a
-# package requires setuptools be available, this is how you can configure#
+# package requires setuptools to be available, this is how you can configure
 # it to be delivered.
 #
 # Takes the place of giant MODULE.bazel annotation tables.

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -500,6 +500,14 @@ support this.
 some key information. Such as what requirements apply when performing sdist
 builds. Annotations are the current workaround for how to associate such
 required but nonstandardized and missing dependency data with requirements.
+
+`uv.project` resolves `[tool.uv.extra-build-dependencies]` against `uv.lock`
+before it knows whether a package will use a prebuilt wheel or require an sdist
+build. As a result, an extra build dependency missing from `uv.lock` fails
+project evaluation even when the annotated package has a usable wheel. Add the
+dependency to the project's locked requirements and regenerate `uv.lock`, or
+remove the annotation if the package does not need to be built from source.
+
 Set `native = true|false` on a package annotation to override automatic sdist
 native detection and select the native or pure-Python wheel build path.
 

--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -162,9 +162,29 @@ write_source_files(
 
         # @sdist_build for tqdm with tool.uv.extra-build-dependencies
         # -----------------------------------------------------------
-        # Pins the uv-native annotation and match-runtime paths independently
-        # of cowsay's composed legacy and uv-native annotations.
+        # Pins marker-qualified uv-native dependencies, build-only extras,
+        # and direct references independently of cowsay's composed legacy
+        # and uv-native annotations. `match-runtime` is ignored.
         "snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel": "@sdist_build__uv_sdist_fallback__tqdm__4_52_0//:BUILD.bazel",
+
+        # @sdist_build for both conflicting versions of packaging
+        # ---------------------------------------------------------
+        # Pins that a package-name keyed uv-native annotation applies to every
+        # locked version, not only packages with a single default version.
+        "snapshots/sdist_build.uv_conflict_817.packaging_21_3.BUILD.bazel": (
+            "@sdist_build__ambig__packaging__21_3" +
+            "//:BUILD.bazel"
+        ),
+        "snapshots/sdist_build.uv_conflict_817.packaging_24_0.BUILD.bazel": (
+            "@sdist_build__ambig__packaging__24_0" +
+            "//:BUILD.bazel"
+        ),
+        # The build-only requirement packaging>=24.0 must retain its exact
+        # locked version even when the application selects packaging==21.3.
+        "snapshots/sdist_build.uv_conflict_817.cowsay.BUILD.bazel": (
+            "@sdist_build__ambig__cowsay__6_0" +
+            "//:BUILD.bazel"
+        ),
 
         # @sdist_build for python-geohash with uv.override_package(resource_set)
         # ----------------------------------------------------------------------

--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -159,6 +159,12 @@ write_source_files(
         # produce a working wheel and wrapper.
         "snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel": "@sdist_build__uv_sdist_fallback__cowsay__6_0//:BUILD.bazel",
 
+        # @sdist_build for tqdm with tool.uv.extra-build-dependencies
+        # -----------------------------------------------------------
+        # Pins the uv-native annotation path independently of cowsay's legacy
+        # annotations.toml entry.
+        "snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel": "@sdist_build__uv_sdist_fallback__tqdm__4_52_0//:BUILD.bazel",
+
         # @sdist_build for python-geohash with uv.override_package(resource_set)
         # ----------------------------------------------------------------------
         # Covers the override_package -> repo-rule -> BUILD-template plumbing

--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -148,21 +148,22 @@ write_source_files(
         # rule expands env keys correctly given an explicit fixture.
         "snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel": "@sdist_build__uv_sdist_jdk_build__jpype1__1_7_1//:BUILD.bazel",
 
-        # @sdist_build for cowsay with native annotation and monitor_memory
-        # ------------------------------------------------------------------
+        # @sdist_build for cowsay with composed annotations and monitor_memory
+        # ---------------------------------------------------------------------
         # cowsay is pure Python, so only `native = true` can select
         # pep517_native_whl. Its build and native annotations are split so the
         # snapshot also pins that a native-only annotation preserves explicit
-        # and configure-discovered build deps. This retains the monitor-only
-        # source-build coverage. The runtime //uv-sdist-fallback:test
+        # and configure-discovered build deps, while legacy build deps compose
+        # with distinctly marker-qualified uv-native deps. This retains the
+        # monitor-only source-build coverage. The runtime //uv-sdist-fallback:test
         # proves that the forced-native build and its detected console script
         # produce a working wheel and wrapper.
         "snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel": "@sdist_build__uv_sdist_fallback__cowsay__6_0//:BUILD.bazel",
 
         # @sdist_build for tqdm with tool.uv.extra-build-dependencies
         # -----------------------------------------------------------
-        # Pins the uv-native annotation path independently of cowsay's legacy
-        # annotations.toml entry.
+        # Pins the uv-native annotation and match-runtime paths independently
+        # of cowsay's composed legacy and uv-native annotations.
         "snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel": "@sdist_build__uv_sdist_fallback__tqdm__4_52_0//:BUILD.bazel",
 
         # @sdist_build for python-geohash with uv.override_package(resource_set)

--- a/e2e/cases/README.md
+++ b/e2e/cases/README.md
@@ -27,9 +27,12 @@ A few cases ship a `cases/<case>/test.sh` because they can't be an `sh_test` und
 `//...` — they assert a build **failure** or need a real top-level `bazel run`
 (or `bazel coverage`): `coverage-drivers`, `hermetic-launcher-1116`,
 `hermetic-launcher-runfiles-1273`, `patch-failure`, `pbs-cc-toolchain`,
-`uv-invalid-build-overrides`, `uv-patched-topology-change`. They still resolve against
-*this* workspace. `cases/test.sh` is the aggregator that runs every `cases/*/test.sh`;
-CI runs it on the `e2e/cases` matrix job alongside `bazel test //...` (see
+`uv-invalid-build-overrides`, `uv-local-sources`, `uv-patched-topology-change`.
+The local-source case generates its archives in a temporary workspace before
+module resolution so binary blobs do not need to be checked in; the other cases
+resolve against *this* workspace. `cases/test.sh` is the aggregator that runs
+every `cases/*/test.sh`; CI runs it on the `e2e/cases` matrix job alongside
+`bazel test //...` (see
 `.github/workflows/ci-workflows.yaml`).
 
 ## Adding a case

--- a/e2e/cases/snapshots/sdist_build.uv_conflict_817.cowsay.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_conflict_817.cowsay.BUILD.bazel
@@ -1,0 +1,33 @@
+
+load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "os_name == \"nt\"",
+)
+
+py_binary(
+    name = "build_tool",
+    main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
+    srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
+    deps = ["@@aspect_rules_py++uv+whl_install__ambig__packaging__24_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__build__1_3_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__pyproject_hooks__1_2_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__tomli__2_4_1//:install", "@whl_install__ambig__setuptools__83_0_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+whl_install__ambig__colorama__0_4_6//:install"],
+        "//conditions:default": [],
+    }),
+)
+
+pep517_whl(
+    name = "whl",
+    src = "@@aspect_rules_py++uv+sdist__cowsay__47445cb273684618//file:file",
+    tool = ":build_tool",
+    version = "6.0",
+    console_scripts = ["cowsay=cowsay.__main__:cli"],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/cases/snapshots/sdist_build.uv_conflict_817.packaging_21_3.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_conflict_817.packaging_21_3.BUILD.bazel
@@ -1,0 +1,32 @@
+
+load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "os_name == \"nt\"",
+)
+
+py_binary(
+    name = "build_tool",
+    main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
+    srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
+    deps = ["@@aspect_rules_py++uv+whl_install__ambig__pyparsing__3_3_2//:install", "@@aspect_rules_py++uv+whl_install__ambig__build__1_3_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__packaging__24_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__pyproject_hooks__1_2_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__tomli__2_4_1//:install", "@whl_install__ambig__setuptools__83_0_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+whl_install__ambig__colorama__0_4_6//:install"],
+        "//conditions:default": [],
+    }),
+)
+
+pep517_whl(
+    name = "whl",
+    src = "@@aspect_rules_py++uv+sdist__packaging__dd47c42927d89ab9//file:file",
+    tool = ":build_tool",
+    version = "21.3",
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/cases/snapshots/sdist_build.uv_conflict_817.packaging_24_0.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_conflict_817.packaging_24_0.BUILD.bazel
@@ -1,0 +1,32 @@
+
+load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "os_name == \"nt\"",
+)
+
+py_binary(
+    name = "build_tool",
+    main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
+    srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
+    deps = ["@@aspect_rules_py++uv+whl_install__ambig__pyparsing__3_3_2//:install", "@@aspect_rules_py++uv+whl_install__ambig__build__1_3_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__packaging__24_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__pyproject_hooks__1_2_0//:install", "@@aspect_rules_py++uv+whl_install__ambig__tomli__2_4_1//:install", "@whl_install__ambig__flit_core__3_12_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+whl_install__ambig__colorama__0_4_6//:install"],
+        "//conditions:default": [],
+    }),
+)
+
+pep517_whl(
+    name = "whl",
+    src = "@@aspect_rules_py++uv+sdist__packaging__eb82c5e3e5620907//file:file",
+    tool = ":build_tool",
+    version = "24.0",
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
@@ -1,12 +1,29 @@
 
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "(sys_platform != 'win32') or (sys_platform != 'imaginary')",
+)
+
+decide_marker(
+    name = "_build_dep_marker_1",
+    marker = "sys_platform != 'emscripten'",
+)
 
 py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
-    deps = ["@aspect_rules_py//uv/private/pep517_whl:memory_monitor", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"],
+    deps = ["@aspect_rules_py//uv/private/pep517_whl:memory_monitor", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+project__uv_sdist_fallback//:colorama"],
+        "//conditions:default": [],
+    }) + select({
+        ":_build_dep_marker_1": ["@@aspect_rules_py++uv+project__uv_sdist_fallback//:pyproject_hooks"],
+        "//conditions:default": [],
+    }),
 )
 
 pep517_native_whl(

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
@@ -5,23 +5,15 @@ load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
 
 decide_marker(
     name = "_build_dep_marker_0",
-    marker = "(sys_platform != 'win32') or (sys_platform != 'imaginary')",
-)
-
-decide_marker(
-    name = "_build_dep_marker_1",
-    marker = "sys_platform != 'emscripten'",
+    marker = "((sys_platform != 'win32') or (sys_platform != 'imaginary')) or (os_name == 'nt')",
 )
 
 py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
-    deps = ["@aspect_rules_py//uv/private/pep517_whl:memory_monitor", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"] + select({
-        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+project__uv_sdist_fallback//:colorama"],
-        "//conditions:default": [],
-    }) + select({
-        ":_build_dep_marker_1": ["@@aspect_rules_py++uv+project__uv_sdist_fallback//:pyproject_hooks"],
+    deps = ["@aspect_rules_py//uv/private/pep517_whl:memory_monitor", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__packaging__25_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__build__1_4_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__setuptools__80_10_2//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__pyproject_hooks__1_2_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__colorama__0_4_6//:install"],
         "//conditions:default": [],
     }),
 )

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel
@@ -1,0 +1,23 @@
+
+load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+
+py_binary(
+    name = "build_tool",
+    main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
+    srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
+    deps = ["@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"],
+)
+
+pep517_whl(
+    name = "whl",
+    src = "@@aspect_rules_py++uv+sdist__tqdm__18d6a615aedd09ec//file:file",
+    tool = ":build_tool",
+    version = "4.52.0",
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel
@@ -1,12 +1,29 @@
 
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "os_name == 'nt'",
+)
+
+decide_marker(
+    name = "_build_dep_marker_1",
+    marker = "sys_platform != 'win32'",
+)
 
 py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
-    deps = ["@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:six", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"],
+    deps = ["@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__urllib3__2_6_3//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__six__1_17_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__build__1_4_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__setuptools__80_10_2//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__packaging__25_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__pyproject_hooks__1_2_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__colorama__0_4_6//:install"],
+        "//conditions:default": [],
+    }) + select({
+        ":_build_dep_marker_1": ["@@aspect_rules_py++uv+whl_install__uv_sdist_fallback__pysocks__1_7_1//:install"],
+        "//conditions:default": [],
+    }),
 )
 
 pep517_whl(
@@ -14,6 +31,7 @@ pep517_whl(
     src = "@@aspect_rules_py++uv+sdist__tqdm__18d6a615aedd09ec//file:file",
     tool = ":build_tool",
     version = "4.52.0",
+    console_scripts = ["tqdm=tqdm.cli:main"],
     visibility = ["//visibility:public"],
 )
 

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.tqdm.BUILD.bazel
@@ -6,7 +6,7 @@ py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
-    deps = ["@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"],
+    deps = ["@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:six", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"],
 )
 
 pep517_whl(

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
@@ -1,12 +1,21 @@
 
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "os_name == 'nt'",
+)
 
 py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
-    deps = ["@@aspect_rules_py++uv+project__uv_sdist_jdk_build//:scikit_build_core", "@@aspect_rules_py++uv+project__uv_sdist_jdk_build//:setuptools", "@@aspect_rules_py++uv+project__uv_sdist_jdk_build//:wheel", "@@aspect_rules_py++uv+project__uv_sdist_jdk_build//:build", "@whl_install__uv_sdist_jdk_build__scikit_build_core__0_12_2//:install"],
+    deps = ["@@aspect_rules_py++uv+whl_install__uv_sdist_jdk_build__scikit_build_core__0_12_2//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_jdk_build__setuptools__82_0_1//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_jdk_build__wheel__0_47_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_jdk_build__build__1_5_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_jdk_build__packaging__26_2//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_jdk_build__pathspec__1_1_1//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_jdk_build__pyproject_hooks__1_2_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+whl_install__uv_sdist_jdk_build__colorama__0_4_6//:install"],
+        "//conditions:default": [],
+    }),
 )
 
 pep517_native_whl(

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
@@ -1,12 +1,21 @@
 
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "os_name == 'nt'",
+)
 
 py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
-    deps = ["@@aspect_rules_py++uv+project__uv_sdist_native_build//:build", "@@aspect_rules_py++uv+project__uv_sdist_native_build//:setuptools", "@whl_install__uv_sdist_native_build__setuptools__75_8_2//:install"],
+    deps = ["@@aspect_rules_py++uv+whl_install__uv_sdist_native_build__build__1_4_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_native_build__setuptools__75_8_2//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_native_build__packaging__26_0//:install", "@@aspect_rules_py++uv+whl_install__uv_sdist_native_build__pyproject_hooks__1_2_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+whl_install__uv_sdist_native_build__colorama__0_4_6//:install"],
+        "//conditions:default": [],
+    }),
 )
 
 pep517_native_whl(

--- a/e2e/cases/uv-conflict-817/BUILD.bazel
+++ b/e2e/cases/uv-conflict-817/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 py_test(
     name = "test_a",
@@ -42,4 +43,19 @@ py_test(
     deps = [
         "@pypi_uv_conflict_817//packaging",
     ],
+)
+
+build_test(
+    name = "source_build_21_3_test",
+    targets = ["@sdist_build__ambig__packaging__21_3//:whl"],
+)
+
+build_test(
+    name = "source_build_24_0_test",
+    targets = ["@sdist_build__ambig__packaging__24_0//:whl"],
+)
+
+build_test(
+    name = "version_constrained_source_build_test",
+    targets = ["@sdist_build__ambig__cowsay__6_0//:whl"],
 )

--- a/e2e/cases/uv-conflict-817/pyproject.toml
+++ b/e2e/cases/uv-conflict-817/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 requires-python = "== 3.10.19"
 dependencies = []
 
+[project.optional-dependencies]
+build-tools = ["build", "cowsay==6.0", "flit-core", "setuptools"]
+
 [dependency-groups]
 ambig-a = [
     "packaging==24.0",
@@ -14,9 +17,14 @@ ambig-b = [
 ]
 
 [tool.uv]
+no-binary-package = ["cowsay"]
 conflicts = [
     [
       { group = "ambig-a" },
       { group = "ambig-b" },
     ],
 ]
+
+[tool.uv.extra-build-dependencies]
+packaging = ["pyparsing"]
+cowsay = ["packaging>=24.0"]

--- a/e2e/cases/uv-conflict-817/setup.MODULE.bazel
+++ b/e2e/cases/uv-conflict-817/setup.MODULE.bazel
@@ -5,4 +5,10 @@ uv.project(
     lock = "//uv-conflict-817:uv.lock",
     pyproject = "//uv-conflict-817:pyproject.toml",
 )
-use_repo(uv, "pypi_uv_conflict_817")
+use_repo(
+    uv,
+    "pypi_uv_conflict_817",
+    "sdist_build__ambig__cowsay__6_0",
+    "sdist_build__ambig__packaging__21_3",
+    "sdist_build__ambig__packaging__24_0",
+)

--- a/e2e/cases/uv-conflict-817/uv.lock
+++ b/e2e/cases/uv-conflict-817/uv.lock
@@ -11,6 +11,14 @@ name = "ambig"
 version = "0.0.0"
 source = { virtual = "." }
 
+[package.optional-dependencies]
+build-tools = [
+    { name = "build" },
+    { name = "cowsay" },
+    { name = "flit-core" },
+    { name = "setuptools" },
+]
+
 [package.dev-dependencies]
 ambig-a = [
     { name = "packaging", version = "24.0", source = { registry = "https://pypi.org/simple" } },
@@ -20,17 +28,68 @@ ambig-b = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "build", marker = "extra == 'build-tools'" },
+    { name = "cowsay", marker = "extra == 'build-tools'", specifier = "==6.0" },
+    { name = "flit-core", marker = "extra == 'build-tools'" },
+    { name = "setuptools", marker = "extra == 'build-tools'" },
+]
+provides-extras = ["build-tools"]
 
 [package.metadata.requires-dev]
 ambig-a = [{ name = "packaging", specifier = "==24.0" }]
 ambig-b = [{ name = "packaging", specifier = "==21.3" }]
 
 [[package]]
+name = "build"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt' or (extra == 'group-5-ambig-ambig-a' and extra == 'group-5-ambig-ambig-b')" },
+    { name = "packaging", version = "21.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-5-ambig-ambig-b'" },
+    { name = "packaging", version = "24.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-5-ambig-ambig-a' or extra != 'group-5-ambig-ambig-b'" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/1c/23e33405a7c9eac261dff640926b8b5adaed6a6eb3e1767d441ed611d0c0/build-1.3.0.tar.gz", hash = "sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397", size = 48544, upload-time = "2025-08-01T21:27:09.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4", size = 23382, upload-time = "2025-08-01T21:27:07.844Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cowsay"
+version = "6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/b5/e8e802ddc7f5219417dc7d7953eec81ffe48ad129b793f3040361e4aff89/cowsay-6.0.tar.gz", hash = "sha256:47445cb273684618a1786db8e8d05ec9258455f7eb74893e5d0933daafeb44ba", size = 25228, upload-time = "2023-09-08T17:16:36.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/56/7922bfc226ccd44221befb6b866aaa4da4170bc9d8b036ef0675ce0f1b53/cowsay-6.0-py2.py3-none-any.whl", hash = "sha256:77b07c508af48aa300a90f3b3c5c013a12360a71fc5c87b1efb763fe2803a775", size = 25411, upload-time = "2023-09-08T17:16:34.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/01/40be54532d7bd37c99d849bbdd590f0135ce13183365df6f0e85c475ca71/cowsay-6.0-py3-none-any.whl", hash = "sha256:011c067841451ea49baf8ff49c355bd7f659d53fc538459e0a84c12ae2b4e027", size = 25409, upload-time = "2023-09-08T17:25:17.505Z" },
+]
+
+[[package]]
+name = "flit-core"
+version = "3.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz", hash = "sha256:18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2", size = 53690, upload-time = "2025-03-25T08:03:23.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/65/b6ba90634c984a4fcc02c7e3afe523fef500c4980fec67cc27536ee50acf/flit_core-3.12.0-py3-none-any.whl", hash = "sha256:e7a0304069ea895172e3c7bb703292e992c5d1555dd1233ab7b5621b5b69e62c", size = 45594, upload-time = "2025-03-25T08:03:20.772Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyparsing" },
+    { name = "pyparsing", marker = "extra == 'group-5-ambig-ambig-b'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb", size = 84848, upload-time = "2021-11-18T00:39:13.586Z" }
 wheels = [
@@ -53,4 +112,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]

--- a/e2e/cases/uv-git-source/BUILD.bazel
+++ b/e2e/cases/uv-git-source/BUILD.bazel
@@ -4,7 +4,8 @@ load("@aspect_rules_py//py:defs.bzl", "py_test")
 # `source = { git = "https://github.com/benjaminp/six?tag=1.17.0#<commit>" }`,
 # exercising parse_git_url on a real uv-generated URL, the GitHub
 # git-to-http_archive conversion in collect_sdists, and the source build of
-# the resulting archive.
+# the resulting archive. cowsay is forced to build from source using that
+# locked git dependency as an extra build requirement.
 py_test(
     name = "test",
     srcs = ["__test__.py"],
@@ -12,6 +13,7 @@ py_test(
     main = "__test__.py",
     python_version = "3.11",
     deps = [
+        "@pypi_git_source//cowsay",
         "@pypi_git_source//six",
     ],
 )

--- a/e2e/cases/uv-git-source/__test__.py
+++ b/e2e/cases/uv-git-source/__test__.py
@@ -1,6 +1,8 @@
+import cowsay
 import six
 
+assert "git build dependency" in cowsay.get_output_string("cow", "git build dependency")
 assert six.__version__ == "1.17.0", six.__version__
 assert six.ensure_str(b"git-source") == "git-source"
 
-print("six", six.__version__, "imported from git source")
+print("six", six.__version__, "and cowsay imported from source builds")

--- a/e2e/cases/uv-git-source/pyproject.toml
+++ b/e2e/cases/uv-git-source/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "build",
     "setuptools",
     "six",
+    "cowsay==6.0",
 ]
 
 # six is resolved from git rather than a registry, exercising the
@@ -16,3 +17,9 @@ dependencies = [
 # git-to-http_archive conversion for GitHub remotes.
 [tool.uv.sources]
 six = { git = "https://github.com/benjaminp/six", tag = "1.17.0" }
+
+[tool.uv]
+no-binary-package = ["cowsay"]
+
+[tool.uv.extra-build-dependencies]
+cowsay = ["six @ git+https://github.com/benjaminp/six@1.17.0"]

--- a/e2e/cases/uv-git-source/uv.lock
+++ b/e2e/cases/uv-git-source/uv.lock
@@ -26,6 +26,16 @@ wheels = [
 ]
 
 [[package]]
+name = "cowsay"
+version = "6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/b5/e8e802ddc7f5219417dc7d7953eec81ffe48ad129b793f3040361e4aff89/cowsay-6.0.tar.gz", hash = "sha256:47445cb273684618a1786db8e8d05ec9258455f7eb74893e5d0933daafeb44ba", size = 25228, upload-time = "2023-09-08T17:16:36.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/56/7922bfc226ccd44221befb6b866aaa4da4170bc9d8b036ef0675ce0f1b53/cowsay-6.0-py2.py3-none-any.whl", hash = "sha256:77b07c508af48aa300a90f3b3c5c013a12360a71fc5c87b1efb763fe2803a775", size = 25411, upload-time = "2023-09-08T17:16:34.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/01/40be54532d7bd37c99d849bbdd590f0135ce13183365df6f0e85c475ca71/cowsay-6.0-py3-none-any.whl", hash = "sha256:011c067841451ea49baf8ff49c355bd7f659d53fc538459e0a84c12ae2b4e027", size = 25409, upload-time = "2023-09-08T17:25:17.505Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -63,6 +73,7 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "build" },
+    { name = "cowsay" },
     { name = "setuptools" },
     { name = "six" },
 ]
@@ -70,6 +81,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "build" },
+    { name = "cowsay", specifier = "==6.0" },
     { name = "setuptools" },
     { name = "six", git = "https://github.com/benjaminp/six?tag=1.17.0" },
 ]

--- a/e2e/cases/uv-invalid-build-overrides/missing-extra-build-dep/BUILD.bazel
+++ b/e2e/cases/uv-invalid-build-overrides/missing-extra-build-dep/BUILD.bazel
@@ -1,0 +1,1 @@
+# Fixture data is consumed by this module's extension.

--- a/e2e/cases/uv-invalid-build-overrides/missing-extra-build-dep/MODULE.bazel
+++ b/e2e/cases/uv-invalid-build-overrides/missing-extra-build-dep/MODULE.bazel
@@ -1,0 +1,17 @@
+module(name = "missing_extra_build_dep_fixture")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../../..",
+)
+
+uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
+uv.declare_hub(hub_name = "missing_extra_build_dep")
+uv.project(
+    default_build_dependencies = [],
+    hub_name = "missing_extra_build_dep",
+    lock = "//:uv.lock",
+    pyproject = "//:pyproject.toml",
+)
+use_repo(uv, "missing_extra_build_dep")

--- a/e2e/cases/uv-invalid-build-overrides/missing-extra-build-dep/pyproject.toml
+++ b/e2e/cases/uv-invalid-build-overrides/missing-extra-build-dep/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "missing-extra-build-dep"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = ["cchardet==2.1.7"]
+
+[tool.uv.extra-build-dependencies]
+cchardet = ["cython"]

--- a/e2e/cases/uv-invalid-build-overrides/missing-extra-build-dep/uv.lock
+++ b/e2e/cases/uv-invalid-build-overrides/missing-extra-build-dep/uv.lock
@@ -1,0 +1,20 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "cchardet"
+version = "2.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/5d/090c9f0312b7988a9433246c9cf0b566b1ae1374368cfb8ac897218a4f65/cchardet-2.1.7.tar.gz", hash = "sha256:c428b6336545053c2589f6caf24ea32276c6664cb86db817e03a94c60afa0eaf", size = 653617, upload-time = "2020-10-27T08:36:15.999Z" }
+
+[[package]]
+name = "missing-extra-build-dep"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "cchardet" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "cchardet", specifier = "==2.1.7" }]

--- a/e2e/cases/uv-invalid-build-overrides/test.sh
+++ b/e2e/cases/uv-invalid-build-overrides/test.sh
@@ -53,8 +53,8 @@ expect_failure \
 expect_failure \
     missing-extra-build-dep \
     '@missing_extra_build_dep//:*' \
-    'Unable to resolve extra build dependency "cython" for package "cchardet" in @@//:pyproject.toml.' \
-    '`uv lock` does not include packages referenced only by `tool.uv.extra-build-dependencies`' \
+    'Unable to resolve extra build dependency `"cython"` for package "cchardet" in @@//:pyproject.toml.' \
+    '`uv.lock` does not include packages referenced only by `tool.uv.extra-build-dependencies`' \
     'Add the dependency as a dependency and regenerate the lock.'
 
 expect_failure \

--- a/e2e/cases/uv-invalid-build-overrides/test.sh
+++ b/e2e/cases/uv-invalid-build-overrides/test.sh
@@ -16,7 +16,8 @@ fail() {
 expect_failure() {
     local fixture="$1"
     local target="$2"
-    local expected="$3"
+    local expected
+    shift 2
 
     if (
         cd "$case_dir/$fixture" &&
@@ -24,16 +25,19 @@ expect_failure() {
     ) >"$output_log" 2>&1; then
         fail "$fixture $target unexpectedly succeeded"
     fi
-    if ! grep -Fq "$expected" "$output_log"; then
-        cat "$output_log" >&2
-        fail "$fixture $target did not report: $expected"
-    fi
+    for expected in "$@"; do
+        if ! grep -Fq "$expected" "$output_log"; then
+            cat "$output_log" >&2
+            fail "$fixture $target did not report: $expected"
+        fi
+    done
 }
 
 expect_failure \
     wheel-only \
     '@invalid_overrides//:*' \
-    'build-only attributes require a source distribution, but the lock record has only wheels: console_scripts, resource_set, env, monitor_memory, pre_build_patches, pre_build_patch_strip, toolchains'
+    'build-only attributes require a source distribution, but the lock record has only wheels:' \
+    'console_scripts, resource_set, env, monitor_memory, pre_build_patches, pre_build_patch_strip, toolchains'
 expect_failure \
     editable-self \
     '@invalid_editable_overrides//:*' \
@@ -46,6 +50,12 @@ expect_failure \
     unmatched-lock \
     '@unmatched_lock_override//:*' \
     'has no uv.project() for that lock'
+expect_failure \
+    missing-extra-build-dep \
+    '@missing_extra_build_dep//:*' \
+    'Unable to resolve extra build dependency "cython" for package "cchardet" in @@//:pyproject.toml.' \
+    '`uv lock` does not include packages referenced only by `tool.uv.extra-build-dependencies`' \
+    'Add the dependency as a dependency and regenerate the lock.'
 
 expect_failure \
     custom-pure \

--- a/e2e/cases/uv-local-sources/.gitignore
+++ b/e2e/cases/uv-local-sources/.gitignore
@@ -1,0 +1,4 @@
+*.egg
+*.egg-info/
+artifacts/
+packages/**/build/

--- a/e2e/cases/uv-local-sources/BUILD.bazel.template
+++ b/e2e/cases/uv-local-sources/BUILD.bazel.template
@@ -1,0 +1,21 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+
+py_test(
+    name = "test",
+    srcs = ["__test__.py"],
+    dep_group = "uv_local_sources",
+    main = "__test__.py",
+    python_version = "3.11",
+    deps = [
+        "@pypi_local_sources//local_directory",
+        "@pypi_local_sources//local_sdist",
+        "@pypi_local_sources//local_wheel",
+    ],
+)
+
+diff_test(
+    name = "source_build_snapshot_test",
+    file1 = "expected_sdist.BUILD.bazel",
+    file2 = "@sdist_build__uv_local_sources__local_sdist__1_0_0//:BUILD.bazel",
+)

--- a/e2e/cases/uv-local-sources/MODULE.bazel.template
+++ b/e2e/cases/uv-local-sources/MODULE.bazel.template
@@ -1,0 +1,48 @@
+module(name = "uv_local_sources_fixture")
+
+bazel_dep(name = "aspect_rules_py")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = __ASPECT_RULES_PY_ROOT__,
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(releases = ["20260303"])
+interpreters.toolchain(python_version = "3.11")
+use_repo(interpreters, "python_interpreters")
+
+register_toolchains("@python_interpreters//:all")
+
+tools = use_extension("@aspect_rules_py//py:extensions.bzl", "py_tools")
+tools.rules_py_tools()
+use_repo(tools, "rules_py_tools")
+
+register_toolchains("@rules_py_tools//:all")
+
+uv_bin = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv_bin")
+uv_bin.toolchain(version = "0.11.6")
+use_repo(uv_bin, "uv")
+
+uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
+uv.declare_hub(hub_name = "pypi_local_sources")
+uv.project(
+    default_build_dependencies = [
+        "build",
+        "setuptools",
+    ],
+    hub_name = "pypi_local_sources",
+    lock = "//:uv.lock",
+    pyproject = "//:pyproject.toml",
+)
+uv.override_package(
+    name = "local-directory",
+    lock = "//:uv.lock",
+    target = "//packages/local;directory:local_directory",
+)
+use_repo(
+    uv,
+    "pypi_local_sources",
+    "sdist_build__uv_local_sources__local_sdist__1_0_0",
+)

--- a/e2e/cases/uv-local-sources/__test__.py
+++ b/e2e/cases/uv-local-sources/__test__.py
@@ -1,0 +1,15 @@
+import importlib.metadata
+
+import local_directory
+import local_sdist
+import local_wheel
+
+assert local_wheel.SOURCE_KIND == "local wheel"
+assert local_sdist.SOURCE_KIND == "local source archive"
+assert local_directory.SOURCE_KIND == "local directory"
+assert "packages/local;directory" in local_directory.__file__
+
+for distribution in ("local-wheel", "local-sdist"):
+    assert importlib.metadata.version(distribution) == "1.0.0"
+
+print("real uv-locked local wheels, source archives, and directories: OK")

--- a/e2e/cases/uv-local-sources/expected_sdist.BUILD.bazel
+++ b/e2e/cases/uv-local-sources/expected_sdist.BUILD.bazel
@@ -1,0 +1,32 @@
+
+load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "os_name == 'nt'",
+)
+
+py_binary(
+    name = "build_tool",
+    main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
+    srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
+    deps = ["@@//packages/local;directory:local_directory", "@@aspect_rules_py++uv+whl_install__uv_local_sources__build__1_4_0//:install", "@@aspect_rules_py++uv+whl_install__uv_local_sources__setuptools__80_10_2//:install", "@@aspect_rules_py++uv+whl_install__uv_local_sources__packaging__25_0//:install", "@@aspect_rules_py++uv+whl_install__uv_local_sources__pyproject_hooks__1_2_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@aspect_rules_py++uv+whl_install__uv_local_sources__colorama__0_4_6//:install"],
+        "//conditions:default": [],
+    }),
+)
+
+pep517_whl(
+    name = "whl",
+    src = "@@aspect_rules_py++uv+sdist__local_sdist__f96ed9ecf12c4d7d//file:file",
+    tool = ":build_tool",
+    version = "1.0.0",
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["BUILD.bazel"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/cases/uv-local-sources/generate_artifacts.py
+++ b/e2e/cases/uv-local-sources/generate_artifacts.py
@@ -1,0 +1,153 @@
+"""Create deterministic local-source fixtures without checking in binary blobs."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import gzip
+import hashlib
+import io
+import json
+import re
+import shutil
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_wheel(artifacts: Path) -> Path:
+    wheel = artifacts / "local_wheel-1.0.0-py3-none-any.whl"
+    metadata = "local_wheel-1.0.0.dist-info"
+    entries = {
+        "local_wheel/__init__.py": b'SOURCE_KIND = "local wheel"\n',
+        f"{metadata}/METADATA": (
+            b"Metadata-Version: 2.3\n"
+            b"Name: local-wheel\n"
+            b"Version: 1.0.0\n"
+            b"Requires-Python: >=3.11\n"
+        ),
+        f"{metadata}/WHEEL": (
+            b"Wheel-Version: 1.0\n"
+            b"Generator: rules_py local-source fixture\n"
+            b"Root-Is-Purelib: true\n"
+            b"Tag: py3-none-any\n"
+        ),
+    }
+    records = io.StringIO(newline="")
+    writer = csv.writer(records, lineterminator="\n")
+    for name, data in entries.items():
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest())
+        writer.writerow((name, "sha256=" + digest.decode().rstrip("="), len(data)))
+    record_name = f"{metadata}/RECORD"
+    writer.writerow((record_name, "", ""))
+    entries[record_name] = records.getvalue().encode()
+
+    with zipfile.ZipFile(wheel, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, data in entries.items():
+            info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, data)
+    return wheel
+
+
+def _write_sdist(artifacts: Path) -> Path:
+    sdist = artifacts / "local_sdist-1.0.0.tar.gz"
+    root = "local_sdist-1.0.0"
+    entries = {
+        f"{root}/PKG-INFO": (
+            b"Metadata-Version: 2.3\n"
+            b"Name: local-sdist\n"
+            b"Version: 1.0.0\n"
+            b"Requires-Python: >=3.11\n"
+        ),
+        f"{root}/pyproject.toml": (
+            b"[build-system]\n"
+            b'requires = ["setuptools>=80"]\n'
+            b'build-backend = "setuptools.build_meta"\n'
+            b"\n"
+            b"[project]\n"
+            b'name = "local-sdist"\n'
+            b'version = "1.0.0"\n'
+            b'requires-python = ">=3.11"\n'
+        ),
+        f"{root}/src/local_sdist/__init__.py": (
+            b'SOURCE_KIND = "local source archive"\n'
+        ),
+    }
+    with sdist.open("wb") as output:
+        with gzip.GzipFile(
+            filename="", fileobj=output, mode="wb", mtime=0
+        ) as gzip_file:
+            with tarfile.open(fileobj=gzip_file, mode="w") as archive:
+                for name, data in entries.items():
+                    info = tarfile.TarInfo(name)
+                    info.mode = 0o644
+                    info.size = len(data)
+                    archive.addfile(info, io.BytesIO(data))
+    return sdist
+
+
+def _assert_locked_hash(lockfile: Path, name: str, artifact: Path) -> None:
+    lock = lockfile.read_text()
+    package = re.search(
+        rf'(?ms)^\[\[package\]\]\nname = "{re.escape(name)}"\n.*?(?=^\[\[package\]\]|\Z)',
+        lock,
+    )
+    if package is None:
+        raise ValueError(f"{name} is missing from {lockfile}")
+    expected = re.search(r'hash = "sha256:([0-9a-f]{64})"', package.group())
+    actual = _sha256(artifact.read_bytes())
+    print(f"{artifact.name}: sha256:{actual}", flush=True)
+    if expected is None or expected.group(1) != actual:
+        raise ValueError(f"{artifact.name} does not match its uv.lock hash")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: generate_artifacts.py WORKSPACE RULES_PY_ROOT")
+
+    fixture = Path(__file__).resolve().parent
+    workspace = Path(sys.argv[1]).resolve()
+    rules_py_root = Path(sys.argv[2]).resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    for name in (
+        "pyproject.toml",
+        "uv.lock",
+        "__test__.py",
+        "expected_sdist.BUILD.bazel",
+    ):
+        shutil.copyfile(fixture / name, workspace / name)
+
+    shutil.copyfile(rules_py_root / ".bazelversion", workspace / ".bazelversion")
+    shutil.copyfile(fixture / "BUILD.bazel.template", workspace / "BUILD.bazel")
+    module = (fixture / "MODULE.bazel.template").read_text()
+    module = module.replace("__ASPECT_RULES_PY_ROOT__", json.dumps(str(rules_py_root)))
+    (workspace / "MODULE.bazel").write_text(module)
+
+    directory = Path("packages/local;directory")
+    for name in ("BUILD.bazel", "pyproject.toml", "src/local_directory/__init__.py"):
+        destination = workspace / directory / name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(fixture / directory / name, destination)
+
+    # Module extensions resolve these local paths before Bazel can execute a
+    # genrule. Generate both archives only in this temporary workspace to keep
+    # real uv.lock coverage without committing blobs or creating egg-info.
+    artifacts = workspace / "artifacts"
+    artifacts.mkdir()
+    for name, artifact in (
+        ("local-wheel", _write_wheel(artifacts)),
+        ("local-sdist", _write_sdist(artifacts)),
+    ):
+        _assert_locked_hash(workspace / "uv.lock", name, artifact)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/cases/uv-local-sources/packages/local;directory/BUILD.bazel
+++ b/e2e/cases/uv-local-sources/packages/local;directory/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+
+py_library(
+    name = "local_directory",
+    srcs = glob(["src/**/*.py"]),
+    imports = ["src"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/cases/uv-local-sources/packages/local;directory/pyproject.toml
+++ b/e2e/cases/uv-local-sources/packages/local;directory/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools>=80"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "local-directory"
+version = "1.0.0"
+requires-python = ">=3.11"

--- a/e2e/cases/uv-local-sources/packages/local;directory/src/local_directory/__init__.py
+++ b/e2e/cases/uv-local-sources/packages/local;directory/src/local_directory/__init__.py
@@ -1,0 +1,1 @@
+SOURCE_KIND = "local directory"

--- a/e2e/cases/uv-local-sources/pyproject.toml
+++ b/e2e/cases/uv-local-sources/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "uv_local_sources"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "build==1.4.0",
+    "setuptools==80.10.2",
+    "local-wheel",
+    "local-sdist",
+    "local-directory",
+]
+
+[tool.uv]
+constraint-dependencies = ["packaging==25.0"]
+
+[tool.uv.sources]
+local-wheel = { path = "artifacts/local_wheel-1.0.0-py3-none-any.whl" }
+local-sdist = { path = "artifacts/local_sdist-1.0.0.tar.gz" }
+local-directory = { path = "packages/local;directory" }
+
+[tool.uv.extra-build-dependencies]
+local-sdist = ["local-directory"]

--- a/e2e/cases/uv-local-sources/test.sh
+++ b/e2e/cases/uv-local-sources/test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# The uv module extension reads local archives before Bazel can run a genrule.
+# Generate them in a temporary workspace so real source-path coverage does not
+# require committing binary blobs or leaving setuptools egg-info in the tree.
+set -euo pipefail
+
+fixture_dir="$(cd "$(dirname "$0")" && pwd)"
+rules_py_root="$(cd "$fixture_dir/../../.." && pwd)"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/rules-py-uv-local-sources.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+python3 "$fixture_dir/generate_artifacts.py" "$workspace" "$rules_py_root"
+
+cd "$workspace"
+"${BAZEL:-bazel}" test --lockfile_mode=off //:all

--- a/e2e/cases/uv-local-sources/uv.lock
+++ b/e2e/cases/uv-local-sources/uv.lock
@@ -1,0 +1,96 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[manifest]
+constraints = [{ name = "packaging", specifier = "==25.0" }]
+
+[[package]]
+name = "build"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", size = 50054, upload-time = "2026-01-08T16:41:47.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/0d/84a4380f930db0010168e0aa7b7a8fed9ba1835a8fbb1472bc6d0201d529/build-1.4.0-py3-none-any.whl", hash = "sha256:6a07c1b8eb6f2b311b96fcbdbce5dab5fe637ffda0fd83c9cac622e927501596", size = 24141, upload-time = "2026-01-08T16:41:46.453Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "local-directory"
+version = "1.0.0"
+source = { directory = "packages/local;directory" }
+
+[[package]]
+name = "local-sdist"
+version = "1.0.0"
+source = { path = "artifacts/local_sdist-1.0.0.tar.gz" }
+sdist = { hash = "sha256:f96ed9ecf12c4d7d16a8646f20eded0964c2d7bd7cdbf31300c32bf909237481" }
+
+[[package]]
+name = "local-wheel"
+version = "1.0.0"
+source = { path = "artifacts/local_wheel-1.0.0-py3-none-any.whl" }
+wheels = [
+    { filename = "local_wheel-1.0.0-py3-none-any.whl", hash = "sha256:eb6ea69ebdbfd0a3f5ba45dd2eda83fd5fe00430eac4c8b4349a82697bf4026e" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
+]
+
+[[package]]
+name = "uv-local-sources"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "build" },
+    { name = "local-directory" },
+    { name = "local-sdist" },
+    { name = "local-wheel" },
+    { name = "setuptools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "build", specifier = "==1.4.0" },
+    { name = "local-directory", directory = "packages/local;directory" },
+    { name = "local-sdist", path = "artifacts/local_sdist-1.0.0.tar.gz" },
+    { name = "local-wheel", path = "artifacts/local_wheel-1.0.0-py3-none-any.whl" },
+    { name = "setuptools", specifier = "==80.10.2" },
+]

--- a/e2e/cases/uv-sdist-fallback/BUILD.bazel
+++ b/e2e/cases/uv-sdist-fallback/BUILD.bazel
@@ -24,6 +24,7 @@ py_test(
     deps = [
         "@pypi_sdist_fallback//cowsay",
         "@pypi_sdist_fallback//tqdm",
+        "@pypi_sdist_fallback//urllib3",
     ],
 )
 
@@ -39,6 +40,7 @@ py_binary(
     deps = [
         "@pypi_sdist_fallback//cowsay",
         "@pypi_sdist_fallback//tqdm",
+        "@pypi_sdist_fallback//urllib3",
     ],
 )
 

--- a/e2e/cases/uv-sdist-fallback/BUILD.bazel
+++ b/e2e/cases/uv-sdist-fallback/BUILD.bazel
@@ -9,9 +9,9 @@ gazelle_python_manifest(
 )
 
 # Regression coverage for the sdist-fallback behavior preserved by the
-# "always keep sdist fallbacks when sources exist" fix. cowsay 6.0 has both
-# an sdist and a `-none-any.whl`; the pyproject's `no-binary-package` setting
-# forces the resolver to build it from source, exercising the sbuild path at
+# "always keep sdist fallbacks when sources exist" fix. cowsay and tqdm both
+# have an sdist and a `-none-any.whl`; the pyproject's `no-binary-package`
+# setting forces both source builds, exercising the two annotation paths at
 # runtime.
 py_test(
     name = "test",
@@ -23,6 +23,7 @@ py_test(
     python_version = "3.11",
     deps = [
         "@pypi_sdist_fallback//cowsay",
+        "@pypi_sdist_fallback//tqdm",
     ],
 )
 
@@ -35,7 +36,10 @@ py_binary(
     dep_group = "uv_sdist_fallback",
     main = "__test__.py",
     python_version = "3.11",
-    deps = ["@pypi_sdist_fallback//cowsay"],
+    deps = [
+        "@pypi_sdist_fallback//cowsay",
+        "@pypi_sdist_fallback//tqdm",
+    ],
 )
 
 py_image_layer(

--- a/e2e/cases/uv-sdist-fallback/__test__.py
+++ b/e2e/cases/uv-sdist-fallback/__test__.py
@@ -1,9 +1,8 @@
-"""Smoke test that cowsay built from sdist (via no-binary-package) works.
+"""Smoke test that cowsay and tqdm built from sdist work.
 
-cowsay 6.0 ships both an sdist and a `-none-any.whl`. With `no-binary-package
-= ["cowsay"]` the resolver must produce a `sdist_build__*` repo so the
-package can be built from source. Importing and exercising cowsay verifies
-the sdist build pathway end-to-end.
+cowsay 6.0 and tqdm 4.52.0 both ship an sdist and a `-none-any.whl`. With
+`no-binary-package = ["cowsay", "tqdm"]` the resolver must produce
+`sdist_build__*` repos so both packages can be built from source.
 """
 
 import importlib.metadata
@@ -14,6 +13,7 @@ import sys
 from pathlib import Path
 
 import cowsay
+import tqdm
 
 package = Path(cowsay.__file__).parent
 assert not (package / "tests").exists()
@@ -35,6 +35,7 @@ for path in distribution.files:
 
 output = cowsay.get_output_string("cow", "sdist fallback works!")
 assert "sdist fallback works!" in output
+assert list(tqdm.tqdm(range(2), disable=True)) == [0, 1]
 marker = "detected console script works"
 wrapper = shutil.which("cowsay")
 assert wrapper is not None, "cowsay wrapper is absent from PATH"
@@ -50,4 +51,4 @@ result = subprocess.run(
     text=True,
 )
 assert marker in result.stdout
-print("cowsay imported from sdist: OK")
+print("cowsay and tqdm imported from sdist: OK")

--- a/e2e/cases/uv-sdist-fallback/__test__.py
+++ b/e2e/cases/uv-sdist-fallback/__test__.py
@@ -6,6 +6,7 @@ cowsay 6.0 and tqdm 4.52.0 both ship an sdist and a `-none-any.whl`. With
 """
 
 import importlib.metadata
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -24,7 +25,10 @@ assert distribution.files is not None
 recorded = {str(path) for path in distribution.files}
 assert "cowsay/main.py" in recorded
 assert "cowsay: cowsay" in Path(sys.argv[1]).read_text()
-assert not any(path.endswith("LICENSE.txt") or "/tests/" in path or path.endswith(".pyc") for path in recorded)
+assert not any(
+    path.endswith("LICENSE.txt") or "/tests/" in path or path.endswith(".pyc")
+    for path in recorded
+)
 for path in distribution.files:
     installed = package.parent / path
     assert installed.is_file(), path
@@ -36,6 +40,9 @@ for path in distribution.files:
 output = cowsay.get_output_string("cow", "sdist fallback works!")
 assert "sdist fallback works!" in output
 assert list(tqdm.tqdm(range(2), disable=True)) == [0, 1]
+assert importlib.util.find_spec("socks") is None, (
+    "urllib3[socks] build dependencies leaked into the application runtime"
+)
 marker = "detected console script works"
 wrapper = shutil.which("cowsay")
 assert wrapper is not None, "cowsay wrapper is absent from PATH"

--- a/e2e/cases/uv-sdist-fallback/pyproject.toml
+++ b/e2e/cases/uv-sdist-fallback/pyproject.toml
@@ -10,11 +10,18 @@ dependencies = [
     "build",
     "setuptools",
     "cowsay==6.0",
+    "tqdm==4.52.0",
 ]
 
-# cowsay 6.0 ships both an sdist and a `py3-none-any.whl`. Forcing it to
-# build from source via `no-binary-package` exercises the source-build
-# pathway end-to-end for a package whose lockfile entry has a matching
-# anyarch wheel.
+# cowsay and tqdm both ship an sdist and a `py3-none-any.whl`. Forcing them to
+# build from source exercises both annotation styles end-to-end.
 [tool.uv]
-no-binary-package = ["cowsay"]
+no-binary-package = ["cowsay", "tqdm"]
+
+[tool.uv.extra-build-dependencies]
+# `packaging` is intentionally absent from `default_build_dependencies`, so
+# the tqdm snapshot catches a broken uv-native annotation path.
+tqdm = [
+    "setuptools==80.10.2",
+    "packaging",
+]

--- a/e2e/cases/uv-sdist-fallback/pyproject.toml
+++ b/e2e/cases/uv-sdist-fallback/pyproject.toml
@@ -21,6 +21,13 @@ no-binary-package = ["cowsay", "tqdm"]
 [tool.uv.extra-build-dependencies]
 # `packaging` is intentionally absent from `default_build_dependencies`, so
 # the tqdm snapshot catches a broken uv-native annotation path.
+cowsay = [
+    # Keep two conditional dependencies under distinct markers so composing
+    # cowsay's legacy annotation does not accidentally discard a marker branch.
+    "colorama; sys_platform != 'win32'",
+    "colorama; sys_platform != 'imaginary'",
+    "pyproject-hooks; sys_platform != 'emscripten'",
+]
 tqdm = [
     "setuptools==80.10.2",
     "packaging",

--- a/e2e/cases/uv-sdist-fallback/pyproject.toml
+++ b/e2e/cases/uv-sdist-fallback/pyproject.toml
@@ -11,9 +11,16 @@ dependencies = [
     "setuptools",
     "cowsay==6.0",
     "tqdm==4.52.0",
+    # Keep the urllib3 requirement plain; its non-empty extra is build-only.
+    "urllib3==2.6.3",
     # Keep a dedicated locked package for the direct-reference build-dep case.
     "six==1.17.0",
 ]
+
+[project.optional-dependencies]
+# Ensure the lock contains the extra's transitive dependencies while the
+# default runtime requirement remains plain.
+build-extra-lock = ["urllib3[socks]==2.6.3"]
 
 # cowsay and tqdm both ship an sdist and a `py3-none-any.whl`. Forcing them to
 # build from source exercises both annotation styles end-to-end.
@@ -31,7 +38,15 @@ cowsay = [
     "pyproject-hooks; sys_platform != 'emscripten'",
 ]
 tqdm = [
-    "setuptools==80.10.2",
-    "packaging",
+    # `socks` is non-empty and must reach the source-build environment even
+    # though the runtime dependency is plain urllib3. Keep the base
+    # unconditional and the extra conditional to catch duplicate labels.
+    "urllib3==2.6.3",
+    "urllib3[socks]==2.6.3; sys_platform != 'win32'",
+    "packaging; sys_platform != 'win32'",
+    "packaging; sys_platform != 'imaginary'",
+    "never-installed-build-dependency; python_version < '3.0'",
     "six @ https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl#sha256=4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+    # Accept uv's table syntax without implementing runtime-version matching.
+    { requirement = "six", match-runtime = true },
 ]

--- a/e2e/cases/uv-sdist-fallback/pyproject.toml
+++ b/e2e/cases/uv-sdist-fallback/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "setuptools",
     "cowsay==6.0",
     "tqdm==4.52.0",
+    # Keep a dedicated locked package for the direct-reference build-dep case.
+    "six==1.17.0",
 ]
 
 # cowsay and tqdm both ship an sdist and a `py3-none-any.whl`. Forcing them to
@@ -31,4 +33,5 @@ cowsay = [
 tqdm = [
     "setuptools==80.10.2",
     "packaging",
+    "six @ https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
 ]

--- a/e2e/cases/uv-sdist-fallback/pyproject.toml
+++ b/e2e/cases/uv-sdist-fallback/pyproject.toml
@@ -33,5 +33,5 @@ cowsay = [
 tqdm = [
     "setuptools==80.10.2",
     "packaging",
-    "six @ https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+    "six @ https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl#sha256=4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
 ]

--- a/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
@@ -10,7 +10,8 @@ uv.declare_hub(hub_name = "pypi_sdist_fallback")
 uv.project(
     default_build_dependencies = [
         "build",
-        "setuptools",
+        # Exercise direct-reference resolution for default build dependencies.
+        "setuptools @ https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl",
     ],
     hub_name = "pypi_sdist_fallback",
     lock = "//uv-sdist-fallback:uv.lock",

--- a/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
@@ -37,4 +37,5 @@ use_repo(
     uv,
     "pypi_sdist_fallback",
     "sdist_build__uv_sdist_fallback__cowsay__6_0",
+    "sdist_build__uv_sdist_fallback__tqdm__4_52_0",
 )

--- a/e2e/cases/uv-sdist-fallback/uv.lock
+++ b/e2e/cases/uv-sdist-fallback/uv.lock
@@ -63,6 +63,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.52.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/30/8c8015735a54e13444a3d4982a7a9538bde27f8b3bd35203f9e920f0d78c/tqdm-4.52.0.tar.gz", hash = "sha256:18d6a615aedd09ec8456d9524489dab330af4bd5c2a14a76eb3f9a0e14471afe", size = 180391, upload-time = "2020-11-16T14:19:13.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/7e/bc84ebdb47cfc1f643d026570cb24dd40c2b7a29e167ea101f1702717658/tqdm-4.52.0-py2.py3-none-any.whl", hash = "sha256:80d9d5165d678dbd027dd102dfb99f71bf05f333b61fb761dbba13b4ab719ead", size = 71328, upload-time = "2020-11-16T14:19:11.069Z" },
+]
+
+[[package]]
 name = "uv-sdist-fallback"
 version = "0.0.0"
 source = { virtual = "." }
@@ -70,6 +79,7 @@ dependencies = [
     { name = "build" },
     { name = "cowsay" },
     { name = "setuptools" },
+    { name = "tqdm" },
 ]
 
 [package.metadata]
@@ -77,4 +87,5 @@ requires-dist = [
     { name = "build" },
     { name = "cowsay", specifier = "==6.0" },
     { name = "setuptools" },
+    { name = "tqdm", specifier = "==4.52.0" },
 ]

--- a/e2e/cases/uv-sdist-fallback/uv.lock
+++ b/e2e/cases/uv-sdist-fallback/uv.lock
@@ -63,6 +63,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.52.0"
 source = { registry = "https://pypi.org/simple" }
@@ -79,6 +88,7 @@ dependencies = [
     { name = "build" },
     { name = "cowsay" },
     { name = "setuptools" },
+    { name = "six" },
     { name = "tqdm" },
 ]
 
@@ -87,5 +97,6 @@ requires-dist = [
     { name = "build" },
     { name = "cowsay", specifier = "==6.0" },
     { name = "setuptools" },
+    { name = "six", specifier = "==1.17.0" },
     { name = "tqdm", specifier = "==4.52.0" },
 ]

--- a/e2e/cases/uv-sdist-fallback/uv.lock
+++ b/e2e/cases/uv-sdist-fallback/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "build"
@@ -54,6 +58,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -81,6 +94,20 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
+]
+
+[[package]]
 name = "uv-sdist-fallback"
 version = "0.0.0"
 source = { virtual = "." }
@@ -90,6 +117,12 @@ dependencies = [
     { name = "setuptools" },
     { name = "six" },
     { name = "tqdm" },
+    { name = "urllib3" },
+]
+
+[package.optional-dependencies]
+build-extra-lock = [
+    { name = "urllib3", extra = ["socks"] },
 ]
 
 [package.metadata]
@@ -99,4 +132,7 @@ requires-dist = [
     { name = "setuptools" },
     { name = "six", specifier = "==1.17.0" },
     { name = "tqdm", specifier = "==4.52.0" },
+    { name = "urllib3", specifier = "==2.6.3" },
+    { name = "urllib3", extras = ["socks"], marker = "extra == 'build-extra-lock'", specifier = "==2.6.3" },
 ]
+provides-extras = ["build-extra-lock"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,12 @@ extra-paths = ["py/private/pytest_shard"]
 [tool.ty.rules]
 missing-type-argument = "error"
 possibly-unresolved-reference = "warn"
+
+# bravado-core 6.1.1. doesn't have a wheel, need to build it. Mark explicitly
+# that we need setuptools and build in order to do so; build being the
+# standard build tool driver.
+[tool.uv.extra-build-dependencies]
+bravado-core = [
+   "build",
+   "setuptools",
+]

--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -86,7 +86,10 @@ bzl_library(
     visibility = ["//uv:__subpackages__"],
     deps = [
         ":dep_groups",
+        ":graph_utils",
+        ":marker_simplify",
         "//uv/private:normalize_name",
+        "//uv/private/markers:pep508_evaluate",
         "//uv/private/versions",
     ],
 )
@@ -148,6 +151,7 @@ bzl_library(
     visibility = ["//uv:__subpackages__"],
     deps = [
         ":projectfile",
+        "//uv/private/markers:pep508_evaluate",
         "@bazel_skylib//lib:unittest",
     ],
 )

--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -70,6 +70,8 @@ bzl_library(
         "//uv/private/constraints/platform:defs",
         "//uv/private/constraints/python:defs",
         "//uv/private/whl_install:repository",
+        "@bazel_lib//lib:strings",
+        "@bazel_skylib//lib:paths",
     ],
 )
 
@@ -150,6 +152,7 @@ bzl_library(
     srcs = ["test_projectfile.bzl"],
     visibility = ["//uv:__subpackages__"],
     deps = [
+        ":lockfile",
         ":projectfile",
         "//uv/private/markers:pep508_evaluate",
         "@bazel_skylib//lib:unittest",

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -70,6 +70,7 @@ load("//uv/private/whl_install:dist_repository.bzl", "whl_dist")
 load("//uv/private/whl_install:metadata.bzl", "parse_console_script")
 load("//uv/private/whl_install:repository.bzl", "whl_install")
 load(":graph_utils.bzl", "activate_extras", "collect_sccs")
+load(":git_utils.bzl", "locked_git_requirement_urls")
 load(":lockfile.bzl", "build_marker_graph", "collect_bdists", "collect_configurations", "collect_sdists", "normalize_deps", "url_basename")
 load(":projectfile.bzl", "collate_versions_by_name", "collect_activated_extras", "extract_requirement_marker_pairs")
 
@@ -307,6 +308,10 @@ def _parse_projects(module_ctx, hub_specs):
                 for artifact in artifacts:
                     url = artifact.get("url")
                     if url:
+                        locked_urls[(locked_package["name"], url)] = dependency
+                git = locked_package.get("source", {}).get("git")
+                if git:
+                    for url in locked_git_requirement_urls(git):
                         locked_urls[(locked_package["name"], url)] = dependency
 
             def _resolve(name, version):

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -453,7 +453,7 @@ def _parse_projects(module_ctx, hub_specs):
 
             whl_configurations.update(collect_configurations(lock_data))
 
-            configuration_names, activated_extras = collect_activated_extras(project.lock, project_id, project_data, lock_data, default_versions, marker_graph, package_versions)
+            configuration_names, activated_extras = collect_activated_extras(project.lock, project_id, project_data, lock_data, default_versions, marker_graph, package_versions, locked_urls = locked_urls)
             version_activations = collate_versions_by_name(activated_extras)
 
             # SCC graph shapes:

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -325,8 +325,8 @@ def _parse_projects(module_ctx, hub_specs):
                     )
                     if not resolved_deps:
                         fail((
-                            "Unable to resolve extra build dependency {} for package {} in {}. " +
-                            "`uv lock` does not include packages referenced only by " +
+                            "Unable to resolve extra build dependency `{}` for package {} in {}. " +
+                            "`uv.lock` does not include packages referenced only by " +
                             "`tool.uv.extra-build-dependencies`. Add the dependency as a dependency " +
                             "and regenerate the lock."
                         ).format(repr(dep), repr(package), project.pyproject))

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -454,6 +454,8 @@ def _parse_projects(module_ctx, hub_specs):
 
             whl_configurations.update(collect_configurations(lock_data))
 
+            # Build environments have their own exact-version closure. Keep
+            # their extras out of the application's dependency-group graph.
             configuration_names, activated_extras = collect_activated_extras(project.lock, project_id, project_data, lock_data, default_versions, marker_graph, package_versions, locked_urls = locked_urls)
             version_activations = collate_versions_by_name(activated_extras)
 

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -276,6 +276,7 @@ def _parse_projects(module_ctx, hub_specs):
 
         for project in mod.tags.project:
             project_data = toml.decode_file(module_ctx, project.pyproject)
+            tool_uv = project_data.get("tool", {}).get("uv", {})
             lock_data = toml.decode_file(module_ctx, project.lock)
 
             # The stamp derives from the project name: stable across reloads and
@@ -291,44 +292,70 @@ def _parse_projects(module_ctx, hub_specs):
 
             no_binary_packages = {
                 normalize_name(p): True
-                for p in project_data.get("tool", {}).get("uv", {}).get("no-binary-package", [])
+                for p in tool_uv.get("no-binary-package", [])
             }
 
             default_versions, package_versions, lock_data = normalize_deps(project_id, lock_data)
 
-            def _resolve(package):
-                name = normalize_name(package["name"])
-                if "version" in package:
-                    return (project_id, name, package["version"], "__base__")
+            def _resolve(name, version):
+                name = normalize_name(name)
+                if version:
+                    return (project_id, name, version, "__base__")
                 elif name in default_versions:
                     return default_versions[name]
                 return None
 
             lock_build_dep_anns = {}
             lock_native_anns = {}
+            extra_build_dependencies = tool_uv.get("extra-build-dependencies", {})
+            for package, extra_deps in extra_build_dependencies.items():
+                target = _resolve(package, None)
+                if target == None:
+                    # Allow a shared annotation file to include entries for other locks.
+                    continue
+                deps = []
+                skip = False
+                for dep in extra_deps:
+                    resolved_deps = extract_requirement_marker_pairs(
+                        project.lock,
+                        project_id,
+                        dep,
+                        default_versions,
+                        package_versions,
+                        fail_if_missing = False
+                    )
+                    if resolved_deps == None:
+                        skip = True
+                        break
+                    # TODO(konsti): Consider the marker too - we shouldn't inject build deps on platforms where they are
+                    # declared.
+                    deps.extend([resolved for resolved, _marker in resolved_deps])
+                if not skip:
+                    lock_build_dep_anns[target] = deps
+
             for ann in mod.tags.annotate_packages:
                 if ann.lock == project.lock:
                     annotations = toml.decode_file(module_ctx, ann.src)
                     for package in annotations.get("package", []):
-                        k = _resolve(package)
-                        if k == None:
+                        target = _resolve(package["name"], package.get("version"))
+                        if target == None:
                             # Allow a shared annotation file to include entries for other locks.
                             continue
                         if "native" in package:
                             if type(package["native"]) != "bool":
                                 fail("Annotation `native` for package {} in {} must be a boolean, got {}".format(package["name"], ann.src, repr(package["native"])))
-                            lock_native_anns[k] = package["native"]
+                            lock_native_anns[target] = package["native"]
                         if "build-dependencies" in package:
                             deps = []
                             skip = False
                             for dep in package["build-dependencies"]:
-                                resolved = _resolve(dep)
+                                resolved = _resolve(dep["name"], dep.get("version"))
                                 if resolved == None:
                                     skip = True
                                     break
                                 deps.append(resolved)
                             if not skip:
-                                lock_build_dep_anns[k] = deps
+                                lock_build_dep_anns[target] = deps
 
             package_overrides = {}
             package_console_scripts = {}

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -353,6 +353,7 @@ def _parse_projects(module_ctx, hub_specs):
                     deps.extend([resolved for resolved, _marker in resolved_deps])
                 lock_build_dep_anns[target] = deps
 
+            uv_build_dep_anns = dict(lock_build_dep_anns)
             for ann in mod.tags.annotate_packages:
                 if ann.lock == project.lock:
                     annotations = toml.decode_file(module_ctx, ann.src)
@@ -377,7 +378,7 @@ def _parse_projects(module_ctx, hub_specs):
                             if not skip:
                                 # Legacy and uv-native annotations compose, including
                                 # any marker-qualified uv-native dependencies.
-                                lock_build_dep_anns[target] = lock_build_dep_anns.get(target, []) + deps
+                                lock_build_dep_anns[target] = uv_build_dep_anns.get(target, []) + deps
 
             package_overrides = {}
             package_console_scripts = {}

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -314,7 +314,6 @@ def _parse_projects(module_ctx, hub_specs):
                     # Allow a shared annotation file to include entries for other locks.
                     continue
                 deps = []
-                skip = False
                 for dep in extra_deps:
                     resolved_deps = extract_requirement_marker_pairs(
                         project.lock,
@@ -324,14 +323,17 @@ def _parse_projects(module_ctx, hub_specs):
                         package_versions,
                         fail_if_missing = False
                     )
-                    if resolved_deps == None:
-                        skip = True
-                        break
+                    if not resolved_deps:
+                        fail((
+                            "Unable to resolve extra build dependency {} for package {} in {}. " +
+                            "`uv lock` does not include packages referenced only by " +
+                            "`tool.uv.extra-build-dependencies`. Add the dependency as a dependency " +
+                            "and regenerate the lock."
+                        ).format(repr(dep), repr(package), project.pyproject))
                     # TODO(konsti): Consider the marker too - we shouldn't inject build deps on platforms where they are
                     # declared.
                     deps.extend([resolved for resolved, _marker in resolved_deps])
-                if not skip:
-                    lock_build_dep_anns[target] = deps
+                lock_build_dep_anns[target] = deps
 
             for ann in mod.tags.annotate_packages:
                 if ann.lock == project.lock:

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -357,7 +357,9 @@ def _parse_projects(module_ctx, hub_specs):
                                     break
                                 deps.append(resolved)
                             if not skip:
-                                lock_build_dep_anns[target] = deps
+                                # Legacy and uv-native annotations compose, including
+                                # any marker-qualified uv-native dependencies.
+                                lock_build_dep_anns[target] = lock_build_dep_anns.get(target, []) + deps
 
             package_overrides = {}
             package_console_scripts = {}

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -69,10 +69,10 @@ load("//uv/private/uv_project:repository.bzl", "uv_project")
 load("//uv/private/whl_install:dist_repository.bzl", "whl_dist")
 load("//uv/private/whl_install:metadata.bzl", "parse_console_script")
 load("//uv/private/whl_install:repository.bzl", "whl_install")
-load(":graph_utils.bzl", "activate_extras", "collect_sccs")
 load(":git_utils.bzl", "locked_git_requirement_urls")
+load(":graph_utils.bzl", "activate_extras", "collect_sccs")
 load(":lockfile.bzl", "build_marker_graph", "collect_bdists", "collect_configurations", "collect_sdists", "normalize_deps", "url_basename")
-load(":projectfile.bzl", "collate_versions_by_name", "collect_activated_extras", "extract_requirement_marker_pairs")
+load(":projectfile.bzl", "collate_versions_by_name", "collect_activated_extras", "collect_build_dependency_markers", "extract_requirement_marker_pairs", "marker_can_apply")
 
 # attr.string_dict cannot distinguish omission from an explicitly empty map.
 # The empty script name is invalid, so this sentinel cannot collide with a
@@ -125,8 +125,18 @@ def dedupe_shared_installs(install_cfgs):
     return id_remap
 
 def _rewrite_available_deps(sbuild_cfg, target_remap):
-    """Rebuild an sbuild spec with its available_deps routed through the remap."""
+    """Route every source-build install label through shared-install deduping."""
     fields = structs.to_dict(sbuild_cfg)
+    fields["deps"] = [
+        target_remap.get(target, target)
+        for target in sbuild_cfg.deps
+    ]
+    conditional_deps = {}
+    for target, marker in sbuild_cfg.conditional_deps.items():
+        target = target_remap.get(target, target)
+        previous = conditional_deps.get(target)
+        conditional_deps[target] = "({}) or ({})".format(previous, marker) if previous else marker
+    fields["conditional_deps"] = conditional_deps
     fields["available_deps"] = {
         pkg: target_remap.get(target, target)
         for pkg, target in sbuild_cfg.available_deps.items()
@@ -323,20 +333,36 @@ def _parse_projects(module_ctx, hub_specs):
                 return None
 
             lock_build_dep_anns = {}
+            lock_conditional_build_dep_anns = {}
             lock_native_anns = {}
             extra_build_dependencies = tool_uv.get("extra-build-dependencies", {})
             for package, extra_deps in extra_build_dependencies.items():
-                target = _resolve(package, None)
-                if target == None:
+                package_name = normalize_name(package)
+                targets = [
+                    (project_id, package_name, version, "__base__")
+                    for version in package_versions.get(package_name, {})
+                ]
+                if not targets:
                     # Allow a shared annotation file to include entries for other locks.
                     continue
                 deps = []
+                conditional_deps = {}
                 for dep in extra_deps:
+                    # TODO(konsti): `match-runtime` is intentionally ignored;
+                    # conflicting runtime versions require separate builds.
+                    if type(dep) == "dict":
+                        dep = dep["requirement"]
+                    marker = dep.partition(";")[2].strip()
+                    if marker and not marker_can_apply(
+                        marker,
+                        lock_data.get("requires-python", project_data["project"].get("requires-python", "")),
+                    ):
+                        continue
                     resolved_deps = extract_requirement_marker_pairs(
                         project.lock,
                         project_id,
                         dep,
-                        default_versions,
+                        {},
                         package_versions,
                         locked_urls = locked_urls,
                         fail_if_missing = False,
@@ -348,10 +374,14 @@ def _parse_projects(module_ctx, hub_specs):
                             "`tool.uv.extra-build-dependencies`. Add the dependency as a dependency " +
                             "and regenerate the lock."
                         ).format(repr(dep), repr(package), project.pyproject))
-                    # TODO(konsti): Consider the marker too - we shouldn't inject build deps on platforms where they are
-                    # declared.
-                    deps.extend([resolved for resolved, _marker in resolved_deps])
-                lock_build_dep_anns[target] = deps
+                    for resolved, marker in resolved_deps:
+                        if marker:
+                            conditional_deps.setdefault(marker, []).append(resolved)
+                        else:
+                            deps.append(resolved)
+                for target in targets:
+                    lock_build_dep_anns[target] = deps
+                    lock_conditional_build_dep_anns[target] = conditional_deps
 
             uv_build_dep_anns = dict(lock_build_dep_anns)
             for ann in mod.tags.annotate_packages:
@@ -510,6 +540,8 @@ def _parse_projects(module_ctx, hub_specs):
             # Pre-build the per-project available_deps mapping from the
             # lockfile. This gives each sdist configure tool visibility
             # into the packages within this project's dependency perimeter.
+            # TODO: The preexisting configure protocol reports package names,
+            # so it cannot disambiguate multiple locked versions.
             project_available_deps = {}
             for package in lock_data.get("package", []):
                 if "editable" in package.get("source", {}) or "virtual" in package.get("source", {}):
@@ -586,6 +618,7 @@ def _parse_projects(module_ctx, hub_specs):
                     # could do pyproject.toml introspection.
                     ann_key = (project_id, normalize_name(package["name"]), package["version"], "__base__")
                     build_deps = lock_build_dep_anns.get(ann_key) or []
+                    conditional_build_deps = lock_conditional_build_dep_anns.get(ann_key) or {}
                     is_native = "auto"
                     if ann_key in lock_native_anns:
                         is_native = "true" if lock_native_anns[ann_key] else "false"
@@ -601,6 +634,9 @@ def _parse_projects(module_ctx, hub_specs):
                         # platform-mismatch cases can't be detected here
                         # because we don't know the target build platform.
                         sbuild_required = is_no_binary or not package.get("wheels", [])
+
+                        # TODO: Preserve preexisting default-build behavior;
+                        # this path does not yet retain requirement markers.
                         lock_build_deps = [
                             it[0]
                             for req in project.default_build_dependencies
@@ -616,6 +652,42 @@ def _parse_projects(module_ctx, hub_specs):
                         ]
 
                     build_deps = sets.to_list(sets.make(build_deps + lock_build_deps))
+                    build_requirements = [
+                        (dep, "")
+                        for dep in build_deps
+                    ] + [
+                        (dep, marker)
+                        for marker, deps in conditional_build_deps.items()
+                        for dep in deps
+                    ]
+                    build_dependency_markers = collect_build_dependency_markers(
+                        marker_graph,
+                        build_requirements,
+                    )
+                    build_install_labels = {
+                        dep: install_table.get(dep, "@whl_install__{}__{}__{}//:install".format(
+                            project_stamp,
+                            dep[1],
+                            normalize_version(dep[2]),
+                        ))
+                        for dep in build_dependency_markers
+                    }
+                    sbuild_deps = sets.to_list(sets.make([
+                        build_install_labels[dep]
+                        for dep, markers in build_dependency_markers.items()
+                        if "" in markers
+                    ]))
+                    sbuild_conditional_deps = {}
+                    for dep, markers in build_dependency_markers.items():
+                        label = build_install_labels[dep]
+                        if label in sbuild_deps:
+                            continue
+                        for marker in markers:
+                            previous = sbuild_conditional_deps.get(label)
+                            if previous:
+                                sbuild_conditional_deps[label] = "({}) or ({})".format(previous, marker)
+                            else:
+                                sbuild_conditional_deps[label] = marker
 
                     pre_build_patches = []
                     pre_build_patch_strip = 0
@@ -638,7 +710,8 @@ def _parse_projects(module_ctx, hub_specs):
 
                     sbuild_specs[sbuild_id] = struct(
                         src = sdist,
-                        deps = ["@{0}//:{1}".format(*it) for it in build_deps],
+                        deps = sbuild_deps,
+                        conditional_deps = sbuild_conditional_deps,
                         is_native = is_native,
                         version = package["version"],
                         pre_build_patches = pre_build_patches,
@@ -869,6 +942,8 @@ def _uv_impl(module_ctx):
 
         if sbuild_cfg.available_deps:
             sbuild_kwargs["available_deps"] = sbuild_cfg.available_deps
+        if sbuild_cfg.conditional_deps:
+            sbuild_kwargs["conditional_deps"] = sbuild_cfg.conditional_deps
         if sbuild_cfg.pre_build_patches:
             sbuild_kwargs["pre_build_patches"] = sbuild_cfg.pre_build_patches
             sbuild_kwargs["pre_build_patch_strip"] = sbuild_cfg.pre_build_patch_strip

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -602,7 +602,7 @@ def _parse_projects(module_ctx, hub_specs):
                                 req,
                                 default_versions,
                                 package_versions,
-                                locked_urls,
+                                locked_urls = locked_urls,
                                 fail_if_missing = sbuild_required,
                             )
                         ]

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -297,6 +297,18 @@ def _parse_projects(module_ctx, hub_specs):
 
             default_versions, package_versions, lock_data = normalize_deps(project_id, lock_data)
 
+            locked_urls = {}
+            for locked_package in lock_data.get("package", []):
+                dependency = (project_id, locked_package["name"], locked_package["version"], "__base__")
+                artifacts = locked_package.get("wheels", []) + [
+                    locked_package.get("sdist", {}),
+                    locked_package.get("source", {}),
+                ]
+                for artifact in artifacts:
+                    url = artifact.get("url")
+                    if url:
+                        locked_urls[(locked_package["name"], url)] = dependency
+
             def _resolve(name, version):
                 name = normalize_name(name)
                 if version:
@@ -321,7 +333,8 @@ def _parse_projects(module_ctx, hub_specs):
                         dep,
                         default_versions,
                         package_versions,
-                        fail_if_missing = False
+                        locked_urls = locked_urls,
+                        fail_if_missing = False,
                     )
                     if not resolved_deps:
                         fail((
@@ -583,7 +596,15 @@ def _parse_projects(module_ctx, hub_specs):
                         lock_build_deps = [
                             it[0]
                             for req in project.default_build_dependencies
-                            for it in extract_requirement_marker_pairs(project.lock, project_id, req, default_versions, package_versions, fail_if_missing = sbuild_required)
+                            for it in extract_requirement_marker_pairs(
+                                project.lock,
+                                project_id,
+                                req,
+                                default_versions,
+                                package_versions,
+                                locked_urls,
+                                fail_if_missing = sbuild_required,
+                            )
                         ]
 
                     build_deps = sets.to_list(sets.make(build_deps + lock_build_deps))

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -69,10 +69,9 @@ load("//uv/private/uv_project:repository.bzl", "uv_project")
 load("//uv/private/whl_install:dist_repository.bzl", "whl_dist")
 load("//uv/private/whl_install:metadata.bzl", "parse_console_script")
 load("//uv/private/whl_install:repository.bzl", "whl_install")
-load(":git_utils.bzl", "locked_git_requirement_urls")
 load(":graph_utils.bzl", "activate_extras", "collect_sccs")
-load(":lockfile.bzl", "build_marker_graph", "collect_bdists", "collect_configurations", "collect_sdists", "normalize_deps", "url_basename")
-load(":projectfile.bzl", "collate_versions_by_name", "collect_activated_extras", "collect_build_dependency_markers", "extract_requirement_marker_pairs", "marker_can_apply")
+load(":lockfile.bzl", "build_marker_graph", "collect_bdists", "collect_configurations", "collect_locked_requirement_urls", "collect_sdists", "normalize_deps", "url_basename")
+load(":projectfile.bzl", "collate_versions_by_name", "collect_activated_extras", "collect_build_dependency_markers", "extract_requirement_marker_pairs", "marker_can_apply", "split_requirement_marker")
 
 # attr.string_dict cannot distinguish omission from an explicitly empty map.
 # The empty script name is invalid, so this sentinel cannot collide with a
@@ -306,23 +305,18 @@ def _parse_projects(module_ctx, hub_specs):
                 for p in tool_uv.get("no-binary-package", [])
             }
 
-            default_versions, package_versions, lock_data = normalize_deps(project_id, lock_data)
+            lockfile_directory = str(module_ctx.path(project.lock).dirname)
+            default_versions, package_versions, lock_data = normalize_deps(
+                project_id,
+                lock_data,
+                lockfile_directory,
+            )
 
-            locked_urls = {}
-            for locked_package in lock_data.get("package", []):
-                dependency = (project_id, locked_package["name"], locked_package["version"], "__base__")
-                artifacts = locked_package.get("wheels", []) + [
-                    locked_package.get("sdist", {}),
-                    locked_package.get("source", {}),
-                ]
-                for artifact in artifacts:
-                    url = artifact.get("url")
-                    if url:
-                        locked_urls[(locked_package["name"], url)] = dependency
-                git = locked_package.get("source", {}).get("git")
-                if git:
-                    for url in locked_git_requirement_urls(git):
-                        locked_urls[(locked_package["name"], url)] = dependency
+            locked_urls = collect_locked_requirement_urls(
+                project_id,
+                lock_data,
+                lockfile_directory,
+            )
 
             def _resolve(name, version):
                 name = normalize_name(name)
@@ -352,7 +346,7 @@ def _parse_projects(module_ctx, hub_specs):
                     # conflicting runtime versions require separate builds.
                     if type(dep) == "dict":
                         dep = dep["requirement"]
-                    marker = dep.partition(";")[2].strip()
+                    _, marker = split_requirement_marker(dep)
                     if marker and not marker_can_apply(
                         marker,
                         lock_data.get("requires-python", project_data["project"].get("requires-python", "")),

--- a/uv/private/extension/git_utils.bzl
+++ b/uv/private/extension/git_utils.bzl
@@ -74,6 +74,30 @@ def parse_git_url(url):
 
     return kwargs
 
+def locked_git_requirement_urls(url):
+    """Returns direct-reference URLs that can identify a locked git source."""
+    remote_and_query, _hash_sep, commit = url.partition("#")
+    remote, _query_sep, query = remote_and_query.partition("?")
+    remote = remote if remote.startswith("git+") else "git+" + remote
+
+    refs = []
+    subdirectory = ""
+    for param in query.split("&") if query else []:
+        key, _eq, value = param.partition("=")
+        value = value.replace("%2F", "/").replace("%2f", "/")
+        if key in ["tag", "branch", "rev", "ref"] and value:
+            refs.append(value)
+        elif key == "subdirectory":
+            subdirectory = value
+
+    suffix = "#subdirectory=" + subdirectory if subdirectory else ""
+    result = {remote + suffix: True}
+    if commit:
+        result[remote + "@" + commit + suffix] = True
+    for ref in refs:
+        result[remote + "@" + ref + suffix] = True
+    return result.keys()
+
 def try_git_to_http_archive(git_cfg):
     """Tries to convert a `git_repository` configuration to an `http_archive`.
 

--- a/uv/private/extension/lockfile.bzl
+++ b/uv/private/extension/lockfile.bzl
@@ -2,6 +2,8 @@
 Machinery specific to interacting with a uv.lock
 """
 
+load("@bazel_lib//lib:strings.bzl", "ord")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//uv/private:normalize_name.bzl", "normalize_name")
 load("//uv/private:normalize_version.bzl", "normalize_version")
 load("//uv/private:parse_whl_name.bzl", "parse_whl_name")
@@ -9,8 +11,86 @@ load("//uv/private:sha1.bzl", "sha1")
 load("//uv/private/constraints/platform:defs.bzl", "supported_platform")
 load("//uv/private/constraints/python:defs.bzl", "supported_python")
 load("//uv/private/whl_install:repository.bzl", "compatible_python_tags")
-load(":git_utils.bzl", "parse_git_url", "try_git_to_http_archive")
+load(":git_utils.bzl", "locked_git_requirement_urls", "parse_git_url", "try_git_to_http_archive")
 load(":marker_simplify.bzl", "simplify_extra_marker")
+
+def _local_file_url(local_path, lockfile_directory):
+    """Convert a uv lockfile-relative source path into uv's canonical file URL.
+
+    Mirrors `VerbatimUrl::from_path -> DisplaySafeUrl::from_file_path ->
+    Url::from_file_path` in uv-pep508 and rust-url. Encode Starlark's UTF-8
+    bytes with rust-url's WHATWG `SPECIAL_PATH_SEGMENT` and `PATH_SEGMENT`
+    rules while retaining path separators and Windows drive or UNC prefixes.
+    Existing `file://` URLs are already canonical and remain unchanged.
+
+    Args:
+        local_path: A local source path or existing `file://` URL.
+        lockfile_directory: The absolute directory containing the uv lockfile.
+
+    Returns:
+        The absolute, percent-encoded `file://` URL used by uv.
+    """
+    if local_path.startswith("file://"):
+        return local_path
+
+    windows_path = (
+        local_path.startswith("\\\\") or
+        (len(local_path) > 2 and local_path[1] == ":") or
+        lockfile_directory.startswith("\\\\") or
+        (len(lockfile_directory) > 2 and lockfile_directory[1] == ":")
+    )
+    if windows_path:
+        local_path = local_path.replace("\\", "/")
+        lockfile_directory = lockfile_directory.replace("\\", "/")
+
+    if not paths.is_absolute(local_path):
+        local_path = paths.join(lockfile_directory, local_path)
+
+    normalized_path = paths.normalize(local_path)
+    if not windows_path and normalized_path.startswith("//"):
+        normalized_path = "/" + normalized_path.lstrip("/")
+
+    hex_digits = "0123456789ABCDEF"
+    encoded_path = []
+    for char in normalized_path.elems():
+        byte = ord(char)
+        if byte < 0x20 or byte >= 0x7F or char in " \"#%<>?`{}\\":
+            encoded_path.append("%" + hex_digits[byte // 16] + hex_digits[byte % 16])
+        else:
+            encoded_path.append(char)
+
+    if normalized_path.startswith("//"):
+        return "file:" + "".join(encoded_path)
+    if len(normalized_path) > 2 and normalized_path[1] == ":":
+        return "file:///" + "".join(encoded_path)
+    return "file://" + "".join(encoded_path)
+
+def collect_locked_requirement_urls(lock_id, lock_data, lockfile_directory):
+    """Index locked artifact, Git, and local-source direct references."""
+    locked_urls = {}
+
+    for package in lock_data.get("package", []):
+        package_name = normalize_name(package["name"])
+        dependency = (lock_id, package_name, package["version"], "__base__")
+        source = package.get("source", {})
+
+        for artifact in package.get("wheels", []) + [package.get("sdist", {}), source]:
+            url = artifact.get("url")
+            if url:
+                locked_urls[(package_name, url)] = dependency
+
+        git = source.get("git")
+        if git:
+            for url in locked_git_requirement_urls(git):
+                locked_urls[(package_name, url)] = dependency
+
+        for source_kind in ("path", "directory", "editable"):
+            local_path = source.get(source_kind)
+            if local_path:
+                url = _local_file_url(local_path, lockfile_directory)
+                locked_urls[(package_name, url)] = dependency
+
+    return locked_urls
 
 def url_basename(url):
     """Returns the trailing file name of a distribution URL.
@@ -41,7 +121,7 @@ def _dist_identifier(dist):
         return dist["hash"].split(":")[1][:16]
     return sha1(dist["url"])[:16]
 
-def normalize_deps(lock_id, lock_data):
+def normalize_deps(lock_id, lock_data, lockfile_directory):
     """Normalizes dependency specifications in a lockfile.
 
     This function performs two main normalization steps:
@@ -54,6 +134,7 @@ def normalize_deps(lock_id, lock_data):
     Args:
         lock_id: A unique identifier for the lockfile.
         lock_data: The parsed content of the `uv.lock` file.
+        lockfile_directory: Absolute directory containing the lockfile.
 
     Returns:
         A tuple containing:
@@ -84,9 +165,22 @@ def normalize_deps(lock_id, lock_data):
             dep["version"] = default_versions.get(dep["name"])[2]
 
     for spec in lock_data.get("package", []):
-        # Backfill the sdist URL if the source is a URL file
+        # uv omits the artifact URL for local wheels and source archives:
+        # their filename/hash records refer to source.path instead.
+        source = spec.get("source", {})
+        source_url = source.get("url")
+        local_path = source.get("path")
+        if local_path:
+            source_url = _local_file_url(local_path, lockfile_directory)
+
         if "sdist" in spec and not "url" in spec["sdist"]:
-            spec["sdist"]["url"] = spec["source"]["url"]
+            if source_url == None:
+                fail("Source distribution for {} has neither a URL nor a local path".format(spec["name"]))
+            spec["sdist"]["url"] = source_url
+
+        for wheel in spec.get("wheels", []):
+            if "url" not in wheel and source_url:
+                wheel["url"] = source_url
 
         for dep in spec.get("dependencies", []):
             _fix_version(dep)

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -6,7 +6,16 @@ load("//uv/private:normalize_name.bzl", "normalize_name")
 load("//uv/private/versions:versions.bzl", "find_matching_version")
 load(":dep_groups.bzl", "resolve_dependency_group_specs")
 
-def extract_requirement_marker_pairs(projectfile, lock_id, req_string, version_map, package_versions = {}, preferred_versions = {}, fail_if_missing = True):
+def extract_requirement_marker_pairs(
+    projectfile,
+    lock_id,
+    req_string,
+    version_map,
+    package_versions = {},
+    preferred_versions = {},
+    locked_urls = {},
+    fail_if_missing = True
+):
     """Parses a requirement string into a list of dependency-marker pairs.
 
     This function parses a PEP 508 requirement string (e.g.,
@@ -23,6 +32,8 @@ def extract_requirement_marker_pairs(projectfile, lock_id, req_string, version_m
             list — useful for advisory requirements like the project-level
             `default_build_dependencies`, which may legitimately be absent
             from lockfiles that ship no sdists needing the build tooling.
+        locked_urls: A dictionary mapping `(package_name, artifact_url)` to a
+            locked dependency tuple, used to resolve direct references.
 
     Returns:
         A list of tuples, where each tuple is `(Dependency, Marker)`.
@@ -55,6 +66,7 @@ def extract_requirement_marker_pairs(projectfile, lock_id, req_string, version_m
         "<": 1,
         "!": 1,
         "~": 1,
+        "@": 1,
         " ": 1,
     }
 
@@ -85,21 +97,26 @@ def extract_requirement_marker_pairs(projectfile, lock_id, req_string, version_m
             remainder = remainder[close_idx + 1:]
 
     # 4. Look up version
-    v = preferred_versions.get(pkg_name)
-    if v == None:
-        v = version_map.get(pkg_name)
-    if v == None:
-        # For multi-version packages (e.g. conflicts), match the version
-        # specifier against all known versions of this package in the lockfile.
-        specifier = remainder.strip()
-        pkg_vers = package_versions.get(pkg_name, {})
-        if pkg_vers:
-            match_spec = specifier if specifier else ">=0"
-            candidates = {
-                ver: (lock_id, pkg_name, ver, "__base__")
-                for ver in pkg_vers.keys()
-            }
-            v = find_matching_version(match_spec, candidates)
+    specifier = remainder.strip()
+    if specifier.startswith("@"):
+        # Direct references identify a locked artifact, not a version
+        # constraint. Never fall back to a different locked version or URL.
+        v = locked_urls.get((pkg_name, specifier[1:].strip()))
+    else:
+        v = preferred_versions.get(pkg_name)
+        if v == None:
+            v = version_map.get(pkg_name)
+        if v == None:
+            # For multi-version packages (e.g. conflicts), match the version
+            # specifier against all known versions in the lockfile.
+            pkg_vers = package_versions.get(pkg_name, {})
+            if pkg_vers:
+                match_spec = specifier if specifier else ">=0"
+                candidates = {
+                    ver: (lock_id, pkg_name, ver, "__base__")
+                    for ver in pkg_vers.keys()
+                }
+                v = find_matching_version(match_spec, candidates)
     if v == None:
         if not fail_if_missing:
             return []

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -9,6 +9,20 @@ load(":dep_groups.bzl", "resolve_dependency_group_specs")
 load(":graph_utils.bzl", "combine_markers")
 load(":marker_simplify.bzl", "simplify_extra_marker")
 
+def split_requirement_marker(req_string):
+    """Split PEP 508 markers without treating URL path semicolons as markers."""
+    direct_reference_idx = req_string.find("@")
+    for i in range(len(req_string)):
+        if req_string[i] != ";":
+            continue
+        if direct_reference_idx != -1 and direct_reference_idx < i:
+            preceded_by_space = i > 0 and req_string[i - 1] in " \t\r\n"
+            followed_by_space = i + 1 < len(req_string) and req_string[i + 1] in " \t\r\n"
+            if not (preceded_by_space or followed_by_space):
+                continue
+        return req_string[:i].strip(), req_string[i + 1:].strip()
+    return req_string.strip(), ""
+
 def extract_requirement_marker_pairs(
         projectfile,
         lock_id,
@@ -41,21 +55,9 @@ def extract_requirement_marker_pairs(
         A list of tuples, where each tuple is `(Dependency, Marker)`.
     """
 
-    # 1. Split Requirement and Marker
-    # Starlark split() often doesn't support maxsplit, so we use find() + slicing
-    semicolon_idx = req_string.find(";")
-
-    marker = ""
-    if semicolon_idx != -1:
-        # Extract and clean the marker
-        marker_text = req_string[semicolon_idx + 1:].strip()
-        if marker_text:
-            marker = marker_text
-
-        # The requirement part is everything before the semicolon
-        req_part = req_string[:semicolon_idx].strip()
-    else:
-        req_part = req_string.strip()
+    # uv-pep508's parse_url treats a semicolon inside a URL as a path
+    # character; a direct-reference marker must have adjacent whitespace.
+    req_part, marker = split_requirement_marker(req_string)
 
     if not req_part:
         return []

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -101,7 +101,12 @@ def extract_requirement_marker_pairs(
     if specifier.startswith("@"):
         # Direct references identify a locked artifact, not a version
         # constraint. Never fall back to a different locked version or URL.
-        v = locked_urls.get((pkg_name, specifier[1:].strip()))
+        url = specifier[1:].strip()
+        # Git uses semantically relevant fragments such as `#subdirectory=`.
+        if not url.startswith("git+"):
+            # uv stores hashes separately from URLs.
+            url = url.split("#", 1)[0]
+        v = locked_urls.get((pkg_name, url))
     else:
         v = preferred_versions.get(pkg_name)
         if v == None:

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -3,19 +3,21 @@ Machinery specific to interacting with a pyproject.toml
 """
 
 load("//uv/private:normalize_name.bzl", "normalize_name")
-load("//uv/private/versions:versions.bzl", "find_matching_version")
+load("//uv/private/markers:pep508_evaluate.bzl", "evaluate", "tokenize")
+load("//uv/private/versions:versions.bzl", "find_matching_version", "version_satisfies")
 load(":dep_groups.bzl", "resolve_dependency_group_specs")
+load(":graph_utils.bzl", "combine_markers")
+load(":marker_simplify.bzl", "simplify_extra_marker")
 
 def extract_requirement_marker_pairs(
-    projectfile,
-    lock_id,
-    req_string,
-    version_map,
-    package_versions = {},
-    preferred_versions = {},
-    locked_urls = {},
-    fail_if_missing = True
-):
+        projectfile,
+        lock_id,
+        req_string,
+        version_map,
+        package_versions = {},
+        preferred_versions = {},
+        locked_urls = {},
+        fail_if_missing = True):
     """Parses a requirement string into a list of dependency-marker pairs.
 
     This function parses a PEP 508 requirement string (e.g.,
@@ -93,7 +95,7 @@ def extract_requirement_marker_pairs(
             for project_data in parts:
                 clean_p = project_data.strip()
                 if clean_p:
-                    extras.append(clean_p)
+                    extras.append(normalize_name(clean_p).replace("_", "-"))
             remainder = remainder[close_idx + 1:]
 
     # 4. Look up version
@@ -102,6 +104,7 @@ def extract_requirement_marker_pairs(
         # Direct references identify a locked artifact, not a version
         # constraint. Never fall back to a different locked version or URL.
         url = specifier[1:].strip()
+
         # Git uses semantically relevant fragments such as `#subdirectory=`.
         if not url.startswith("git+"):
             # uv stores hashes separately from URLs.
@@ -143,6 +146,112 @@ def extract_requirement_marker_pairs(
         results.append((dep, marker or ""))
 
     return results
+
+def marker_can_apply(marker, requires_python):
+    """Return whether a marker can apply to the project's Python versions."""
+    if not marker:
+        return True
+
+    candidates = {
+        "0.0.0": True,
+        "2.7.0": True,
+        "3.0.0": True,
+        "3.11.0": True,
+        "4.0.0": True,
+    }
+
+    # Python markers change truth only at a version boundary. Probe each
+    # boundary and its neighbors, while leaving platform markers unresolved.
+    for literal in tokenize(marker) + requires_python.split(","):
+        literal = literal.strip("\"' ").lstrip("<>=!~ ").rstrip(".*")
+        parts = literal.split(".")
+        if not parts or not all([part.isdigit() for part in parts]):
+            continue
+
+        version = [int(part) for part in parts[:3]]
+        version += [0] * (3 - len(version))
+        for component in range(3):
+            for offset in [-1, 0, 1]:
+                adjacent = list(version)
+                adjacent[component] += offset
+                if adjacent[component] >= 0:
+                    candidates["{}.{}.{}".format(*adjacent)] = True
+
+    has_supported_candidate = False
+    for candidate in candidates:
+        if not version_satisfies(candidate, requires_python):
+            continue
+
+        has_supported_candidate = True
+        major, minor, _patch = candidate.split(".")
+        result = evaluate(
+            marker,
+            env = {
+                "python_full_version": candidate,
+                "python_version": "{}.{}".format(major, minor),
+            },
+            strict = False,
+        )
+        if result != False:
+            return True
+
+    # An unusual Python constraint must not silently discard a dependency when
+    # none of the marker boundary candidates can represent its environment.
+    return not has_supported_candidate
+
+def _build_environment_marker(marker):
+    """Resolve runtime-only extras outside an isolated build environment."""
+    if "extra" not in tokenize(marker):
+        return marker
+    return simplify_extra_marker(marker, "")
+
+def collect_build_dependency_markers(graph, requirements):
+    """Collect the exact-version, marker-qualified isolated build closure."""
+    marked_deps = {}
+    worklist = []
+
+    # Keep ancestors per path so cycles terminate without dropping another
+    # marker-qualified route to the same locked package.
+    for dep, marker in requirements:
+        marker = _build_environment_marker(marker)
+        if marker != None:
+            worklist.append((dep, marker, {dep: True}))
+    visited = {}
+    idx = 0
+
+    for _ in range(1000000):
+        if idx == len(worklist):
+            break
+
+        dep, marker, path = worklist[idx]
+        idx += 1
+        state = (dep, marker)
+        if state in visited:
+            continue
+        visited[state] = True
+
+        base = (dep[0], dep[1], dep[2], "__base__")
+        marked_deps.setdefault(base, {})[marker] = 1
+
+        # Optional-dependency graph nodes do not link to the base package.
+        if dep != base and base not in path:
+            base_path = dict(path)
+            base_path[base] = True
+            worklist.append((base, marker, base_path))
+
+        for next_dep, next_markers in graph.get(dep, {}).items():
+            if next_dep in path:
+                continue
+            for edge_marker in next_markers:
+                edge_marker = _build_environment_marker(edge_marker)
+                if edge_marker == None:
+                    continue
+                for next_marker in combine_markers({marker: 1}, {edge_marker: 1}):
+                    next_path = dict(path)
+                    next_path[next_dep] = True
+                    worklist.append((next_dep, next_marker, next_path))
+
+    return marked_deps
 
 def _extract_lockfile_group_versions(lock_id, lock_data):
     """Extracts resolved package versions per dependency group from the lockfile.
@@ -257,7 +366,6 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
                     target_dep = (next_dep[0], next_dep[1], pref[2], next_dep[3])
 
                 base = (target_dep[0], target_dep[1], target_dep[2], "__base__")
-
                 activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(target_dep, {}).update(markers)
                 if target_dep not in visited:
                     visited[target_dep] = 1

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -177,7 +177,9 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
     This function determines the full set of extras that are activated for each
     dependency group defined in the `pyproject.toml`. It performs a transitive
     traversal of the dependency graph to find all extras that are pulled in by
-    the initial set of requirements.
+    the initial set of requirements, preserving the graph's existing
+    dependency-edge markers. Isolated build extras are collected separately and
+    never added to the runtime graph.
 
     Args:
         project_data: The parsed content of the `pyproject.toml` file.
@@ -216,6 +218,8 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
     for group_name in dep_groups.keys():
         resolved_specs = resolve_dependency_group_specs(dep_groups, group_name)
 
+        # Collect every selected version before resolving group requirements so
+        # included groups and extras consistently follow this group's solution.
         group_preferences = dict(lockfile_group_versions.get(group_name, {}))
 
         for spec in resolved_specs:

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -166,7 +166,7 @@ def _extract_lockfile_group_versions(lock_id, lock_data):
                     result.setdefault(group_name, {})[pkg_name] = (lock_id, pkg_name, dep["version"], "__base__")
     return result
 
-def collect_activated_extras(projectfile, lock_id, project_data, lock_data, default_versions, graph, package_versions = {}):
+def collect_activated_extras(projectfile, lock_id, project_data, lock_data, default_versions, graph, package_versions = {}, locked_urls = {}):
     """Collects the set of transitively activated extras for each configuration.
 
     This function determines the full set of extras that are activated for each
@@ -179,6 +179,8 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
         default_versions: A dictionary mapping package names to their default
             version dependency tuples.
         graph: The dependency graph, as returned by `build_marker_graph`.
+        locked_urls: A dictionary mapping direct-reference URLs to locked
+            dependencies.
 
     Returns:
         A tuple containing:
@@ -212,13 +214,13 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
         group_preferences = dict(lockfile_group_versions.get(group_name, {}))
 
         for spec in resolved_specs:
-            for dep, _marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, group_preferences):
+            for dep, _marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, group_preferences, locked_urls = locked_urls):
                 group_preferences[dep[1]] = (dep[0], dep[1], dep[2], "__base__")
 
         all_group_preferences[group_name] = group_preferences
 
         for spec in resolved_specs:
-            for dep, marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, group_preferences):
+            for dep, marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, group_preferences, locked_urls = locked_urls):
                 normalized_dep_groups.setdefault(group_name, []).append(dep)
 
                 # Note that this is the base case for the reach set walk below

--- a/uv/private/extension/test_defs.bzl
+++ b/uv/private/extension/test_defs.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load(":defs.bzl", "dedupe_shared_installs", "parse_declared_console_script", "shared_install_key")
-load(":lockfile.bzl", "url_basename")
+load(":lockfile.bzl", "collect_bdists", "collect_sdists", "normalize_deps", "url_basename")
 
 def _url_basename_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -52,6 +52,69 @@ def _url_basename_test_impl(ctx):
     return unittest.end(env)
 
 url_basename_test = unittest.make(_url_basename_test_impl)
+
+def _normalize_local_source_artifacts_test_impl(ctx):
+    env = unittest.begin(ctx)
+    wheel_hash = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    sdist_hash = "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+    lock_data = {
+        "package": [
+            {
+                "name": "local-wheel",
+                "version": "1.0.0",
+                "source": {"path": "artifacts/local_wheel-1.0.0-py3-none-any.whl"},
+                "wheels": [{
+                    "filename": "local_wheel-1.0.0-py3-none-any.whl",
+                    "hash": wheel_hash,
+                }],
+            },
+            {
+                "name": "local-sdist",
+                "version": "2.0.0",
+                "source": {"path": "artifacts/local_sdist-2.0.0.tar.gz"},
+                "sdist": {"hash": sdist_hash},
+            },
+            {
+                "name": "local-directory",
+                "version": "3.0.0",
+                "source": {"directory": "packages/local;directory"},
+            },
+        ],
+    }
+
+    _, _, normalized = normalize_deps("proj", lock_data, "/workspace/project")
+    wheel_url = "file:///workspace/project/artifacts/local_wheel-1.0.0-py3-none-any.whl"
+    sdist_url = "file:///workspace/project/artifacts/local_sdist-2.0.0.tar.gz"
+    asserts.equals(env, wheel_url, normalized["package"][0]["wheels"][0]["url"])
+    asserts.equals(env, sdist_url, normalized["package"][1]["sdist"]["url"])
+
+    bdist_specs, bdist_table = collect_bdists(normalized)
+    asserts.equals(env, {
+        "whl__local_wheel__0123456789abcdef": {
+            "filename": "local_wheel-1.0.0-py3-none-any.whl",
+            "hash": wheel_hash,
+            "url": wheel_url,
+        },
+    }, bdist_specs)
+    asserts.equals(env, {
+        wheel_url: "@whl__local_wheel__0123456789abcdef//:whl",
+    }, bdist_table)
+
+    sdist_specs, sdist_table = collect_sdists("proj", normalized)
+    asserts.equals(env, {
+        "sdist__local_sdist__fedcba9876543210": {"file": {
+            "hash": sdist_hash,
+            "url": sdist_url,
+        }},
+    }, sdist_specs)
+    asserts.equals(env, {
+        "sdist_build__proj__local_sdist__2_0_0": "@sdist__local_sdist__fedcba9876543210//file",
+    }, sdist_table)
+    return unittest.end(env)
+
+normalize_local_source_artifacts_test = unittest.make(
+    _normalize_local_source_artifacts_test_impl,
+)
 
 def _declared_console_script_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -165,6 +228,10 @@ def defs_test_suite():
     unittest.suite(
         "declared_console_script_tests",
         declared_console_script_test,
+    )
+    unittest.suite(
+        "normalize_local_source_artifacts_tests",
+        normalize_local_source_artifacts_test,
     )
     unittest.suite(
         "shared_install_key_tests",

--- a/uv/private/extension/test_git_utils.bzl
+++ b/uv/private/extension/test_git_utils.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":git_utils.bzl", "ensure_ref", "parse_git_url", "try_git_to_http_archive")
+load(":git_utils.bzl", "ensure_ref", "locked_git_requirement_urls", "parse_git_url", "try_git_to_http_archive")
 
 def _ensure_ref_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -65,6 +65,25 @@ def _parse_git_url_bare_remote_test_impl(ctx):
     return unittest.end(env)
 
 parse_git_url_bare_remote_test = unittest.make(_parse_git_url_bare_remote_test_impl)
+
+def _locked_git_requirement_urls_test_impl(ctx):
+    env = unittest.begin(ctx)
+    result = locked_git_requirement_urls("https://github.com/benjaminp/six?tag=1.17.0#ebd9b3af90247b8858d415a05e96e9ee61e48d07")
+    asserts.equals(env, [
+        "git+https://github.com/benjaminp/six",
+        "git+https://github.com/benjaminp/six@ebd9b3af90247b8858d415a05e96e9ee61e48d07",
+        "git+https://github.com/benjaminp/six@1.17.0",
+    ], result)
+
+    result = locked_git_requirement_urls("git+https://github.com/example/project?branch=release%2F1.x&subdirectory=python%2Fpkg#abc123")
+    asserts.equals(env, [
+        "git+https://github.com/example/project#subdirectory=python/pkg",
+        "git+https://github.com/example/project@abc123#subdirectory=python/pkg",
+        "git+https://github.com/example/project@release/1.x#subdirectory=python/pkg",
+    ], result)
+    return unittest.end(env)
+
+locked_git_requirement_urls_test = unittest.make(_locked_git_requirement_urls_test_impl)
 
 def _git_to_http_archive_commit_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -133,6 +152,7 @@ def git_utils_test_suite():
         parse_git_url_query_ref_test,
         parse_git_url_fragment_wins_over_query_test,
         parse_git_url_bare_remote_test,
+        locked_git_requirement_urls_test,
         git_to_http_archive_commit_test,
         git_to_http_archive_ref_test,
         git_to_http_archive_parsed_ref_url_test,

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -96,6 +96,16 @@ def _extract_requirement_marker_pairs_direct_reference_test_impl(ctx):
     asserts.equals(env, (("proj", "build", "1.3.0", "__base__"), 'python_version >= "3.9"'), result[0])
     asserts.equals(env, (("proj", "build", "1.3.0", "extra"), 'python_version >= "3.9"'), result[1])
 
+    hashed = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "build @ https://example.invalid/build-1.3.0-py3-none-any.whl#sha256=4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+        {},
+        versions,
+        locked_urls = locked_urls,
+    )
+    asserts.equals(env, [(("proj", "build", "1.3.0", "__base__"), "")], hashed)
+
     missing = extract_requirement_marker_pairs(
         "//:pyproject.toml",
         "proj",

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -78,6 +78,40 @@ extract_requirement_marker_pairs_with_extras_test = unittest.make(
     _extract_requirement_marker_pairs_with_extras_test_impl,
 )
 
+def _extract_requirement_marker_pairs_direct_reference_test_impl(ctx):
+    env = unittest.begin(ctx)
+    versions = {"build": {"1.3.0": 1, "2.0.0": 1}}
+    locked_urls = {
+        ("build", "https://example.invalid/build-1.3.0-py3-none-any.whl"): ("proj", "build", "1.3.0", "__base__"),
+    }
+    result = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        'build[extra] @ https://example.invalid/build-1.3.0-py3-none-any.whl ; python_version >= "3.9"',
+        {},
+        versions,
+        locked_urls = locked_urls,
+    )
+    asserts.equals(env, 2, len(result))
+    asserts.equals(env, (("proj", "build", "1.3.0", "__base__"), 'python_version >= "3.9"'), result[0])
+    asserts.equals(env, (("proj", "build", "1.3.0", "extra"), 'python_version >= "3.9"'), result[1])
+
+    missing = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "build@https://example.invalid/build-2.0.0-py3-none-any.whl",
+        {},
+        versions,
+        fail_if_missing = False,
+        locked_urls = locked_urls,
+    )
+    asserts.equals(env, [], missing)
+    return unittest.end(env)
+
+extract_requirement_marker_pairs_direct_reference_test = unittest.make(
+    _extract_requirement_marker_pairs_direct_reference_test_impl,
+)
+
 def _extract_requirement_marker_pairs_preferred_overrides_version_map_test_impl(ctx):
     env = unittest.begin(ctx)
     version_map = {"build": ("proj", "build", "1.2.0", "__base__")}
@@ -207,6 +241,7 @@ def projectfile_test_suite():
         extract_requirement_marker_pairs_multi_version_with_specifier_test,
         extract_requirement_marker_pairs_single_version_via_map_test,
         extract_requirement_marker_pairs_with_extras_test,
+        extract_requirement_marker_pairs_direct_reference_test,
         extract_requirement_marker_pairs_preferred_overrides_version_map_test,
         extract_requirement_marker_pairs_preferred_overrides_multi_version_test,
         collect_activated_extras_transitive_remap_test,

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//uv/private/markers:pep508_evaluate.bzl", "evaluate")
+load(":lockfile.bzl", "collect_locked_requirement_urls")
 load(":projectfile.bzl", "collect_activated_extras", "collect_build_dependency_markers", "extract_requirement_marker_pairs", "marker_can_apply")
 
 def _extract_requirement_marker_pairs_multi_version_no_specifier_test_impl(ctx):
@@ -205,6 +206,192 @@ def _extract_requirement_marker_pairs_direct_reference_test_impl(ctx):
 
 extract_requirement_marker_pairs_direct_reference_test = unittest.make(
     _extract_requirement_marker_pairs_direct_reference_test_impl,
+)
+
+def _collect_locked_requirement_urls_local_sources_test_impl(ctx):
+    env = unittest.begin(ctx)
+    cases = [
+        (
+            "archive-build",
+            "path",
+            "../artifacts/archive-build-1.0.0.whl",
+            "file:///workspace/artifacts/archive-build-1.0.0.whl",
+        ),
+        (
+            "directory-build",
+            "directory",
+            "packages/../packages/directory-build",
+            "file:///workspace/project/packages/directory-build",
+        ),
+        (
+            "editable-build",
+            "editable",
+            "packages/editable-build",
+            "file:///workspace/project/packages/editable-build",
+        ),
+        (
+            "absolute-build",
+            "path",
+            "/opt/build/absolute-build-4.0.0.whl",
+            "file:///opt/build/absolute-build-4.0.0.whl",
+        ),
+        (
+            "double-slash-build",
+            "path",
+            "//opt/build/double-slash-build.whl",
+            "file:///opt/build/double-slash-build.whl",
+        ),
+        (
+            "file-build",
+            "path",
+            "file:///opt/build/file-build-5.0.0.whl",
+            "file:///opt/build/file-build-5.0.0.whl",
+        ),
+        (
+            "spaced-build",
+            "directory",
+            "packages/local build",
+            "file:///workspace/project/packages/local%20build",
+        ),
+        (
+            "reserved-build",
+            "directory",
+            "packages/uv #?%\"<>`{}\\path",
+            "file:///workspace/project/packages/uv%20%23%3F%25%22%3C%3E%60%7B%7D%5Cpath",
+        ),
+        (
+            "safe-build",
+            "directory",
+            "packages/[keep]@name;version:",
+            "file:///workspace/project/packages/[keep]@name;version:",
+        ),
+        (
+            "unicode-build",
+            "directory",
+            "packages/ümlaut/雪😀",
+            "file:///workspace/project/packages/%C3%BCmlaut/%E9%9B%AA%F0%9F%98%80",
+        ),
+        (
+            "control-build",
+            "directory",
+            "packages/line\nbreak\tend",
+            "file:///workspace/project/packages/line%0Abreak%09end",
+        ),
+        (
+            "windows-build",
+            "path",
+            "C:\\build tools\\windows-build-11.0.0.whl",
+            "file:///C:/build%20tools/windows-build-11.0.0.whl",
+        ),
+        (
+            "unc-build",
+            "directory",
+            "\\\\fileserver\\build tools\\unc#build",
+            "file://fileserver/build%20tools/unc%23build",
+        ),
+    ]
+    packages = []
+    expected_urls = {}
+    for i, (name, source_kind, local_path, expected_url) in enumerate(cases):
+        version = "{}.0.0".format(i + 1)
+        normalized_name = name.replace("-", "_")
+        packages.append({
+            "name": name,
+            "version": version,
+            "source": {source_kind: local_path},
+        })
+        expected_urls[(normalized_name, expected_url)] = (
+            "proj",
+            normalized_name,
+            version,
+            "__base__",
+        )
+
+    asserts.equals(
+        env,
+        expected_urls,
+        collect_locked_requirement_urls("proj", {"package": packages}, "/workspace/project"),
+    )
+    return unittest.end(env)
+
+collect_locked_requirement_urls_local_sources_test = unittest.make(
+    _collect_locked_requirement_urls_local_sources_test_impl,
+)
+
+def _extract_requirement_marker_pairs_local_reference_test_impl(ctx):
+    env = unittest.begin(ctx)
+    locked_urls = collect_locked_requirement_urls(
+        "proj",
+        {
+            "package": [
+                {
+                    "name": "directory-build",
+                    "version": "2.0.0",
+                    "source": {"directory": "packages/directory-build"},
+                },
+                {
+                    "name": "safe-build",
+                    "version": "8.0.0",
+                    "source": {"directory": "packages/[keep]@name;version:"},
+                },
+            ],
+        },
+        "/workspace/project",
+    )
+
+    result = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "directory-build[feature] @ file:///workspace/project/packages/directory-build; sys_platform == 'linux'",
+        {},
+        {"directory_build": {"2.0.0": 1}},
+        locked_urls = locked_urls,
+    )
+    asserts.equals(env, [
+        (("proj", "directory_build", "2.0.0", "__base__"), "sys_platform == 'linux'"),
+        (("proj", "directory_build", "2.0.0", "feature"), "sys_platform == 'linux'"),
+    ], result)
+
+    safe_url = "file:///workspace/project/packages/[keep]@name;version:"
+    safe = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "safe-build @ " + safe_url,
+        {},
+        {"safe_build": {"8.0.0": 1}},
+        locked_urls = locked_urls,
+    )
+    asserts.equals(env, [
+        (("proj", "safe_build", "8.0.0", "__base__"), ""),
+    ], safe)
+
+    marked_safe = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "safe-build[feature] @ " + safe_url + " ; sys_platform == 'linux'",
+        {},
+        {"safe_build": {"8.0.0": 1}},
+        locked_urls = locked_urls,
+    )
+    asserts.equals(env, [
+        (("proj", "safe_build", "8.0.0", "__base__"), "sys_platform == 'linux'"),
+        (("proj", "safe_build", "8.0.0", "feature"), "sys_platform == 'linux'"),
+    ], marked_safe)
+
+    missing = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        "directory-build @ file:///workspace/project/packages/other-build",
+        {},
+        {"directory_build": {"2.0.0": 1}},
+        fail_if_missing = False,
+        locked_urls = locked_urls,
+    )
+    asserts.equals(env, [], missing)
+    return unittest.end(env)
+
+extract_requirement_marker_pairs_local_reference_test = unittest.make(
+    _extract_requirement_marker_pairs_local_reference_test_impl,
 )
 
 def _extract_requirement_marker_pairs_preferred_overrides_version_map_test_impl(ctx):
@@ -509,6 +696,8 @@ def projectfile_test_suite():
         collect_build_dependency_markers_cycle_test,
         collect_build_dependency_markers_conflict_extras_test,
         extract_requirement_marker_pairs_direct_reference_test,
+        collect_locked_requirement_urls_local_sources_test,
+        extract_requirement_marker_pairs_local_reference_test,
         extract_requirement_marker_pairs_preferred_overrides_version_map_test,
         extract_requirement_marker_pairs_preferred_overrides_multi_version_test,
         collect_activated_extras_transitive_remap_test,

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":projectfile.bzl", "collect_activated_extras", "extract_requirement_marker_pairs")
+load("//uv/private/markers:pep508_evaluate.bzl", "evaluate")
+load(":projectfile.bzl", "collect_activated_extras", "collect_build_dependency_markers", "extract_requirement_marker_pairs", "marker_can_apply")
 
 def _extract_requirement_marker_pairs_multi_version_no_specifier_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -76,6 +77,90 @@ def _extract_requirement_marker_pairs_with_extras_test_impl(ctx):
 
 extract_requirement_marker_pairs_with_extras_test = unittest.make(
     _extract_requirement_marker_pairs_with_extras_test_impl,
+)
+
+def _extract_requirement_marker_pairs_normalizes_extras_test_impl(ctx):
+    env = unittest.begin(ctx)
+    result = extract_requirement_marker_pairs(
+        "//:pyproject.toml",
+        "proj",
+        'build[SOCKS, Extra__Two, extra...three]; python_version >= "3.9"',
+        {"build": ("proj", "build", "1.2.0", "__base__")},
+    )
+    marker = 'python_version >= "3.9"'
+    asserts.equals(env, [
+        (("proj", "build", "1.2.0", "__base__"), marker),
+        (("proj", "build", "1.2.0", "socks"), marker),
+        (("proj", "build", "1.2.0", "extra-two"), marker),
+        (("proj", "build", "1.2.0", "extra-three"), marker),
+    ], result)
+    return unittest.end(env)
+
+extract_requirement_marker_pairs_normalizes_extras_test = unittest.make(
+    _extract_requirement_marker_pairs_normalizes_extras_test_impl,
+)
+
+def _marker_can_apply_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.false(env, marker_can_apply("python_version < '3.0'", ">=3.11"))
+    asserts.false(
+        env,
+        marker_can_apply("sys_platform == 'linux' and python_version < '3.0'", ">=3.11"),
+    )
+    asserts.false(env, marker_can_apply("python_version >= '3.11'", "==3.10.19"))
+    asserts.true(env, marker_can_apply("python_version == '3.12'", ">=3.11"))
+    asserts.true(
+        env,
+        marker_can_apply("sys_platform == 'linux' and python_version >= '3.11'", ">=3.11"),
+    )
+    asserts.true(env, marker_can_apply("sys_platform == 'linux'", ">=3.11"))
+    return unittest.end(env)
+
+marker_can_apply_test = unittest.make(_marker_can_apply_test_impl)
+
+def _collect_build_dependency_markers_test_impl(ctx):
+    env = unittest.begin(ctx)
+    build = ("lock", "build", "1.0.0", "__base__")
+    build_extra = ("lock", "build", "1.0.0", "feature")
+    packaging_21 = ("lock", "packaging", "21.3", "__base__")
+    packaging_24 = ("lock", "packaging", "24.0", "__base__")
+    colorama = ("lock", "colorama", "0.4.6", "__base__")
+    pysocks = ("lock", "pysocks", "1.7.1", "__base__")
+    root_marker = "sys_platform == 'linux'"
+    version_marker = "python_version >= '3.11'"
+    extra_marker = "platform_machine == 'aarch64'"
+    transitive_marker = "platform_python_implementation == 'CPython'"
+
+    marked_deps = collect_build_dependency_markers(
+        {
+            build: {packaging_24: {version_marker: 1}},
+            build_extra: {pysocks: {extra_marker: 1}},
+            packaging_21: {},
+            packaging_24: {colorama: {transitive_marker: 1}},
+            colorama: {},
+            pysocks: {},
+        },
+        [(build, root_marker), (build_extra, root_marker)],
+    )
+
+    packaging_marker = "({}) and ({})".format(root_marker, version_marker)
+    asserts.equals(env, {root_marker: 1}, marked_deps.get(build, {}))
+    asserts.equals(env, {packaging_marker: 1}, marked_deps.get(packaging_24, {}))
+    asserts.equals(
+        env,
+        {"({}) and ({})".format(packaging_marker, transitive_marker): 1},
+        marked_deps.get(colorama, {}),
+    )
+    asserts.equals(
+        env,
+        {"({}) and ({})".format(root_marker, extra_marker): 1},
+        marked_deps.get(pysocks, {}),
+    )
+    asserts.false(env, packaging_21 in marked_deps)
+    return unittest.end(env)
+
+collect_build_dependency_markers_test = unittest.make(
+    _collect_build_dependency_markers_test_impl,
 )
 
 def _extract_requirement_marker_pairs_direct_reference_test_impl(ctx):
@@ -161,6 +246,171 @@ def _extract_requirement_marker_pairs_preferred_overrides_multi_version_test_imp
 
 extract_requirement_marker_pairs_preferred_overrides_multi_version_test = unittest.make(
     _extract_requirement_marker_pairs_preferred_overrides_multi_version_test_impl,
+)
+
+def _collect_build_dependency_markers_nested_extras_test_impl(ctx):
+    env = unittest.begin(ctx)
+    build = ("lock", "build", "1.0.0", "__base__")
+    build_extra = ("lock", "build", "1.0.0", "first")
+    nested = ("lock", "nested", "1.0.0", "__base__")
+    nested_extra = ("lock", "nested", "1.0.0", "second")
+    base_leaf = ("lock", "base_leaf", "1.0.0", "__base__")
+    nested_leaf = ("lock", "nested_leaf", "1.0.0", "__base__")
+    extra_leaf = ("lock", "extra_leaf", "1.0.0", "__base__")
+    root_marker = "sys_platform == 'linux'"
+    base_marker = "python_version >= '3.11'"
+    nested_marker = "platform_machine == 'aarch64'"
+    nested_base_marker = "os_name == 'posix'"
+    extra_marker = "platform_python_implementation == 'CPython'"
+
+    marked_deps = collect_build_dependency_markers(
+        {
+            build: {base_leaf: {base_marker: 1}},
+            build_extra: {nested_extra: {nested_marker: 1}},
+            nested: {nested_leaf: {nested_base_marker: 1}},
+            nested_extra: {extra_leaf: {extra_marker: 1}},
+            base_leaf: {},
+            nested_leaf: {},
+            extra_leaf: {},
+        },
+        [(build_extra, root_marker)],
+    )
+
+    nested_path = "({}) and ({})".format(root_marker, nested_marker)
+    asserts.equals(env, {root_marker: 1}, marked_deps.get(build, {}))
+    asserts.equals(
+        env,
+        {"({}) and ({})".format(root_marker, base_marker): 1},
+        marked_deps.get(base_leaf, {}),
+    )
+    asserts.equals(env, {nested_path: 1}, marked_deps.get(nested, {}))
+    asserts.equals(
+        env,
+        {"({}) and ({})".format(nested_path, nested_base_marker): 1},
+        marked_deps.get(nested_leaf, {}),
+    )
+    asserts.equals(
+        env,
+        {"({}) and ({})".format(nested_path, extra_marker): 1},
+        marked_deps.get(extra_leaf, {}),
+    )
+    return unittest.end(env)
+
+collect_build_dependency_markers_nested_extras_test = unittest.make(
+    _collect_build_dependency_markers_nested_extras_test_impl,
+)
+
+def _collect_build_dependency_markers_multiple_paths_test_impl(ctx):
+    env = unittest.begin(ctx)
+    first = ("lock", "first", "1.0.0", "__base__")
+    second = ("lock", "second", "1.0.0", "__base__")
+    shared = ("lock", "shared", "1.0.0", "__base__")
+    leaf = ("lock", "leaf", "1.0.0", "__base__")
+    first_root = "sys_platform == 'linux'"
+    second_root = "sys_platform == 'darwin'"
+    first_edge = "python_version >= '3.11'"
+    second_edge = "os_name == 'posix'"
+    leaf_edge = "platform_python_implementation == 'CPython'"
+
+    marked_deps = collect_build_dependency_markers(
+        {
+            first: {shared: {first_edge: 1}},
+            second: {shared: {second_edge: 1}},
+            shared: {leaf: {leaf_edge: 1}},
+            leaf: {},
+        },
+        [(first, first_root), (second, second_root)],
+    )
+
+    shared_markers = {
+        "({}) and ({})".format(first_root, first_edge): 1,
+        "({}) and ({})".format(second_root, second_edge): 1,
+    }
+    asserts.equals(env, shared_markers, marked_deps.get(shared, {}))
+    asserts.equals(
+        env,
+        {
+            "({}) and ({})".format(marker, leaf_edge): 1
+            for marker in shared_markers
+        },
+        marked_deps.get(leaf, {}),
+    )
+    return unittest.end(env)
+
+collect_build_dependency_markers_multiple_paths_test = unittest.make(
+    _collect_build_dependency_markers_multiple_paths_test_impl,
+)
+
+def _collect_build_dependency_markers_cycle_test_impl(ctx):
+    env = unittest.begin(ctx)
+    first = ("lock", "first", "1.0.0", "__base__")
+    second = ("lock", "second", "1.0.0", "__base__")
+    leaf = ("lock", "leaf", "1.0.0", "__base__")
+    root_marker = "sys_platform != 'win32'"
+    edge_marker = "python_version >= '3.11'"
+    leaf_marker = "platform_python_implementation == 'CPython'"
+
+    marked_deps = collect_build_dependency_markers(
+        {
+            first: {second: {edge_marker: 1}},
+            second: {
+                first: {"os_name == 'posix'": 1},
+                leaf: {leaf_marker: 1},
+            },
+            leaf: {},
+        },
+        [(first, root_marker)],
+    )
+
+    second_marker = "({}) and ({})".format(root_marker, edge_marker)
+    asserts.equals(env, {root_marker: 1}, marked_deps.get(first, {}))
+    asserts.equals(env, {second_marker: 1}, marked_deps.get(second, {}))
+    asserts.equals(
+        env,
+        {"({}) and ({})".format(second_marker, leaf_marker): 1},
+        marked_deps.get(leaf, {}),
+    )
+    return unittest.end(env)
+
+collect_build_dependency_markers_cycle_test = unittest.make(
+    _collect_build_dependency_markers_cycle_test_impl,
+)
+
+def _collect_build_dependency_markers_conflict_extras_test_impl(ctx):
+    env = unittest.begin(ctx)
+    build = ("lock", "build", "1.0.0", "__base__")
+    selected = ("lock", "packaging", "24.0", "__base__")
+    unselected = ("lock", "packaging", "21.3", "__base__")
+    windows_only = ("lock", "colorama", "0.4.6", "__base__")
+    selected_marker = "extra == 'group-a' or extra != 'group-b'"
+    unselected_marker = "extra == 'group-b'"
+    platform_marker = "os_name == 'nt' or (extra == 'group-a' and extra == 'group-b')"
+
+    marked_deps = collect_build_dependency_markers(
+        {
+            build: {
+                selected: {selected_marker: 1},
+                unselected: {unselected_marker: 1},
+                windows_only: {platform_marker: 1},
+            },
+            selected: {},
+            unselected: {},
+            windows_only: {},
+        },
+        [(build, "")],
+    )
+
+    asserts.equals(env, {"": 1}, marked_deps.get(selected, {}))
+    asserts.false(env, unselected in marked_deps)
+    markers = marked_deps.get(windows_only, {})
+    asserts.equals(env, 1, len(markers))
+    for marker in markers:
+        asserts.true(env, evaluate(marker, env = {"os_name": "nt"}))
+        asserts.false(env, evaluate(marker, env = {"os_name": "posix"}))
+    return unittest.end(env)
+
+collect_build_dependency_markers_conflict_extras_test = unittest.make(
+    _collect_build_dependency_markers_conflict_extras_test_impl,
 )
 
 def _collect_activated_extras_transitive_remap_test_impl(ctx):
@@ -251,6 +501,13 @@ def projectfile_test_suite():
         extract_requirement_marker_pairs_multi_version_with_specifier_test,
         extract_requirement_marker_pairs_single_version_via_map_test,
         extract_requirement_marker_pairs_with_extras_test,
+        extract_requirement_marker_pairs_normalizes_extras_test,
+        marker_can_apply_test,
+        collect_build_dependency_markers_test,
+        collect_build_dependency_markers_nested_extras_test,
+        collect_build_dependency_markers_multiple_paths_test,
+        collect_build_dependency_markers_cycle_test,
+        collect_build_dependency_markers_conflict_extras_test,
         extract_requirement_marker_pairs_direct_reference_test,
         extract_requirement_marker_pairs_preferred_overrides_version_map_test,
         extract_requirement_marker_pairs_preferred_overrides_multi_version_test,

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -203,8 +203,23 @@ def _sdist_build_impl(repository_ctx):
     # conservatively add setuptools + wheel as fallback build deps. For now
     # we rely on the configure tool succeeding.
 
-    # Merge explicit deps with auto-discovered deps
-    all_deps = [str(d) for d in repository_ctx.attr.deps] + extra_dep_labels
+    # Label-valued attrs render canonical repository names, while configure
+    # results use their apparent names. Deduplicate their shared install repo.
+    all_deps_by_repo = {}
+    for dep in list(repository_ctx.attr.deps) + extra_dep_labels:
+        label = str(dep)
+        repo, _separator, target = label.partition("//")
+        repo_key = repo.rsplit("+", 1)[-1].lstrip("@")
+        all_deps_by_repo.setdefault((repo_key, target), label)
+    all_deps = all_deps_by_repo.values()
+
+    conditional_deps = {}
+    for dep, marker in repository_ctx.attr.conditional_deps.items():
+        dep = str(dep)
+        repo, _separator, target = dep.partition("//")
+        repo_key = repo.rsplit("+", 1)[-1].lstrip("@")
+        if (repo_key, target) not in all_deps_by_repo:
+            conditional_deps.setdefault(marker, []).append(dep)
 
     monitor_memory_attr = ""
     if repository_ctx.attr.monitor_memory:
@@ -255,12 +270,35 @@ def _sdist_build_impl(repository_ctx):
     if inspection and inspection.get("console_scripts"):
         console_scripts_attr = "\n    console_scripts = {},".format(repr(inspection["console_scripts"]))
 
+    rule = "pep517_native_whl" if is_native else "pep517_whl"
+    loads = [
+        'load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{}")'.format(rule),
+        'load("@aspect_rules_py//py:defs.bzl", "py_binary")',
+    ]
+    if conditional_deps:
+        loads.append('load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")')
+    marker_rules = ""
+    deps_expr = repr(all_deps)
+    for idx, (marker, deps) in enumerate(conditional_deps.items()):
+        if not deps:
+            continue
+        marker_name = "_build_dep_marker_{}".format(idx)
+        marker_rules += """
+decide_marker(
+    name = "{name}",
+    marker = {marker},
+)
+""".format(name = marker_name, marker = repr(marker))
+        deps_expr += """ + select({{
+        ":{marker}": {deps},
+        "//conditions:default": [],
+    }})""".format(marker = marker_name, deps = repr(deps))
+
     # Leave args unset: the pure rule validates anyarch wheels by default,
     # while the native rule defaults to no validation.
     repository_ctx.file("BUILD.bazel", content = """
-load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{rule}")
-load("@aspect_rules_py//py:defs.bzl", "py_binary")
-
+{loads}
+{marker_rules}
 py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
@@ -282,10 +320,12 @@ exports_files(
 )
 """.format(
         src = repository_ctx.attr.src,
-        deps = repr(all_deps),
         console_scripts_attr = console_scripts_attr,
+        deps = deps_expr,
+        loads = "\n".join(loads),
+        marker_rules = marker_rules,
         monitor_memory_attr = monitor_memory_attr,
-        rule = "pep517_native_whl" if is_native else "pep517_whl",
+        rule = rule,
         version = repository_ctx.attr.version,
         resource_set_attr = resource_set_attr,
         patch_attrs = patch_attrs,
@@ -297,6 +337,12 @@ sdist_build = repository_rule(
     attrs = {
         "src": attr.label(),
         "deps": attr.label_list(),
+        "conditional_deps": attr.label_keyed_string_dict(
+            default = {},
+            doc = "Dict mapping build dependency labels to PEP 508 marker " +
+                  "expressions. The generated build tool adds " +
+                  "these dependencies only when their markers match.",
+        ),
         "available_deps": attr.string_dict(
             doc = "Dict mapping normalized package names to install labels. " +
                   "Passed from the uv extension; used to resolve deps " +

--- a/uv/private/uv_hub/snapshots/sdist_build.bravado_core.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/sdist_build.bravado_core.BUILD.bazel
@@ -1,12 +1,45 @@
 
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
+
+decide_marker(
+    name = "_build_dep_marker_0",
+    marker = "os_name == 'nt'",
+)
+
+decide_marker(
+    name = "_build_dep_marker_1",
+    marker = "python_full_version < '3.10.2'",
+)
+
+decide_marker(
+    name = "_build_dep_marker_2",
+    marker = "python_full_version < '3.11'",
+)
+
+decide_marker(
+    name = "_build_dep_marker_3",
+    marker = "(python_full_version < '3.10.2') and (python_full_version < '3.11')",
+)
 
 py_binary(
     name = "build_tool",
     main = "@aspect_rules_py//uv/private/pep517_whl:build_helper.py",
     srcs = ["@aspect_rules_py//uv/private/pep517_whl:build_helper.py"],
-    deps = ["@@+uv+project__aspect_rules_py//:build", "@@+uv+project__aspect_rules_py//:setuptools", "@@+uv+project__aspect_rules_py//:maturin", "@whl_install__aspect_rules_py__setuptools__80_9_0//:install"],
+    deps = ["@@+uv+whl_install__aspect_rules_py__build__1_3_0//:install", "@@+uv+whl_install__aspect_rules_py__setuptools__80_9_0//:install", "@@+uv+whl_install__aspect_rules_py__maturin__1_11_5//:install", "@@+uv+whl_install__aspect_rules_py__packaging__24_0//:install", "@@+uv+whl_install__aspect_rules_py__pyproject_hooks__1_2_0//:install"] + select({
+        ":_build_dep_marker_0": ["@@+uv+whl_install__aspect_rules_py__colorama__0_4_6//:install"],
+        "//conditions:default": [],
+    }) + select({
+        ":_build_dep_marker_1": ["@@+uv+whl_install__aspect_rules_py__importlib_metadata__8_7_1//:install"],
+        "//conditions:default": [],
+    }) + select({
+        ":_build_dep_marker_2": ["@@+uv+whl_install__aspect_rules_py__tomli__2_4_0//:install"],
+        "//conditions:default": [],
+    }) + select({
+        ":_build_dep_marker_3": ["@@+uv+whl_install__aspect_rules_py__zipp__3_23_0//:install"],
+        "//conditions:default": [],
+    }),
 )
 
 pep517_whl(


### PR DESCRIPTION
Currently, `annotations.toml` supports declaring extra build dependencies in a format that runs parallel to [`tool.uv.extra-build-dependencies`](https://docs.astral.sh/uv/reference/settings/#extra-build-dependencies). This PR adds support for loading uv's `tool.uv.extra-build-dependencies` to `rules_py`'s `uv.project`. This moves rules_py closer to uv's interface.

Unlike `annotations.toml`, `tool.uv.extra-build-dependencies` supports the full requirements syntax.

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

Extended the existing e2e snapshot test on top of uv-sdist-fallback to cover both the old and the new syntax for two different packages.
