### PR TITLE
fix(uv): prefer the rules_py Python version

### DIFF
--- a/e2e/cases/rules-python-consumers/exec_tools_facts.bzl
+++ b/e2e/cases/rules-python-consumers/exec_tools_facts.bzl
@@ -22,7 +22,7 @@ exec_tools_facts = rule(
 )
 
 def _set_python_version_impl(settings, attr):
-    # Both flags together so the uv constraints mismatch guard stays satisfied.
+    # Keep the rules_python toolchain consumer on the same interpreter.
     return {
         "@aspect_rules_py//py/private/interpreter:python_version": attr.python_version,
         "@rules_python//python/config_settings:python_version": attr.python_version,

--- a/e2e/interpreter-toolchain-settings/BUILD.bazel
+++ b/e2e/interpreter-toolchain-settings/BUILD.bazel
@@ -32,6 +32,17 @@ platform(
     ],
 )
 
+# The uv constraint is selected by a downstream target rather than built
+# directly, so this fails if the public rules_py selector is not propagated.
+filegroup(
+    name = "uv_constraint_selected",
+    srcs = ["BUILD.bazel"],
+    target_compatible_with = select({
+        "@aspect_rules_py//uv/private/constraints/python:py312": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
 interpreter_toolchain_check(
     name = "resolved_311",
     expected_interpreter = "@python_3_11_x86_64_unknown_linux_gnu//:bin/python3",

--- a/e2e/interpreter-toolchain-settings/MODULE.bazel
+++ b/e2e/interpreter-toolchain-settings/MODULE.bazel
@@ -3,6 +3,7 @@ module(name = "interpreter_toolchain_settings")
 bazel_dep(name = "aspect_rules_py")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_python", version = "1.9.0")
 
 local_path_override(
     module_name = "aspect_rules_py",

--- a/e2e/interpreter-toolchain-settings/test.sh
+++ b/e2e/interpreter-toolchain-settings/test.sh
@@ -30,6 +30,19 @@ check_toolchain() {
 check_toolchain 3.11 311 --define=interpreter_setting_secondary=311
 check_toolchain 3.12 312
 
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.12 \
+    --@rules_python//python/config_settings:python_version=3.11 \
+    -- //:uv_constraint_selected \
+    || fail "rules_py Python version did not take precedence over rules_python"
+
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@rules_python//python/config_settings:python_version=3.12 \
+    -- //:uv_constraint_selected \
+    || fail "rules_python Python version did not remain the uv fallback"
+
 failure_log="$(mktemp)"
 trap 'rm -f "$failure_log"' EXIT
 

--- a/uv/private/constraints/python/defs.bzl
+++ b/uv/private/constraints/python/defs.bzl
@@ -63,16 +63,8 @@ def _python_version_at_least_impl(ctx):
         if len(parts) >= 2:
             arpy_value = "{}.{}".format(parts[0], parts[1])
 
-    # Error on disagreement when both are set
-    if arpy_value and rpy_value and arpy_value != rpy_value:
-        fail(
-            "Python version mismatch: " +
-            "@aspect_rules_py//py/private/interpreter:python_version is {}, ".format(arpy_value) +
-            "but @rules_python python_version_major_minor is {}. ".format(rpy_value) +
-            "These must agree.",
-        )
-
-    # Aspect flag is authoritative; rules_python is fallback
+    # rules_python always supplies a default, so it cannot distinguish an
+    # explicit conflict from untouched state. Our flag is authoritative.
     flag_value = arpy_value or rpy_value
 
     if not flag_value:


### PR DESCRIPTION
Make the rules_py Python-version selector authoritative for uv constraints while retaining the rules_python fallback, so downstream consumers no longer need to keep both flags in sync.