### PR TITLE
refactor(venv): extract toolchain path resolution into toolchains_resolver.bzl

### DIFF
--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -43,7 +43,16 @@ bzl_library(
 bzl_library(
     name = "venv",
     srcs = ["venv.bzl"],
-    deps = ["//py/private:py_library"],
+    deps = [
+        ":toolchains_resolver",
+        "//py/private:py_library",
+    ],
+)
+
+bzl_library(
+    name = "toolchains_resolver",
+    srcs = ["toolchains_resolver.bzl"],
+    deps = ["@bazel_lib//lib:paths"],
 )
 
 bzl_library(

--- a/py/private/py_venv/toolchains_resolver.bzl
+++ b/py/private/py_venv/toolchains_resolver.bzl
@@ -1,0 +1,157 @@
+"""Toolchain-derived path and flag resolution for venv assembly."""
+
+load("@bazel_lib//lib:paths.bzl", "to_rlocation_path")
+
+def _relative_up(depth):
+    """Join ``depth`` repetitions of ``..`` into a single relative path."""
+    return "/".join([".."] * depth)
+
+def _package_depth(ctx):
+    """Count the ``/``-separated segments in the target's Bazel package."""
+    return len(ctx.label.package.split("/")) if ctx.label.package else 0
+
+def _py_versions(py_toolchain):
+    """Compute the ``lib/`` directory names used by wheels and the venv.
+
+    Wheels always use ``python<MAJ>.<MIN>`` regardless of freethreaded
+    status — the unpacker hardcodes this layout. Freethreaded CPython
+    3.13+ expects site-packages under ``python<MAJ>.<MIN>t/``, so the
+    venv directory name carries the ``t`` suffix when applicable.
+
+    Returns:
+      ``(wheel_py_ver, venv_py_ver)``
+    """
+    base = "python{}.{}".format(
+        py_toolchain.interpreter_version_info.major,
+        py_toolchain.interpreter_version_info.minor,
+    )
+    return base, base + ("t" if py_toolchain.freethreaded else "")
+
+def _site_packages_escape(package_depth):
+    """Relative path from ``<venv>/lib/pythonX.Y/site-packages/`` to the
+    runfiles root.
+
+    Ascends: workspace (1) + package segments (N) + venv dir (1) +
+    lib/pythonX.Y/site-packages (3) = 5 + N.
+    """
+    return _relative_up(5 + package_depth)
+
+def _venv_root_escape(package_depth):
+    """Relative path from the venv root (``sys.prefix``) to the runfiles
+    root.
+
+    Ascends: workspace (1) + package segments (N) + venv dir (1) = 2 + N.
+    """
+    return _relative_up(2 + package_depth)
+
+def _uses_empty_venv_home(py_toolchain, is_windows):
+    """Whether to leave ``home`` empty in ``pyvenv.cfg``.
+
+    CPython 3.11/3.12 runfiles interpreters with build-time venv support
+    on non-Windows resolve a relocatable ``bin/python`` symlink correctly
+    only when ``home`` is empty and ``relocatable = true``. With a
+    non-empty relative ``home``, ``getpath.py`` resolves from the startup
+    cwd, which breaks under sandbox/RBE where the cwd is not the
+    execroot.
+
+    Omitting the key entirely leaves ``sys._base_executable`` at the
+    outer venv symlink, so a stdlib-created nested venv writes the outer
+    venv's ``bin/`` as ``home`` — also incorrect.
+
+    See ``getpath.py`` L362-365, L431-432 and ``Lib/venv/__init__.py``
+    L158-166:
+    https://github.com/python/cpython/blob/3bb231a6/Modules/getpath.py#L362-L365
+    """
+    return (
+        py_toolchain.runfiles_interpreter and
+        not is_windows and
+        getattr(py_toolchain.toolchain, "implementation_name", None) == "cpython" and
+        getattr(py_toolchain.toolchain, "supports_build_time_venv", False) and
+        py_toolchain.interpreter_version_info.major == 3 and
+        py_toolchain.interpreter_version_info.minor in [11, 12]
+    )
+
+def _pyvenv_home(ctx, py_toolchain, is_windows, venv_root_escape):
+    """Resolve the ``home =`` line for ``pyvenv.cfg``.
+
+    Three branches:
+
+    - Empty for qualifying CPython 3.11/3.12 (see ``_uses_empty_venv_home``).
+    - A venv-root-relative path to the interpreter's ``bin/`` for other
+      runfiles interpreters.
+    - The absolute filesystem path for system interpreters (already
+      non-hermetic by construction).
+    """
+    if _uses_empty_venv_home(py_toolchain, is_windows):
+        return ""
+    if py_toolchain.runfiles_interpreter:
+        interpreter_rlocation = to_rlocation_path(ctx, py_toolchain.python)
+        interpreter_bin_dir = "/".join(interpreter_rlocation.split("/")[:-1])
+        return "{}/{}".format(venv_root_escape, interpreter_bin_dir)
+    return py_toolchain.python.path.rsplit("/", 1)[0]
+
+def _versioned_python_names(py_toolchain):
+    """Symlink names under which CPython looks itself up.
+
+    ``python3``, ``python3.<MIN>``, and ``python3.<MIN>t`` for
+    freethreaded builds. All point at the sibling ``python`` symlink.
+    """
+    major = py_toolchain.interpreter_version_info.major
+    minor = py_toolchain.interpreter_version_info.minor
+    names = ["python{}".format(major), "python{}.{}".format(major, minor)]
+    if py_toolchain.freethreaded:
+        names.append("python{}.{}t".format(major, minor))
+    return names
+
+def _bin_python_target_path(ctx, py_toolchain, package_depth):
+    """Compute the ``target_path`` for the ``bin/python`` unresolved
+    symlink.
+
+    Uses an explicit relative path through the runfiles tree instead of
+    Bazel's ``target_file`` mechanism. ``target_file`` lets Bazel choose
+    the symlink target, and the choice (relative vs absolute) differs
+    across Bazel versions — Bazel 8 tends relative, Bazel 9 absolute.
+    Absolute targets bake in the build-host execroot path, which does
+    not exist inside an OCI container, leaving ``bin/python`` as a
+    dangling symlink.
+
+    From ``<venv>/bin/``, ascends bin (1) + venv (1) + package (N) +
+    workspace (1) = 3 + N, then descends into the interpreter's
+    rlocation path. System interpreters fall back to the absolute path.
+    """
+    if not py_toolchain.runfiles_interpreter:
+        return py_toolchain.python.path
+    return "{}/{}".format(
+        _relative_up(3 + package_depth),
+        to_rlocation_path(ctx, py_toolchain.python),
+    )
+
+def resolve_venv_toolchain(ctx, *, py_toolchain, is_windows, venv_name):
+    """Compute toolchain-derived paths and flags for venv assembly.
+
+    Args:
+      ctx: The rule context.
+      py_toolchain: Resolved Python toolchain struct from py_semantics.
+      is_windows: Whether the venv targets Windows.
+      venv_name: The venv dir basename (e.g. ``.safe_name``).
+
+    Returns:
+      struct with ``wheel_py_ver``, ``venv_py_ver``, ``escape``,
+      ``venv_to_runfiles_escape``, ``site_packages_rel``,
+      ``pyvenv_home``, ``versioned_python_names``,
+      ``bin_python_target_path``.
+    """
+    wheel_py_ver, venv_py_ver = _py_versions(py_toolchain)
+    depth = _package_depth(ctx)
+    venv_to_runfiles_escape = _venv_root_escape(depth)
+
+    return struct(
+        wheel_py_ver = wheel_py_ver,
+        venv_py_ver = venv_py_ver,
+        escape = _site_packages_escape(depth),
+        venv_to_runfiles_escape = venv_to_runfiles_escape,
+        site_packages_rel = "{}/lib/{}/site-packages".format(venv_name, venv_py_ver),
+        pyvenv_home = _pyvenv_home(ctx, py_toolchain, is_windows, venv_to_runfiles_escape),
+        versioned_python_names = _versioned_python_names(py_toolchain),
+        bin_python_target_path = _bin_python_target_path(ctx, py_toolchain, depth),
+    )

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -35,9 +35,9 @@ Bazel's action cache treats each piece independently (no tree-artifact
 + remote-exec materialisation surprises).
 """
 
-load("@bazel_lib//lib:paths.bzl", "to_rlocation_path")
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
+load(":toolchains_resolver.bzl", "resolve_venv_toolchain")
 
 # Template for console-script wrappers under <venv>/bin/<name>. A tiny shell
 # script that execs the venv's own bin/python with an inline `-c` to import
@@ -615,49 +615,19 @@ def assemble_venv(
         package_collisions,
     )
 
-    # Layout + escape math — the venv is a sibling of the target's
-    # declared outputs at <pkg>/<venv_name>/, so from the .pth / symlinks
-    # inside site-packages we need to walk up to the runfiles root before
-    # descending into an external wheel repo.
-    #
-    # Components below the runfiles root, from the .pth's directory:
-    #   1 workspace
-    # + N package segments
-    # + 1 venv segment
-    # + 3 (lib, python<MAJ>.<MIN>, site-packages)
-    # `py_ver` controls two distinct layouts that agree most of the time
-    # but diverge for freethreaded interpreters:
-    #
-    # * `venv_py_ver` — the lib-dir name inside OUR venv. Freethreaded
-    #   Python 3.13+ (and onwards) expects its site-packages at
-    #   `lib/python<M>.<m>t/site-packages/`. If we put ours at
-    #   `python<M>.<m>/`, the interpreter never finds our symlinks.
-    # * `wheel_py_ver` — the lib-dir name inside a wheel's `install_tree`.
-    #   The unpacker hardcodes `lib/python<M>.<m>/site-packages/`
-    #   regardless of freethreaded status (same wheel install layout for
-    #   both non-t and t interpreters). Keep this without the `t`.
-    wheel_py_ver = "python{}.{}".format(
-        py_toolchain.interpreter_version_info.major,
-        py_toolchain.interpreter_version_info.minor,
+    # All toolchain-derived path/flag math (runfiles escape arithmetic,
+    # wheel/venv lib-dir names, pyvenv.cfg home, versioned python names,
+    # bin/python target_path) is concentrated in resolve_venv_toolchain.
+    tc = resolve_venv_toolchain(
+        ctx,
+        py_toolchain = py_toolchain,
+        is_windows = is_windows,
+        venv_name = venv_name,
     )
-    venv_py_ver = wheel_py_ver + ("t" if py_toolchain.freethreaded else "")
-    package_depth = len(ctx.label.package.split("/")) if ctx.label.package else 0
-
-    # From .pth / symlink dir up to runfiles root.
-    escape_count = 1 + package_depth + 1 + 3
-    escape = "/".join([".."] * escape_count)
-
-    # From venv root (= sys.prefix at runtime) up to runfiles root.
-    venv_to_runfiles_escape = "/".join([".."] * (2 + package_depth))
-
-    # The leading-dot basename (e.g. `.{name}.venv/`) is the Pythonic
-    # name that IDEs auto-detect. The leading dot also keeps this
-    # distinct from a sibling py_venv target at `:<name>.venv`
-    # (auto-emitted when `expose_venv = True` is set): the sibling's
-    # launcher file lands at `bazel-bin/<pkg>/<name>.venv`, while any
-    # internal venv tree lives under `bazel-bin/<pkg>/.<name>.venv/`.
-    # Different filesystem paths, no collision.
-    site_packages_rel = "{}/lib/{}/site-packages".format(venv_name, venv_py_ver)
+    escape = tc.escape
+    venv_to_runfiles_escape = tc.venv_to_runfiles_escape
+    wheel_py_ver = tc.wheel_py_ver
+    site_packages_rel = tc.site_packages_rel
 
     # site_packages_rfpath → install_tree, used only by the regular-package
     # merge action below. The per-top-level symlinks and .pth lines locate
@@ -799,38 +769,8 @@ def assemble_venv(
     )
     declared.append(site_packages_pth_file)
 
-    # `relocatable = true` below is a rules_py extension: for an in-build
-    # CPython 3.11/3.12 runtime that supports build-time venvs, keep `home`
-    # empty so getpath resolves the relocatable bin/python symlink into the
-    # base executable without forcing prefix discovery from a relative path.
-    # Omitting the key leaves sys._base_executable at the outer venv symlink,
-    # so a stdlib-created nested venv writes the outer venv's bin/ as home.
-    # A relative `home` instead resolves from the startup cwd:
-    # https://github.com/python/cpython/blob/3bb231a6/Modules/getpath.py#L362-L365
-    # https://github.com/python/cpython/blob/3bb231a6/Modules/getpath.py#L431-L432
-    # https://github.com/python/cpython/blob/3bb231a6/Lib/venv/__init__.py#L158-L166
-    # Direct runtimes use that symlink. The capability also permits wrappers
-    # that set PYTHONEXECUTABLE to preserve the underlying base executable:
-    # https://github.com/bazel-contrib/rules_python/blob/bac54949/python/private/py_runtime_info.bzl#L316-L337
-    use_empty_venv_home = (
-        py_toolchain.runfiles_interpreter and
-        not is_windows and
-        getattr(py_toolchain.toolchain, "implementation_name", None) == "cpython" and
-        getattr(py_toolchain.toolchain, "supports_build_time_venv", False) and
-        py_toolchain.interpreter_version_info.major == 3 and
-        py_toolchain.interpreter_version_info.minor in [11, 12]
-    )
-    if use_empty_venv_home:
-        pyvenv_home = ""
-    elif py_toolchain.runfiles_interpreter:
-        pbs_rlocation = to_rlocation_path(ctx, py_toolchain.python)
-        pbs_bin_dir = "/".join(pbs_rlocation.split("/")[:-1])
-        pyvenv_home = "{}/{}".format(venv_to_runfiles_escape, pbs_bin_dir)
-    else:
-        pyvenv_home = py_toolchain.python.path.rsplit("/", 1)[0]
-
     pyvenv_cfg = ctx.actions.declare_file("{}/pyvenv.cfg".format(venv_name))
-    home_line = "home =\n" if pyvenv_home == "" else "home = {}\n".format(pyvenv_home)
+    home_line = "home =\n" if tc.pyvenv_home == "" else "home = {}\n".format(tc.pyvenv_home)
     ctx.actions.write(
         output = pyvenv_cfg,
         content = home_line + (
@@ -849,60 +789,23 @@ def assemble_venv(
     )
     declared.append(pyvenv_cfg)
 
-    # bin/python — the symlink the launcher exec's and that Python reads
-    # to compute sys.base_prefix. We emit an UNRESOLVED symlink
-    # (`declare_symlink` + `target_path`) with an explicit relative
-    # target rather than a `declare_file` + `target_file` on
-    # `py_toolchain.python` for two reasons:
-    #
-    #  1. `target_file` lets Bazel pick the symlink target, and the
-    #     choice differs across Bazel versions (Bazel 8 tends to write
-    #     relative, Bazel 9 absolute). Downstream tools that repack the
-    #     tar (`py_image_layer`) need a stable, runfiles-correct target.
-    #  2. Absolute targets bake in the build-host execroot path — in an
-    #     OCI container that path doesn't exist, bin/python becomes a
-    #     dangling symlink, Python falls back to its compile-time
-    #     `/install` base_prefix, then fails to locate the stdlib.
-    #
-    # From `<venv>/bin/`, walk up to the runfiles root (`.runfiles/`)
-    # and then down through the interpreter's rlocation path — which is
-    # exactly the shape `runfiles` libraries would compute. Up count:
-    # 1 (bin) + 1 (venv) + package_depth + 1 (workspace) = 3 + pkg.
-    # For system-interpreter (no runfiles_interpreter), fall back to the
-    # absolute path — these are already non-hermetic by construction.
+    # bin/python — unresolved symlink (declare_symlink + target_path)
+    # rather than declare_file + target_file: target_file lets Bazel pick
+    # relative vs absolute per version (Bazel 8 rel, Bazel 9 abs), and an
+    # absolute target bakes in the build-host execroot path that does not
+    # exist inside an OCI container, leaving a dangling symlink. The
+    # target path itself is computed by resolve_venv_toolchain.
     bin_python = ctx.actions.declare_symlink("{}/bin/python".format(venv_name))
-    if py_toolchain.runfiles_interpreter:
-        bin_to_runfiles_root = "/".join([".."] * (3 + package_depth))
-        ctx.actions.symlink(
-            output = bin_python,
-            target_path = "{}/{}".format(
-                bin_to_runfiles_root,
-                to_rlocation_path(ctx, py_toolchain.python),
-            ),
-        )
-    else:
-        ctx.actions.symlink(
-            output = bin_python,
-            target_path = py_toolchain.python.path,
-        )
+    ctx.actions.symlink(
+        output = bin_python,
+        target_path = tc.bin_python_target_path,
+    )
     declared.append(bin_python)
 
-    # Versioned python symlinks: python3, python3.<MAJ>.<MIN>, and on
-    # freethreaded interpreters also python3.<MAJ>.<MIN>t (the name the
-    # interpreter looks itself up under). All point at the sibling `python`.
-    versioned_names = [
-        "python{}".format(py_toolchain.interpreter_version_info.major),
-        "python{}.{}".format(
-            py_toolchain.interpreter_version_info.major,
-            py_toolchain.interpreter_version_info.minor,
-        ),
-    ]
-    if py_toolchain.freethreaded:
-        versioned_names.append("python{}.{}t".format(
-            py_toolchain.interpreter_version_info.major,
-            py_toolchain.interpreter_version_info.minor,
-        ))
-    for versioned_name in versioned_names:
+    # Versioned python symlinks (python3, python3.<MAJ>.<MIN>, and
+    # python3.<MAJ>.<MIN>t for freethreaded) all point at the sibling
+    # `python`; names resolved by resolve_venv_toolchain.
+    for versioned_name in tc.versioned_python_names:
         sym = ctx.actions.declare_symlink("{}/bin/{}".format(venv_name, versioned_name))
         ctx.actions.symlink(
             output = sym,


### PR DESCRIPTION
Hoists the pure toolchain-derived path/flag math currently inline in `venv.bzl`'s assemble_venv into a standalone, ctx-action-free module: wheel/venv lib-dir versions, runfiles escape arithmetic, the CPython 3.11/3.12 empty-home rule, pyvenv.cfg home resolution, versioned python symlink names, and the bin/python target_path computation.

Dead code on landing: no consumer loads it yet (`venv.bzl` retains its inline copies). Subsequent PRs rewire `assemble_venv` to call `resolve_venv_toolchain` and delete the duplicated logic.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
