### PR TITLE
ci: skip benchmark comment on fork PRs

### DIFF
--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -277,6 +277,8 @@ jobs:
           name: analysis-benchmark-results
 
       - name: Post combined benchmark comment
+        # Fork PRs get a read-only GITHUB_TOKEN; posting the comment 403s.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Fork PRs run with a read-only GITHUB_TOKEN, so the comment post 403s regardless of the declared pull-requests: write permission. The regression gate step still runs.

### Changes are visible to end-users: no

### Test plan

- Manual testing; TODO
