### PR TITLE
feat(py): expose rules_python compatibility APIs

### DIFF
--- a/e2e/cases/interpreter-local-pyvenv-home/BUILD.bazel
+++ b/e2e/cases/interpreter-local-pyvenv-home/BUILD.bazel
@@ -1,6 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_test", "py_venv")
-load("@rules_python//python:py_runtime.bzl", "py_runtime")
-load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
+load("@aspect_rules_py//py:defs.bzl", "py_runtime", "py_runtime_pair", "py_test", "py_venv")
 
 # Regression test: a venv built under a system-interpreter toolchain
 # (`py_runtime(interpreter_path = ...)`) must write pyvenv.cfg `home`

--- a/e2e/cases/pbs-cc-toolchain/BUILD.bazel
+++ b/e2e/cases/pbs-cc-toolchain/BUILD.bazel
@@ -13,8 +13,20 @@ cc_binary(
     srcs = ["embed_python.cc"],
     target_compatible_with = _WINDOWS_INCOMPATIBLE,
     deps = [
-        "@rules_python//python/cc:current_py_cc_headers",
-        "@rules_python//python/cc:current_py_cc_libs",
+        "@aspect_rules_py//py:current_py_cc_headers",
+        "@aspect_rules_py//py:current_py_cc_libs",
+    ],
+)
+
+cc_binary(
+    name = "embed_python_abi3",
+    testonly = True,
+    srcs = ["embed_python.cc"],
+    copts = ["-DPy_LIMITED_API=0x03080000"],
+    target_compatible_with = _WINDOWS_INCOMPATIBLE,
+    deps = [
+        "@aspect_rules_py//py:current_py_cc_headers_abi3",
+        "@aspect_rules_py//py:current_py_cc_libs",
     ],
 )
 

--- a/e2e/cases/rules-python-consumers/BUILD.bazel
+++ b/e2e/cases/rules-python-consumers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_library", "py_test", "py_wheel", "whl_filegroup")
 load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(":exec_tools_facts.bzl", "exec_tools_facts", "with_python_version")
@@ -34,12 +34,40 @@ exec_tools_facts(
 # version flag.
 report_exec_version(name = "report_exec_version")
 
+genrule(
+    name = "python_launcher",
+    outs = ["python_launcher.txt"],
+    cmd = "$(location @aspect_rules_py//py:python) -c 'import sys; print(\"{}.{}\".format(*sys.version_info))' > $@",
+    tools = ["@aspect_rules_py//py:python"],
+)
+
+py_library(
+    name = "wheel_lib",
+    srcs = ["consumers_test.py"],
+)
+
+py_wheel(
+    name = "compat_wheel",
+    distribution = "compat_wheel",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [":wheel_lib"],
+)
+
+whl_filegroup(
+    name = "compat_wheel_files",
+    runfiles = True,
+    whl = ":compat_wheel",
+)
+
 py_test(
     name = "consumers_test",
     srcs = ["consumers_test.py"],
     data = [
+        ":compat_wheel_files",
         ":exec_tools_facts",
         ":python3_var_313",
+        ":python_launcher",
     ],
 )
 

--- a/e2e/cases/rules-python-consumers/consumers_test.py
+++ b/e2e/cases/rules-python-consumers/consumers_test.py
@@ -28,4 +28,18 @@ facts = read("exec_tools_facts.txt").splitlines()
 assert "python_interpreters+" in facts[0], facts
 assert facts[1] == "None", facts
 
+assert read("python_launcher.txt") == "3.11"
+
+wheel_root = os.path.join(
+    os.environ["TEST_SRCDIR"],
+    os.environ["TEST_WORKSPACE"],
+    "rules-python-consumers",
+    "compat_wheel_files",
+)
+assert any(
+    name.endswith("consumers_test.py")
+    for _, _, files in os.walk(wheel_root)
+    for name in files
+), wheel_root
+
 print("OK")

--- a/e2e/cases/rules-python-consumers/test.sh
+++ b/e2e/cases/rules-python-consumers/test.sh
@@ -26,3 +26,23 @@ for version in 3.9 3.10 3.11 3.12 3.13; do
     check_exec_version @aspect_rules_py//py:python_version "${version}"
     check_exec_version @rules_python//python/config_settings:python_version "${version}"
 done
+
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.13 \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --platforms=//pbs-cc-toolchain:linux_x86_64 \
+    -- \
+    //pbs-cc-toolchain:embed_python \
+    //pbs-cc-toolchain:embed_python_abi3 \
+    //pbs-cc-toolchain:regular_313 \
+    //rules-python-consumers:python_launcher
+
+bazel_bin="$("$BAZEL" info --lockfile_mode=off bazel-bin)"
+version="$(<"${bazel_bin}/rules-python-consumers/python_launcher.txt")"
+if [[ "${version}" != "3.13" ]]; then
+    echo "FAIL: rules_py Python version selected launcher ${version}, expected 3.13" >&2
+    exit 1
+fi
+
+echo "PASS: rules_py Python version selected the 3.13 launcher and C toolchain"

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -7,6 +7,34 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# Actions that need a Python executable should not need a direct rules_python
+# dependency just to use its remote-safe interpreter launcher.
+alias(
+    name = "python",
+    actual = "@rules_python//python/bin:python",
+    visibility = ["//visibility:public"],
+)
+
+# C-extension and embedding consumers should not need a direct rules_python
+# dependency just to use the C toolchain that python_interpreters registers.
+alias(
+    name = "current_py_cc_headers",
+    actual = "@rules_python//python/cc:current_py_cc_headers",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "current_py_cc_headers_abi3",
+    actual = "@rules_python//python/cc:current_py_cc_headers_abi3",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "current_py_cc_libs",
+    actual = "@rules_python//python/cc:current_py_cc_libs",
+    visibility = ["//visibility:public"],
+)
+
 # Users can set --@aspect_rules_py//py:layer_tier=//path:custom_tier to switch
 # the pip-package grouping + compression plan consumed by py_image_layer.
 label_flag(
@@ -38,6 +66,10 @@ bzl_library(
         "//py/private/interpreter:current_py_toolchain",
         "//py/private/py_venv:defs",
         "@bazel_lib//lib:utils",
+        "@rules_python//python:packaging_bzl",
+        "@rules_python//python:pip_bzl",
+        "@rules_python//python:py_runtime_bzl",
+        "@rules_python//python:py_runtime_pair_bzl",
     ],
 )
 

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -7,12 +7,17 @@ The `python_version` attribute must refer to a python toolchain version
 which has been registered in the `MODULE.bazel` file, e.g.:
 
 ```starlark
-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.8.12", is_default = False)
-python.toolchain(python_version = "3.9", is_default = True)
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.toolchain(python_version = "3.9")
+use_repo(interpreters, "python_interpreters")
+register_toolchains("@python_interpreters//:all")
 ```
 """
 
+load("@rules_python//python:packaging.bzl", _py_wheel = "py_wheel")
+load("@rules_python//python:pip.bzl", _whl_filegroup = "whl_filegroup")
+load("@rules_python//python:py_runtime.bzl", _py_runtime = "py_runtime")
+load("@rules_python//python:py_runtime_pair.bzl", _py_runtime_pair = "py_runtime_pair")
 load(
     "//py/private:py_image_layer.bzl",
     _PyLayerTierInfo = "PyLayerTierInfo",
@@ -36,6 +41,10 @@ load(
 )
 
 current_py_toolchain = _current_py_toolchain
+py_wheel = _py_wheel
+py_runtime = _py_runtime
+py_runtime_pair = _py_runtime_pair
+whl_filegroup = _whl_filegroup
 py_pex_binary = _py_pex_binary
 py_pytest_main = _py_pytest_main
 

--- a/py/tests/cc-deps/BUILD.bazel
+++ b/py/tests/cc-deps/BUILD.bazel
@@ -18,7 +18,7 @@ cc_binary(
     linkopts = _EXTENSION_LINKOPTS,
     linkshared = True,
     target_compatible_with = _WINDOWS_INCOMPATIBLE,
-    deps = ["@rules_python//python/cc:current_py_cc_headers"],
+    deps = ["//py:current_py_cc_headers"],
 )
 
 cc_binary(
@@ -28,7 +28,7 @@ cc_binary(
     linkopts = _EXTENSION_LINKOPTS,
     linkshared = True,
     target_compatible_with = _WINDOWS_INCOMPATIBLE,
-    deps = ["@rules_python//python/cc:current_py_cc_headers_abi3"],
+    deps = ["//py:current_py_cc_headers_abi3"],
 )
 
 # Python extensions retain the terminal's interpreter configuration through


### PR DESCRIPTION
Expose the Python runtime, wheel, launcher, and C-toolchain compatibility APIs through rules_py so downstream consumers can stop loading rules_python directly.