### PR TITLE
refactor: remove unnecessary feature checks for bazel_compatibility>=8.5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,6 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "bazel_features", version = "1.38.0")
 bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "gawk", version = "5.3.2.bcr.7")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -33,7 +33,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.31.0/MODULE.bazel": "eca40770b202b2161c1e20be7f1c323c8836dc959ae48dcf02ee7a051ffe4e8e",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.0/MODULE.bazel": "e8ca15cb2639c5f12183db6dcb678735555d0cdd739b32a0418b6532b5e565f8",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",

--- a/e2e/interpreter-input-validation/MODULE.bazel.lock
+++ b/e2e/interpreter-input-validation/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/e2e/interpreter-runtime-metadata/MODULE.bazel.lock
+++ b/e2e/interpreter-runtime-metadata/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/e2e/interpreter-toolchain-settings/MODULE.bazel.lock
+++ b/e2e/interpreter-toolchain-settings/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/e2e/rules-proto-grpc-python/MODULE.bazel.lock
+++ b/e2e/rules-proto-grpc-python/MODULE.bazel.lock
@@ -58,7 +58,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
     "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/debugger/MODULE.bazel.lock
+++ b/examples/debugger/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.0/MODULE.bazel": "e8ca15cb2639c5f12183db6dcb678735555d0cdd739b32a0418b6532b5e565f8",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",

--- a/examples/dev_deps/MODULE.bazel.lock
+++ b/examples/dev_deps/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.0/MODULE.bazel": "e8ca15cb2639c5f12183db6dcb678735555d0cdd739b32a0418b6532b5e565f8",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",

--- a/examples/django/MODULE.bazel.lock
+++ b/examples/django/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/multi_version/MODULE.bazel.lock
+++ b/examples/multi_version/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/protobuf/MODULE.bazel.lock
+++ b/examples/protobuf/MODULE.bazel.lock
@@ -33,7 +33,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/py_binary/MODULE.bazel.lock
+++ b/examples/py_binary/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/py_pex_binary/MODULE.bazel.lock
+++ b/examples/py_pex_binary/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/py_venv/MODULE.bazel.lock
+++ b/examples/py_venv/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/pytest/MODULE.bazel.lock
+++ b/examples/pytest/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/uv_pip_compile/MODULE.bazel.lock
+++ b/examples/uv_pip_compile/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/examples/virtual_deps/MODULE.bazel.lock
+++ b/examples/virtual_deps/MODULE.bazel.lock
@@ -23,7 +23,6 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
-    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/source.json": "1c4207dc858d6de0eecef30026793616bbf420c74aac27b6bad212534a730437",

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -49,7 +49,6 @@ bzl_library(
         ":toolchains",
         "//py/private/interpreter:extension",
         "@aspect_tools_telemetry_report//:defs.bzl",
-        "@bazel_features//:features",
     ],
 )
 
@@ -60,7 +59,6 @@ bzl_library(
     deps = [
         "//py/private/toolchain:repo",
         "//py/private/toolchain:tools",
-        "@bazel_features//:features",
         "@bazel_lib//lib:repositories",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
     ],

--- a/py/extensions.bzl
+++ b/py/extensions.bzl
@@ -1,7 +1,6 @@
 "Module Extensions used from MODULE.bazel"
 
 load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load("//py/private/interpreter:extension.bzl", _python_interpreters = "python_interpreters")
 load(":toolchains.bzl", "DEFAULT_TOOLS_REPOSITORY", "rules_py_toolchains")
 
@@ -36,8 +35,6 @@ def _toolchains_extension_impl(module_ctx):
         if name != root_name:
             rules_py_toolchains(name)
 
-    if not features.external_deps.extension_metadata_has_reproducible:
-        return None
     return module_ctx.extension_metadata(reproducible = True)
 
 py_tools = module_extension(

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -100,7 +100,6 @@ bzl_library(
     srcs = ["repository.bzl"],
     deps = [
         ":exclude_feature_bzl",  # keep
-        "@bazel_features//:features",
     ],
 )
 

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -56,7 +56,7 @@ def _python_interpreter_impl(rctx):
         serial = serial,
     ))
 
-    if not features.external_deps.extension_metadata_has_reproducible:
+    if not features.external_deps.repo_metadata_has_reproducible:
         return None
     return rctx.repo_metadata(reproducible = True)
 
@@ -490,7 +490,7 @@ current_py_toolchain(
 
     rctx.file("BUILD.bazel", content = "\n".join(content))
 
-    if not features.external_deps.extension_metadata_has_reproducible:
+    if not features.external_deps.repo_metadata_has_reproducible:
         return None
     return rctx.repo_metadata(reproducible = True)
 

--- a/py/private/interpreter/repository.bzl
+++ b/py/private/interpreter/repository.bzl
@@ -1,6 +1,5 @@
 """Repository rules for Python interpreter toolchains."""
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load(":exclude_feature.bzl", "INTERPRETER_FEATURES")
 
 _PYTHON_VERSION_FLAG = "@aspect_rules_py//py/private/interpreter:python_version"
@@ -56,8 +55,6 @@ def _python_interpreter_impl(rctx):
         serial = serial,
     ))
 
-    if not features.external_deps.repo_metadata_has_reproducible:
-        return None
     return rctx.repo_metadata(reproducible = True)
 
 def _feature_filegroups(major, minor, is_windows):
@@ -490,8 +487,6 @@ current_py_toolchain(
 
     rctx.file("BUILD.bazel", content = "\n".join(content))
 
-    if not features.external_deps.repo_metadata_has_reproducible:
-        return None
     return rctx.repo_metadata(reproducible = True)
 
 python_toolchains = repository_rule(

--- a/py/private/toolchain/repo.bzl
+++ b/py/private/toolchain/repo.bzl
@@ -4,7 +4,6 @@ Generates native_build toolchain entries — one per supported platform — that
 back pep517_whl's cross-compilation guard (see NATIVE_BUILD_TOOLCHAIN in types.bzl).
 """
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load("//py/private/toolchain:tools.bzl", "TOOLCHAIN_PLATFORMS")
 
 def _toolchains_repo_impl(repository_ctx):
@@ -32,8 +31,6 @@ toolchain(
 
     repository_ctx.file("BUILD.bazel", build_content)
 
-    if not features.external_deps.repo_metadata_has_reproducible:
-        return None
     return repository_ctx.repo_metadata(reproducible = True)
 
 toolchains_repo = repository_rule(

--- a/py/private/toolchain/repo.bzl
+++ b/py/private/toolchain/repo.bzl
@@ -32,7 +32,7 @@ toolchain(
 
     repository_ctx.file("BUILD.bazel", build_content)
 
-    if not features.external_deps.extension_metadata_has_reproducible:
+    if not features.external_deps.repo_metadata_has_reproducible:
         return None
     return repository_ctx.repo_metadata(reproducible = True)
 

--- a/uv/private/constraints/repository.bzl
+++ b/uv/private/constraints/repository.bzl
@@ -57,7 +57,7 @@ exports_files(
 
     repository_ctx.file("BUILD.bazel", content = "\n".join(content))
 
-    if not features.external_deps.extension_metadata_has_reproducible:
+    if not features.external_deps.repo_metadata_has_reproducible:
         return None
     return repository_ctx.repo_metadata(reproducible = True)
 

--- a/uv/private/constraints/repository.bzl
+++ b/uv/private/constraints/repository.bzl
@@ -10,8 +10,6 @@ and makes debugging easier as well as the generated selections more meaningful.
 
 """
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
-
 def _format_list(items):
     return "[\n" + "".join(["    {},\n".format(repr(it)) for it in items]) + "]"
 
@@ -57,8 +55,6 @@ exports_files(
 
     repository_ctx.file("BUILD.bazel", content = "\n".join(content))
 
-    if not features.external_deps.repo_metadata_has_reproducible:
-        return None
     return repository_ctx.repo_metadata(reproducible = True)
 
 configurations_hub = repository_rule(

--- a/uv/private/extension/BUILD.bazel
+++ b/uv/private/extension/BUILD.bazel
@@ -35,7 +35,6 @@ bzl_library(
         "//uv/private/uv_hub:repository",
         "//uv/private/uv_project:repository",
         "//uv/private/whl_install:repository",
-        "@bazel_features//:features",
         "@bazel_lib//lib:resource_sets",
         "@bazel_skylib//lib:sets",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
@@ -137,7 +136,6 @@ bzl_library(
     deps = [
         "//uv/private/toolchain:repositories",
         "//uv/private/toolchain:versions",
-        "@bazel_features//:features",
     ],
 )
 

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -51,7 +51,6 @@ resolved dependencies available in the `@uv` repository.
 [2] https://peps.python.org/pep-0751/#locking-build-requirements-for-sdists
 """
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set_values")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
@@ -758,8 +757,6 @@ def _uv_impl(module_ctx):
             packages = json.encode(hub_cfg.packages),
         )
 
-    if not features.external_deps.extension_metadata_has_reproducible:
-        return None
     return module_ctx.extension_metadata(reproducible = True)
 
 _hub_tag = tag_class(

--- a/uv/private/extension/uv_bin.bzl
+++ b/uv/private/extension/uv_bin.bzl
@@ -1,6 +1,5 @@
 """A Bazel module extension for downloading and registering UV binaries."""
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load("//uv/private/toolchain:repositories.bzl", "uv_hub_repository", "uv_repository")
 load("//uv/private/toolchain:versions.bzl", "UV_VERSIONS")
 
@@ -65,8 +64,6 @@ def _uv_bin_impl(module_ctx):
             repo_prefix = repo_prefix,
         )
 
-    if not features.external_deps.extension_metadata_has_reproducible:
-        return None
     return module_ctx.extension_metadata(reproducible = True)
 
 _toolchain_tag = tag_class(

--- a/uv/private/git_archive/BUILD.bazel
+++ b/uv/private/git_archive/BUILD.bazel
@@ -9,5 +9,4 @@ exports_files(["defs.bzl"])
 bzl_library(
     name = "repository",
     srcs = ["repository.bzl"],
-    deps = ["@bazel_features//:features"],
 )

--- a/uv/private/git_archive/repository.bzl
+++ b/uv/private/git_archive/repository.bzl
@@ -74,7 +74,7 @@ filegroup(
         print(status.stdout)
         print(status.stderr)
 
-    if features.external_deps.extension_metadata_has_reproducible:
+    if features.external_deps.repo_metadata_has_reproducible:
         if is_reproducible:
             return repository_ctx.repo_metadata(reproducible = True)
         else:

--- a/uv/private/git_archive/repository.bzl
+++ b/uv/private/git_archive/repository.bzl
@@ -2,8 +2,6 @@
 A repository rule for creating an archive from a remote git repository.
 """
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
-
 def _is_sha1(s):
     """Check if a string is a 40-character hex string (SHA-1)."""
     if len(s) != 40:
@@ -74,14 +72,12 @@ filegroup(
         print(status.stdout)
         print(status.stderr)
 
-    if features.external_deps.repo_metadata_has_reproducible:
-        if is_reproducible:
-            return repository_ctx.repo_metadata(reproducible = True)
-        else:
-            return repository_ctx.repo_metadata(
-                reproducible = False,
-                attrs_for_reproducibility = {"commit": resolved_commit},
-            )
+    if is_reproducible:
+        return repository_ctx.repo_metadata(reproducible = True)
+    return repository_ctx.repo_metadata(
+        reproducible = False,
+        attrs_for_reproducibility = {"commit": resolved_commit},
+    )
 
 git_archive = repository_rule(
     implementation = _git_archive_impl,

--- a/uv/private/host/extension.bzl
+++ b/uv/private/host/extension.bzl
@@ -5,14 +5,11 @@ Required under bzlmod so that we can evaluate host-dependent configuration
 defaults.
 """
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load(":repository.bzl", "host_platform_repo")
 
 def _host_platform_impl(module_ctx):
     host_platform_repo(name = "aspect_rules_py_uv_host")
 
-    if not features.external_deps.extension_metadata_has_reproducible:
-        return None
     return module_ctx.extension_metadata(reproducible = True)
 
 host_platform = module_extension(

--- a/uv/private/uv_hub/BUILD.bazel
+++ b/uv/private/uv_hub/BUILD.bazel
@@ -11,7 +11,6 @@ bzl_library(
     srcs = ["repository.bzl"],
     deps = [
         "//uv/private/pprint:defs",
-        "@bazel_features//:features",
     ],
 )
 

--- a/uv/private/uv_hub/repository.bzl
+++ b/uv/private/uv_hub/repository.bzl
@@ -270,7 +270,7 @@ def requirement(name):
     ))
     repository_ctx.file("requirements.bzl", content = "\n".join(content))
 
-    if not features.external_deps.extension_metadata_has_reproducible:
+    if not features.external_deps.repo_metadata_has_reproducible:
         return None
     return repository_ctx.repo_metadata(reproducible = True)
 

--- a/uv/private/uv_hub/repository.bzl
+++ b/uv/private/uv_hub/repository.bzl
@@ -2,7 +2,6 @@
 
 """
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load("//uv/private/pprint:defs.bzl", "indent", "pprint")
 
 def _hub_impl(repository_ctx):
@@ -270,8 +269,6 @@ def requirement(name):
     ))
     repository_ctx.file("requirements.bzl", content = "\n".join(content))
 
-    if not features.external_deps.repo_metadata_has_reproducible:
-        return None
     return repository_ctx.repo_metadata(reproducible = True)
 
 uv_hub = repository_rule(

--- a/uv/private/uv_project/BUILD.bazel
+++ b/uv/private/uv_project/BUILD.bazel
@@ -15,7 +15,6 @@ bzl_library(
         ":select_gen",
         "//uv/private:sha1",
         "//uv/private/pprint:defs",
-        "@bazel_features//:features",
     ],
 )
 

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -298,7 +298,7 @@ exports_files(
 
     repository_ctx.file("private/markers/BUILD.bazel", "\n".join(content))
 
-    if not features.external_deps.extension_metadata_has_reproducible:
+    if not features.external_deps.repo_metadata_has_reproducible:
         return None
     return repository_ctx.repo_metadata(reproducible = True)
 

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -2,7 +2,6 @@
 
 """
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load("//uv/private/pprint:defs.bzl", "indent", "pprint")
 load("//uv/private/uv_project:select_gen.bzl", "build_package_select_arms")
 
@@ -298,8 +297,6 @@ exports_files(
 
     repository_ctx.file("private/markers/BUILD.bazel", "\n".join(content))
 
-    if not features.external_deps.repo_metadata_has_reproducible:
-        return None
     return repository_ctx.repo_metadata(reproducible = True)
 
 uv_project = repository_rule(

--- a/uv/private/whl_install/BUILD.bazel
+++ b/uv/private/whl_install/BUILD.bazel
@@ -26,7 +26,6 @@ bzl_library(
         "//uv/private/constraints/platform:defs",
         "//uv/private/constraints/python:defs",
         "//uv/private/pprint:defs",
-        "@bazel_features//:features",
     ],
 )
 

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -7,7 +7,6 @@ produce a filegroup/TreeArtifact.
 
 """
 
-load("@bazel_features//:features.bzl", features = "bazel_features")
 load("//uv/private:parse_whl_name.bzl", "parse_whl_name")
 load("//uv/private/constraints:defs.bzl", "MAJORS", "MINORS")
 load("//uv/private/constraints/platform:defs.bzl", "supported_platform")
@@ -898,8 +897,6 @@ exports_files(
 
     repository_ctx.file("BUILD.bazel", content = "\n".join(content))
 
-    if not features.external_deps.repo_metadata_has_reproducible:
-        return None
     return repository_ctx.repo_metadata(reproducible = True)
 
 whl_install = repository_rule(

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -898,7 +898,7 @@ exports_files(
 
     repository_ctx.file("BUILD.bazel", content = "\n".join(content))
 
-    if not features.external_deps.extension_metadata_has_reproducible:
+    if not features.external_deps.repo_metadata_has_reproducible:
         return None
     return repository_ctx.repo_metadata(reproducible = True)
 


### PR DESCRIPTION
The wrong flags were being used (see first commit), but the `bazel_features` checks aren't even necessary when we declare bazel_compatibility>=8.5.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
