### PR TITLE
refactor(venv): extract console-script wrapper template into a file

### DIFF
--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//py:__subpackages__"])
 
 exports_files([
     "templates/_virtualenv.py",
+    "templates/console_script.tmpl.sh",
     "templates/link.py",
     "templates/venv.tmpl.sh",
     "templates/venv_activate.tmpl.sh",

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -80,6 +80,7 @@ def _assemble_shared(ctx):
         venv_activate_tmpl = ctx.file._venv_activate_tmpl,
         virtualenv_shim_py = ctx.file._virtualenv_shim,
         site_merge_script_py = ctx.file._site_merge_script,
+        console_script_tmpl = ctx.file._console_script_tmpl,
         venv_name = ".{}".format(safe_name),
     )
 
@@ -241,6 +242,10 @@ does not reinsert a wheel.
     "_site_merge_script": attr.label(
         allow_single_file = True,
         default = "//py/tools/site_merge:site_merge.py",
+    ),
+    "_console_script_tmpl": attr.label(
+        allow_single_file = True,
+        default = "//py/private/py_venv:templates/console_script.tmpl.sh",
     ),
 })
 

--- a/py/private/py_venv/templates/console_script.tmpl.sh
+++ b/py/private/py_venv/templates/console_script.tmpl.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+case $0 in
+    */*) script_dir=${0%/*} ;;
+    *) script_dir=. ;;
+esac
+exec "${script_dir}/python" -c 'import sys; from importlib import import_module; from operator import attrgetter; sys.argv[0] = "{{name}}"; sys.exit(attrgetter("{{func}}")(import_module("{{module}}"))())' "$@"

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -40,24 +40,6 @@ load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
 load(":toolchains_resolver.bzl", "resolve_venv_toolchain")
 load(":virtuals_resolvers.bzl", "enforce_collision_policy", "resolve_wheel_collisions")
 
-# Template for console-script wrappers under <venv>/bin/<name>. A tiny shell
-# script that execs the venv's own bin/python with an inline `-c` to import
-# the entry point and call it. Keeping this as pure sh (no polyglot) sidesteps
-# tokenisation quirks with `$` in strings, and the inline Python is short
-# enough that not having a real `__file__` doesn't matter in practice.
-# `"$@"` preserves the original argv, while sys.argv[0] is patched so the
-# called function sees the script's own name. Entry-point object references
-# may contain dotted attributes:
-# https://packaging.python.org/en/latest/specifications/entry-points/#data-model
-_CONSOLE_SCRIPT_TEMPLATE = """\
-#!/bin/sh
-case $0 in
-    */*) script_dir=${{0%/*}} ;;
-    *) script_dir=. ;;
-esac
-exec "${{script_dir}}/python" -c 'import sys; from importlib import import_module; from operator import attrgetter; sys.argv[0] = "{name}"; sys.exit(attrgetter("{func}")(import_module("{module}"))())' "$@"
-"""
-
 def _dict_to_exports(env):
     return ["export %s=\"%s\"" % (k, v) for (k, v) in env.items()]
 
@@ -75,6 +57,7 @@ def assemble_venv(
         venv_activate_tmpl,
         virtualenv_shim_py,
         site_merge_script_py,
+        console_script_tmpl,
         venv_name):
     """Declare every file + symlink that makes up a venv for a target.
 
@@ -104,6 +87,8 @@ def assemble_venv(
         wheel graph contains a regular package needing a physical merge; the
         merge action also requires the rule to declare the (optional)
         EXEC_TOOLS_TOOLCHAIN for an exec-configuration interpreter.
+      console_script_tmpl: File — the console-script wrapper template
+        (usually `ctx.file._console_script_tmpl`).
       venv_name: str — the venv dir basename (e.g. "." + safe_name).
 
     Returns:
@@ -359,13 +344,14 @@ def assemble_venv(
     # Console-script wrappers under <venv>/bin/<name>.
     for name, target in console_scripts_map.items():
         script = ctx.actions.declare_file("{}/bin/{}".format(venv_name, name))
-        ctx.actions.write(
+        ctx.actions.expand_template(
+            template = console_script_tmpl,
             output = script,
-            content = _CONSOLE_SCRIPT_TEMPLATE.format(
-                name = name,
-                module = target.module,
-                func = target.func,
-            ),
+            substitutions = {
+                "{{name}}": name,
+                "{{module}}": target.module,
+                "{{func}}": target.func,
+            },
             is_executable = True,
         )
         declared.append(script)


### PR DESCRIPTION
Moves the inline `_CONSOLE_SCRIPT_TEMPLATE` string out of `venv.bzl` into `templates/console_script.tmpl.sh`, rendered via `ctx.actions.expand_template` with `{{name}}/{{module}}/{{func}}` substitutions instead of str.format. A real template file avoids the {{...}} escaping the inline string needed for shell ${0%/*} and keeps every venv artifact as a materialised file.
`assemble_venv` gains a `console_script_tmpl` parameter; `py_venv` wires it via a `_console_script_tmpl` attribute. Console-scripts test passes on a forced re-run and venv snapshots regenerate byte-identical.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
