### PR TITLE
fix(py): reject unsafe wheel paths

### DIFF
--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -71,7 +71,7 @@ def _relative_path(value, what):
     if (
         not value
         or "\\" in value
-        or any(part in ("", ".", "..") or ":" in part for part in parts)
+        or any(not part or part.endswith((" ", ".")) or ":" in part for part in parts)
     ):
         raise SystemExit("Invalid {}: {}".format(what, value))
     return Path(*parts)

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -29,6 +29,10 @@ _RELOCATABLE_SHEBANG = """\
 ' '''
 """
 
+_WINDOWS_RESERVED = {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"} | {
+    prefix + suffix for prefix in ("COM", "LPT") for suffix in "123456789¹²³"
+}
+
 
 def _sha256(path):
     h = hashlib.sha256()
@@ -71,7 +75,13 @@ def _relative_path(value, what):
     if (
         not value
         or "\\" in value
-        or any(not part or part.endswith((" ", ".")) or ":" in part for part in parts)
+        or any(
+            not part
+            or part.endswith((" ", "."))
+            or ":" in part
+            or part.partition(".")[0].rstrip(" ").upper() in _WINDOWS_RESERVED
+            for part in parts
+        )
     ):
         raise SystemExit("Invalid {}: {}".format(what, value))
     return Path(*parts)

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -65,6 +65,18 @@ def _write_executable(path, content):
     path.chmod(0o755)
 
 
+def _relative_path(value, what):
+    """Return a safe host path for a wheel-controlled POSIX path."""
+    parts = value.split("/")
+    if (
+        not value
+        or "\\" in value
+        or any(part in ("", ".", "..") or ":" in part for part in parts)
+    ):
+        raise SystemExit("Invalid {}: {}".format(what, value))
+    return Path(*parts)
+
+
 def install_wheel(version_major, version_minor, into, wheel_path):
     """Install a wheel into *into*, following PEP 427 layout conventions.
 
@@ -92,6 +104,10 @@ def install_wheel(version_major, version_minor, into, wheel_path):
     with zipfile.ZipFile(wheel_path, "r") as zf:
         for info in zf.infolist():
             member = info.filename
+            member_path = _relative_path(
+                member[:-1] if member.endswith("/") else member,
+                "wheel member path",
+            )
             if member.endswith("/"):
                 continue
 
@@ -101,19 +117,20 @@ def install_wheel(version_major, version_minor, into, wheel_path):
                 category, sep, rel = rest.partition("/")
                 if not sep:
                     continue
+                rel_path = _relative_path(rel, "wheel member path")
                 if category in ("purelib", "platlib"):
-                    dest = site_packages / rel
+                    dest = site_packages / rel_path
                 elif category == "scripts":
-                    dest = bin_dir / Path(rel).name
+                    dest = bin_dir / rel_path.name
                     is_script = True
                 elif category == "headers":
-                    dest = into / "lib" / "include" / rel
+                    dest = into / "lib" / "include" / rel_path
                 elif category == "data":
-                    dest = into / rel
+                    dest = into / rel_path
                 else:
-                    dest = site_packages / rest
+                    dest = site_packages / category / rel_path
             else:
-                dest = site_packages / member
+                dest = site_packages / member_path
 
             dest.parent.mkdir(parents=True, exist_ok=True)
             data = zf.read(member)
@@ -132,7 +149,7 @@ def install_wheel(version_major, version_minor, into, wheel_path):
                 installed.append(dest)
 
     for ep_path in site_packages.glob("*.dist-info/entry_points.txt"):
-        cp = configparser.ConfigParser(strict=False)
+        cp = configparser.ConfigParser(strict=False, delimiters=("=",))
         cp.optionxform = str
         cp.read(str(ep_path), encoding="utf-8")
         for section in ("console_scripts", "gui_scripts"):
@@ -145,7 +162,10 @@ def install_wheel(version_major, version_minor, into, wheel_path):
                 module = module.strip()
                 if not name or not module or not func:
                     continue
-                script_path = bin_dir / name
+                name_path = _relative_path(name, "console script name")
+                if len(name_path.parts) != 1:
+                    raise SystemExit("Invalid console script name: {}".format(name))
+                script_path = bin_dir / name_path
                 # Entry-point object references may contain dotted attributes:
                 # https://packaging.python.org/en/latest/specifications/entry-points/#data-model
                 wrapper = (

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -114,12 +114,14 @@ def main() -> None:
             ("rootnesteddrive", "fixture/D:/escaped.py"),
             ("rootunc", "//server/share/escaped.py"),
             ("rootbackslash", "fixture\\escaped.py"),
+            ("roottrailing", "fixture/.. /escaped.py"),
             ("datatraversal", "datatraversal-1.0.data/data/../escaped.py"),
             ("dataabsolute", "dataabsolute-1.0.data/data//escaped.py"),
             ("datadrive", "datadrive-1.0.data/data/C:/escaped.py"),
             ("datanesteddrive", "datanesteddrive-1.0.data/data/fixture/D:/escaped.py"),
             ("dataunc", "dataunc-1.0.data/data///server/share/escaped.py"),
             ("databackslash", "databackslash-1.0.data/data/fixture\\escaped.py"),
+            ("datatrailing", "datatrailing-1.0.data/data/.. ./escaped.py"),
         ]:
             traversal_wheel = root / f"{case}-1.0-py3-none-any.whl"
             _write_wheel(traversal_wheel, case, {member: b"escaped\n"})
@@ -412,6 +414,7 @@ else:
             ("unc", "//server/share/entry-point-escaped"),
             ("backslash", "fixture\\entry-point-escaped"),
             ("nested", "fixture/entry-point-escaped"),
+            ("trailing", "entry-point-escaped. "),
         ]:
             distribution = "entry_point_{}".format(case)
             entry_point_wheel = root / f"{distribution}-1.0-py3-none-any.whl"

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -107,67 +107,19 @@ def main() -> None:
         )
         assert next((site_packages / "fixture" / "__pycache__").glob("*.pyc"))
 
-        for case, member, escaped_name in [
-            (
-                "roottraversal",
-                "../../../../root-escaped.py",
-                "root-escaped.py",
-            ),
-            (
-                "rootabsolute",
-                str(root / "absolute-escaped.py"),
-                "absolute-escaped.py",
-            ),
-            (
-                "rootdrive",
-                "C:/root-drive-escaped.py",
-                "root-drive-escaped.py",
-            ),
-            (
-                "rootnesteddrive",
-                "fixture/D:/root-nested-drive-escaped.py",
-                "root-nested-drive-escaped.py",
-            ),
-            (
-                "rootunc",
-                "//server/share/root-unc-escaped.py",
-                "root-unc-escaped.py",
-            ),
-            (
-                "rootbackslash",
-                "fixture\\root-backslash-escaped.py",
-                "root-backslash-escaped.py",
-            ),
-            (
-                "datatraversal",
-                "datatraversal-1.0.data/data/../data-escaped.py",
-                "data-escaped.py",
-            ),
-            (
-                "dataabsolute",
-                "dataabsolute-1.0.data/data//data-absolute-escaped.py",
-                "data-absolute-escaped.py",
-            ),
-            (
-                "datadrive",
-                "datadrive-1.0.data/data/C:/data-drive-escaped.py",
-                "data-drive-escaped.py",
-            ),
-            (
-                "datanesteddrive",
-                "datanesteddrive-1.0.data/data/fixture/D:/data-nested-drive-escaped.py",
-                "data-nested-drive-escaped.py",
-            ),
-            (
-                "dataunc",
-                "dataunc-1.0.data/data///server/share/data-unc-escaped.py",
-                "data-unc-escaped.py",
-            ),
-            (
-                "databackslash",
-                "databackslash-1.0.data/data/fixture\\data-backslash-escaped.py",
-                "data-backslash-escaped.py",
-            ),
+        for case, member in [
+            ("roottraversal", "../../../../escaped.py"),
+            ("rootabsolute", str(root / "escaped.py")),
+            ("rootdrive", "C:/escaped.py"),
+            ("rootnesteddrive", "fixture/D:/escaped.py"),
+            ("rootunc", "//server/share/escaped.py"),
+            ("rootbackslash", "fixture\\escaped.py"),
+            ("datatraversal", "datatraversal-1.0.data/data/../escaped.py"),
+            ("dataabsolute", "dataabsolute-1.0.data/data//escaped.py"),
+            ("datadrive", "datadrive-1.0.data/data/C:/escaped.py"),
+            ("datanesteddrive", "datanesteddrive-1.0.data/data/fixture/D:/escaped.py"),
+            ("dataunc", "dataunc-1.0.data/data///server/share/escaped.py"),
+            ("databackslash", "databackslash-1.0.data/data/fixture\\escaped.py"),
         ]:
             traversal_wheel = root / f"{case}-1.0-py3-none-any.whl"
             _write_wheel(traversal_wheel, case, {member: b"escaped\n"})
@@ -183,7 +135,6 @@ def main() -> None:
                 rejected.stderr,
             )
             assert "Invalid wheel member path" in rejected.stderr
-            assert not (root / escaped_name).exists()
 
         site_packages_relative = (
             f"lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages"
@@ -488,7 +439,6 @@ else:
                 )
             )
             assert "Invalid console script name" in rejected_entry_point.stderr
-            assert not (root / "entry-point-escaped").exists()
 
 
 if __name__ == "__main__":

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -115,6 +115,8 @@ def main() -> None:
             ("rootunc", "//server/share/escaped.py"),
             ("rootbackslash", "fixture\\escaped.py"),
             ("roottrailing", "fixture/.. /escaped.py"),
+            ("rootreserved", "fixture/NuL .txt/escaped.py"),
+            ("rootconin", "fixture/cOnIn$.txt/escaped.py"),
             ("datatraversal", "datatraversal-1.0.data/data/../escaped.py"),
             ("dataabsolute", "dataabsolute-1.0.data/data//escaped.py"),
             ("datadrive", "datadrive-1.0.data/data/C:/escaped.py"),
@@ -122,6 +124,8 @@ def main() -> None:
             ("dataunc", "dataunc-1.0.data/data///server/share/escaped.py"),
             ("databackslash", "databackslash-1.0.data/data/fixture\\escaped.py"),
             ("datatrailing", "datatrailing-1.0.data/data/.. ./escaped.py"),
+            ("datareserved", "datareserved-1.0.data/data/fixture/lPt9.log/escaped.py"),
+            ("dataconout", "dataconout-1.0.data/data/fixture/ConOut$.log/escaped.py"),
         ]:
             traversal_wheel = root / f"{case}-1.0-py3-none-any.whl"
             _write_wheel(traversal_wheel, case, {member: b"escaped\n"})
@@ -378,6 +382,9 @@ else:
                 "entry_point-1.0.dist-info/entry_points.txt": (
                     b"[console_scripts]\n"
                     b"Fixture-Cli = fixture:Commands.main [extra]\n"
+                    b"COM10 = fixture:Commands.main\n"
+                    b"LPT0 = fixture:Commands.main\n"
+                    b"NULled = fixture:Commands.main\n"
                 ),
             },
         )
@@ -391,7 +398,10 @@ else:
         )
         assert entry_point.returncode == 0, entry_point.stderr
         assert {entry.name for entry in (entry_point_out / "bin").iterdir()} == {
+            "COM10",
             "Fixture-Cli",
+            "LPT0",
+            "NULled",
         }, "console-script name was not preserved"
         script = entry_point_out / "bin" / "Fixture-Cli"
         site_packages = (
@@ -415,6 +425,7 @@ else:
             ("backslash", "fixture\\entry-point-escaped"),
             ("nested", "fixture/entry-point-escaped"),
             ("trailing", "entry-point-escaped. "),
+            ("reserved", "cOm¹.exe"),
         ]:
             distribution = "entry_point_{}".format(case)
             entry_point_wheel = root / f"{distribution}-1.0-py3-none-any.whl"

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -107,6 +107,84 @@ def main() -> None:
         )
         assert next((site_packages / "fixture" / "__pycache__").glob("*.pyc"))
 
+        for case, member, escaped_name in [
+            (
+                "roottraversal",
+                "../../../../root-escaped.py",
+                "root-escaped.py",
+            ),
+            (
+                "rootabsolute",
+                str(root / "absolute-escaped.py"),
+                "absolute-escaped.py",
+            ),
+            (
+                "rootdrive",
+                "C:/root-drive-escaped.py",
+                "root-drive-escaped.py",
+            ),
+            (
+                "rootnesteddrive",
+                "fixture/D:/root-nested-drive-escaped.py",
+                "root-nested-drive-escaped.py",
+            ),
+            (
+                "rootunc",
+                "//server/share/root-unc-escaped.py",
+                "root-unc-escaped.py",
+            ),
+            (
+                "rootbackslash",
+                "fixture\\root-backslash-escaped.py",
+                "root-backslash-escaped.py",
+            ),
+            (
+                "datatraversal",
+                "datatraversal-1.0.data/data/../data-escaped.py",
+                "data-escaped.py",
+            ),
+            (
+                "dataabsolute",
+                "dataabsolute-1.0.data/data//data-absolute-escaped.py",
+                "data-absolute-escaped.py",
+            ),
+            (
+                "datadrive",
+                "datadrive-1.0.data/data/C:/data-drive-escaped.py",
+                "data-drive-escaped.py",
+            ),
+            (
+                "datanesteddrive",
+                "datanesteddrive-1.0.data/data/fixture/D:/data-nested-drive-escaped.py",
+                "data-nested-drive-escaped.py",
+            ),
+            (
+                "dataunc",
+                "dataunc-1.0.data/data///server/share/data-unc-escaped.py",
+                "data-unc-escaped.py",
+            ),
+            (
+                "databackslash",
+                "databackslash-1.0.data/data/fixture\\data-backslash-escaped.py",
+                "data-backslash-escaped.py",
+            ),
+        ]:
+            traversal_wheel = root / f"{case}-1.0-py3-none-any.whl"
+            _write_wheel(traversal_wheel, case, {member: b"escaped\n"})
+            rejected = _run_unpack(
+                unpack,
+                traversal_wheel,
+                root / f"{case}-out",
+                Path(sys.executable),
+            )
+            assert rejected.returncode != 0, "{} was accepted\n{}{}".format(
+                case,
+                rejected.stdout,
+                rejected.stderr,
+            )
+            assert "Invalid wheel member path" in rejected.stderr
+            assert not (root / escaped_name).exists()
+
         site_packages_relative = (
             f"lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages"
         )
@@ -374,6 +452,43 @@ else:
             check=True,
             env={"PYTHONPATH": str(site_packages)},
         )
+
+        for case, name in [
+            ("traversal", "../../entry-point-escaped"),
+            ("absolute", "/entry-point-escaped"),
+            ("drive", "C:/entry-point-escaped"),
+            ("nested-drive", "fixture/D:entry-point-escaped"),
+            ("unc", "//server/share/entry-point-escaped"),
+            ("backslash", "fixture\\entry-point-escaped"),
+            ("nested", "fixture/entry-point-escaped"),
+        ]:
+            distribution = "entry_point_{}".format(case)
+            entry_point_wheel = root / f"{distribution}-1.0-py3-none-any.whl"
+            _write_wheel(
+                entry_point_wheel,
+                distribution,
+                {
+                    "fixture/__init__.py": b"def main():\n    return 0\n",
+                    f"{distribution}-1.0.dist-info/entry_points.txt": (
+                        "[console_scripts]\n{} = fixture:main\n".format(name).encode()
+                    ),
+                },
+            )
+            rejected_entry_point = _run_unpack(
+                unpack,
+                entry_point_wheel,
+                root / f"entry-point-{case}-out",
+                Path(sys.executable),
+            )
+            assert rejected_entry_point.returncode != 0, (
+                "{} was accepted\n{}{}".format(
+                    case,
+                    rejected_entry_point.stdout,
+                    rejected_entry_point.stderr,
+                )
+            )
+            assert "Invalid console script name" in rejected_entry_point.stderr
+            assert not (root / "entry-point-escaped").exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reject absolute, parent-traversal, and Windows path forms before routing wheel members or creating console scripts, preventing malformed wheels from writing outside the declared output. Parse entry-point names using the equals delimiter so drive-qualified names are validated instead of being rewritten.