### PR TITLE
perf(py): batch private-venv symlinks

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -43,6 +43,11 @@ label_flag(
     visibility = ["//visibility:public"],
 )
 
+toolchain_type(
+    name = "venv_symlink_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "current_py_toolchain",
     srcs = ["current_py_toolchain.bzl"],

--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -7,6 +7,7 @@ exports_files([
     "templates/_virtualenv.py",
     "templates/console_script.tmpl.sh",
     "templates/link.py",
+    "templates/symlinks.py",
     "templates/venv.tmpl.sh",
     "templates/venv_activate.tmpl.sh",
 ])

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -30,7 +30,7 @@ load("@bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path"
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "python_transition")
-load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
+load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN", "VENV_SYMLINK_TOOLCHAIN")
 load(":py_venv_exec.bzl", _py_venv_exec = "py_venv_exec")
 load(":types.bzl", "VirtualenvInfo", "venv_root")
 load(":venv.bzl", "assemble_venv")
@@ -46,7 +46,7 @@ def _interpreter_flags(ctx):
 
     return args
 
-def _assemble_shared(ctx, venv_symlinks_script_py):
+def _assemble_shared(ctx, venv_symlink_tool):
     """Resolve the py toolchain, virtual deps, imports depset — then run
     the shared venv-assembly helper.
     """
@@ -80,7 +80,7 @@ def _assemble_shared(ctx, venv_symlinks_script_py):
         venv_activate_tmpl = ctx.file._venv_activate_tmpl,
         virtualenv_shim_py = ctx.file._virtualenv_shim,
         site_merge_script_py = ctx.file._site_merge_script,
-        venv_symlinks_script_py = venv_symlinks_script_py,
+        venv_symlink_tool = venv_symlink_tool,
         console_script_tmpl = ctx.file._console_script_tmpl,
         venv_name = ".{}".format(safe_name),
     )
@@ -248,10 +248,6 @@ does not reinsert a wheel.
         allow_single_file = True,
         default = "//py/private/py_venv:templates/console_script.tmpl.sh",
     ),
-    "_venv_symlinks_script": attr.label(
-        allow_single_file = True,
-        default = "//py/private/py_venv:templates/symlinks.py",
-    ),
 })
 
 _lib_attrs.update(**_py_library.attrs)
@@ -305,7 +301,8 @@ def _py_venv_lib_rule_impl(ctx):
     launcher and no RunEnvironmentInfo (Bazel rejects it on
     non-executable targets; py_venv_exec.bzl gates its read on
     `if RunEnvironmentInfo in venv`)."""
-    shared = _assemble_shared(ctx, ctx.file._venv_symlinks_script)
+    toolchain = ctx.toolchains[VENV_SYMLINK_TOOLCHAIN]
+    shared = _assemble_shared(ctx, toolchain.tool if toolchain else None)
     return _common_providers(ctx, shared)
 
 # Internal-only non-executable variant. Uses `_lib_attrs` — the
@@ -319,6 +316,7 @@ _py_venv_lib = rule(
         # Same optional exec-tools dependency as `_py_venv`: assemble_venv
         # needs it to run the site_merge action when a package needs a merge.
         config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
+        config_common.toolchain_type(VENV_SYMLINK_TOOLCHAIN, mandatory = False),
     ],
     cfg = python_transition,
 )

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -46,7 +46,7 @@ def _interpreter_flags(ctx):
 
     return args
 
-def _assemble_shared(ctx):
+def _assemble_shared(ctx, venv_symlinks_script_py):
     """Resolve the py toolchain, virtual deps, imports depset — then run
     the shared venv-assembly helper.
     """
@@ -80,6 +80,7 @@ def _assemble_shared(ctx):
         venv_activate_tmpl = ctx.file._venv_activate_tmpl,
         virtualenv_shim_py = ctx.file._virtualenv_shim,
         site_merge_script_py = ctx.file._site_merge_script,
+        venv_symlinks_script_py = venv_symlinks_script_py,
         console_script_tmpl = ctx.file._console_script_tmpl,
         venv_name = ".{}".format(safe_name),
     )
@@ -132,7 +133,7 @@ def _py_venv_rule_impl(ctx):
     """A virtualenv target whose own executable activates the venv and
     exec's the interpreter — a `bazel run :name`-able venv."""
 
-    shared = _assemble_shared(ctx)
+    shared = _assemble_shared(ctx, None)
 
     ctx.actions.expand_template(
         template = ctx.file._run_tmpl,
@@ -247,6 +248,10 @@ does not reinsert a wheel.
         allow_single_file = True,
         default = "//py/private/py_venv:templates/console_script.tmpl.sh",
     ),
+    "_venv_symlinks_script": attr.label(
+        allow_single_file = True,
+        default = "//py/private/py_venv:templates/symlinks.py",
+    ),
 })
 
 _lib_attrs.update(**_py_library.attrs)
@@ -300,7 +305,7 @@ def _py_venv_lib_rule_impl(ctx):
     launcher and no RunEnvironmentInfo (Bazel rejects it on
     non-executable targets; py_venv_exec.bzl gates its read on
     `if RunEnvironmentInfo in venv`)."""
-    shared = _assemble_shared(ctx)
+    shared = _assemble_shared(ctx, ctx.file._venv_symlinks_script)
     return _common_providers(ctx, shared)
 
 # Internal-only non-executable variant. Uses `_lib_attrs` — the

--- a/py/private/py_venv/templates/symlinks.py
+++ b/py/private/py_venv/templates/symlinks.py
@@ -1,0 +1,18 @@
+"""Materialize declared venv site-packages symlinks from a parameter file."""
+
+import os
+import sys
+from pathlib import Path
+
+
+def main(params):
+    entries = Path(params).read_text().splitlines()
+    if len(entries) % 2:
+        raise ValueError("expected output/target pairs")
+    for output, target in zip(entries[::2], entries[1::2]):
+        Path(output).parent.mkdir(parents=True, exist_ok=True)
+        os.symlink(target, output)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/py/private/py_venv/tests/BUILD.bazel
+++ b/py/private/py_venv/tests/BUILD.bazel
@@ -73,4 +73,14 @@ py_test(
     main = "//py/private/py_venv/tests:test_link.py",
 )
 
+py_test(
+    name = "test_symlinks",
+    srcs = [
+        "//py/private/py_venv:templates/symlinks.py",
+        "//py/private/py_venv/tests:test_symlinks.py",
+    ],
+    imports = ["../templates"],
+    main = "//py/private/py_venv/tests:test_symlinks.py",
+)
+
 virtuals_resolvers_test_suite(name = "virtuals_resolvers_tests")

--- a/py/private/py_venv/tests/BUILD.bazel
+++ b/py/private/py_venv/tests/BUILD.bazel
@@ -81,6 +81,10 @@ py_test(
     ],
     imports = ["../templates"],
     main = "//py/private/py_venv/tests:test_symlinks.py",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 virtuals_resolvers_test_suite(name = "virtuals_resolvers_tests")

--- a/py/private/py_venv/tests/test_symlinks.py
+++ b/py/private/py_venv/tests/test_symlinks.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+from pathlib import Path
+
+from symlinks import main
+
+
+with tempfile.TemporaryDirectory() as temporary_directory:
+    root = Path(temporary_directory)
+    first = root / "site-packages/example"
+    nested = root / "site-packages/namespace/example"
+    params = root / "symlinks.params"
+    params.write_text("\n".join([
+        str(first),
+        "../../../wheel/site-packages/example",
+        str(nested),
+        "../../../../wheel/site-packages/namespace/example",
+    ]))
+
+    main(params)
+
+    assert os.readlink(first) == "../../../wheel/site-packages/example"
+    assert os.readlink(nested) == "../../../../wheel/site-packages/namespace/example"

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -31,12 +31,12 @@ distutils, etc.) treat it as a real venv:
 
 The whole tree is declared at analysis time as individual
 `ctx.actions.declare_file` / `ctx.actions.declare_symlink` outputs (no
-tree-artifact + remote-exec materialisation surprises). Private non-Windows
-venvs can materialize projected site-packages symlinks in one action.
+tree-artifact + remote-exec materialisation surprises). Private venvs can
+materialize projected site-packages symlinks in one action on POSIX executors.
 """
 
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
-load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
+load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "VENV_SYMLINK_TOOLCHAIN")
 load(":toolchains_resolver.bzl", "resolve_venv_toolchain")
 load(":virtuals_resolvers.bzl", "enforce_collision_policy", "resolve_wheel_collisions")
 
@@ -57,7 +57,7 @@ def assemble_venv(
         venv_activate_tmpl,
         virtualenv_shim_py,
         site_merge_script_py,
-        venv_symlinks_script_py,
+        venv_symlink_tool,
         console_script_tmpl,
         venv_name):
     """Declare every file + symlink that makes up a venv for a target.
@@ -88,8 +88,8 @@ def assemble_venv(
         wheel graph contains a regular package needing a physical merge; the
         merge action also requires the rule to declare the (optional)
         EXEC_TOOLS_TOOLCHAIN for an exec-configuration interpreter.
-      venv_symlinks_script_py: Optional File — materializes projected
-        site-packages symlinks in one action for private non-Windows venvs.
+      venv_symlink_tool: Optional FilesToRunProvider — materializes projected
+        site-packages symlinks in one action for private venvs.
       console_script_tmpl: File — the console-script wrapper template
         (usually `ctx.file._console_script_tmpl`).
       venv_name: str — the venv dir basename (e.g. "." + safe_name).
@@ -146,12 +146,8 @@ def assemble_venv(
     # a cached per-wheel prefix rather than formatting every component.
     site_packages_prefix = site_packages_rel + "/"
     target_prefix_by_sp = {}
-    exec_runtime = None
-    if not is_windows and venv_symlinks_script_py != None:
-        exec_toolchain = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN]
-        exec_runtime = exec_toolchain.exec_tools.exec_runtime if exec_toolchain else None
     symlink_outputs = []
-    if exec_runtime:
+    if venv_symlink_tool:
         symlink_arguments = ctx.actions.args()
         symlink_arguments.use_param_file("%s", use_always = True)
         symlink_arguments.set_param_file_format("multiline")
@@ -164,7 +160,7 @@ def assemble_venv(
         target_path = target_prefix + tl
         if "/" in tl:
             target_path = "../" * tl.count("/") + target_path
-        if exec_runtime:
+        if venv_symlink_tool:
             symlink_arguments.add(out.path)
             symlink_arguments.add(target_path)
             symlink_outputs.append(out)
@@ -178,13 +174,10 @@ def assemble_venv(
     if symlink_outputs:
         ctx.actions.run(
             mnemonic = "PyVenvSymlinks",
-            executable = exec_runtime.interpreter,
-            toolchain = EXEC_TOOLS_TOOLCHAIN,
-            arguments = [venv_symlinks_script_py.path, symlink_arguments],
-            inputs = depset(
-                direct = [venv_symlinks_script_py],
-                transitive = [exec_runtime.files],
-            ),
+            executable = venv_symlink_tool.executable,
+            toolchain = VENV_SYMLINK_TOOLCHAIN,
+            arguments = [symlink_arguments],
+            tools = [venv_symlink_tool],
             outputs = symlink_outputs,
         )
 

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -30,9 +30,9 @@ distutils, etc.) treat it as a real venv:
                                                 whole-wheel fallback
 
 The whole tree is declared at analysis time as individual
-`ctx.actions.declare_file` / `ctx.actions.declare_symlink` outputs so
-Bazel's action cache treats each piece independently (no tree-artifact
-+ remote-exec materialisation surprises).
+`ctx.actions.declare_file` / `ctx.actions.declare_symlink` outputs (no
+tree-artifact + remote-exec materialisation surprises). Private non-Windows
+venvs can materialize projected site-packages symlinks in one action.
 """
 
 load("//py/private:py_library.bzl", _py_library = "py_library_utils")
@@ -57,6 +57,7 @@ def assemble_venv(
         venv_activate_tmpl,
         virtualenv_shim_py,
         site_merge_script_py,
+        venv_symlinks_script_py,
         console_script_tmpl,
         venv_name):
     """Declare every file + symlink that makes up a venv for a target.
@@ -87,6 +88,8 @@ def assemble_venv(
         wheel graph contains a regular package needing a physical merge; the
         merge action also requires the rule to declare the (optional)
         EXEC_TOOLS_TOOLCHAIN for an exec-configuration interpreter.
+      venv_symlinks_script_py: Optional File — materializes projected
+        site-packages symlinks in one action for private non-Windows venvs.
       console_script_tmpl: File — the console-script wrapper template
         (usually `ctx.file._console_script_tmpl`).
       venv_name: str — the venv dir basename (e.g. "." + safe_name).
@@ -143,6 +146,15 @@ def assemble_venv(
     # a cached per-wheel prefix rather than formatting every component.
     site_packages_prefix = site_packages_rel + "/"
     target_prefix_by_sp = {}
+    exec_runtime = None
+    if not is_windows and venv_symlinks_script_py != None:
+        exec_toolchain = ctx.toolchains[EXEC_TOOLS_TOOLCHAIN]
+        exec_runtime = exec_toolchain.exec_tools.exec_runtime if exec_toolchain else None
+    symlink_outputs = []
+    if exec_runtime:
+        symlink_arguments = ctx.actions.args()
+        symlink_arguments.use_param_file("%s", use_always = True)
+        symlink_arguments.set_param_file_format("multiline")
     for tl, wheel_site_pkgs in top_level_to_site_pkgs.items():
         out = ctx.actions.declare_symlink(site_packages_prefix + tl)
         target_prefix = target_prefix_by_sp.get(wheel_site_pkgs)
@@ -152,11 +164,29 @@ def assemble_venv(
         target_path = target_prefix + tl
         if "/" in tl:
             target_path = "../" * tl.count("/") + target_path
-        ctx.actions.symlink(
-            output = out,
-            target_path = target_path,
-        )
+        if exec_runtime:
+            symlink_arguments.add(out.path)
+            symlink_arguments.add(target_path)
+            symlink_outputs.append(out)
+        else:
+            ctx.actions.symlink(
+                output = out,
+                target_path = target_path,
+            )
         declared.append(out)
+
+    if symlink_outputs:
+        ctx.actions.run(
+            mnemonic = "PyVenvSymlinks",
+            executable = exec_runtime.interpreter,
+            toolchain = EXEC_TOOLS_TOOLCHAIN,
+            arguments = [venv_symlinks_script_py.path, symlink_arguments],
+            inputs = depset(
+                direct = [venv_symlinks_script_py],
+                transitive = [exec_runtime.files],
+            ),
+            outputs = symlink_outputs,
+        )
 
     # Physical merges for regular packages that span wheels or collide at the
     # top level (see

--- a/py/private/toolchain/BUILD.bazel
+++ b/py/private/toolchain/BUILD.bazel
@@ -15,11 +15,6 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
-toolchain_type(
-    name = "venv_symlink_toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
 py_binary(
     name = "venv_symlinks",
     srcs = ["//py/private/py_venv:templates/symlinks.py"],

--- a/py/private/toolchain/BUILD.bazel
+++ b/py/private/toolchain/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
-load(":tools.bzl", "dummy_toolchain")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load(":tools.bzl", "dummy_toolchain", "venv_symlink_toolchain")
 
 # Dummy toolchain backing target — no binary, used as a sentinel.
 # Public so the generated @rules_py_tools repo can reference it for
@@ -11,6 +12,30 @@ dummy_toolchain(
 
 toolchain_type(
     name = "native_build_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+toolchain_type(
+    name = "venv_symlink_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "venv_symlinks",
+    srcs = ["//py/private/py_venv:templates/symlinks.py"],
+    main = "//py/private/py_venv:templates/symlinks.py",
+)
+
+venv_symlink_toolchain(
+    name = "venv_symlink_tool",
+    tool = ":venv_symlinks",
+    visibility = ["//visibility:public"],
+)
+
+# Keep unsupported execution platforms eligible while falling back to native
+# symlink actions; dangling directory links cannot be created by the POSIX tool.
+venv_symlink_toolchain(
+    name = "empty_venv_symlink_tool",
     visibility = ["//visibility:public"],
 )
 

--- a/py/private/toolchain/repo.bzl
+++ b/py/private/toolchain/repo.bzl
@@ -1,7 +1,7 @@
 """Create the toolchains repository for rules_py.
 
-Generates native_build toolchain entries — one per supported platform — that
-back pep517_whl's cross-compilation guard (see NATIVE_BUILD_TOOLCHAIN in types.bzl).
+Generates native-build and venv-symlink toolchain entries for supported POSIX
+platforms and a native-symlink fallback for other executors.
 """
 
 load("//py/private/toolchain:tools.bzl", "TOOLCHAIN_PLATFORMS")
@@ -24,10 +24,27 @@ toolchain(
     toolchain_type = "@aspect_rules_py//py/private/toolchain:native_build_toolchain_type",
 )
 
+toolchain(
+    name = "venv_symlink_{platform}_toolchain",
+    exec_compatible_with = {compatible_with},
+    toolchain = "@aspect_rules_py//py/private/toolchain:venv_symlink_tool",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:venv_symlink_toolchain_type",
+)
+
 """.format(
             platform = platform,
             compatible_with = meta.compatible_with,
         )
+
+    build_content += """
+# Keep the fallback last when :all is registered so supported POSIX tools win.
+toolchain(
+    name = "venv_symlink_zfallback_toolchain",
+    toolchain = "@aspect_rules_py//py/private/toolchain:empty_venv_symlink_tool",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:venv_symlink_toolchain_type",
+)
+
+"""
 
     repository_ctx.file("BUILD.bazel", build_content)
 
@@ -35,5 +52,5 @@ toolchain(
 
 toolchains_repo = repository_rule(
     _toolchains_repo_impl,
-    doc = "Creates a repository with native_build toolchain entries for all supported platforms.",
+    doc = "Creates a repository with native-build and venv-symlink toolchain entries.",
 )

--- a/py/private/toolchain/repo.bzl
+++ b/py/private/toolchain/repo.bzl
@@ -28,7 +28,7 @@ toolchain(
     name = "venv_symlink_{platform}_toolchain",
     exec_compatible_with = {compatible_with},
     toolchain = "@aspect_rules_py//py/private/toolchain:venv_symlink_tool",
-    toolchain_type = "@aspect_rules_py//py/private/toolchain:venv_symlink_toolchain_type",
+    toolchain_type = "@aspect_rules_py//py:venv_symlink_toolchain_type",
 )
 
 """.format(
@@ -41,7 +41,7 @@ toolchain(
 toolchain(
     name = "venv_symlink_zfallback_toolchain",
     toolchain = "@aspect_rules_py//py/private/toolchain:empty_venv_symlink_tool",
-    toolchain_type = "@aspect_rules_py//py/private/toolchain:venv_symlink_toolchain_type",
+    toolchain_type = "@aspect_rules_py//py:venv_symlink_toolchain_type",
 )
 
 """

--- a/py/private/toolchain/tools.bzl
+++ b/py/private/toolchain/tools.bzl
@@ -37,3 +37,22 @@ dummy_toolchain = rule(
     implementation = _dummy_toolchain_impl,
     attrs = {},
 )
+
+def _venv_symlink_toolchain_impl(ctx):
+    tool = ctx.attr.tool[DefaultInfo].files_to_run if ctx.attr.tool else None
+    return [platform_common.ToolchainInfo(tool = tool)]
+
+venv_symlink_toolchain = rule(
+    doc = "Declares a venv site-packages symlink tool or a native-symlink fallback.",
+    implementation = _venv_symlink_toolchain_impl,
+    attrs = {
+        "tool": attr.label(
+            cfg = "exec",
+            doc = """Executable that receives a parameter-file path as its only argument.
+The file contains alternating output and relative-target lines. The tool
+creates parent directories and materializes the unresolved symlinks. Omit to
+use native symlink actions.""",
+            executable = True,
+        ),
+    },
+)

--- a/py/private/toolchain/types.bzl
+++ b/py/private/toolchain/types.bzl
@@ -3,3 +3,4 @@
 PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
 EXEC_TOOLS_TOOLCHAIN = "@rules_python//python:exec_tools_toolchain_type"
 NATIVE_BUILD_TOOLCHAIN = "@aspect_rules_py//py/private/toolchain:native_build_toolchain_type"
+VENV_SYMLINK_TOOLCHAIN = "@aspect_rules_py//py/private/toolchain:venv_symlink_toolchain_type"

--- a/py/private/toolchain/types.bzl
+++ b/py/private/toolchain/types.bzl
@@ -3,4 +3,4 @@
 PY_TOOLCHAIN = "@bazel_tools//tools/python:toolchain_type"
 EXEC_TOOLS_TOOLCHAIN = "@rules_python//python:exec_tools_toolchain_type"
 NATIVE_BUILD_TOOLCHAIN = "@aspect_rules_py//py/private/toolchain:native_build_toolchain_type"
-VENV_SYMLINK_TOOLCHAIN = "@aspect_rules_py//py/private/toolchain:venv_symlink_toolchain_type"
+VENV_SYMLINK_TOOLCHAIN = "@aspect_rules_py//py:venv_symlink_toolchain_type"

--- a/py/tests/py-internal-venv/BUILD.bazel
+++ b/py/tests/py-internal-venv/BUILD.bazel
@@ -1,4 +1,14 @@
-load("//py:defs.bzl", "py_test")
+load("//py:defs.bzl", "py_test", "py_venv")
+load(
+    ":venv_symlinks_test.bzl",
+    "explicit_venv_symlinks_test",
+    "exposed_venv_symlinks_test",
+    "no_runtime_toolchain",
+    "no_runtime_venv_symlinks_test",
+    "no_runtime_wheel",
+    "private_venv_symlinks_test",
+    "windows_private_venv_symlinks_test",
+)
 
 # Two variants of the same test: `test` uses `py_test` defaults
 # (`isolated = True`); `test_non_isolated` flips `isolated = False`.
@@ -17,6 +27,74 @@ py_test(
     deps = [
         "@pypi//cowsay",
     ],
+)
+
+py_test(
+    name = "_exposed_test",
+    srcs = ["test.py"],
+    expose_venv = True,
+    imports = ["."],
+    main = "test.py",
+    tags = ["manual"],
+    deps = ["@pypi//cowsay"],
+)
+
+py_venv(
+    name = "_explicit_venv",
+    tags = ["manual"],
+    deps = ["@pypi//cowsay"],
+)
+
+platform(
+    name = "_windows_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+)
+
+no_runtime_toolchain(name = "_no_runtime_toolchain_impl")
+
+no_runtime_wheel(name = "_no_runtime_wheel")
+
+py_test(
+    name = "_no_runtime_test",
+    srcs = ["test.py"],
+    imports = ["."],
+    main = "test.py",
+    tags = ["manual"],
+    deps = [":_no_runtime_wheel"],
+)
+
+toolchain(
+    name = "_no_runtime_toolchain",
+    toolchain = ":_no_runtime_toolchain_impl",
+    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
+)
+
+private_venv_symlinks_test(
+    name = "private_venv_symlinks_test",
+    target_under_test = ":_test.venv",
+)
+
+exposed_venv_symlinks_test(
+    name = "exposed_venv_symlinks_test",
+    target_under_test = ":_exposed_test.venv",
+)
+
+explicit_venv_symlinks_test(
+    name = "explicit_venv_symlinks_test",
+    target_under_test = ":_explicit_venv",
+)
+
+windows_private_venv_symlinks_test(
+    name = "windows_private_venv_symlinks_test",
+    target_under_test = ":_test.venv",
+)
+
+no_runtime_venv_symlinks_test(
+    name = "no_runtime_venv_symlinks_test",
+    target_under_test = ":__no_runtime_test.venv",
 )
 
 py_test(

--- a/py/tests/py-internal-venv/BUILD.bazel
+++ b/py/tests/py-internal-venv/BUILD.bazel
@@ -74,7 +74,7 @@ venv_symlink_toolchain(
 toolchain(
     name = "_custom_symlink_toolchain",
     toolchain = ":_custom_symlink_toolchain_impl",
-    toolchain_type = "//py/private/toolchain:venv_symlink_toolchain_type",
+    toolchain_type = "//py:venv_symlink_toolchain_type",
 )
 
 venv_symlink_toolchain(name = "_no_symlink_toolchain_impl")
@@ -82,7 +82,7 @@ venv_symlink_toolchain(name = "_no_symlink_toolchain_impl")
 toolchain(
     name = "_no_symlink_toolchain",
     toolchain = ":_no_symlink_toolchain_impl",
-    toolchain_type = "//py/private/toolchain:venv_symlink_toolchain_type",
+    toolchain_type = "//py:venv_symlink_toolchain_type",
 )
 
 private_venv_symlinks_test(

--- a/py/tests/py-internal-venv/BUILD.bazel
+++ b/py/tests/py-internal-venv/BUILD.bazel
@@ -1,13 +1,15 @@
 load("//py:defs.bzl", "py_test", "py_venv")
+load("//py:toolchains.bzl", "venv_symlink_toolchain")
 load(
     ":venv_symlinks_test.bzl",
+    "custom_symlink_tool",
+    "custom_venv_symlinks_test",
     "explicit_venv_symlinks_test",
     "exposed_venv_symlinks_test",
-    "no_runtime_toolchain",
-    "no_runtime_venv_symlinks_test",
-    "no_runtime_wheel",
+    "no_symlink_venv_symlinks_test",
     "private_venv_symlinks_test",
-    "windows_private_venv_symlinks_test",
+    "windows_exec_private_venv_symlinks_test",
+    "windows_target_private_venv_symlinks_test",
 )
 
 # Two variants of the same test: `test` uses `py_test` defaults
@@ -53,23 +55,34 @@ platform(
     ],
 )
 
-no_runtime_toolchain(name = "_no_runtime_toolchain_impl")
+platform(
+    name = "_linux_x86_64_windows_exec",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    flags = ["--extra_execution_platforms=//py/tests/py-internal-venv:_windows_x86_64"],
+)
 
-no_runtime_wheel(name = "_no_runtime_wheel")
+custom_symlink_tool(name = "_custom_symlink_tool")
 
-py_test(
-    name = "_no_runtime_test",
-    srcs = ["test.py"],
-    imports = ["."],
-    main = "test.py",
-    tags = ["manual"],
-    deps = [":_no_runtime_wheel"],
+venv_symlink_toolchain(
+    name = "_custom_symlink_toolchain_impl",
+    tool = ":_custom_symlink_tool",
 )
 
 toolchain(
-    name = "_no_runtime_toolchain",
-    toolchain = ":_no_runtime_toolchain_impl",
-    toolchain_type = "@rules_python//python:exec_tools_toolchain_type",
+    name = "_custom_symlink_toolchain",
+    toolchain = ":_custom_symlink_toolchain_impl",
+    toolchain_type = "//py/private/toolchain:venv_symlink_toolchain_type",
+)
+
+venv_symlink_toolchain(name = "_no_symlink_toolchain_impl")
+
+toolchain(
+    name = "_no_symlink_toolchain",
+    toolchain = ":_no_symlink_toolchain_impl",
+    toolchain_type = "//py/private/toolchain:venv_symlink_toolchain_type",
 )
 
 private_venv_symlinks_test(
@@ -87,14 +100,24 @@ explicit_venv_symlinks_test(
     target_under_test = ":_explicit_venv",
 )
 
-windows_private_venv_symlinks_test(
-    name = "windows_private_venv_symlinks_test",
+custom_venv_symlinks_test(
+    name = "custom_venv_symlinks_test",
     target_under_test = ":_test.venv",
 )
 
-no_runtime_venv_symlinks_test(
-    name = "no_runtime_venv_symlinks_test",
-    target_under_test = ":__no_runtime_test.venv",
+windows_exec_private_venv_symlinks_test(
+    name = "windows_exec_private_venv_symlinks_test",
+    target_under_test = ":_test.venv",
+)
+
+windows_target_private_venv_symlinks_test(
+    name = "windows_target_private_venv_symlinks_test",
+    target_under_test = ":_test.venv",
+)
+
+no_symlink_venv_symlinks_test(
+    name = "no_symlink_venv_symlinks_test",
+    target_under_test = ":_test.venv",
 )
 
 py_test(

--- a/py/tests/py-internal-venv/venv_symlinks_test.bzl
+++ b/py/tests/py-internal-venv/venv_symlinks_test.bzl
@@ -1,39 +1,15 @@
 """Analysis checks for private venv site-packages symlink batching."""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//py/private:providers.bzl", "PyWheelsInfo", "make_wheel_record")
-load("//py/private:py_info.bzl", "PyInfo")
 
-def _no_runtime_toolchain_impl(_ctx):
-    return [platform_common.ToolchainInfo(exec_tools = struct(exec_runtime = None))]
+def _custom_symlink_tool_impl(ctx):
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+    data = ctx.actions.declare_file(ctx.label.name + ".data")
+    ctx.actions.write(executable, "#!/usr/bin/env bash\nexit 0\n", is_executable = True)
+    ctx.actions.write(data, "custom tool runfile\n")
+    return [DefaultInfo(executable = executable, runfiles = ctx.runfiles(files = [data]))]
 
-no_runtime_toolchain = rule(implementation = _no_runtime_toolchain_impl)
-
-def _no_runtime_wheel_impl(ctx):
-    tree = ctx.actions.declare_directory(ctx.label.name + ".install")
-    site_packages = "/".join([
-        ctx.workspace_name,
-        ctx.label.package,
-        tree.basename,
-        "lib/python3.9/site-packages",
-    ])
-    ctx.actions.run_shell(
-        outputs = [tree],
-        command = "mkdir -p \"$1/lib/python3.9/site-packages/example\" && touch \"$1/lib/python3.9/site-packages/example/__init__.py\"",
-        arguments = [tree.path],
-    )
-    wheel = make_wheel_record(
-        top_levels = ("example",),
-        site_packages_rfpath = site_packages,
-        install_tree = tree,
-    )
-    return [
-        DefaultInfo(files = depset([tree]), runfiles = ctx.runfiles(files = [tree])),
-        PyInfo(imports = depset([site_packages]), transitive_sources = depset([tree])),
-        PyWheelsInfo(wheels = depset([wheel])),
-    ]
-
-no_runtime_wheel = rule(implementation = _no_runtime_wheel_impl)
+custom_symlink_tool = rule(implementation = _custom_symlink_tool_impl, executable = True)
 
 def _outputs(actions, mnemonic):
     return [
@@ -74,28 +50,57 @@ def _explicit_impl(ctx):
     _assert_fallback(env, analysistest.target_actions(env), "._explicit_venv", 2)
     return analysistest.end(env)
 
-def _windows_private_impl(ctx):
+def _custom_impl(ctx):
+    env = analysistest.begin(ctx)
+    actions = analysistest.target_actions(env)
+    symlink_actions = [action for action in actions if action.mnemonic == "PyVenvSymlinks"]
+    asserts.equals(env, 1, len(symlink_actions))
+    inputs = [file.short_path for file in symlink_actions[0].inputs.to_list()]
+    asserts.true(env, any([path.endswith("/_custom_symlink_tool.sh") for path in inputs]))
+    asserts.true(env, any(["custom" in path and "symlink" in path and path.endswith("runfiles") for path in inputs]))
+    return analysistest.end(env)
+
+def _windows_exec_private_impl(ctx):
     env = analysistest.begin(ctx)
     _assert_fallback(env, analysistest.target_actions(env), "._test.venv", 2)
     return analysistest.end(env)
 
-def _no_runtime_impl(ctx):
+def _windows_target_private_impl(ctx):
     env = analysistest.begin(ctx)
-    _assert_fallback(env, analysistest.target_actions(env), ".__no_runtime_test.venv", 1)
+    outputs = _outputs(analysistest.target_actions(env), "PyVenvSymlinks")
+    asserts.equals(env, 2, len(outputs))
+    asserts.true(env, all(["/._test.venv/lib/" in path for path in outputs]))
+    return analysistest.end(env)
+
+def _no_symlink_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_fallback(env, analysistest.target_actions(env), "._test.venv", 2)
     return analysistest.end(env)
 
 private_venv_symlinks_test = analysistest.make(_private_impl)
 exposed_venv_symlinks_test = analysistest.make(_exposed_impl)
 explicit_venv_symlinks_test = analysistest.make(_explicit_impl)
-windows_private_venv_symlinks_test = analysistest.make(
-    _windows_private_impl,
+custom_venv_symlinks_test = analysistest.make(
+    _custom_impl,
+    config_settings = {
+        "//command_line_option:extra_toolchains": [str(Label(":_custom_symlink_toolchain"))],
+    },
+)
+windows_exec_private_venv_symlinks_test = analysistest.make(
+    _windows_exec_private_impl,
+    config_settings = {
+        "//command_line_option:platforms": str(Label(":_linux_x86_64_windows_exec")),
+    },
+)
+windows_target_private_venv_symlinks_test = analysistest.make(
+    _windows_target_private_impl,
     config_settings = {
         "//command_line_option:platforms": str(Label(":_windows_x86_64")),
     },
 )
-no_runtime_venv_symlinks_test = analysistest.make(
-    _no_runtime_impl,
+no_symlink_venv_symlinks_test = analysistest.make(
+    _no_symlink_impl,
     config_settings = {
-        "//command_line_option:extra_toolchains": [str(Label(":_no_runtime_toolchain"))],
+        "//command_line_option:extra_toolchains": [str(Label(":_no_symlink_toolchain"))],
     },
 )

--- a/py/tests/py-internal-venv/venv_symlinks_test.bzl
+++ b/py/tests/py-internal-venv/venv_symlinks_test.bzl
@@ -1,0 +1,101 @@
+"""Analysis checks for private venv site-packages symlink batching."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//py/private:providers.bzl", "PyWheelsInfo", "make_wheel_record")
+load("//py/private:py_info.bzl", "PyInfo")
+
+def _no_runtime_toolchain_impl(_ctx):
+    return [platform_common.ToolchainInfo(exec_tools = struct(exec_runtime = None))]
+
+no_runtime_toolchain = rule(implementation = _no_runtime_toolchain_impl)
+
+def _no_runtime_wheel_impl(ctx):
+    tree = ctx.actions.declare_directory(ctx.label.name + ".install")
+    site_packages = "/".join([
+        ctx.workspace_name,
+        ctx.label.package,
+        tree.basename,
+        "lib/python3.9/site-packages",
+    ])
+    ctx.actions.run_shell(
+        outputs = [tree],
+        command = "mkdir -p \"$1/lib/python3.9/site-packages/example\" && touch \"$1/lib/python3.9/site-packages/example/__init__.py\"",
+        arguments = [tree.path],
+    )
+    wheel = make_wheel_record(
+        top_levels = ("example",),
+        site_packages_rfpath = site_packages,
+        install_tree = tree,
+    )
+    return [
+        DefaultInfo(files = depset([tree]), runfiles = ctx.runfiles(files = [tree])),
+        PyInfo(imports = depset([site_packages]), transitive_sources = depset([tree])),
+        PyWheelsInfo(wheels = depset([wheel])),
+    ]
+
+no_runtime_wheel = rule(implementation = _no_runtime_wheel_impl)
+
+def _outputs(actions, mnemonic):
+    return [
+        output.short_path
+        for action in actions
+        if action.mnemonic == mnemonic
+        for output in action.outputs.to_list()
+    ]
+
+def _assert_fallback(env, actions, venv_name, expected_links):
+    asserts.equals(env, [], _outputs(actions, "PyVenvSymlinks"))
+    links = _outputs(actions, "UnresolvedSymlink")
+    prefix = "py/tests/py-internal-venv/{}/lib/".format(venv_name)
+    asserts.equals(env, expected_links, len([path for path in links if path.startswith(prefix)]))
+
+def _private_impl(ctx):
+    env = analysistest.begin(ctx)
+    actions = analysistest.target_actions(env)
+    symlink_actions = [action for action in actions if action.mnemonic == "PyVenvSymlinks"]
+    asserts.equals(env, 1, len(symlink_actions))
+    outputs = _outputs(symlink_actions, "PyVenvSymlinks")
+    asserts.equals(env, 2, len(outputs))
+    asserts.true(env, all(["/._test.venv/lib/" in path for path in outputs]))
+    asserts.true(
+        env,
+        any([path.endswith("/._test.venv/bin/cowsay") for path in _outputs(actions, "TemplateExpand")]),
+        "console scripts should keep their TemplateExpand actions",
+    )
+    return analysistest.end(env)
+
+def _exposed_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_fallback(env, analysistest.target_actions(env), "._exposed_test.venv", 2)
+    return analysistest.end(env)
+
+def _explicit_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_fallback(env, analysistest.target_actions(env), "._explicit_venv", 2)
+    return analysistest.end(env)
+
+def _windows_private_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_fallback(env, analysistest.target_actions(env), "._test.venv", 2)
+    return analysistest.end(env)
+
+def _no_runtime_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_fallback(env, analysistest.target_actions(env), ".__no_runtime_test.venv", 1)
+    return analysistest.end(env)
+
+private_venv_symlinks_test = analysistest.make(_private_impl)
+exposed_venv_symlinks_test = analysistest.make(_exposed_impl)
+explicit_venv_symlinks_test = analysistest.make(_explicit_impl)
+windows_private_venv_symlinks_test = analysistest.make(
+    _windows_private_impl,
+    config_settings = {
+        "//command_line_option:platforms": str(Label(":_windows_x86_64")),
+    },
+)
+no_runtime_venv_symlinks_test = analysistest.make(
+    _no_runtime_impl,
+    config_settings = {
+        "//command_line_option:extra_toolchains": [str(Label(":_no_runtime_toolchain"))],
+    },
+)

--- a/py/toolchains.bzl
+++ b/py/toolchains.bzl
@@ -2,6 +2,9 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("//py/private/toolchain:repo.bzl", "toolchains_repo")
+load("//py/private/toolchain:tools.bzl", _venv_symlink_toolchain = "venv_symlink_toolchain")
+
+venv_symlink_toolchain = _venv_symlink_toolchain
 
 DEFAULT_TOOLS_REPOSITORY = "rules_py_tools"
 


### PR DESCRIPTION
Batch private-venv top-level symlinks into one action while preserving declared outputs and runfiles. The current benchmark increases analysis cost, so an end-to-end win for large dependency graphs is still required before this is ready to land.