### PR TITLE
fix(uv): honor the rules_py Python version in markers

### DIFF
--- a/docs/uv.md
+++ b/docs/uv.md
@@ -340,6 +340,16 @@ An sdist (if available) will be built into a wheel for installation if no wheels
 are available, or no wheels matching the target configuration are found. Sdist
 builds occur using the configured Python and Cc toolchains.
 
+### Marker version precision
+
+Markers evaluate `python_version` and `python_full_version` from the configured
+version flags: `--@aspect_rules_py//py:python_version` when set, otherwise the
+rules_python `python_version` flag. Comparison happens at the precision the
+flag provides — a bare `3.12` evaluates `python_full_version` as `3.12.0`,
+regardless of the patch version the provisioned interpreter ships. Patch-precise
+markers such as `python_full_version < '3.12.4'` require a full
+`major.minor.patch` flag value to evaluate correctly.
+
 ### Declaring source-built console scripts
 
 Downloaded wheels expose their console scripts while repositories are

--- a/e2e/interpreter-toolchain-settings/BUILD.bazel
+++ b/e2e/interpreter-toolchain-settings/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@aspect_rules_py//uv/private/markers:defs.bzl", "decide_marker")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load(":marker_dependency_test.bzl", "marker_dependency_check")
 load(":toolchain_test.bzl", "interpreter_toolchain_check")
 
 # Smoke test so `bazel test //...` has a target here. The real checks are in
@@ -39,6 +41,85 @@ filegroup(
     srcs = ["BUILD.bazel"],
     target_compatible_with = select({
         "@aspect_rules_py//uv/private/constraints/python:py312": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+marker_dependency_check(
+    name = "uv_dependency_selected",
+    dep = "@pypi_marker//six",
+    present = True,
+)
+
+marker_dependency_check(
+    name = "uv_dependency_not_selected",
+    dep = "@pypi_marker//six",
+    present = False,
+)
+
+decide_marker(
+    name = "_python_version_312",
+    marker = "python_version == '3.12'",
+)
+
+decide_marker(
+    name = "_python_full_version_312",
+    marker = "python_full_version >= '3.12' and python_full_version < '3.13'",
+)
+
+decide_marker(
+    name = "_implementation_version_312",
+    marker = "implementation_version >= '3.12' and implementation_version < '3.13'",
+)
+
+decide_marker(
+    name = "_python_full_version_patch",
+    marker = "python_full_version == '3.12.7'",
+)
+
+decide_marker(
+    name = "_implementation_version_patch",
+    marker = "implementation_version == '3.12.7'",
+)
+
+filegroup(
+    name = "uv_markers_selected",
+    srcs = ["BUILD.bazel"],
+    target_compatible_with = select({
+        ":_python_version_312": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        ":_python_full_version_312": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        ":_implementation_version_312": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+filegroup(
+    name = "uv_markers_not_selected",
+    srcs = ["BUILD.bazel"],
+    target_compatible_with = select({
+        ":_python_version_312": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }) + select({
+        ":_python_full_version_312": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }) + select({
+        ":_implementation_version_312": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
+
+filegroup(
+    name = "uv_patch_markers_selected",
+    srcs = ["BUILD.bazel"],
+    target_compatible_with = select({
+        ":_python_full_version_patch": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        ":_implementation_version_patch": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )

--- a/e2e/interpreter-toolchain-settings/BUILD.bazel
+++ b/e2e/interpreter-toolchain-settings/BUILD.bazel
@@ -87,6 +87,13 @@ decide_marker(
     marker = "implementation_version == '3.12.7'",
 )
 
+# Declared contract: markers evaluate at the precision the flags provide, so
+# a bare 3.12 compares as 3.12.0 regardless of the provisioned patch.
+decide_marker(
+    name = "_python_full_version_minor_only",
+    marker = "python_full_version == '3.12.0'",
+)
+
 filegroup(
     name = "uv_markers_selected",
     srcs = ["BUILD.bazel"],
@@ -125,6 +132,15 @@ filegroup(
         "//conditions:default": ["@platforms//:incompatible"],
     }) + select({
         ":_implementation_version_patch": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+filegroup(
+    name = "uv_minor_precision_selected",
+    srcs = ["BUILD.bazel"],
+    target_compatible_with = select({
+        ":_python_full_version_minor_only": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )

--- a/e2e/interpreter-toolchain-settings/BUILD.bazel
+++ b/e2e/interpreter-toolchain-settings/BUILD.bazel
@@ -45,16 +45,21 @@ filegroup(
     }),
 )
 
+# Exactly one of this pair fails analysis under any given configuration, so
+# they must stay out of `bazel build //...`; test.sh builds each under the
+# matching flags.
 marker_dependency_check(
     name = "uv_dependency_selected",
     dep = "@pypi_marker//six",
     present = True,
+    tags = ["manual"],
 )
 
 marker_dependency_check(
     name = "uv_dependency_not_selected",
     dep = "@pypi_marker//six",
     present = False,
+    tags = ["manual"],
 )
 
 decide_marker(

--- a/e2e/interpreter-toolchain-settings/MODULE.bazel
+++ b/e2e/interpreter-toolchain-settings/MODULE.bazel
@@ -38,3 +38,16 @@ use_repo(
 )
 
 register_toolchains("@python_interpreters//:all")
+
+uv_bin = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv_bin")
+uv_bin.toolchain(version = "0.11.6")
+use_repo(uv_bin, "uv")
+
+uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
+uv.declare_hub(hub_name = "pypi_marker")
+uv.project(
+    hub_name = "pypi_marker",
+    lock = "//:uv.lock",
+    pyproject = "//:pyproject.toml",
+)
+use_repo(uv, "pypi_marker")

--- a/e2e/interpreter-toolchain-settings/marker_dependency_test.bzl
+++ b/e2e/interpreter-toolchain-settings/marker_dependency_test.bzl
@@ -1,0 +1,20 @@
+"""Checks whether a lock-generated conditional Python dependency is active."""
+
+load("@aspect_rules_py//py:defs.bzl", "PyInfo")
+
+def _marker_dependency_check_impl(ctx):
+    sources = ctx.attr.dep[PyInfo].transitive_sources.to_list()
+    if bool(sources) != ctx.attr.present:
+        fail("{} was {}selected by its uv marker".format(
+            ctx.attr.dep.label,
+            "not " if ctx.attr.present else "",
+        ))
+    return []
+
+marker_dependency_check = rule(
+    implementation = _marker_dependency_check_impl,
+    attrs = {
+        "dep": attr.label(mandatory = True, providers = [PyInfo]),
+        "present": attr.bool(mandatory = True),
+    },
+)

--- a/e2e/interpreter-toolchain-settings/pyproject.toml
+++ b/e2e/interpreter-toolchain-settings/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "interpreter-toolchain-settings"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "six==1.17.0; python_version >= '3.12'",
+]

--- a/e2e/interpreter-toolchain-settings/test.sh
+++ b/e2e/interpreter-toolchain-settings/test.sh
@@ -85,6 +85,12 @@ check_toolchain 3.12 312
     -- //:uv_patch_markers_selected \
     || fail "uv full-version markers did not preserve the fallback patch version"
 
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.12.7 \
+    -- //:uv_markers_selected //:uv_patch_markers_selected \
+    || fail "a rules_py patch version was not honored by uv markers"
+
 failure_log="$(mktemp)"
 trap 'rm -f "$failure_log"' EXIT
 

--- a/e2e/interpreter-toolchain-settings/test.sh
+++ b/e2e/interpreter-toolchain-settings/test.sh
@@ -43,6 +43,48 @@ check_toolchain 3.12 312
     -- //:uv_constraint_selected \
     || fail "rules_python Python version did not remain the uv fallback"
 
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@aspect_rules_py//uv/private/constraints/dep_group:dep_group=interpreter-toolchain-settings \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --define=interpreter_setting=312 \
+    --platforms=//:linux_x86_64 \
+    --@aspect_rules_py//py:python_version=3.12 \
+    --@rules_python//python/config_settings:python_version=3.11 \
+    -- //:uv_markers_selected //:uv_dependency_selected \
+    || fail "rules_py Python version did not take precedence for uv markers"
+
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@aspect_rules_py//uv/private/constraints/dep_group:dep_group=interpreter-toolchain-settings \
+    --@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc \
+    --define=interpreter_setting=312 \
+    --platforms=//:linux_x86_64 \
+    --@rules_python//python/config_settings:python_version=3.12 \
+    -- //:uv_markers_selected //:uv_dependency_selected \
+    || fail "rules_python Python version did not remain the uv marker fallback"
+
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@aspect_rules_py//uv/private/constraints/dep_group:dep_group=interpreter-toolchain-settings \
+    --@aspect_rules_py//py:python_version=3.11 \
+    --@rules_python//python/config_settings:python_version=3.12 \
+    -- //:uv_markers_not_selected //:uv_dependency_not_selected \
+    || fail "rules_py Python version did not disable mismatched uv markers"
+
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@aspect_rules_py//py:python_version=3.12 \
+    --@rules_python//python/config_settings:python_version=3.12.7 \
+    -- //:uv_patch_markers_selected \
+    || fail "uv full-version markers did not preserve the selected patch version"
+
+"$BAZEL" build \
+    --lockfile_mode=off \
+    --@rules_python//python/config_settings:python_version=3.12.7 \
+    -- //:uv_patch_markers_selected \
+    || fail "uv full-version markers did not preserve the fallback patch version"
+
 failure_log="$(mktemp)"
 trap 'rm -f "$failure_log"' EXIT
 

--- a/e2e/interpreter-toolchain-settings/test.sh
+++ b/e2e/interpreter-toolchain-settings/test.sh
@@ -51,7 +51,7 @@ check_toolchain 3.12 312
     --platforms=//:linux_x86_64 \
     --@aspect_rules_py//py:python_version=3.12 \
     --@rules_python//python/config_settings:python_version=3.11 \
-    -- //:uv_markers_selected //:uv_dependency_selected \
+    -- //:uv_markers_selected //:uv_dependency_selected //:uv_minor_precision_selected \
     || fail "rules_py Python version did not take precedence for uv markers"
 
 "$BAZEL" build \
@@ -61,7 +61,7 @@ check_toolchain 3.12 312
     --define=interpreter_setting=312 \
     --platforms=//:linux_x86_64 \
     --@rules_python//python/config_settings:python_version=3.12 \
-    -- //:uv_markers_selected //:uv_dependency_selected \
+    -- //:uv_markers_selected //:uv_dependency_selected //:uv_minor_precision_selected \
     || fail "rules_python Python version did not remain the uv marker fallback"
 
 "$BAZEL" build \

--- a/e2e/interpreter-toolchain-settings/uv.lock
+++ b/e2e/interpreter-toolchain-settings/uv.lock
@@ -1,0 +1,27 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "interpreter-toolchain-settings"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "six", marker = "python_full_version >= '3.12'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "six", marker = "python_full_version >= '3.12'", specifier = "==1.17.0" }]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]

--- a/uv/private/markers/BUILD.bazel
+++ b/uv/private/markers/BUILD.bazel
@@ -1,22 +1,23 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//py:defs.bzl", "py_test")
-load(":defs.bzl", "configurable_string", "decide_marker")
+load(":defs.bzl", "configurable_python_version", "configurable_string", "decide_marker")
 load(":pep508_evaluate_test.bzl", "pep508_evaluate_test_suite")
 
 # 'python_version'
 #   {major}.{minor}
-alias(
+configurable_python_version(
     name = "python_version",
-    actual = "@rules_python//python/config_settings:python_version_major_minor",
+    rules_python = "@rules_python//python/config_settings:python_version_major_minor",
     visibility = ["//visibility:public"],
 )
 
 # 'python_full_version'
 #   {major}.{minor}.{patch}[...]
-alias(
+configurable_python_version(
     name = "python_full_version",
-    actual = "@rules_python//python/config_settings:python_version",
+    full = True,
+    rules_python = "@rules_python//python/config_settings:python_version",
     visibility = ["//visibility:public"],
 )
 

--- a/uv/private/markers/defs.bzl
+++ b/uv/private/markers/defs.bzl
@@ -188,14 +188,17 @@ def _configurable_python_version_impl(ctx):
     rules_python = ctx.attr.rules_python[config_common.FeatureFlagInfo].value
     aspect = ctx.attr._aspect_python_version[BuildSettingInfo].value
 
+    # As in constraints/python, a value without a minor component is unusable.
+    if len(aspect.split(".")) < 2:
+        aspect = ""
+
     if not ctx.attr.full and aspect:
         aspect = ".".join(aspect.split(".")[:2])
     elif aspect and (rules_python == aspect or rules_python.startswith(aspect + ".")):
         # Keep the selected interpreter's patch version when both flags agree.
+        # On disagreement the rules_python patch belongs to the wrong
+        # interpreter, so keep the aspect value as-is.
         aspect = rules_python
-
-    # Aspect identifies a minor version. When the flags select different
-    # minors, the rules_python patch belongs to the wrong interpreter.
 
     return [config_common.FeatureFlagInfo(value = aspect or rules_python)]
 
@@ -204,6 +207,6 @@ configurable_python_version = rule(
     attrs = {
         "full": attr.bool(),
         "rules_python": attr.label(mandatory = True),
-        "_aspect_python_version": attr.label(default = "@aspect_rules_py//py/private/interpreter:python_version"),
+        "_aspect_python_version": attr.label(default = Label("@aspect_rules_py//py/private/interpreter:python_version")),
     },
 )

--- a/uv/private/markers/defs.bzl
+++ b/uv/private/markers/defs.bzl
@@ -183,3 +183,27 @@ configurable_string = rule(
         "value": attr.string(),
     },
 )
+
+def _configurable_python_version_impl(ctx):
+    rules_python = ctx.attr.rules_python[config_common.FeatureFlagInfo].value
+    aspect = ctx.attr._aspect_python_version[BuildSettingInfo].value
+
+    if not ctx.attr.full and aspect:
+        aspect = ".".join(aspect.split(".")[:2])
+    elif aspect and (rules_python == aspect or rules_python.startswith(aspect + ".")):
+        # Keep the selected interpreter's patch version when both flags agree.
+        aspect = rules_python
+
+    # Aspect identifies a minor version. When the flags select different
+    # minors, the rules_python patch belongs to the wrong interpreter.
+
+    return [config_common.FeatureFlagInfo(value = aspect or rules_python)]
+
+configurable_python_version = rule(
+    implementation = _configurable_python_version_impl,
+    attrs = {
+        "full": attr.bool(),
+        "rules_python": attr.label(mandatory = True),
+        "_aspect_python_version": attr.label(default = "@aspect_rules_py//py/private/interpreter:python_version"),
+    },
+)

--- a/uv/private/markers/defs.bzl
+++ b/uv/private/markers/defs.bzl
@@ -197,7 +197,9 @@ def _configurable_python_version_impl(ctx):
     elif aspect and (rules_python == aspect or rules_python.startswith(aspect + ".")):
         # Keep the selected interpreter's patch version when both flags agree.
         # On disagreement the rules_python patch belongs to the wrong
-        # interpreter, so keep the aspect value as-is.
+        # interpreter, so keep the aspect value as-is: markers evaluate at the
+        # precision the flags provide, so a bare minor compares as patch zero.
+        # Patch-precise markers require a full version in one of the flags.
         aspect = rules_python
 
     return [config_common.FeatureFlagInfo(value = aspect or rules_python)]


### PR DESCRIPTION
Use the effective rules_py Python version when evaluating generated UV dependency markers while preserving the rules_python fallback, so selected dependencies agree with the configured interpreter.