### PR TITLE
feat: add interpreters.configure(build_config)

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -45,6 +45,7 @@ jobs:
                 - { path: "e2e/interpreter-runtime-metadata", slug: "e2e-interpreter-runtime-metadata", runner: "ubuntu-latest" }
                 - { path: "e2e/interpreter-toolchain-settings", slug: "e2e-interpreter-toolchain-settings", runner: "ubuntu-latest" }
                 - { path: "e2e/interpreter-input-validation", slug: "e2e-interpreter-input-validation", runner: "ubuntu-latest" }
+                - { path: "e2e/interpreter-build-config", slug: "e2e-interpreter-build-config", runner: "ubuntu-latest" }
                 - { path: "e2e/rules-python-interop", slug: "e2e-rules-python-interop", runner: "ubuntu-latest" }
                 - { path: "e2e/rules-proto-grpc-python", slug: "e2e-rules-proto-grpc-python", runner: "ubuntu-22.04-32core" }
                 - { path: "examples/debugger", slug: "examples-debugger", runner: "ubuntu-latest" }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -408,848 +408,848 @@
   },
   "facts": {
     "//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -184,11 +184,11 @@ The target attribute takes precedence over the build-wide flag.
 
 ## Runtime modes
 
-The extension registers one normal `install_only` PBS archive for each
-available Python version and platform. It also registers an optimized
-free-threaded archive where PBS publishes one, currently for Python 3.13 and
-newer. Normal mode is selected by default. Select free-threaded mode with the
-build setting:
+The extension registers one normal PBS archive for each available Python version
+and platform (the archive is chosen by `build_config`, see below). It also
+registers an optimized free-threaded archive where PBS publishes one, currently
+for Python 3.13 and newer. Normal mode is selected by default. Select
+free-threaded mode with the build setting:
 
 ```shell
 bazel build \
@@ -198,6 +198,48 @@ bazel build \
 
 `interpreters.toolchain()` chooses Python versions; the build setting above
 selects runtime mode.
+
+## Build configuration
+
+PBS publishes each interpreter in several build configurations. `configure()`
+selects which one backs the normal (non-free-threaded) runtime, hub-wide:
+
+```starlark
+interpreters.configure(
+    releases = ["20260303"],
+    build_config = "install_only_stripped",
+)
+```
+
+Supported values:
+
+| `build_config`          | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| `install_only`          | Optimized, minimal redistributable (default).          |
+| `install_only_stripped` | Same as `install_only` with debug symbols removed (smallest download). |
+| `<opt>[+<opt>...]-full` | A full archive; each `<opt>` is one of `debug`, `noopt`, `pgo`, `lto`, in that order (e.g. `pgo+lto-full`, `debug-full`). |
+
+Only `install_only` and `install_only_stripped` are published for every platform
+listed below, so they are the only configurations usable as a hub-wide default.
+Each platform family publishes different `-full` flavors — glibc Linux and macOS
+get `debug-full` and `pgo+lto-full`, musl Linux gets `debug-full`, `lto-full`,
+and `noopt-full`, and Windows gets only `pgo-full` — and platforms without the
+selected archive get no normal-mode toolchain (their interpreter repos still
+exist and fetch cleanly, so `use_repo()` imports, `bazel fetch --all`, and
+`bazel vendor` keep working, but referencing anything in them fails with an
+explanation). A `build_config` that matches no platform at all for a requested
+version fails extension evaluation eagerly. `debug-full` comes closest to
+hub-wide, covering every platform except Windows. Statically linked (`+static`)
+configurations are rejected because extension modules resolve Python symbols from
+the loading interpreter. Free-threading is a separate axis selected at build time
+(see [Runtime modes](#runtime-modes)), so `build_config` must not name a
+`freethreaded` suffix.
+
+`debug-full` produces a `Py_DEBUG` interpreter (ABI flag `d`); PyPI ships no
+matching wheels, so C-extension dependencies must be built from source. The
+debug property does not carry across the free-threading axis: with a
+`debug-full` hub, selecting free-threaded mode still yields the optimized
+free-threaded archive (ABI flag `t`, not `td`).
 
 ## Platforms
 

--- a/e2e/cases/MODULE.bazel.lock
+++ b/e2e/cases/MODULE.bazel.lock
@@ -883,1060 +883,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/e2e/interpreter-build-config/.bazelignore
+++ b/e2e/interpreter-build-config/.bazelignore
@@ -1,0 +1,5 @@
+root-debug-full-build-config
+root-misordered-build-config
+root-static-build-config
+root-freethreaded-build-config
+root-unmatched-build-config

--- a/e2e/interpreter-build-config/.bazelrc
+++ b/e2e/interpreter-build-config/.bazelrc
@@ -1,0 +1,3 @@
+# Build without the bytes
+common:ci --remote_download_outputs=minimal
+common:ci --nobuild_runfile_links

--- a/e2e/interpreter-build-config/.bazelversion
+++ b/e2e/interpreter-build-config/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/interpreter-build-config/BUILD.bazel
+++ b/e2e/interpreter-build-config/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+# build_config = "install_only_stripped" (set in MODULE.bazel): the smaller,
+# symbol-stripped redistributable. It is functionally identical to install_only,
+# so this asserts the archive resolves and runs as a regular (non-debug) 3.13
+# interpreter under a plain `bazel test //...`.
+py_test(
+    name = "check",
+    srcs = ["check_interpreter.py"],
+    main = "check_interpreter.py",
+    python_version = "3.13",
+)

--- a/e2e/interpreter-build-config/MODULE.bazel
+++ b/e2e/interpreter-build-config/MODULE.bazel
@@ -1,0 +1,19 @@
+# Invalid build_config fixtures live in the sibling root-*/ modules, driven by
+# test.sh.
+module(name = "interpreter_build_config")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(
+    build_config = "install_only_stripped",
+    releases = ["20260303"],
+)
+interpreters.toolchain(python_version = "3.13")
+use_repo(interpreters, "python_interpreters")
+
+register_toolchains("@python_interpreters//:all")

--- a/e2e/interpreter-build-config/MODULE.bazel.lock
+++ b/e2e/interpreter-build-config/MODULE.bazel.lock
@@ -210,6 +210,123 @@
         ]
       }
     },
+    "@@pybind11_bazel+//:python_configure.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "c9ZWWeXeu6bctL4/SsY2otFWyeFN0JJ20+ymGyJZtWk=",
+        "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_python": {
+            "repoRuleId": "@@pybind11_bazel+//:python_configure.bzl%python_configure",
+            "attributes": {}
+          },
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11.BUILD",
+              "strip_prefix": "pybind11-2.11.1",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.11.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "WHRlQQnxW7e7XMRBhq7SARkDarLDOAbg6iLaJpk5QYM=",
+        "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "platforms": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_python": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "bazel_skylib": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "repoRuleId": "@@rules_fuzzing+//fuzzing/private/oss_fuzz:repository.bzl%oss_fuzz_repository",
+            "attributes": {}
+          },
+          "honggfuzz": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@rules_fuzzing+//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_fuzzing+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
@@ -318,141 +435,141 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only_stripped": {
         "3.10/aarch64-apple-darwin/default": {
-          "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.10.20",
-          "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
+          "sha256": "853c7e10306b21e85a64656351070ec8004f8382a825439e04fc6a0c1275f9e4"
         },
         "3.10/aarch64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.10.20",
-          "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
+          "sha256": "72375d05ab7e43182adda8d93a48c141e5eea1101277db3a20b9aedc3deba6a2"
         },
         "3.10/aarch64-unknown-linux-musl/default": {
-          "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.10.20",
-          "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
+          "sha256": "438a3cc1dee60f58e66b601c34fe73062d787370a3f64c6f5789c24ac274a148"
         },
         "3.10/i686-pc-windows-msvc/default": {
-          "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.10.20",
-          "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
+          "sha256": "4136dccd273eedac8cb2be7a955321b468d085fc1748837274a52d1602983747"
         },
         "3.10/x86_64-apple-darwin/default": {
-          "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.10.20",
-          "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
+          "sha256": "4aeaa5f794095dd4e854a4cfeec94dec13f317a196620880193ddcd069d05c7a"
         },
         "3.10/x86_64-pc-windows-msvc/default": {
-          "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.10.20",
-          "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
+          "sha256": "738f9a7f046405947748558acf7c24a087baf7a7cb68bf791d240c8c942ba2a0"
         },
         "3.10/x86_64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.10.20",
-          "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
+          "sha256": "19a592cd6a9f82fecd7bcab853550b28b3e1294a1983209cfd40721dd5275e51"
         },
         "3.10/x86_64-unknown-linux-musl/default": {
-          "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.10.20",
-          "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
+          "sha256": "341066085f9c6d276b0f05d01665b4c61f91c1be3611f668020ca0d50257be64"
         },
         "3.11/aarch64-apple-darwin/default": {
-          "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
+          "sha256": "3ac3262428d899422dcf07ec0c69f8c99abc78ba36b497ffcb0f981d28ae0136"
         },
         "3.11/aarch64-pc-windows-msvc/default": {
-          "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
+          "sha256": "89ec5ed4caa2170ce06c5c91d55b7e035d70020bc89d8fbd00e6a42b78c70284"
         },
         "3.11/aarch64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
+          "sha256": "113bda2f964720c7067afc1c81f166d0524600cfe26cda46ff0df8c1988259c9"
         },
         "3.11/aarch64-unknown-linux-musl/default": {
-          "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
+          "sha256": "faf917bed3c4070cc32536f1e7a679dbb37c41b195e267dd6f4fd18b10bd0f12"
         },
         "3.11/i686-pc-windows-msvc/default": {
-          "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
+          "sha256": "30a4755ea3290e37b1ff8c146c4675031ec92aec2f722ea48c8f71ac3be91b70"
         },
         "3.11/x86_64-apple-darwin/default": {
-          "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
+          "sha256": "9038d161defcbedc0b723fa48f60890057d18a89167609d594299432f2e059f1"
         },
         "3.11/x86_64-pc-windows-msvc/default": {
-          "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
+          "sha256": "05272c1b0dce6ac310ec821872391da642a91278a33d0472df8bf57390e48239"
         },
         "3.11/x86_64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
+          "sha256": "bf1f2b630fed4b65b8fbee7971e7e50b36df3de506c7c5ae32aa3373651c4403"
         },
         "3.11/x86_64-unknown-linux-musl/default": {
-          "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.11.15",
-          "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
+          "sha256": "2e7b4c319eeebd0ebfc27cb55101d8afdcda6cea39b130ac5c266b291678ad1a"
         },
         "3.12/aarch64-apple-darwin/default": {
-          "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
+          "sha256": "377234f346fce41b6d3112b5ead89cb6af2d5596244f9edc1a739065770dde1f"
         },
         "3.12/aarch64-pc-windows-msvc/default": {
-          "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
+          "sha256": "27855a3b97c507d64b91b1380d67354b9a0a2eebff13ca70a325f3e9f819ed97"
         },
         "3.12/aarch64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
+          "sha256": "9e0349ac08f40e33151bb9693de762101541f07633dea61dbaca17d03290cb58"
         },
         "3.12/aarch64-unknown-linux-musl/default": {
-          "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
+          "sha256": "70e8dd52bb3e45c02167b230e1fa650bd7f17a153083cd1de071973a24f1ebda"
         },
         "3.12/i686-pc-windows-msvc/default": {
-          "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
+          "sha256": "fc8496f3e7778e65ed72f0063e738e2d81aeefa4b6fa017a8f327f954390937d"
         },
         "3.12/x86_64-apple-darwin/default": {
-          "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
+          "sha256": "b7ad42eef6a5729af319ba8a89eedd155e4d7c2a9884beff174a4c13e1286e68"
         },
         "3.12/x86_64-pc-windows-msvc/default": {
-          "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
+          "sha256": "10b7a95b928e551fc78cac665999e1ae1f08fb738b255adb0a8d3b9c2824a9c0"
         },
         "3.12/x86_64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
+          "sha256": "c710dd6b63e4df92f4c5b7b29ccad4276226a024a9017d5018f15321c7854af4"
         },
         "3.12/x86_64-unknown-linux-musl/default": {
-          "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.12.13",
-          "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+          "sha256": "8d72ce14c813f7d09912f7dddc79b4335c653f0aa6faac10b318a81ef7cafc9e"
         },
         "3.13/aarch64-apple-darwin/default": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "0103ab534b93472b1e2036fbb127a0dd4df73f437a4d8d7ce6fbe7e3d1f4fbbd"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
@@ -460,9 +577,9 @@
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
         "3.13/aarch64-pc-windows-msvc/default": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "f7d43d6afab4f08df78427015f4fb4ad231abcce472302e9a1f72cdf8bce908a"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -470,9 +587,9 @@
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
         "3.13/aarch64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "207c5504dfd2627949be652f2740bddab5ba6e6bea6ce45de9db1858f67c9b42"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
@@ -480,9 +597,9 @@
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
         "3.13/aarch64-unknown-linux-musl/default": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "19ccbf96c1083eb7550a13097f57d269b623dd5329c2a3489a994c8f67a684ee"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
@@ -490,9 +607,9 @@
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
         "3.13/i686-pc-windows-msvc/default": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "eb8c0733331f25eeb9dcd1c730b7cfe0e5d881689fe089b7c3d02d3d5412235f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -500,9 +617,9 @@
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
         "3.13/x86_64-apple-darwin/default": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "ca97cdd8338716dac48204f1b33e51ec4f072eeeb91cecdb9ea3bfecae1c538a"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
@@ -510,9 +627,9 @@
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
         "3.13/x86_64-pc-windows-msvc/default": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "eb1e212b97b001efc1281bb01fd26ca1ecdfe9ef2875b52c58d39e9719ab75df"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -520,9 +637,9 @@
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
         "3.13/x86_64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "4ecfaffe0db6d4363c2bca7a40f017c56fdad1f399d6218b7ddc1f47f071ffc6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
@@ -530,9 +647,9 @@
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
         "3.13/x86_64-unknown-linux-musl/default": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+          "sha256": "2bd8e7e85011ad8d8c0ff8238ad28c20781a69ad0d0737f6793901c10442b0d9"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
@@ -540,9 +657,9 @@
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
         "3.14/aarch64-apple-darwin/default": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "4703cdf18b26798fde7b49b6b66149674c25f97127be6a10dbcf29309bdcdcdb"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
@@ -550,9 +667,9 @@
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
         "3.14/aarch64-pc-windows-msvc/default": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "1f95ae489da15aa1341bc1b2628eee91069ea1385859514beaa123bc55a7fc78"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -560,9 +677,9 @@
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
         "3.14/aarch64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "be0f4dc2932f762292b27d46ea7d3e8e66ddf3969a5eb0254a229015ed402625"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
@@ -570,9 +687,9 @@
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
         "3.14/aarch64-unknown-linux-musl/default": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "b9baac091b6533512645e24132eeb7863bdd2389044ba37ffcda1faf6141fa4a"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
@@ -580,9 +697,9 @@
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
         "3.14/i686-pc-windows-msvc/default": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "33222fbcf1e83133bfde73ca916087363cdd479381b0239c2933e40fdd303ce4"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -590,9 +707,9 @@
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
         "3.14/x86_64-apple-darwin/default": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "76f1cc26e3d262eae8ca546a93e8bded10cf0323613f7e246fea2e10a8115eb7"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
@@ -600,9 +717,9 @@
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
         "3.14/x86_64-pc-windows-msvc/default": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "950c5f21a015c1bdd1337f233456df2470fab71e4d794407d27a84cb8b9909a0"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -610,9 +727,9 @@
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
         "3.14/x86_64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "0a73413f89efd417871876c9accaab28a9d1e3cd6358fbfff171a38ec99302f0"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
@@ -620,9 +737,9 @@
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
         "3.14/x86_64-unknown-linux-musl/default": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+          "sha256": "b92aa62170120fb7e404e408ea0da75c091050a8e165bdd4a69f46b79fd9c755"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
@@ -630,9 +747,9 @@
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
         "3.15/aarch64-apple-darwin/default": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "d0dc02141b1d3bb0f2a114e8ff598c794c4455b81b7f990bc2aebe49de7362bc"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
@@ -640,9 +757,9 @@
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
         "3.15/aarch64-pc-windows-msvc/default": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "54d5679f0420a790e574f4f2751672f78665b6176bbb2903070a801c77ac0eae"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -650,9 +767,9 @@
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
         "3.15/aarch64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "998384ee6d2265264e792f578b01f25c250ad7299943bde9e8895b4f492239cb"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
@@ -660,9 +777,9 @@
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
         "3.15/aarch64-unknown-linux-musl/default": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "08bd89c0840924b5c8d0061084425db5b73879bc005c4ff07dcf5f156e8f4c88"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
@@ -670,9 +787,9 @@
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
         "3.15/i686-pc-windows-msvc/default": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "67bec783c0e13067376cd74ecef3c60519324bfdc9b43c631a2be753d212c504"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -680,9 +797,9 @@
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
         "3.15/x86_64-apple-darwin/default": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "d1315f6376e2a578eba11afb8cf6418b1b9516e79dda27fc5cee10ed5ddd1b80"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
@@ -690,9 +807,9 @@
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
         "3.15/x86_64-pc-windows-msvc/default": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "e65685e02b25de039b71e05a19602bcec45548f516548224b0adb22841d34e3f"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
@@ -700,9 +817,9 @@
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
         "3.15/x86_64-unknown-linux-gnu/default": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "24104f5a01e717561094c5178114ec5eb85e28ca6a6c1d395eb96693a12c13d7"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
@@ -710,9 +827,9 @@
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
         "3.15/x86_64-unknown-linux-musl/default": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
+          "sha256": "d627acd34f891058f1292d0db29054613fc5d0fc9831751d3fc2877cbc831df9"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",

--- a/e2e/interpreter-build-config/check_interpreter.py
+++ b/e2e/interpreter-build-config/check_interpreter.py
@@ -1,0 +1,16 @@
+"""install_only_stripped provisions a regular (non-debug) 3.13 interpreter."""
+
+import sys
+
+
+def main():
+    assert sys.version_info[:2] == (3, 13), sys.version
+    # A stripped install_only build is a regular build: the debug-only
+    # sys.gettotalrefcount must be absent and the ABI must carry no flags.
+    assert not hasattr(sys, "gettotalrefcount"), "expected a non-debug interpreter"
+    assert sys.abiflags == "", "expected empty abiflags, got %r" % sys.abiflags
+    print("OK install_only_stripped:", sys.executable, sys.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/interpreter-build-config/root-debug-full-build-config/.bazelrc
+++ b/e2e/interpreter-build-config/root-debug-full-build-config/.bazelrc
@@ -1,0 +1,3 @@
+# Build without the bytes
+common:ci --remote_download_outputs=minimal
+common:ci --nobuild_runfile_links

--- a/e2e/interpreter-build-config/root-debug-full-build-config/.bazelversion
+++ b/e2e/interpreter-build-config/root-debug-full-build-config/.bazelversion
@@ -1,0 +1,1 @@
+../../../.bazelversion

--- a/e2e/interpreter-build-config/root-debug-full-build-config/BUILD.bazel
+++ b/e2e/interpreter-build-config/root-debug-full-build-config/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+# The only runtime coverage for a "-full" default mode: tar.zst extraction with
+# strip_prefix python/install, and abi_flags "d" flowing into the repo's
+# include/lib paths. Kept to one fixture because full archives are large
+# downloads.
+py_test(
+    name = "check",
+    srcs = ["check_debug_interpreter.py"],
+    main = "check_debug_interpreter.py",
+    python_version = "3.13",
+)

--- a/e2e/interpreter-build-config/root-debug-full-build-config/MODULE.bazel
+++ b/e2e/interpreter-build-config/root-debug-full-build-config/MODULE.bazel
@@ -1,0 +1,23 @@
+# Provisions a Py_DEBUG interpreter via build_config = "debug-full".
+# test.sh runs //:check and expects it to PASS.
+module(name = "root_debug_full_build_config")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(
+    build_config = "debug-full",
+    releases = ["20260303"],
+)
+interpreters.toolchain(python_version = "3.13")
+use_repo(interpreters, "python_interpreters")
+
+# Windows publishes no debug-full archive: the repo name must still exist (or
+# this use_repo would fail), but fetching it errors; test.sh asserts both.
+use_repo(interpreters, "python_3_13_x86_64_pc_windows_msvc")
+
+register_toolchains("@python_interpreters//:all")

--- a/e2e/interpreter-build-config/root-debug-full-build-config/check_debug_interpreter.py
+++ b/e2e/interpreter-build-config/root-debug-full-build-config/check_debug_interpreter.py
@@ -1,0 +1,15 @@
+"""debug-full provisions a Py_DEBUG 3.13 interpreter (ABI flag "d")."""
+
+import sys
+
+
+def main():
+    assert sys.version_info[:2] == (3, 13), sys.version
+    assert sys.abiflags == "d", "expected abiflags 'd', got %r" % sys.abiflags
+    # sys.gettotalrefcount only exists in Py_DEBUG builds.
+    assert hasattr(sys, "gettotalrefcount"), "expected a Py_DEBUG interpreter"
+    print("OK debug-full:", sys.executable, sys.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/interpreter-build-config/root-freethreaded-build-config/.bazelrc
+++ b/e2e/interpreter-build-config/root-freethreaded-build-config/.bazelrc
@@ -1,0 +1,3 @@
+# Build without the bytes
+common:ci --remote_download_outputs=minimal
+common:ci --nobuild_runfile_links

--- a/e2e/interpreter-build-config/root-freethreaded-build-config/.bazelversion
+++ b/e2e/interpreter-build-config/root-freethreaded-build-config/.bazelversion
@@ -1,0 +1,1 @@
+../../../.bazelversion

--- a/e2e/interpreter-build-config/root-freethreaded-build-config/BUILD.bazel
+++ b/e2e/interpreter-build-config/root-freethreaded-build-config/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/interpreter-build-config/root-freethreaded-build-config/MODULE.bazel
+++ b/e2e/interpreter-build-config/root-freethreaded-build-config/MODULE.bazel
@@ -1,0 +1,18 @@
+# Designed to FAIL extension evaluation: free-threaded build_config.
+# test.sh asserts the error message.
+module(name = "root_freethreaded_build_config")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(
+    # Free-threading is selected at build time, not via build_config.
+    build_config = "freethreaded+pgo+lto-full",
+    releases = ["20260303"],
+)
+interpreters.toolchain(python_version = "3.13")
+use_repo(interpreters, "python_interpreters")

--- a/e2e/interpreter-build-config/root-misordered-build-config/.bazelrc
+++ b/e2e/interpreter-build-config/root-misordered-build-config/.bazelrc
@@ -1,0 +1,3 @@
+# Build without the bytes
+common:ci --remote_download_outputs=minimal
+common:ci --nobuild_runfile_links

--- a/e2e/interpreter-build-config/root-misordered-build-config/.bazelversion
+++ b/e2e/interpreter-build-config/root-misordered-build-config/.bazelversion
@@ -1,0 +1,1 @@
+../../../.bazelversion

--- a/e2e/interpreter-build-config/root-misordered-build-config/BUILD.bazel
+++ b/e2e/interpreter-build-config/root-misordered-build-config/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/interpreter-build-config/root-misordered-build-config/MODULE.bazel
+++ b/e2e/interpreter-build-config/root-misordered-build-config/MODULE.bazel
@@ -1,0 +1,18 @@
+# Designed to FAIL extension evaluation: build_config tokens out of PBS's
+# canonical order. test.sh asserts the error message.
+module(name = "root_misordered_build_config")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(
+    # PBS publishes "pgo+lto-full"; the reversed spelling can never match.
+    build_config = "lto+pgo-full",
+    releases = ["20260303"],
+)
+interpreters.toolchain(python_version = "3.13")
+use_repo(interpreters, "python_interpreters")

--- a/e2e/interpreter-build-config/root-static-build-config/.bazelrc
+++ b/e2e/interpreter-build-config/root-static-build-config/.bazelrc
@@ -1,0 +1,3 @@
+# Build without the bytes
+common:ci --remote_download_outputs=minimal
+common:ci --nobuild_runfile_links

--- a/e2e/interpreter-build-config/root-static-build-config/.bazelversion
+++ b/e2e/interpreter-build-config/root-static-build-config/.bazelversion
@@ -1,0 +1,1 @@
+../../../.bazelversion

--- a/e2e/interpreter-build-config/root-static-build-config/BUILD.bazel
+++ b/e2e/interpreter-build-config/root-static-build-config/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/interpreter-build-config/root-static-build-config/MODULE.bazel
+++ b/e2e/interpreter-build-config/root-static-build-config/MODULE.bazel
@@ -1,0 +1,17 @@
+# Designed to FAIL extension evaluation: statically linked build_config.
+# test.sh asserts the error message.
+module(name = "root_static_build_config")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(
+    build_config = "lto+static-full",
+    releases = ["20260303"],
+)
+interpreters.toolchain(python_version = "3.13")
+use_repo(interpreters, "python_interpreters")

--- a/e2e/interpreter-build-config/root-unmatched-build-config/.bazelrc
+++ b/e2e/interpreter-build-config/root-unmatched-build-config/.bazelrc
@@ -1,0 +1,3 @@
+# Build without the bytes
+common:ci --remote_download_outputs=minimal
+common:ci --nobuild_runfile_links

--- a/e2e/interpreter-build-config/root-unmatched-build-config/.bazelversion
+++ b/e2e/interpreter-build-config/root-unmatched-build-config/.bazelversion
@@ -1,0 +1,1 @@
+../../../.bazelversion

--- a/e2e/interpreter-build-config/root-unmatched-build-config/BUILD.bazel
+++ b/e2e/interpreter-build-config/root-unmatched-build-config/BUILD.bazel
@@ -1,0 +1,1 @@
+# Intentionally empty: evaluating the module extension must fail first.

--- a/e2e/interpreter-build-config/root-unmatched-build-config/MODULE.bazel
+++ b/e2e/interpreter-build-config/root-unmatched-build-config/MODULE.bazel
@@ -1,0 +1,19 @@
+# Designed to FAIL extension evaluation: valid build_config that PBS never
+# publishes. test.sh asserts the error message.
+module(name = "root_unmatched_build_config")
+
+bazel_dep(name = "aspect_rules_py")
+local_path_override(
+    module_name = "aspect_rules_py",
+    path = "../../..",
+)
+
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.configure(
+    # 3.13 has free-threaded archives, but they must not mask the missing
+    # default mode: zero default-mode platforms is an eager failure.
+    build_config = "debug+lto-full",
+    releases = ["20260303"],
+)
+interpreters.toolchain(python_version = "3.13")
+use_repo(interpreters, "python_interpreters")

--- a/e2e/interpreter-build-config/test.sh
+++ b/e2e/interpreter-build-config/test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# These cases need their own root modules (build_config is hub-wide, and most
+# assert module-extension evaluation failures), so they cannot be sh_tests
+# under //...; CI runs this script directly.
+set -uo pipefail
+
+case_dir="$(cd "$(dirname "$0")" && pwd)"
+BAZEL="${BAZEL:-bazel}"
+failure_log="$(mktemp)"
+trap 'rm -f "$failure_log"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+expect_failure() {
+    local fixture="$1"
+    local expected="$2"
+    local target="${3:-@python_interpreters//:*}"
+
+    if (
+        cd "$case_dir/$fixture" &&
+            "$BAZEL" query --lockfile_mode=off -- "$target"
+    ) >"$failure_log" 2>&1; then
+        fail "$fixture unexpectedly succeeded"
+    fi
+    if ! grep -Fq "$expected" "$failure_log"; then
+        cat "$failure_log" >&2
+        fail "$fixture did not report: $expected"
+    fi
+}
+
+expect_success() {
+    local fixture="$1"
+    local target="$2"
+
+    if ! (
+        cd "$case_dir/$fixture" &&
+            "$BAZEL" test --lockfile_mode=off -- "$target"
+    ) >"$failure_log" 2>&1; then
+        cat "$failure_log" >&2
+        fail "$fixture failed"
+    fi
+}
+
+# The only runtime coverage for a "-full" default mode: tar.zst extraction
+# with strip_prefix python/install, and abi_flags "d" in the repo layout.
+expect_success \
+    root-debug-full-build-config \
+    //:check
+# Platforms the build_config doesn't cover still generate a repo name (so
+# use_repo() imports stay valid) but fail at load time with an explanation.
+expect_failure \
+    root-debug-full-build-config \
+    "No CPython 3.13 'debug-full' archive for x86_64-pc-windows-msvc" \
+    '@python_3_13_x86_64_pc_windows_msvc//:*'
+
+# The stub must not break eager fetching (`bazel fetch --all`, `bazel vendor`):
+# the repo materializes cleanly and only referencing its targets errors.
+if ! (
+    cd "$case_dir/root-debug-full-build-config" &&
+        "$BAZEL" fetch --lockfile_mode=off --repo=@python_3_13_x86_64_pc_windows_msvc
+) >"$failure_log" 2>&1; then
+    cat "$failure_log" >&2
+    fail "unavailable-interpreter stub is not eagerly fetchable"
+fi
+
+# build_config must not affect the free-threaded axis: the hub still registers
+# free-threaded toolchains alongside the debug-full default mode.
+if ! (
+    cd "$case_dir/root-debug-full-build-config" &&
+        "$BAZEL" query --lockfile_mode=off -- '@python_interpreters//:*'
+) >"$failure_log" 2>&1; then
+    cat "$failure_log" >&2
+    fail "querying the toolchain hub failed"
+fi
+if ! grep -Fq "python_3_13_x86_64_unknown_linux_gnu_freethreaded" "$failure_log"; then
+    cat "$failure_log" >&2
+    fail "debug-full hub does not register free-threaded toolchains"
+fi
+
+# Tokens in canonical order matter: manifests publish "pgo+lto-full", never
+# "lto+pgo-full", so the misordered spelling must be rejected at parse time
+# rather than silently matching zero assets.
+expect_failure \
+    root-misordered-build-config \
+    "Unrecognized PBS build_config 'lto+pgo-full'"
+expect_failure \
+    root-static-build-config \
+    "build_config 'lto+static-full' selects a statically linked libpython"
+expect_failure \
+    root-freethreaded-build-config \
+    "build_config 'freethreaded+pgo+lto-full' must not select free-threading"
+# "debug+lto-full" parses (tokens are in canonical order) but PBS never
+# publishes it, so no platform matches. 3.13's free-threaded archives must not
+# mask the empty default mode, and the failure must point at build_config as
+# the likely cause, not only at the release list.
+expect_failure \
+    root-unmatched-build-config \
+    "No CPython 3.13 'debug+lto-full' archives found for any platform"
+expect_failure \
+    root-unmatched-build-config \
+    "PBS publishes build_config 'debug+lto-full' only for some version/platform combinations"
+
+echo "PASS: build_config provisions -full runtimes and is validated with actionable errors"

--- a/e2e/interpreter-input-validation/MODULE.bazel.lock
+++ b/e2e/interpreter-input-validation/MODULE.bazel.lock
@@ -318,1060 +318,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/e2e/interpreter-toolchain-settings/MODULE.bazel.lock
+++ b/e2e/interpreter-toolchain-settings/MODULE.bazel.lock
@@ -318,406 +318,406 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/e2e/rules-proto-grpc-python/MODULE.bazel.lock
+++ b/e2e/rules-proto-grpc-python/MODULE.bazel.lock
@@ -544,1060 +544,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     },

--- a/e2e/rules-python-interop/.bazelversion
+++ b/e2e/rules-python-interop/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/rules-python-interop/MODULE.bazel.lock
+++ b/e2e/rules-python-interop/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 28,
+  "lockFileVersion": 24,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -9,38 +9,21 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
-    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
-    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
-    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
-    "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
-    "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
-    "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
-    "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
-    "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
-    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.24.0/MODULE.bazel": "4796b4c25b47053e9bbffa792b3792d07e228ff66cd0405faef56a978708acd4",
-    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
-    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
-    "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
-    "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
@@ -63,26 +46,21 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
-    "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
-    "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/MODULE.bazel": "f1b7bb2dd53e8f2ef984b39485ec8a44e9076dda5c4b8efd2fb4c6a6e856a31d",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.7/MODULE.bazel": "1e5e03c383fa64ebbe0942a225c32168fd6ef6b270351bbec481d47d19d1b96d",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.7/source.json": "34a83d58ae2f1ef6731d1fc8a1b6f07825741aff3f5993b67b67ec21d2c2946e",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
-    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
-    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
-    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
     "https://bcr.bazel.build/modules/hermetic_launcher/0.0.11/MODULE.bazel": "aba15d5a4745cedcb4750faf0c49f946d004ccb09475b6ade1dea4efe0399d82",
     "https://bcr.bazel.build/modules/hermetic_launcher/0.0.11/source.json": "0c4d45a10e956dc30c7278de756c81d4b55612218b1a20fa55fc2988063ba4eb",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
-    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
-    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
     "https://bcr.bazel.build/modules/package_metadata/0.0.3/MODULE.bazel": "77890552ecea9e284b5424c9de827a58099348763a4359e975c359a83d4faa83",
     "https://bcr.bazel.build/modules/package_metadata/0.0.3/source.json": "742075a428ad12a3fa18a69014c2f57f01af910c6d9d18646c990200853e641a",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
@@ -92,7 +70,6 @@
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
-    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
     "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
     "https://bcr.bazel.build/modules/platforms/1.1.0/MODULE.bazel": "1c0c09f5bdcf4b3f924720d2478a3711cb39f4977019ca5988685e5b7e18b3d2",
     "https://bcr.bazel.build/modules/platforms/1.1.0/source.json": "fcf351c47596c939140ab0d333dfdd08ed1ea6ce33c2fe70c12493a301cf1344",
@@ -101,26 +78,19 @@
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
-    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
-    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
-    "https://bcr.bazel.build/modules/protobuf/33.4/MODULE.bazel": "114775b816b38b6d0ca620450d6b02550c60ceedfdc8d9a229833b34a223dc42",
-    "https://bcr.bazel.build/modules/protobuf/33.4/source.json": "555f8686b4c7d6b5ba731fbea13bf656b4bfd9a7ff629c1d9d3f6e1d6155de79",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
     "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
-    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
-    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
-    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
-    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
-    "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
-    "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
@@ -129,37 +99,37 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
-    "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
     "https://bcr.bazel.build/modules/rules_cc/0.2.18/MODULE.bazel": "4460ec36adc8f722a6a2a4ac9374cb91f2acebadaa93fc37966129afb3dece87",
     "https://bcr.bazel.build/modules/rules_cc/0.2.18/source.json": "abad668ff2fd63ada1ac49bf386d37e27048b89a3465a6fd968bb832b00a09d3",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
     "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
     "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.0/MODULE.bazel": "9c064c434606d75a086f15ade5edb514308cccd1544c2b2a89bbac4310e41c71",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
-    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
@@ -172,43 +142,30 @@
     "https://bcr.bazel.build/modules/rules_pkg/1.1.0/source.json": "fef768df13a92ce6067e1cd0cdc47560dace01354f1d921cfb1d632511f7d608",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
-    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
-    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
-    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
     "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
     "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
-    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
     "https://bcr.bazel.build/modules/rules_python/1.0.0/MODULE.bazel": "898a3d999c22caa585eb062b600f88654bf92efb204fa346fb55f6f8edffca43",
-    "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
-    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
-    "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
-    "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
     "https://bcr.bazel.build/modules/rules_python/1.9.0/MODULE.bazel": "afc3a05f29f09f2d3ee95ad99a145250dab41a2b2d8d6f82cc91936b3213282c",
     "https://bcr.bazel.build/modules/rules_python/1.9.0/source.json": "3921ea0b65298d51aead5b9e4a82203d7be9b5918619b58b53f1c259f4e63169",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
-    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
-    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
-    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
-    "https://bcr.bazel.build/modules/rules_swift/2.4.0/MODULE.bazel": "1639617eb1ede28d774d967a738b4a68b0accb40650beadb57c21846beab5efd",
-    "https://bcr.bazel.build/modules/rules_swift/3.1.2/MODULE.bazel": "72c8f5cf9d26427cee6c76c8e3853eb46ce6b0412a081b2b6db6e8ad56267400",
-    "https://bcr.bazel.build/modules/rules_swift/3.1.2/source.json": "e85761f3098a6faf40b8187695e3de6d97944e98abd0d8ce579cb2daf6319a66",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
-    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
-    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "75aab2373a4bbe2a1260b9bf2a1ebbdbf872d3bd36f80bff058dccd82e89422f",
-    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
     "https://bcr.bazel.build/modules/tar.bzl/0.10.1/MODULE.bazel": "bf5fda5b5ccef8c3c4a5f4886144377386e0baa382972f257acb42dcf40ea908",
     "https://bcr.bazel.build/modules/tar.bzl/0.10.1/source.json": "3f1beb35acf53c270a9de493cdc775a985551d7069cfcf24e136b42f683bbb10",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
@@ -225,10 +182,9 @@
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
         "usagesDigest": "9blYmJygEZWQR5a/Myvp61XErKXTzb80Gu2XjdU/ml4=",
-        "recordedInputs": [
-          "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
-          "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
-        ],
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
         "generatedRepoSpecs": {
           "aspect_tools_telemetry_report": {
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
@@ -239,38 +195,28 @@
               }
             }
           }
-        }
-      }
-    },
-    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "NRXra7941UfmNUyIxnLt82V5hULluVGL2nBsijTl4j4=",
-        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
-        "recordedInputs": [
-          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
-          "FILE:@@pybind11_bazel+//MODULE.bazel e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
-        ],
-        "generatedRepoSpecs": {
-          "pybind11": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
-              "strip_prefix": "pybind11-2.12.0",
-              "urls": [
-                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
-              ]
-            }
-          }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_tools_telemetry+",
+            "bazel_lib",
+            "bazel_lib+"
+          ],
+          [
+            "aspect_tools_telemetry+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ]
+        ]
       }
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "+Kp6j204mBZ3mxlIDDR0gBoP45BZ4jYRhRAcB8sU0qc=",
+        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
-        "recordedInputs": [
-          "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
-        ],
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
         "generatedRepoSpecs": {
           "com_github_jetbrains_kotlin_git": {
             "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
@@ -318,17 +264,23 @@
               ]
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "yG9F6L2IZXKRbD/aIUa6sU7uITLUTBKOMWPbIvl1VdM=",
+        "bzlTransitiveDigest": "xMgnVVV6SeyGCaYQT+4rYddx63q6+JXtyCrlLeA8OLM=",
         "usagesDigest": "6MjoD3H+netDdhklgMWks3NARpHVXxy8kfsMe9XXPa8=",
-        "recordedInputs": [
-          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
-          "REPO_MAPPING:rules_python+,platforms platforms"
-        ],
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
         "generatedRepoSpecs": {
           "uv": {
             "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
@@ -348,1069 +300,1080 @@
               "toolchain_target_settings": {}
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_python+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_python+",
+            "platforms",
+            "platforms"
+          ]
+        ]
       }
     }
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }
-  },
-  "factsVersions": {}
+  }
 }

--- a/examples/debugger/MODULE.bazel.lock
+++ b/examples/debugger/MODULE.bazel.lock
@@ -325,1060 +325,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/dev_deps/MODULE.bazel.lock
+++ b/examples/dev_deps/MODULE.bazel.lock
@@ -325,1060 +325,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/django/MODULE.bazel.lock
+++ b/examples/django/MODULE.bazel.lock
@@ -318,1060 +318,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/multi_version/MODULE.bazel.lock
+++ b/examples/multi_version/MODULE.bazel.lock
@@ -318,1060 +318,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/protobuf/MODULE.bazel.lock
+++ b/examples/protobuf/MODULE.bazel.lock
@@ -352,1060 +352,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/py_binary/MODULE.bazel.lock
+++ b/examples/py_binary/MODULE.bazel.lock
@@ -318,1060 +318,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/py_pex_binary/MODULE.bazel.lock
+++ b/examples/py_pex_binary/MODULE.bazel.lock
@@ -318,1060 +318,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/py_venv/MODULE.bazel.lock
+++ b/examples/py_venv/MODULE.bazel.lock
@@ -318,1060 +318,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/pytest/MODULE.bazel.lock
+++ b/examples/pytest/MODULE.bazel.lock
@@ -318,1060 +318,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/uv_pip_compile/MODULE.bazel.lock
+++ b/examples/uv_pip_compile/MODULE.bazel.lock
@@ -523,1060 +523,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/examples/virtual_deps/MODULE.bazel.lock
+++ b/examples/virtual_deps/MODULE.bazel.lock
@@ -318,1060 +318,1060 @@
   },
   "facts": {
     "@@aspect_rules_py+//py:extensions.bzl%python_interpreters": {
-      "release_index_v1_20241002_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20241002_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "bcfdf8235cd4f84ca280f33a17030e65ba23e7905e70a8ed2ed2c83229ad136f"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "2e364a47cdbfcfaf56122b7656a3e8a7163babbda4f6bb6165aa644cbc65bd57"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "814561a8addee5f56a19223ecdd879a22b82d631bd5704eac7b2e98287e797a8"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "35678c2ba6d7aff56ca96f06ca735fe4bd09e4a5d3d40f552d76a1653c80a123"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "422fb92c310f030b05ca8e59a256c72ffde38f03382a006284d9e5e2a7b646f5"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "f17cba68a55dcd386be4cbb0002cf3037718019fc1585b2ff9a32efd3283557d"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.15+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.15",
           "sha256": "7b2baf761282600359d43e6f14b01437a8d0e517ba3a28f50688806dd8897b11"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "540225743ca9ca04d7e0de520e211ecafb379677c49fba4b89334e7248219cb2"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "047e687b561f8e38740819cc3e112e83ae349927cca846921a1c301e5d9cc873"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d9e75d5028c8975c158f4b9c01ef820480249b3401dbde755c0f344e15feebf5"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "f498693f03fd672a4dc581ef0e1101102d33964352c35ecff21686a8d00744c9"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "d71cde066b614903e9f243c4babd179e7e978fcfa95702355566463e623abe6c"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "9c0197e72b2dd1ebf56eb562cb7a078052b4ab71d5666cd3be3b6e75db42c79e"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.10+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.10",
           "sha256": "fb86dce628d2008eefd3550193839fb9f283f5f6c25a09c8b676713ff4757156"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5a9cdbb8536839a83edae3e41eb44161b640d78181fec083e07c668ba796a875"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "5481ca52e7ac8685c1e9d4e804a66e5c928879e0f44799aa6934735f66266643"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "8c62920e2fef022fc49d58cc999c77ea45318f96a5a5c0ba3bb155d33732d7f3"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "60eaf2c9a63926f5edfe7a0ecf4b2fbb37de6764f0c0100be245d098e3995da7"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "1c74dd0499ef7d993d8942ebe6692c90c50d09719e0335f8e210b91277f8e7c0"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "04ffccbbb1beedd0bc80347c061fe527833001681ee543c3ba85dac5134ed500"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.7+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.7",
           "sha256": "d4a8f2b3e422089475bcd6f2b855c9ed0e666af2de4f19df7c764362eb8c4aca"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
+        "3.13/aarch64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "577e846eaf0a27342b3f80b5f292eb292b0eb6a9df3a0fa0c5925e86cfe046a3"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
+        "3.13/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "48974ab9b4a6990b17e6740393492fc5557e6acc4ab02be9d9543e0e506e48a6"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
+        "3.13/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "fa5e8195fa7a6b6d4df0bc92b36d38836b72c4f5fb41978d495abe5a454fed67"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
+        "3.13/x86_64-apple-darwin/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "81a01923b25a4b2b68f517b07a4a4a9186d873e6518f060e4a004e77d7094687"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
+        "3.13/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "319ecb727317868c4f3bfecd480f216b38275f5373f72c022d255318b650ebe2"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
+        "3.13/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "a4b4e0a79b53938db050daf7f78dd09faf49d1e29dbba6cac87cf857c0a51fb4"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
+        "3.13/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.13.0rc3+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.0rc3",
           "sha256": "56fac98fb5ed39f67cd7c0ce6e503a1e551ce727dc46796a0f16c09d26e845aa"
         },
-        "3.8/aarch64-apple-darwin/install_only": {
+        "3.8/aarch64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "2ddfc04bdb3e240f30fb782fa1deec6323799d0e857e0b63fa299218658fd3d4"
         },
-        "3.8/aarch64-unknown-linux-gnu/install_only": {
+        "3.8/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "9d8798f9e79e0fc0f36fcb95bfa28a1023407d51a8ea5944b4da711f1f75f1ed"
         },
-        "3.8/i686-pc-windows-msvc/install_only": {
+        "3.8/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "06988218600fe3e2c02c3182d5629a1d4e596b3771ab32a9e99756c5904b5fac"
         },
-        "3.8/x86_64-apple-darwin/install_only": {
+        "3.8/x86_64-apple-darwin/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "68d060cd373255d2ca5b8b3441363d5aa7cc45b0c11bbccf52b1717c2b5aa8bb"
         },
-        "3.8/x86_64-pc-windows-msvc/install_only": {
+        "3.8/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "41b6709fec9c56419b7de1940d1f87fa62045aff81734480672dcb807eedc47e"
         },
-        "3.8/x86_64-unknown-linux-gnu/install_only": {
+        "3.8/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "285e141c36f88b2e9357654c5f77d1f8fb29cc25132698fe35bb30d787f38e87"
         },
-        "3.8/x86_64-unknown-linux-musl/install_only": {
+        "3.8/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.8.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.8.20",
           "sha256": "ea8d7f9dd35815cf88f5ed257b5d0206d97df5a9500f719b6a6031b8c7071db8"
         },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "dc5f3b4c54deea7a42479b3f81b1c1b3a330f721aea3aff7df9833567bbfa8ea"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "0d84fa0884e843828312a1fcbfd8756abe3d6cf3c27086f79cd7352bad13ac4c"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "bd2c7cf4d7eba224ada44dfbccf5248d313ba5072462c71aa753c824354704f3"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "a07be8fddd5f6f6a0db7abd16f2b2a8a94a891e54091e4f45b64e822597e4d7d"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "94000af8e9d9f5aba6d2325963a6b3403afbf310f6790edff3dfe8becd8197de"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "fec849569158e5e46610621d7da91b02dca2cc5f66dd49cc0f85d7469c8f5a84"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.20+20241002-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.20",
           "sha256": "31f5e329f14ac8b79527712c4265edfea1cb6dff4bb04cf8c51cd809290e136c"
         }
       },
-      "release_index_v1_20251031_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20251031_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "43bda24c2fc073bc308bf631203b917a72640d59b59fdad4ba14503d84727012"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "f77a8a8aa77f3f943126fa9215a25309da4bf20398fc8f4b4eec54b5fc7570ef"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "9b9deba652d98857ae99bd11b05fb560144aafbd9b9e8e01c8c6d56577a06a4d"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "0240edca85508661e20bb69562686965c85b8328727332d9ebfd57cceb7fb372"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "76c12e633c09c2a790f8a958a55df4495527e0718d1875310c836e757c0c7b55"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "cfa08a4caf2df1b43551b843c052d6a8814e2ea0c97268b021f0423646c244c3"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "fb1caac917d7b6497bb6f5950da5f1e48d05c43a498948dd97f85760c4382d9f"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.19+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.19",
           "sha256": "ba85013ed5ac7733fc6840168cc33ed19e9959b363dc80227d54f8fd9c92c0f4"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "6de5572b33c65af1c9b7caf00ec593fb04cffb7e14fa393a98261bb9bc464713"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "38d0d1466561e15965e8d2c20f5e5be649598f55c761ecab553d087fbd217337"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "510edb027527413c4249256194cb8ad2590b52dd93f7123b4cb341aff5d05894"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "27609ec2b0c6172d5d9f502115a6d48c20ee0a578bf5b0470cd1090be95c22aa"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "b4341ef60bc157f992a0d171f1be4e4c42dcfc537f3562f72aa7f1f9561935e0"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "4891cbf34e8652b7bd1054b9502395e4b7e048e2e517c040fbf6c8297cb954d6"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "5223b83ed9e2aa5e9e17d2ebcf767956e998876339b9cde1980a47e9d4655fb6"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "60f0bd473d861cc45d3401d9914e47ccb9fa037f88a91879ed517a62042b8477"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.14+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.14",
           "sha256": "25e82d1e85b90a8ab724ee633a1811b1921797f5c25ee69c6595052371b91a87"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "5e110cb821d2eb8246065d3b46faa655180c976c4e17250f7883c634a629bc63"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "b190fed7c2b0f6e1010f554a0d1fd191c0754c4c0718e69d9d795ae559613780"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "81b644d166e0bfb918615af8a2363f8fcf26eccdcc60a5334b6a62c088470bac"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "fc423af42f4eb454c99779d9eedc619141606572da3851f7980a8da719f0f8db"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "7d333e58a53edb1ba3c85bb35dc718ea3e599d0f6b58a0cbef35b2d8184a763e"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "687052a046d33be49dc95dd671816709067cf6176ed36c93ea61b1fe0b883b0f"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "cff398b3f520c442a1b085dd347126c10c1b03f01ccc0decd8c897a687e893f1"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "80c3882f14e15cef8260ef5257d198e8f4371ca265887431d939e0d561de3253"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.12+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.12",
           "sha256": "0a461330b9b89f2ea3088dde10d7a3f96aa65897b7c5ce2404fa3b5c4b8daa14"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.9",
+          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "eae1272a72ccce601590a10a9ca2a58199b5fcdf022aa603a527e3e2a04de9bc"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "1f3568d17383426d52350c2ef7c93c1a5a043198b860cb05e5d19b35f9c25cef"
+          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "743ff69935ef28834621647dab30f032dfcd80315732917531eea333210941c7"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "20db43873d3c4c2175d866806545e4ad4ec6bb72ca95e60082a4df6c24567e8c"
+          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6e72f9de5d9b46cf6968d6a492f2401a919f9b959f8da2d87f43484b80169ee"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "0a56d11b0fb1662e67f892b9d5d1717aef06f24dbb8362bc25b8f784e620d44e"
+          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "ba6a8d199c9f2a7aa5b88fdf16132049d675ab483eb6250e176a90fa0726eac4"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "90c803b66f8483caeeb5655ca82b7f19068515826a569ed05414326a6ff8d06d"
+          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "a6cb3d7df191cde663ebf5f0108a9d7742e33862676ecde97fd90184333e822d"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "c0b0a34a492465bd44e9512582ae4ca47c06f9696807048cd917cb71c03a8416"
+          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "e2bf5fa6a3ef443ade362e08b0a19bbc172f7bfe34dabe933ccaad31d53af5da"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "48c0f3ca5d31e90658ef99138dc21865bb62f388ab97a1ce72cac176da194ab0"
+          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "318a9a1e43dd52054327de3bccc0c5b7afde7b7f2a398ccb4d38e03d28b05386"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "874593f641f31ea101440c70f81768c35d4d7d6df111fde63094db67465ef787"
+          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "dcc29b069d0588fbd4ea29c6df840c8d1207d2a3bce8cd5cd57d1b85373b6048"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.9",
-          "sha256": "6f05b91ee8c7e6dd0f9c60b95bb29130e2d623961de6578b643e80ddd83f96b6"
+          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.9",
           "sha256": "4c5c9a251a45288ebd4a51900708eb2ada9197173ba56e5604b6b63727fb87ff"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.9+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.9",
-          "sha256": "ad987197034185e628715da504a50613af213dc21ba6d5ccaeab3db2c464aa6c"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.0",
+          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "d9c7b430b25bd3837dbb03f945dbe6b7bc526c5940ca96f5db7cdc42f6b2b801"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "b4bcd3c6c24cab32ae99e1b05c89312b783b4d69431d702e5012fe1fdcad4087"
+          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "40266e60f655e49cd1d5303295255909a4b593b08b88be6e6a55b2c9fe6ed13d"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "599a8b7e12439cd95a201dbdfe95cf363146b1ff91f379555dafd86b170caab9"
+          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f383ef50d1da6ca511212e5ae601923b56636b87351fd5fc847e0ea0a19fa9b3"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "128a9cbfb9645d5237ec01704d9d1d2ac5f084464cc43c37a4cd96aa9c3b1ad5"
+          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "33c7aa105634102c61b8ad01c801dbaf1950e59c04a876b72004cf4fbcfc6e33"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "e850ffb10a13cf16fb6ee08989e53532b606e7e96045ee65f7a3f41a9de14010"
+          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "c47e0e4fd3a2d334a9f3df1d40fd9a7a8f743572dbd798b68fe5a6361c399806"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "35703b8b813afd37036ec88973c0f5a7626ee0dd48544a1c69cddeee994b5274"
+          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b3196f6b57bbb3dc2ee07f348f1d51117ffa376979eceafbf50c15f0f7980bf8"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "4e71a3ce973be377ef18637826648bb936e2f9490f64a9e4f33a49bcc431d344"
+          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "b81de5fc9e783ea6dfcf1098c28a278c874999c71afbb0309f6a8b4276c769d0"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "39acfcb3857d83eab054a3de11756ffc16b3d49c31393b9800dd2704d1f07fdf"
+          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "f4acbef0fbfaf7ab31ac63986da1d93dfa1c5cb797de1dcdc1a988aa18670120"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.0",
-          "sha256": "3dec1ab70758a3467ac3313bbcdabf7a9b3016db5c072c4537e3cf0a9e6290f6"
+          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.0",
           "sha256": "9e18302759734fb14694efb0418e7291c8d590d880abc2da1d7e6f14ac9a381d"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.0+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.0",
-          "sha256": "d0a2a6d3b1bb00dce2105377fda8aa79675d187f8d6d7010a42f651af25018dc"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a1",
+          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "12f1b16be4017181ad67904caf9e59e525b9b5d62f49105017d837e27b832959"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "3acf7aa3559b746498b18929456c5cacb84bae4e09249834cbc818970d71de87"
+          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "54ca78dae455ece6fefbd7f5f287cc55d5ce197caf51921f6d871d15069d9489"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1508bcd7195008479ed156aad3afbb3a3793097ed530690f0304a8107f0e53e8"
+          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "981fe8dfc6e7e1d0ffefa945a18d5c4c759bbe21722acf3a5cc7e62f16aa5f3c"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "d55c2aeece827e6bec83fd18515ee281d9ea0efaa3e2d20130db8f1c7cbb71c6"
+          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "017cd58a8e6d93a8d60453899d4bac6f540414003ec9a73dc106c20045d542ee"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "abbd20235411d7cc24cba48ac519324b8bb71a52e05b26e7012de815e43d6e73"
+          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "9f4bc934ef9c56e6d1d7263949430cecc19d301fa4cad74fcd36c9b3c6a7ba01"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "6ffdbe54c45d0a9c309498f65c5ddf3de587c84aee89a227836f42b4e7e25691"
+          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "64fc29e6c7a2f02a18645d968f1b3fc1d00d12a5ef3fcbb0d077fa8c62c08904"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "0ab19d3ac25f99da438b088751e5ec2421f9f6aa4292fd2dc0f8e49eb3e16bdf"
+          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "34abc5603e1b4131f753d29b7deac865b9277912b851cbed5a149cf3e6745d3d"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "5f5d6bec2b381cfc771c49972d2a6f7b7e7ab6a1651d8fb6ef3983f3571722b3"
+          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "0e0272186d9f5169394dbc4d4d72a3f4a5762a04c2e5ac2ab1e23aa41fc8538a"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a1",
-          "sha256": "1f356288c2b2713619cb7a4e453d33bf8882f812af2987e21e01e7ae382fefba"
+          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a1",
           "sha256": "621ac3b8b8afa1593d63fb130dadc6eec2bd9e3603d6c028efe60146e05ec430"
         },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a1+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a1",
-          "sha256": "caf5311f333eef082dd69a669ca65aceba09a08fc1e78aad602ad649106f294c"
-        },
-        "3.9/aarch64-apple-darwin/install_only": {
+        "3.9/aarch64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "87275619c2706affa4d1090d2ca3dad354b6d69f8b85dbfafe38785870751b9a"
         },
-        "3.9/aarch64-unknown-linux-gnu/install_only": {
+        "3.9/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "6112d46355857680b81849764a6cf9f38cc4cd0d1cf29d432bc12fe5aeedf9d0"
         },
-        "3.9/aarch64-unknown-linux-musl/install_only": {
+        "3.9/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "f4d8eb93c54cbf7dc37d5599748582d91c268c60008f17daf19c0ad183ec78ab"
         },
-        "3.9/i686-pc-windows-msvc/install_only": {
+        "3.9/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "5056f28d59653a6bddcc8007f024af00147a7e6f82e797f073a59f16a5cacc19"
         },
-        "3.9/x86_64-apple-darwin/install_only": {
+        "3.9/x86_64-apple-darwin/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "ace63cfe27a9487c4d72e1cb518be01c1d985271da0b2158e813801f7d3e5503"
         },
-        "3.9/x86_64-pc-windows-msvc/install_only": {
+        "3.9/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "4fb1b416482ce94d73cfa140317a670c596c830671d137b07c26afe8c461768a"
         },
-        "3.9/x86_64-unknown-linux-gnu/install_only": {
+        "3.9/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "42834f61eb6df43432c3dd6ab9ca3fdf8c06d10a404ebdb53d6902e6b9570b08"
         },
-        "3.9/x86_64-unknown-linux-musl/install_only": {
+        "3.9/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.9.25+20251031-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.9.25",
           "sha256": "76593e8c889e81e82db5fe117fe15b69466f85100ab2ec0e4035aa86242b4e93"
         }
       },
-      "release_index_v1_20260303_https://github.com/astral-sh/python-build-standalone/releases/download": {
-        "3.10/aarch64-apple-darwin/install_only": {
+      "release_index_v2_20260303_https://github.com/astral-sh/python-build-standalone/releases/download_install_only": {
+        "3.10/aarch64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "b41060c26454b21990254fdc08a4988f4e325708d785f8a0b4b4533881cf5fd4"
         },
-        "3.10/aarch64-unknown-linux-gnu/install_only": {
+        "3.10/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "dcf3b9bd0062276866b4fc84c9e4c39be7ef161d22c769e5f4ee01c8e27100f4"
         },
-        "3.10/aarch64-unknown-linux-musl/install_only": {
+        "3.10/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "92713c7f4a7bb77bf8593818e4c1da8db44d415f45b0b5b7a8eb741695c08303"
         },
-        "3.10/i686-pc-windows-msvc/install_only": {
+        "3.10/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "9bc6cd476a2670a054dc8dbdd22c5b7c7642ac2f0ac810c5bb18aa39083a8a99"
         },
-        "3.10/x86_64-apple-darwin/install_only": {
+        "3.10/x86_64-apple-darwin/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "2fd25586216e5e6932d767034618b7bb97654c689f07513009d858398fe181f3"
         },
-        "3.10/x86_64-pc-windows-msvc/install_only": {
+        "3.10/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "aa55177f1247cdac1ccdf0877cdf68e9d6718b0914e56f1083404b1dcbac847b"
         },
-        "3.10/x86_64-unknown-linux-gnu/install_only": {
+        "3.10/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c830fc25bc6e318e7ad4961caadee6cc79c041c122884c90ecfad4fe02e20344"
         },
-        "3.10/x86_64-unknown-linux-musl/install_only": {
+        "3.10/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.10.20+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.10.20",
           "sha256": "c781a93c1030c814bc0861dc424c476ca2e0083b429b968f557e1664f3ef223f"
         },
-        "3.11/aarch64-apple-darwin/install_only": {
+        "3.11/aarch64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "0d29ed7cb6711890b3c6da27b6258c4ad3b506bf8d5a381bff531ca8fa67417f"
         },
-        "3.11/aarch64-pc-windows-msvc/install_only": {
+        "3.11/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "84afaa698da2bc12f05aa317ad1ad6bf6708461e737efd08ad7e95d9a8857c1b"
         },
-        "3.11/aarch64-unknown-linux-gnu/install_only": {
+        "3.11/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "4786f5ef8567c982517fcd7cb189a5ef4a712ed0aaf3034e839749794155ad4c"
         },
-        "3.11/aarch64-unknown-linux-musl/install_only": {
+        "3.11/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "d37ebd873138f85603607a56bc821e07551f45e6938e02d36b04885a6eded7ff"
         },
-        "3.11/i686-pc-windows-msvc/install_only": {
+        "3.11/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "1924013f72c36c8d19d6887979cded6ca7f2295667d591b88f74260f141e1fee"
         },
-        "3.11/x86_64-apple-darwin/install_only": {
+        "3.11/x86_64-apple-darwin/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6ea2168c4e18cb31d9dc8486634dc375929bcc2adde0957399ce59d90b52297a"
         },
-        "3.11/x86_64-pc-windows-msvc/install_only": {
+        "3.11/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "6f194e1ede02260fd3d758893bbf1d3bb4084652d436a8300a229da721c3ddf8"
         },
-        "3.11/x86_64-unknown-linux-gnu/install_only": {
+        "3.11/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "17e1f5b2c9668217ba554decd94db04adf3d085203d322c690fd44cde549d576"
         },
-        "3.11/x86_64-unknown-linux-musl/install_only": {
+        "3.11/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.11.15+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.11.15",
           "sha256": "ee54c7baaa5a1fb65922505a646a2d097660b005e55bd35055d0a9c46a5ab916"
         },
-        "3.12/aarch64-apple-darwin/install_only": {
+        "3.12/aarch64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2c01f29e9e4ddbd57e0319fedecf1f3e222558fce394a3ed4e39d0f750c11988"
         },
-        "3.12/aarch64-pc-windows-msvc/install_only": {
+        "3.12/aarch64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "f003d15139e0baa39563388b7e29c44a6c4dda3987dbd7cec2050eca32450d4f"
         },
-        "3.12/aarch64-unknown-linux-gnu/install_only": {
+        "3.12/aarch64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "15c00b489fb89c7e3dc433800cd8b932ab3f8825870c1919fbe747f493edf81d"
         },
-        "3.12/aarch64-unknown-linux-musl/install_only": {
+        "3.12/aarch64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "2e3e3fc934a597c5c0e95fe9093a89cd6d3e248f9d3f6a0e82dbfa923499bd9d"
         },
-        "3.12/i686-pc-windows-msvc/install_only": {
+        "3.12/i686-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "af220242f3d2bebff6b9a01666895bb7198d7e4be608752f7e4007dd0fddfa22"
         },
-        "3.12/x86_64-apple-darwin/install_only": {
+        "3.12/x86_64-apple-darwin/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "8ad52a15de26e67d53f5c14f338433c59d5a2711852adc59043a20ec8da71a52"
         },
-        "3.12/x86_64-pc-windows-msvc/install_only": {
+        "3.12/x86_64-pc-windows-msvc/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "43990976c8de6b72a7525cb509eedaf869a8dd116167e708af08bca50cd8ef00"
         },
-        "3.12/x86_64-unknown-linux-gnu/install_only": {
+        "3.12/x86_64-unknown-linux-gnu/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4e5ac5a04afc4fe164e92e3844d6dbda03b33baeb62e032b5c9a8198280221e2"
         },
-        "3.12/x86_64-unknown-linux-musl/install_only": {
+        "3.12/x86_64-unknown-linux-musl/default": {
           "filename": "cpython-3.12.13+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.12.13",
           "sha256": "4099347cfb11427ceb6fe40d1b9f2af9fee3a3a8915df0e439e13dfbe948b91e"
+        },
+        "3.13/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.13.12",
+          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
         },
         "3.13/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d152a8ec3a31a7b49772e70ff7fed1e7f6ec721497151b104532957744703d86"
         },
-        "3.13/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.13/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "267592285674e21982d84f2cd0b56e13e63ce60c3e85ffb0d67a842edaf5b5e9"
+          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
         },
         "3.13/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "33e4de818b5419f0b6c599ccfc98a0468c441f83e02d4e0ef18b4a632408dc57"
         },
-        "3.13/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "4cb0d143eeaf51582fa8292d00061fc201e41bf3ce5e2de814d0b273f73d4c25"
+          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
         },
         "3.13/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "a2e320b8b7ec76f538f4414bb56927e0a35fb169a4748594b3b0946df0d8942b"
         },
-        "3.13/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "3b88fc6dd6f0290f075353ca860b9dc48faca0d849a0a03c088883507ed63881"
+          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
         },
         "3.13/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5c71151ce936e495b0dc49fe3bdd67a9ec332542e2fc250257cd76276481103c"
         },
-        "3.13/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.13/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "c8f2e10261f327b3b9606c23c79788e1c909f0d703c4b06ebd59b318fa271c77"
+          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
         },
         "3.13/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "e27287866347dd2cc1dc766174bb67f6b459cbadfbeff74c981abe7fe6cf86ba"
         },
-        "3.13/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "202a933d5435eced5e92f474fac9480a82959de2b3ea5555569de9bda6f4af4f"
+          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
         },
         "3.13/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "d603daefc04db99a764942a835497e52beebeb8797f7ac828826969e6f8ea165"
         },
-        "3.13/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.13/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "07833bcaf50c80065db8a21d7ae0459939d95e3cf399ce8f7df908ddfc4d275f"
+          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
         },
         "3.13/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "5703d1e5fcd43d0ac3bce24e65d03a5684f3fec3625794ca9a0a47ad2ecbd0a1"
         },
-        "3.13/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "61d5f9750e6971cf3bc91a1c8e7ab2eed1c22a34067f0762917bfde12b121f9f"
+          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
         },
         "3.13/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "8f1a00de7342d161bfefcb6bb90f50076b0c49e1ac4d4faa7fb303015369f310"
         },
-        "3.13/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.13/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.13.12",
-          "sha256": "ee1d08c3e6149343077d410d7de835a7a7dda8e2cec80df94f393e858a300055"
+          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
         },
         "3.13/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.13.12",
           "sha256": "6bae3d9f3c03448efe7e72aaf7eba1c4af4531ee22964876b36c1569e5123159"
         },
-        "3.13/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.13.12+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.13.12",
-          "sha256": "36f73e0b72ac670bd56c927a078e3e2ef0b1fef1d89a792088766bf1236815b7"
+        "3.14/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.14.3",
+          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
         },
         "3.14/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "cedbfdb352b7b0dbdfd2e4dba11244a64665402c44099f36af9e22dc269dd0c0"
         },
-        "3.14/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.14/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "adce81b366416e8d1b95c9c5483607282ae43c98fc155677020d20076d333fec"
+          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
         },
         "3.14/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "5af1b60808d4e8df3838267086556e2518b24a71080a7c4dc0edf3ef6a5bd8c4"
         },
-        "3.14/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "f64e500abf0ff11b320cba756114caae6ea733c62af1c9516d28d92cf4223d74"
+          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
         },
         "3.14/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "9ca5169b62fdedbbeb1e01429e5ed75d0c89efb0dffb3d5924c58f667f365863"
         },
-        "3.14/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "80030e336255241a76cd05c874b70a8840fef24e344907a4ae89f0f6c3c7daf6"
+          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
         },
         "3.14/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff4076086f55f83746d680792f8346037060453cf078feba233ba28e4b2a3514"
         },
-        "3.14/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.14/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "97b7e0182daf74f884456a4a24cf882d0296092c918939d25ed1e1f4edee0469"
+          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
         },
         "3.14/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "e3085abf12bdf84a91784915082eaffd4cac154acd9818aefc71a69e13bdaf24"
         },
-        "3.14/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "d969b1807fe6a3ebe9c1468c55331859d329119951ab01dc6ec5b2853c217a66"
+          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
         },
         "3.14/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "ff7ba9353fb4f6f923e5a0c30564e448cb678deb69ac58e7f4f3a78944b40806"
         },
-        "3.14/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.14/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "29469be54c9e471b916f0375f83836811b4df29dc98e0b7452ae9ec483a500a0"
+          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
         },
         "3.14/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "7921cf0fa140f3714c4772b8af161ab463d0ad641ac35db0beff9d45273ab5f5"
         },
-        "3.14/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "201d5c13ee115e029bf6caa6bb17af2bfb3e4a3baf14c7f31e9145e2aa6571ef"
+          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
         },
         "3.14/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "0629158c702d4ba732c722f24e5a775885e93915c7b04fe29cfb9c81e37f499f"
         },
-        "3.14/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.14/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.14.3",
-          "sha256": "8070ec22c0ea164b826a57102f1bf1fa0b360e143ab3378b3c5eb4178bc0c26b"
+          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
         },
         "3.14/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.14.3",
           "sha256": "dc478897cecef7b6dfcd089b8a425e959885883d123ba4ce3e3ec1fcf5f9637a"
         },
-        "3.14/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.14.3+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.14.3",
-          "sha256": "e72b682f652eb8ba71550a7aa4f267ddf3fe06b165a29acd4194dfff0b51ed4e"
+        "3.15/aarch64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+          "full_version": "3.15.0a6",
+          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
         },
         "3.15/aarch64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "c2c9679a505c94abb6e0dcbcb1a9ea2148fbcab5b443e9c8efac388e591233a8"
         },
-        "3.15/aarch64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-apple-darwin-install_only.tar.gz",
+        "3.15/aarch64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "7a6bb30a11361b58849ceeaf4d74f4085306f9b00de0c7f4703f9031cbb409ee"
+          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
         },
         "3.15/aarch64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "62890d115b54d2456a74db09d3026834faee19ba1be257c287025b0e8ae6ad16"
         },
-        "3.15/aarch64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "aafd627b816dd83cb9ae670383482f3aa166e8f8910ca946278c5cc22f96bff6"
+          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
         },
         "3.15/aarch64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "93792d31d2232f6bf27e08fbfe6aec221aab1a4aa42463ac879540d399b54bc2"
         },
-        "3.15/aarch64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/aarch64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "bc351efe2ef61f2d6fae1491b0d240f7616a7be28fcdad2d1644ce0429001ad6"
+          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
         },
         "3.15/aarch64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "497bbd7bc486a3092e003761f6a4fb9fd2c9854dea249042b330cb70d2ebf42a"
         },
-        "3.15/aarch64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "3.15/i686-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "55fabc3bfa81d6248db65da659c8f728fdfe8aa5dcd9551a5b1eaef09bc05cbd"
+          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
         },
         "3.15/i686-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "4174719f384f3c6893c59e23ea88242c3ab9d84b7fffb9d1ed3a11e9d6a6a068"
         },
-        "3.15/i686-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-i686-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-apple-darwin/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "a49e43ea7971bb975e00f132bd45bc6834177997add3de7a07361a7449a10bda"
+          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
         },
         "3.15/x86_64-apple-darwin/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "cf23826a427d19ea945965ba0e00a210b0cd96c3e7c2741ccf1174c18c37d5a6"
         },
-        "3.15/x86_64-apple-darwin/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-apple-darwin-install_only.tar.gz",
+        "3.15/x86_64-pc-windows-msvc/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "3c25506d64f6b8e0c38bb66f8430332578a69343c1b27078b7f91d5919f2549a"
+          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
         },
         "3.15/x86_64-pc-windows-msvc/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-freethreaded+pgo-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "8c3de05f4df81a3b482fd62daa14b7863df2b517a487b75661e37dfee845a4e6"
         },
-        "3.15/x86_64-pc-windows-msvc/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-gnu/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "42690076ba8f6311b737b884f56217cab7d7287f3374ab8c629fd446913534d6"
+          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
         },
         "3.15/x86_64-unknown-linux-gnu/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "9d95b1429958effe665c0dd7e2a9b8dfe1364b477637df87ddf372438adfa109"
         },
-        "3.15/x86_64-unknown-linux-gnu/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "3.15/x86_64-unknown-linux-musl/default": {
+          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
           "full_version": "3.15.0a6",
-          "sha256": "ac11f7e619c154e3d9b56186b461f52b4afc583a5524e7109686a7a9e1835b6d"
+          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         },
         "3.15/x86_64-unknown-linux-musl/freethreaded": {
           "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-freethreaded+lto-full.tar.zst",
           "full_version": "3.15.0a6",
           "sha256": "2b5d35017190248ebbbf8b24432ec730e496dc68b911308a0cd4c21d8181d090"
-        },
-        "3.15/x86_64-unknown-linux-musl/install_only": {
-          "filename": "cpython-3.15.0a6+20260303-x86_64-unknown-linux-musl-install_only.tar.gz",
-          "full_version": "3.15.0a6",
-          "sha256": "427675a1e0e79051540cce0f1b450ca0d11a8897486aba03796a8881cadf831f"
         }
       }
     }

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -1,7 +1,9 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load(":exclude_feature.bzl", "exclude_feature_flag")
+load(":extension_test.bzl", "extension_test_suite")
 load(":version_util_test.bzl", "version_util_test_suite")
+load(":versions_test.bzl", "versions_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -87,7 +89,11 @@ bool_flag(
     build_setting_default = False,
 )
 
+extension_test_suite()
+
 version_util_test_suite()
+
+versions_test_suite()
 
 # keep
 bzl_library(

--- a/py/private/interpreter/extension.bzl
+++ b/py/private/interpreter/extension.bzl
@@ -1,18 +1,55 @@
 """Module extension for provisioning Python interpreters from python-build-standalone."""
 
-load(":repository.bzl", "python_interpreter", "python_toolchains")
+load(":repository.bzl", "python_interpreter", "python_interpreter_unavailable", "python_toolchains")
 load(":sanitize.bzl", "sanitize")
 load(":version_util.bzl", "is_decimal", "is_pre_release", "version_gt")
-load(":versions.bzl", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS", "RUNTIME_MODES")
+load(":versions.bzl", "DEFAULT_RELEASE_BASE_URL", "DEFAULT_RELEASE_DATES", "PLATFORMS", "parse_build_config", "validate_build_config")
 
 # The GitHub API endpoint for resolving "latest" releases.
 _GITHUB_API_LATEST = "https://api.github.com/repos/{owner}/{repo}/releases/latest"
 
+# Default hub-level build configuration: the optimized, minimal redistributable.
+_DEFAULT_BUILD_CONFIG = "install_only"
+
 # Facts can outlive an extension implementation change, so index shape changes
 # must use a new key rather than accepting cached data from the old schema.
-_RELEASE_INDEX_SCHEMA = 1
+# v2: mode keys became "default"/"freethreaded" and the default mode's archive
+# suffix is build_config-dependent (folded into the facts key).
+_RELEASE_INDEX_SCHEMA = 2
 
-def _parse_sha256sums(content, release_date):
+def _resolve_modes(build_config):
+    """Build the ordered list of runtime modes to provision.
+
+    "default" uses the hub-level build_config's archive on every platform;
+    "freethreaded" parses each platform's own freethreaded_suffix, so
+    free-threading stays a build-time select() (see the freethreaded
+    config_setting in repository.bzl). Order is default-then-freethreaded to
+    keep generated output stable.
+
+    Each mode maps platform -> parse_build_config() dict (suffix, extension,
+    strip_prefix, abi_flags, ...) in config_for_platform.
+    """
+    default = validate_build_config(build_config)
+
+    return [
+        {
+            "name": "default",
+            "repo_suffix": "",  # the default mode owns the unsuffixed repo name
+            "freethreaded": False,
+            "config_for_platform": {platform: default for platform in PLATFORMS},
+        },
+        {
+            "name": "freethreaded",
+            "repo_suffix": "freethreaded",
+            "freethreaded": True,
+            "config_for_platform": {
+                platform: parse_build_config(info["freethreaded_suffix"])
+                for platform, info in PLATFORMS.items()
+            },
+        },
+    ]
+
+def _parse_sha256sums(content, release_date, modes):
     """Parse a SHA256SUMS file into a structured index.
 
     Returns a dict mapping (major_minor, platform, runtime_mode) -> {
@@ -21,20 +58,21 @@ def _parse_sha256sums(content, release_date):
         "full_version": str,
     }
 
-    When multiple patch versions exist for the same major.minor, only the
-    newest is kept.
+    where runtime_mode is a mode name from _resolve_modes ("default" or
+    "freethreaded"). When multiple patch versions exist for the same
+    major.minor, only the newest is kept.
     """
     index = {}
     configured_assets = {}
 
-    for platform, platform_info in PLATFORMS.items():
-        for mode_name, mode_info in RUNTIME_MODES.items():
+    for mode in modes:
+        for platform, config in mode["config_for_platform"].items():
             asset = "{}-{}.{}".format(
                 platform,
-                platform_info["asset_suffixes"][mode_name],
-                mode_info["extension"],
+                config["suffix"],
+                config["extension"],
             )
-            configured_assets[asset] = (platform, mode_name)
+            configured_assets[asset] = (platform, mode["name"])
 
     for line in content.split("\n"):
         line = line.strip()
@@ -86,8 +124,10 @@ def _parse_sha256sums(content, release_date):
 
     return index
 
-def _release_index_facts_key(release_date, base_url):
-    return "release_index_v{}_{}_{}".format(_RELEASE_INDEX_SCHEMA, release_date, base_url)
+def _release_index_facts_key(release_date, base_url, build_config):
+    # build_config selects the default mode's archive, so it changes the parsed
+    # index contents and must scope the cache key.
+    return "release_index_v{}_{}_{}_{}".format(_RELEASE_INDEX_SCHEMA, release_date, base_url, build_config)
 
 def _owner_repo_from_base_url(base_url):
     """Extract GitHub owner/repo from a base URL like https://github.com/{owner}/{repo}/releases/download."""
@@ -125,12 +165,12 @@ def _resolve_latest(module_ctx, base_url):
         fail('Could not resolve "latest" release from {}'.format(api_url))
     return tag
 
-def _fetch_release_index(module_ctx, release_date, base_url, facts):
+def _fetch_release_index(module_ctx, release_date, base_url, build_config, modes, facts):
     """Fetch and parse SHA256SUMS for a release, using facts as cache.
 
     Returns the parsed index dict for this release date.
     """
-    facts_key = _release_index_facts_key(release_date, base_url)
+    facts_key = _release_index_facts_key(release_date, base_url, build_config)
     cached = facts.get(facts_key)
     if cached:
         return cached
@@ -145,7 +185,7 @@ def _fetch_release_index(module_ctx, release_date, base_url, facts):
     )
     content = module_ctx.read(sha256sums_path)
 
-    index = _parse_sha256sums(content, release_date)
+    index = _parse_sha256sums(content, release_date, modes)
     if not index:
         fail(
             "No CPython assets found in SHA256SUMS for release date \"{}\". ".format(release_date) +
@@ -168,6 +208,7 @@ def _python_interpreters_impl(module_ctx):
     # to carry a configure() for development without breaking downstream users.
     release_dates = []
     release_base_urls = {}  # date -> base_url
+    build_config = _DEFAULT_BUILD_CONFIG
     has_configure = False
 
     for mod in module_ctx.modules:
@@ -180,6 +221,7 @@ def _python_interpreters_impl(module_ctx):
                     "Pass all release dates as a single list.",
                 )
             has_configure = True
+            build_config = tag.build_config
             base_url = tag.base_url if tag.base_url else DEFAULT_RELEASE_BASE_URL
             for date in tag.releases:
                 if date == "latest":
@@ -200,6 +242,10 @@ def _python_interpreters_impl(module_ctx):
 
     # Sort newest-first for "prefer newest release" semantics
     release_dates = sorted(release_dates, reverse = True)
+
+    # Resolve the runtime modes to provision. Validates build_config eagerly so
+    # a typo fails before any downloads happen.
+    modes = _resolve_modes(build_config)
 
     # Collect all requested Python versions. Any module can request a version,
     # but only the root module's pre_release flag and toolchain settings are
@@ -267,11 +313,11 @@ def _python_interpreters_impl(module_ctx):
 
     for date in release_dates:
         base_url = release_base_urls.get(date, DEFAULT_RELEASE_BASE_URL)
-        index = _fetch_release_index(module_ctx, date, base_url, facts)
+        index = _fetch_release_index(module_ctx, date, base_url, build_config, modes, facts)
         release_indices[date] = index
 
         # Cache in facts for next run — but never cache under "latest"
-        facts_key = _release_index_facts_key(date, base_url)
+        facts_key = _release_index_facts_key(date, base_url, build_config)
         new_facts[facts_key] = index
 
     # Create per-platform, per-runtime-mode interpreter repos and collect
@@ -279,50 +325,65 @@ def _python_interpreters_impl(module_ctx):
     # which entries are eligible.
     toolchain_entries = []
 
-    # Keep generated output stable: regular modes, then freethreaded modes.
-    ordered_modes = (
-        [(name, mode) for name, mode in RUNTIME_MODES.items() if not mode["freethreaded"]] +
-        [(name, mode) for name, mode in RUNTIME_MODES.items() if mode["freethreaded"]]
-    )
-
     # Target-pattern registration orders toolchains lexicographically by name,
     # so BUILD declaration order cannot select a default toolchain:
     # https://bazel.build/extending/toolchains#registering-building-toolchains
     for major_minor in sorted(requested_versions):
         version_found = False
+        default_mode_found = False
+        pre_release_versions = {}  # full_version -> True, rejected by the pre_release gate
         settings = root_settings.get(major_minor, {
             "config_settings": [],
             "exec_compatible_with": [],
             "target_compatible_with": [],
         })
-        for mode_name, mode_info in ordered_modes:
+        for mode in modes:
             for platform_triple, platform_info in PLATFORMS.items():
+                config = mode["config_for_platform"][platform_triple]
                 repo_name = "python_{}_{}".format(
                     sanitize(major_minor),
                     sanitize(platform_triple),
                 )
-                if mode_name != "install_only":
-                    repo_name += "_" + sanitize(mode_name)
+                if mode["repo_suffix"]:
+                    repo_name += "_" + sanitize(mode["repo_suffix"])
 
                 # Find the best release for this version/platform/mode
                 asset_info = _find_asset(
                     major_minor,
                     platform_triple,
-                    mode_name,
+                    mode["name"],
                     release_dates,
                     release_indices,
                 )
 
+                unavailable = None
                 if not asset_info:
-                    # Version/platform/mode combo doesn't exist — skip it
-                    # rather than registering a stub toolchain.
-                    continue
+                    unavailable = "No CPython {} '{}' archive for {} in the configured PBS releases ({}).".format(
+                        major_minor,
+                        config["suffix"],
+                        platform_triple,
+                        ", ".join(release_dates),
+                    )
+                elif is_pre_release(asset_info["full_version"]) and not allow_pre_release.get(major_minor, False):
+                    pre_release_versions[asset_info["full_version"]] = True
+                    unavailable = "CPython {} for {} is a pre-release ({}) not enabled via interpreters.toolchain(pre_release = True).".format(
+                        major_minor,
+                        platform_triple,
+                        asset_info["full_version"],
+                    )
 
-                # Skip pre-release versions unless explicitly allowed
-                if is_pre_release(asset_info["full_version"]) and not allow_pre_release.get(major_minor, False):
+                if unavailable:
+                    # No toolchain, but the repo name must still exist so
+                    # use_repo() imports stay valid for every build_config.
+                    python_interpreter_unavailable(
+                        name = repo_name,
+                        message = unavailable,
+                    )
                     continue
 
                 version_found = True
+                if mode["name"] == "default":
+                    default_mode_found = True
 
                 base_url = release_base_urls.get(asset_info["release_date"], DEFAULT_RELEASE_BASE_URL)
                 url = "{}/{}/{}".format(
@@ -332,19 +393,19 @@ def _python_interpreters_impl(module_ctx):
                 )
                 python_interpreter(
                     name = repo_name,
-                    abi_flags = mode_info["abi_flags"],
+                    abi_flags = config["abi_flags"],
                     python_version = asset_info["full_version"],
                     platform = platform_triple,
                     url = url,
                     sha256 = asset_info["sha256"],
-                    strip_prefix = mode_info["strip_prefix"],
+                    strip_prefix = config["strip_prefix"],
                 )
 
                 toolchain_entries.append(json.encode({
                     "name": repo_name,
                     "repo": repo_name,
                     "python_version": major_minor,
-                    "freethreaded": mode_info["freethreaded"],
+                    "freethreaded": mode["freethreaded"],
                     "compatible_with": platform_info["compatible_with"],
                     "platform_target_settings": platform_info.get("target_settings", {}),
                     "config_settings": settings["config_settings"],
@@ -353,13 +414,36 @@ def _python_interpreters_impl(module_ctx):
                     "register_exec_tools": platform_info["register_exec_tools"],
                 }))
 
-        if not version_found:
+        # A version backed only by free-threaded toolchains is unusable in the
+        # default runtime mode, so a build_config with no matching platform is
+        # an eager failure, not a hub of stubs.
+        if not version_found or not default_mode_found:
             sources = version_sources.get(major_minor, ["unknown"])
+            if version_found:
+                what = "No CPython {} '{}' archives found for any platform in the configured PBS releases. ".format(major_minor, build_config)
+            else:
+                what = "No CPython {} builds found in any configured PBS release. ".format(major_minor)
+            if pre_release_versions:
+                hint = (
+                    "CPython {} exists only as a pre-release ({}); enable it with ".format(major_minor, ", ".join(sorted(pre_release_versions))) +
+                    "interpreters.toolchain(pre_release = True). "
+                )
+            elif build_config != _DEFAULT_BUILD_CONFIG:
+                hint = (
+                    "PBS publishes build_config '{}' only for some ".format(build_config) +
+                    "version/platform combinations; check the release SHA256SUMS " +
+                    "manifests or use 'install_only'. "
+                )
+            else:
+                hint = (
+                    "The root module's interpreters.configure(releases = [...]) must include " +
+                    "a release that contains this version. "
+                )
             fail(
-                "No CPython {} builds found in any configured PBS release. ".format(major_minor) +
+                what +
                 "Requested by module(s): {}. ".format(", ".join(sources)) +
-                "The root module's interpreters.configure(releases = [...]) must include " +
-                "a release that contains this version. Configured releases: " +
+                hint +
+                "Configured releases: " +
                 ", ".join(release_dates),
             )
 
@@ -393,6 +477,28 @@ def _find_asset(major_minor, platform, runtime_mode, release_dates, release_indi
 
 _configure_tag = tag_class(
     attrs = {
+        "build_config": attr.string(
+            default = _DEFAULT_BUILD_CONFIG,
+            doc = """\
+python-build-standalone build configuration for the non-free-threaded
+interpreter, hub-wide. This is the archive suffix PBS publishes, and selects
+size/optimization/debug tradeoffs for every provisioned version and platform.
+
+Supported values:
+  - "install_only" (default): optimized, minimal redistributable (tar.gz).
+  - "install_only_stripped": same as install_only with debug symbols removed
+    (smallest download).
+  - "<opt>[+<opt>...]-full": a full archive, where each component is one of
+    debug, noopt, pgo, lto, in that order. Examples: "pgo+lto-full",
+    "lto-full", "noopt-full", "debug-full".
+
+Per-platform availability of the "-full" flavors, the "+static" and
+"freethreaded" exclusions, and the Py_DEBUG caveat are documented in
+docs/interpreter.md under "Build configuration".
+
+Only honored from the root module.
+""",
+        ),
         "base_url": attr.string(
             default = "",
             doc = """\
@@ -488,4 +594,10 @@ python_interpreters = module_extension(
         "configure": _configure_tag,
         "toolchain": _toolchain_tag,
     },
+)
+
+# Exposed for unit tests only.
+extension_testlib = struct(
+    parse_sha256sums = _parse_sha256sums,
+    resolve_modes = _resolve_modes,
 )

--- a/py/private/interpreter/extension_test.bzl
+++ b/py/private/interpreter/extension_test.bzl
@@ -1,0 +1,108 @@
+"""Tests for extension.bzl mode resolution and SHA256SUMS parsing."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//py/private/interpreter:extension.bzl", "extension_testlib")
+load("//py/private/interpreter:versions.bzl", "PLATFORMS")
+
+_RELEASE_DATE = "20260303"
+
+# A synthetic SHA256SUMS excerpt: two 3.13 patches, sibling build
+# configurations, a free-threaded archive, and a second minor version.
+_SHA256SUMS = "\n".join([
+    "aaa1  cpython-3.13.1+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+    "bbb2  cpython-3.13.2+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+    "ccc3  cpython-3.13.2+20260303-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "ddd4  cpython-3.13.2+20260303-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "eee5  cpython-3.13.2+20260303-x86_64-unknown-linux-gnu-freethreaded+pgo+lto-full.tar.zst",
+    "fff6  cpython-3.12.9+20260303-x86_64-unknown-linux-gnu-install_only.tar.gz",
+    "",
+    "not a manifest line",
+])
+
+_LINUX_GNU = "x86_64-unknown-linux-gnu"
+
+def _resolve_modes_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    modes = extension_testlib.resolve_modes("install_only")
+    asserts.equals(env, 2, len(modes))
+
+    default = modes[0]
+    asserts.equals(env, "default", default["name"])
+    asserts.equals(env, "", default["repo_suffix"])
+    asserts.false(env, default["freethreaded"])
+    for platform in PLATFORMS:
+        config = default["config_for_platform"][platform]
+        asserts.equals(env, "install_only", config["suffix"], platform)
+        asserts.equals(env, "", config["abi_flags"], platform)
+
+    ft = modes[1]
+    asserts.equals(env, "freethreaded", ft["name"])
+    asserts.equals(env, "freethreaded", ft["repo_suffix"])
+    asserts.true(env, ft["freethreaded"])
+
+    # Each platform's free-threaded config is parsed from its own PBS suffix,
+    # independent of build_config.
+    for platform in PLATFORMS:
+        config = ft["config_for_platform"][platform]
+        asserts.equals(env, "tar.zst", config["extension"], platform)
+        asserts.equals(env, "python/install", config["strip_prefix"], platform)
+        asserts.equals(env, "t", config["abi_flags"], platform)
+    asserts.equals(env, "freethreaded+pgo+lto-full", ft["config_for_platform"][_LINUX_GNU]["suffix"])
+    asserts.equals(env, "freethreaded+lto-full", ft["config_for_platform"]["x86_64-unknown-linux-musl"]["suffix"])
+    asserts.equals(env, "freethreaded+pgo-full", ft["config_for_platform"]["x86_64-pc-windows-msvc"]["suffix"])
+
+    debug = extension_testlib.resolve_modes("debug-full")[0]["config_for_platform"][_LINUX_GNU]
+    asserts.equals(env, "tar.zst", debug["extension"])
+    asserts.equals(env, "python/install", debug["strip_prefix"])
+    asserts.equals(env, "d", debug["abi_flags"])
+    asserts.equals(env, "debug-full", debug["suffix"])
+
+    return unittest.end(env)
+
+resolve_modes_test = unittest.make(_resolve_modes_test_impl)
+
+def _parse_sha256sums_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    modes = extension_testlib.resolve_modes("install_only")
+    index = extension_testlib.parse_sha256sums(_SHA256SUMS, _RELEASE_DATE, modes)
+
+    # Newest patch wins; sibling build configurations must not shadow it.
+    default = index["3.13/{}/default".format(_LINUX_GNU)]
+    asserts.equals(env, "bbb2", default["sha256"])
+    asserts.equals(env, "3.13.2", default["full_version"])
+
+    ft = index["3.13/{}/freethreaded".format(_LINUX_GNU)]
+    asserts.equals(env, "eee5", ft["sha256"])
+
+    asserts.equals(env, "fff6", index["3.12/{}/default".format(_LINUX_GNU)]["sha256"])
+    asserts.false(env, "3.12/{}/freethreaded".format(_LINUX_GNU) in index)
+
+    return unittest.end(env)
+
+parse_sha256sums_test = unittest.make(_parse_sha256sums_test_impl)
+
+def _parse_sha256sums_build_config_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # The default mode's asset follows build_config, and the free-threaded
+    # entry is identical across configurations.
+    for build_config, want_sha in [("install_only_stripped", "ccc3"), ("debug-full", "ddd4")]:
+        modes = extension_testlib.resolve_modes(build_config)
+        index = extension_testlib.parse_sha256sums(_SHA256SUMS, _RELEASE_DATE, modes)
+        asserts.equals(env, want_sha, index["3.13/{}/default".format(_LINUX_GNU)]["sha256"], build_config)
+        asserts.equals(env, "eee5", index["3.13/{}/freethreaded".format(_LINUX_GNU)]["sha256"], build_config)
+        asserts.false(env, "3.12/{}/default".format(_LINUX_GNU) in index, build_config)
+
+    return unittest.end(env)
+
+parse_sha256sums_build_config_test = unittest.make(_parse_sha256sums_build_config_test_impl)
+
+def extension_test_suite():
+    unittest.suite(
+        "extension_tests",
+        resolve_modes_test,
+        parse_sha256sums_test,
+        parse_sha256sums_build_config_test,
+    )

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -306,6 +306,22 @@ python_interpreter = repository_rule(
     },
 )
 
+def _python_interpreter_unavailable_impl(rctx):
+    rctx.file("BUILD.bazel", content = "fail({})\n".format(repr(rctx.attr.message)))
+    return rctx.repo_metadata(reproducible = True)
+
+# Stub for version/platform/mode combos with no usable PBS asset. The extension
+# must generate every repo name regardless of build_config so use_repo()
+# imports stay valid. The repo fetches cleanly (eager fetchers like
+# `bazel fetch --all` and `bazel vendor` must not break); referencing any
+# target in it fails at load time with the message.
+python_interpreter_unavailable = repository_rule(
+    implementation = _python_interpreter_unavailable_impl,
+    attrs = {
+        "message": attr.string(mandatory = True),
+    },
+)
+
 def _platform_setting_name(flag, value):
     """Generate a unique config_setting name for a flag/value pair."""
 

--- a/py/private/interpreter/versions.bzl
+++ b/py/private/interpreter/versions.bzl
@@ -1,6 +1,6 @@
 """Python-build-standalone release metadata.
 
-This file contains platform mappings and runtime mode definitions for CPython
+This file contains platform mappings and build-configuration parsing for CPython
 interpreters built by the python-build-standalone project
 (https://github.com/astral-sh/python-build-standalone).
 
@@ -40,7 +40,9 @@ DEFAULT_RELEASE_DATES = [
 # https://github.com/astral-sh/python-build-standalone/releases/download/20260303/SHA256SUMS
 # https://github.com/astral-sh/python-build-standalone/releases/download/20251031/SHA256SUMS
 #
-# - asset_suffixes: exact PBS filename suffix for each logical runtime mode
+# - freethreaded_suffix: exact PBS filename suffix for the free-threaded archive
+#   (the non-free-threaded archive's suffix is chosen by the hub-level
+#   build_config; see parse_build_config)
 # - compatible_with: constraint_values for exec_compatible_with / target_compatible_with
 # - target_settings: additional config_settings the toolchain must match (optional)
 # - register_exec_tools: whether the hub emits the platform's exec registration
@@ -54,10 +56,7 @@ DEFAULT_RELEASE_DATES = [
 # buildifier: disable=unsorted-dict-items
 PLATFORMS = {
     "aarch64-apple-darwin": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+pgo+lto-full",
-        },
+        "freethreaded_suffix": "freethreaded+pgo+lto-full",
         "compatible_with": [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
@@ -65,10 +64,7 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-unknown-linux-gnu": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+pgo+lto-full",
-        },
+        "freethreaded_suffix": "freethreaded+pgo+lto-full",
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
@@ -79,10 +75,7 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-unknown-linux-musl": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+lto-full",
-        },
+        "freethreaded_suffix": "freethreaded+lto-full",
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
@@ -93,10 +86,7 @@ PLATFORMS = {
         "register_exec_tools": False,
     },
     "x86_64-apple-darwin": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+pgo+lto-full",
-        },
+        "freethreaded_suffix": "freethreaded+pgo+lto-full",
         "compatible_with": [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
@@ -104,10 +94,7 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "x86_64-unknown-linux-gnu": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+pgo+lto-full",
-        },
+        "freethreaded_suffix": "freethreaded+pgo+lto-full",
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
@@ -118,10 +105,7 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "x86_64-unknown-linux-musl": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+lto-full",
-        },
+        "freethreaded_suffix": "freethreaded+lto-full",
         "compatible_with": [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
@@ -132,10 +116,7 @@ PLATFORMS = {
         "register_exec_tools": False,
     },
     "x86_64-pc-windows-msvc": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+pgo-full",
-        },
+        "freethreaded_suffix": "freethreaded+pgo-full",
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
@@ -143,10 +124,7 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "aarch64-pc-windows-msvc": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+pgo-full",
-        },
+        "freethreaded_suffix": "freethreaded+pgo-full",
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:aarch64",
@@ -154,10 +132,7 @@ PLATFORMS = {
         "register_exec_tools": True,
     },
     "i686-pc-windows-msvc": {
-        "asset_suffixes": {
-            "install_only": "install_only",
-            "freethreaded": "freethreaded+pgo-full",
-        },
+        "freethreaded_suffix": "freethreaded+pgo-full",
         "compatible_with": [
             "@platforms//os:windows",
             "@platforms//cpu:x86_32",
@@ -166,24 +141,122 @@ PLATFORMS = {
     },
 }
 
-# Logical runtime modes registered by this extension. Each mode specifies:
-# - extension: the archive file extension
-# - strip_prefix: the prefix to strip when extracting
-# - freethreaded: whether this is a free-threaded build
-# - abi_flags: CPython ABI flags used in header and Windows import-library paths
-#
-# buildifier: disable=unsorted-dict-items
-RUNTIME_MODES = {
-    "install_only": {
-        "abi_flags": "",
-        "extension": "tar.gz",
-        "strip_prefix": "python",
-        "freethreaded": False,
-    },
-    "freethreaded": {
-        "abi_flags": "t",
+# Tokens permitted in a "-full" build configuration suffix, ranked by PBS's
+# canonical filename order (e.g. "pgo+lto-full", "freethreaded+debug-full",
+# "lto+static-full"). Manifests only ever use this order, so misordered or
+# duplicated tokens can never match an asset and are rejected at parse time.
+_FULL_TOKEN_RANK = {
+    "freethreaded": 0,
+    "debug": 1,
+    "noopt": 2,
+    "pgo": 3,
+    "lto": 4,
+    "static": 5,
+}
+
+def parse_build_config(suffix):
+    """Decode a python-build-standalone build configuration suffix.
+
+    PBS asset filenames end in a build configuration suffix drawn from a fixed
+    grammar visible in the SHA256SUMS manifests. This parses that suffix into
+    the archive and ABI properties a toolchain needs, without enumerating every
+    published combination:
+
+        install_only[_stripped]                    redistributable, tar.gz
+        [freethreaded+]<opt...>[+static]-full      full archive,     tar.zst
+
+    where each <opt> component is one of debug, noopt, pgo, lto, in that
+    order (e.g. "pgo+lto-full", "debug-full", "freethreaded+pgo+lto-full").
+
+    Availability of a given suffix for a specific version/platform is a
+    separate question, resolved against the release manifest.
+
+    Args:
+        suffix: a PBS build configuration suffix, e.g. "install_only".
+
+    Returns:
+        None if the suffix does not match the grammar, else a dict with:
+            suffix:        the input, unchanged (the exact filename suffix)
+            extension:     archive extension ("tar.gz" or "tar.zst")
+            strip_prefix:  extraction prefix ("python" or "python/install")
+            abi_flags:     CPython ABI flags ("", "t", "d", or "td")
+            freethreaded:  whether this is a free-threaded build
+            debug:         whether this is a Py_DEBUG build
+            static:        whether libpython is statically linked
+    """
+    if suffix in ("install_only", "install_only_stripped"):
+        return {
+            "suffix": suffix,
+            "extension": "tar.gz",
+            "strip_prefix": "python",
+            "abi_flags": "",
+            "freethreaded": False,
+            "debug": False,
+            "static": False,
+        }
+
+    if not suffix.endswith("-full"):
+        return None
+
+    tokens = suffix[:-len("-full")].split("+")
+    last_rank = -1
+    for token in tokens:
+        rank = _FULL_TOKEN_RANK.get(token)
+        if rank == None or rank <= last_rank:
+            return None
+        last_rank = rank
+    freethreaded = "freethreaded" in tokens
+    debug = "debug" in tokens
+    static = "static" in tokens
+
+    return {
+        "suffix": suffix,
         "extension": "tar.zst",
         "strip_prefix": "python/install",
-        "freethreaded": True,
-    },
-}
+        "abi_flags": ("t" if freethreaded else "") + ("d" if debug else ""),
+        "freethreaded": freethreaded,
+        "debug": debug,
+        "static": static,
+    }
+
+def validate_build_config(suffix):
+    """Validate a hub-level build_config.
+
+    Fails with an actionable message when the configuration is unrecognized or
+    cannot back a working non-free-threaded runtime toolchain.
+
+    Args:
+        suffix: the build_config attribute value from interpreters.configure().
+
+    Returns:
+        The parse_build_config() dict for the suffix.
+    """
+    parsed = parse_build_config(suffix)
+    if parsed == None:
+        fail(
+            "Unrecognized PBS build_config '{}'. ".format(suffix) +
+            "Expected 'install_only', 'install_only_stripped', or a " +
+            "'<opt>[+<opt>...]-full' suffix where each component is one of " +
+            "debug, noopt, pgo, lto — at most once and in that order, as PBS " +
+            "publishes them (e.g. 'pgo+lto-full', 'debug-full'). " +
+            "See https://github.com/astral-sh/python-build-standalone/releases.",
+        )
+    if parsed["static"]:
+        fail(
+            "build_config '{}' selects a statically linked libpython. ".format(suffix) +
+            "Extension modules resolve Python symbols from the loading " +
+            "interpreter, so a static build cannot back a runtime toolchain. " +
+            "Use a non-static build configuration.",
+        )
+    if parsed["freethreaded"]:
+        # Bare "freethreaded-full" has no non-free-threaded counterpart, so
+        # only offer an example when dropping the token leaves a valid suffix.
+        alternative = suffix.replace("freethreaded+", "")
+        example = " (e.g. '{}')".format(alternative) if alternative != suffix else ""
+        fail(
+            "build_config '{}' must not select free-threading. ".format(suffix) +
+            "Free-threading is an orthogonal axis chosen at build time via " +
+            "--@aspect_rules_py//py/private/interpreter:freethreaded; pass the " +
+            "non-free-threaded suffix instead{}.".format(example),
+        )
+    return parsed

--- a/py/private/interpreter/versions_test.bzl
+++ b/py/private/interpreter/versions_test.bzl
@@ -1,0 +1,128 @@
+"""Tests for versions.bzl."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//py/private/interpreter:versions.bzl", "PLATFORMS", "parse_build_config")
+
+def _parse_build_config_install_only_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    got = parse_build_config("install_only")
+    asserts.equals(env, "tar.gz", got["extension"])
+    asserts.equals(env, "python", got["strip_prefix"])
+    asserts.equals(env, "", got["abi_flags"])
+    asserts.false(env, got["freethreaded"])
+    asserts.false(env, got["debug"])
+    asserts.false(env, got["static"])
+
+    # Stripped is the same interpreter, same ABI, smaller download.
+    stripped = parse_build_config("install_only_stripped")
+    asserts.equals(env, "tar.gz", stripped["extension"])
+    asserts.equals(env, "python", stripped["strip_prefix"])
+    asserts.equals(env, "", stripped["abi_flags"])
+    asserts.equals(env, "install_only_stripped", stripped["suffix"])
+
+    return unittest.end(env)
+
+parse_build_config_install_only_test = unittest.make(_parse_build_config_install_only_test_impl)
+
+def _parse_build_config_full_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Full archives extract from python/install and are zstd-compressed.
+    for suffix in ["noopt-full", "lto-full", "pgo-full", "pgo+lto-full"]:
+        got = parse_build_config(suffix)
+        asserts.equals(env, "tar.zst", got["extension"], suffix)
+        asserts.equals(env, "python/install", got["strip_prefix"], suffix)
+        asserts.equals(env, "", got["abi_flags"], suffix)
+        asserts.false(env, got["freethreaded"], suffix)
+
+    return unittest.end(env)
+
+parse_build_config_full_test = unittest.make(_parse_build_config_full_test_impl)
+
+def _parse_build_config_abi_flags_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # debug => Py_DEBUG => "d"
+    asserts.equals(env, "d", parse_build_config("debug-full")["abi_flags"])
+
+    # freethreaded => "t"
+    ft = parse_build_config("freethreaded+pgo+lto-full")
+    asserts.equals(env, "t", ft["abi_flags"])
+    asserts.true(env, ft["freethreaded"])
+
+    # freethreaded + debug => "td"
+    ftd = parse_build_config("freethreaded+debug-full")
+    asserts.equals(env, "td", ftd["abi_flags"])
+    asserts.true(env, ftd["freethreaded"])
+    asserts.true(env, ftd["debug"])
+
+    return unittest.end(env)
+
+parse_build_config_abi_flags_test = unittest.make(_parse_build_config_abi_flags_test_impl)
+
+def _parse_build_config_static_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Static parses (validate_build_config rejects it, but the parser reports it).
+    got = parse_build_config("debug+static-full")
+    asserts.true(env, got["static"])
+    asserts.true(env, got["debug"])
+
+    asserts.true(env, parse_build_config("lto+static-full")["static"])
+
+    return unittest.end(env)
+
+parse_build_config_static_test = unittest.make(_parse_build_config_static_test_impl)
+
+def _parse_build_config_invalid_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Not a known packaging and no -full suffix.
+    asserts.equals(env, None, parse_build_config("install"))
+    asserts.equals(env, None, parse_build_config("optimized"))
+    asserts.equals(env, None, parse_build_config(""))
+
+    # Unknown optimization token inside a -full suffix.
+    asserts.equals(env, None, parse_build_config("bogus-full"))
+    asserts.equals(env, None, parse_build_config("pgo+bogus-full"))
+    asserts.equals(env, None, parse_build_config("-full"))
+
+    # Tokens must follow PBS's canonical filename order; a misordered suffix
+    # parses under a looser grammar but can never match a published asset.
+    asserts.equals(env, None, parse_build_config("pgo+freethreaded-full"))
+    asserts.equals(env, None, parse_build_config("lto+pgo-full"))
+    asserts.equals(env, None, parse_build_config("static+lto-full"))
+    asserts.equals(env, None, parse_build_config("lto+debug-full"))
+
+    # Duplicate tokens never appear in manifests.
+    asserts.equals(env, None, parse_build_config("pgo+pgo-full"))
+
+    return unittest.end(env)
+
+parse_build_config_invalid_test = unittest.make(_parse_build_config_invalid_test_impl)
+
+def _parse_build_config_platform_suffixes_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # The extension parses every platform's freethreaded_suffix, so each entry
+    # in PLATFORMS must stay within the grammar.
+    for platform, info in PLATFORMS.items():
+        got = parse_build_config(info["freethreaded_suffix"])
+        asserts.true(env, got != None, platform)
+        asserts.true(env, got["freethreaded"], platform)
+
+    return unittest.end(env)
+
+parse_build_config_platform_suffixes_test = unittest.make(_parse_build_config_platform_suffixes_test_impl)
+
+def versions_test_suite():
+    unittest.suite(
+        "versions_tests",
+        parse_build_config_install_only_test,
+        parse_build_config_full_test,
+        parse_build_config_abi_flags_test,
+        parse_build_config_static_test,
+        parse_build_config_invalid_test,
+        parse_build_config_platform_suffixes_test,
+    )


### PR DESCRIPTION
This adds functionality lost in #1187.

PBS publishes each interpreter in several build configurations. Let the root module choose which one backs the non-free-threaded runtime, hub-wide:

    interpreters.configure(
        releases = ["20260303"],
        build_config = "install_only_stripped",
    )

Supported values are install_only (the default), install_only_stripped (same interpreter, smallest download), and the "<opt>[+<opt>...]-full" suffixes (e.g. pgo+lto-full, debug-full). Suffixes are parsed against PBS's filename grammar rather than enumerated, so the archive extension, strip prefix, and ABI flags (debug-full is a Py_DEBUG "d" build) all derive from the configuration. Statically linked (+static) suffixes are rejected because extension modules resolve Python symbols from the loading interpreter; freethreaded+ suffixes are rejected because free-threading remains a separate axis selected at build time via the existing --freethreaded flag, with its per-platform optimized archive unchanged.

Availability is resolved against the release manifests: each platform family publishes different -full flavors (glibc Linux/macOS: debug-full and pgo+lto-full; musl: debug-full/lto-full/noopt-full; Windows: pgo-full only), so only install_only and install_only_stripped exist everywhere, and platforms without the selected archive get no normal-mode toolchain.

Close #1218

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add `interpreters.configure(build_config)` to configure build configurations.

### Test plan

- Covered by existing test cases
- New test cases added
