### PR TITLE
test(venv): Add venv tree snapshots and expose all_files in VirtualenvInfo

### DIFF
--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -117,6 +117,7 @@ def _common_providers(ctx, shared, executable = None):
             bin_python = shared.venv.bin_python,
             imports = shared.imports_depset,
             transitive_sources = shared.srcs_depset,
+            all_files = depset(direct = shared.venv.all_files),
         ),
         # `bazel coverage` finds this by walking the consumer's `venv` attr.
         coverage_common.instrumented_files_info(

--- a/py/private/py_venv/tests/BUILD.bazel
+++ b/py/private/py_venv/tests/BUILD.bazel
@@ -1,0 +1,53 @@
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("//py/private/py_venv:defs.bzl", "py_venv", "py_venv_exec")
+load(":venv_tree.bzl", "venv_tree")
+
+py_venv(
+    name = "venv",
+    testonly = True,
+    srcs = ["main.py"],
+    tags = ["manual"],
+    deps = ["@pypi//cowsay"],
+)
+
+py_venv_exec(
+    name = "exec",
+    testonly = True,
+    srcs = ["main.py"],
+    main = "main.py",
+    tags = ["manual"],
+    venv = ":venv",
+)
+
+genrule(
+    name = "venv_launcher_snap",
+    testonly = True,
+    outs = ["venv.launcher.snap"],
+    cmd = "cp $(execpath :venv) $@",
+    tags = ["manual"],
+    tools = [":venv"],
+)
+
+venv_tree(
+    name = "venv_tree_snap",
+    testonly = True,
+    tags = ["manual"],
+    venv = ":venv",
+)
+
+write_source_files(
+    name = "snapshots",
+    testonly = True,
+    files = {
+        "snapshots/venv.launcher.snap": ":venv_launcher_snap",
+        "snapshots/venv.tree.snap": ":venv_tree_snap",
+    },
+)
+
+bzl_library(
+    name = "venv_tree",
+    srcs = ["venv_tree.bzl"],
+    visibility = ["//py/private/py_venv:__subpackages__"],
+    deps = ["//py/private/py_venv:defs"],
+)

--- a/py/private/py_venv/tests/main.py
+++ b/py/private/py_venv/tests/main.py
@@ -1,0 +1,2 @@
+# Placeholder entrypoint — these targets exist only so their launcher
+# scripts can be snapshotted; they are never executed.

--- a/py/private/py_venv/tests/snapshots/venv.launcher.snap
+++ b/py/private/py_venv/tests/snapshots/venv.launcher.snap
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+if false; then
+    set -x
+fi
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+# https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: runfiles.bash initializer cannot find $f. An executable rule may have forgotten to expose it in the runfiles, or the binary may require RUNFILES_DIR to be set."; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+runfiles_export_envvars
+
+set -o errexit -o nounset -o pipefail
+
+VENV_PYTHON="$(rlocation _main/py/private/py_venv/tests/.venv/bin/python)"
+VENV_BIN="$(dirname "${VENV_PYTHON}")"
+VENV_HOME="$(dirname "${VENV_BIN}")"
+
+export VIRTUAL_ENV="${VENV_HOME}"
+export PATH="${VENV_BIN}:${PATH-}"
+
+exec "${VENV_PYTHON}" -B "$@"

--- a/py/private/py_venv/tests/snapshots/venv.tree.snap
+++ b/py/private/py_venv/tests/snapshots/venv.tree.snap
@@ -1,0 +1,209 @@
+FILE bin/activate
+---
+# Adapted from CPython Lib/venv/scripts/common/activate
+
+deactivate () {
+    # reset old environment variables
+    if [ -n "${_OLD_VIRTUAL_PATH:-}" ] ; then
+        PATH="${_OLD_VIRTUAL_PATH:-}"
+        export PATH
+    fi
+
+    if [ "${_OLD_VIRTUAL_PYTHONHOME:-}" = "_activate_undef" ]; then
+        unset _OLD_VIRTUAL_PYTHONHOME
+        unset PYTHONHOME
+    elif [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
+        PYTHONHOME="${_OLD_VIRTUAL_PYTHONHOME:-}"
+        export PYTHONHOME
+    fi
+
+    # Call hash to forget past locations. Without forgetting past locations the
+    # $PATH changes we made may not be respected. See "man bash" for more
+    # details. hash is usually a builtin of your shell
+    hash -r 2> /dev/null
+
+    if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
+        PS1="${_OLD_VIRTUAL_PS1:-}"
+        export PS1
+    fi
+
+    unset _OLD_VIRTUAL_PS1
+    unset _OLD_VIRTUAL_PATH
+    unset _OLD_VIRTUAL_PYTHONHOME
+    unset VIRTUAL_ENV
+    unset VIRTUAL_ENV_PROMPT
+
+    # Unset Bazel-injected vars
+    unset BAZEL_TARGET
+    unset BAZEL_WORKSPACE
+    unset BAZEL_TARGET_NAME
+
+    if [ ! "${1:-}" = "nondestructive" ] ; then
+    # Self destruct!
+        unset -f deactivate
+    fi
+}
+
+# unset irrelevant variables
+deactivate nondestructive
+
+# For ZSH, emulate BASH_SOURCE.
+# The runfiles library code has some deps on this so we just set it :/
+: "${BASH_SOURCE:=$0}"
+
+VIRTUAL_ENV="$(dirname "$(dirname "${BASH_SOURCE}")")"
+export VIRTUAL_ENV
+
+# unset PYTHONHOME if set
+# this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
+# could use `if (set -u; : $PYTHONHOME) ;` in bash.
+_OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-_activate_undef}"
+unset PYTHONHOME
+
+_OLD_VIRTUAL_PATH="$PATH"
+
+# Aspect additions
+export BAZEL_TARGET="//py/private/py_venv/tests:venv"
+export BAZEL_WORKSPACE="_main"
+export BAZEL_TARGET_NAME="venv"
+
+# Now we can put the venv's absolute bin on the path
+PATH="$VIRTUAL_ENV/bin:$PATH"
+export PATH
+
+# Call hash to forget past commands. Without forgetting
+# past commands the $PATH changes we made may not be respected
+hash -r 2> /dev/null
+---
+FILE bin/cowsay
+---
+#!/bin/sh
+case $0 in
+    */*) script_dir=${0%/*} ;;
+    *) script_dir=. ;;
+esac
+exec "${script_dir}/python" -c 'import sys; from importlib import import_module; from operator import attrgetter; sys.argv[0] = "cowsay"; sys.exit(attrgetter("cli")(import_module("cowsay.__main__"))())' "$@"
+---
+LINK bin/python -> ../../../../../../../rules_python++python+python_3_9_x86_64-unknown-linux-gnu/bin/python3
+LINK bin/python3 -> python
+LINK bin/python3.9 -> python
+FILE lib/python3.9/site-packages/_virtualenv.pth
+---
+import _virtualenv
+---
+FILE lib/python3.9/site-packages/_virtualenv.py
+---
+"""Patches that are applied at runtime to the virtual environment."""
+
+import os
+import sys
+
+# Make wheel-declared console scripts reachable via `subprocess.run("name", ...)`.
+# Use dirname(sys.executable) so this works on Windows too, where the scripts
+# dir is `Scripts/` rather than `bin/`.
+_venv_bin = os.path.dirname(sys.executable)
+if _venv_bin not in os.environ.get("PATH", "").split(os.pathsep):
+    os.environ["PATH"] = _venv_bin + os.pathsep + os.environ.get("PATH", "")
+del _venv_bin
+
+VIRTUALENV_PATCH_FILE = os.path.join(__file__)
+
+
+def patch_dist(dist):
+    """
+    Distutils allows user to configure some arguments via a configuration file:
+    https://docs.python.org/3.11/install/index.html#distutils-configuration-files.
+
+    Some of this arguments though don't make sense in context of the virtual environment files, let's fix them up.
+    """  # noqa: D205
+    # we cannot allow some install config as that would get packages installed outside of the virtual environment
+    old_parse_config_files = dist.Distribution.parse_config_files
+
+    def parse_config_files(self, *args, **kwargs):
+        result = old_parse_config_files(self, *args, **kwargs)
+        install = self.get_option_dict("install")
+
+        if "prefix" in install:  # the prefix governs where to install the libraries
+            install["prefix"] = VIRTUALENV_PATCH_FILE, os.path.abspath(sys.prefix)
+        for base in ("purelib", "platlib", "headers", "scripts", "data"):
+            key = f"install_{base}"
+            if key in install:  # do not allow global configs to hijack venv paths
+                install.pop(key, None)
+        return result
+
+    dist.Distribution.parse_config_files = parse_config_files
+
+
+# Import hook that patches some modules to ignore configuration values that break package installation in case
+# of virtual environments.
+_DISTUTILS_PATCH = "distutils.dist", "setuptools.dist"
+# https://docs.python.org/3/library/importlib.html#setting-up-an-importer
+
+
+class _Finder:
+    """A meta path finder that allows patching the imported distutils modules."""
+
+    fullname = None
+
+    # lock[0] is threading.Lock(), but initialized lazily to avoid importing threading very early at startup,
+    # because there are gevent-based applications that need to be first to import threading by themselves.
+    # See https://github.com/pypa/virtualenv/issues/1895 for details.
+    lock = []  # noqa: RUF012
+
+    def find_spec(self, fullname, path, target=None):  # noqa: ARG002
+        if fullname in _DISTUTILS_PATCH and self.fullname is None:
+            # initialize lock[0] lazily
+            if len(self.lock) == 0:
+                import threading
+
+                lock = threading.Lock()
+                # there is possibility that two threads T1 and T2 are simultaneously running into find_spec,
+                # observing .lock as empty, and further going into hereby initialization. However due to the GIL,
+                # list.append() operation is atomic and this way only one of the threads will "win" to put the lock
+                # - that every thread will use - into .lock[0].
+                # https://docs.python.org/3/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe
+                self.lock.append(lock)
+
+            from functools import partial
+            from importlib.util import find_spec
+
+            with self.lock[0]:
+                self.fullname = fullname
+                try:
+                    spec = find_spec(fullname, path)
+                    if spec is not None:
+                        # https://www.python.org/dev/peps/pep-0451/#how-loading-will-work
+                        old = spec.loader.exec_module
+                        if old is not self.exec_module:
+                            spec.loader.exec_module = partial(self.exec_module, old)
+                        return spec
+                finally:
+                    self.fullname = None
+        return None
+
+    @staticmethod
+    def exec_module(old, module):
+        old(module)
+        if module.__name__ in _DISTUTILS_PATCH:
+            patch_dist(module)
+
+
+sys.meta_path.insert(0, _Finder())
+---
+LINK lib/python3.9/site-packages/cowsay -> ../../../../../../../../../+uv+whl_install__aspect_rules_py__cowsay__6_1/actual_install.install/lib/python3.9/site-packages/cowsay
+LINK lib/python3.9/site-packages/cowsay-6.1.dist-info -> ../../../../../../../../../+uv+whl_install__aspect_rules_py__cowsay__6_1/actual_install.install/lib/python3.9/site-packages/cowsay-6.1.dist-info
+FILE lib/python3.9/site-packages/venv.pth
+---
+../../../../../../../../..
+../../../../../../../../../_main
+../../../../../../../../../+uv+project__aspect_rules_py
+---
+FILE pyvenv.cfg
+---
+home = ../../../../../../rules_python++python+python_3_9_x86_64-unknown-linux-gnu/bin
+implementation = CPython
+version_info = 3.9.25
+include-system-site-packages = false
+aspect-include-user-site-packages = false
+relocatable = true
+---

--- a/py/private/py_venv/tests/venv_tree.bzl
+++ b/py/private/py_venv/tests/venv_tree.bzl
@@ -1,0 +1,62 @@
+"""Snapshot rule that dumps the full venv tree structure for review diffs.
+
+Produces a deterministic text file listing every symlink (with target)
+and text file (with content) inside a ``py_venv`` target's output tree.
+Used via ``write_source_files`` so changes to the venv assembly surface
+as a reviewable diff.
+"""
+
+load("//py/private/py_venv:defs.bzl", "VirtualenvInfo")
+
+def _venv_tree_impl(ctx):
+    output = ctx.actions.declare_file(ctx.label.name + ".snap")
+    bin_python = ctx.attr.venv[VirtualenvInfo].bin_python
+    ctx.actions.run_shell(
+        inputs = ctx.attr.venv[VirtualenvInfo].all_files,
+        outputs = [output],
+        arguments = [output.path, bin_python.path],
+        command = r"""
+            set -e
+            OUT="$(pwd)/$1"
+            BIN_PYTHON="$2"
+            ROOT="$(dirname "$(dirname "$BIN_PYTHON")")"
+            cd "$ROOT"
+            {
+                find . | sort | while read p; do
+                    if [ -L "$p" ]; then
+                        target=$(readlink "$p")
+                        case "$target" in
+                            /*)
+                                if [ -f "$p" ] && [ "$(wc -c < "$p")" -lt 8192 ]; then
+                                    echo "FILE ${p#./}"
+                                    echo "---"
+                                    cat "$p"
+                                    echo "---"
+                                fi
+                                ;;
+                            *)
+                                echo "LINK ${p#./} -> $target"
+                                ;;
+                        esac
+                    elif [ -f "$p" ] && [ "$(wc -c < "$p")" -lt 8192 ]; then
+                        echo "FILE ${p#./}"
+                        echo "---"
+                        cat "$p"
+                        echo "---"
+                    fi
+                done
+            } > "$OUT"
+        """,
+    )
+    return DefaultInfo(files = depset([output]))
+
+venv_tree = rule(
+    implementation = _venv_tree_impl,
+    attrs = {
+        "venv": attr.label(
+            providers = [VirtualenvInfo],
+            mandatory = True,
+            doc = "A `py_venv` target whose venv tree to snapshot.",
+        ),
+    },
+)

--- a/py/private/py_venv/types.bzl
+++ b/py/private/py_venv/types.bzl
@@ -18,5 +18,6 @@ binary's launcher exec's the venv's `bin_python`.
         "bin_python": "File — the venv's bin/python symlink. Callers needing a launcher target point here.",
         "imports": "depset[str] — rlocation-root-relative import paths covered by this venv. Mirrors `PyInfo.imports` of the venv's dep closure.",
         "transitive_sources": "depset[File] — first-party Python sources carried by this venv (its own `srcs` plus those of any `deps` that emit `PyInfo`). Surfaced by py_binary as `PyInfo.transitive_sources` so downstream consumers see the same source closure they'd see if srcs/deps lived on the binary directly.",
+        "all_files": "depset[File] — every file and symlink declared by `assemble_venv`, for snapshot/test consumers that need the full venv output set.",
     },
 )


### PR DESCRIPTION
This change adds an `all_files` field to `VirtualenvInfo` so snapshot consumers can depend on the complete venv output set, and introduces a new `venv_tree` snapshot rule under `py/private/py_venv/snapshots/` that renders the full venv tree as a reviewable text file. Generated launcher and tree snapshots are checked in to catch unintended changes to venv assembly. 

---

### Changes are visible to end-users: no


### Test plan

- Covered by existing test cases
