### PR TITLE
fix(pytest): point TMPDIR at TEST_TMPDIR in the pytest_main launcher

### DIFF
--- a/py/private/pytest_main.py
+++ b/py/private/pytest_main.py
@@ -18,6 +18,20 @@ import os
 from pathlib import Path
 from typing import List
 
+# Point the temp dir at Bazel's per-test TEST_TMPDIR before pytest or the stdlib
+# `tempfile` module resolve it. Bazel's default test setup exports
+# TMPDIR=$TEST_TMPDIR so a test's temp files land in its private, writable temp
+# directory; rules_py's launcher didn't, so pytest's `tmp_path`/`tmpdir` fixtures
+# and `tempfile` fell back to the system temp dir (usually /tmp). That is
+# non-hermetic (temp files leak across parallel tests / runs) and outright breaks
+# on remote-execution workers that mount /tmp `noexec` — e.g. a test that writes an
+# executable helper into `tmp_path` and runs it gets EACCES. TMP/TEMP are set too so
+# `tempfile` resolves consistently on Windows. Must run before the first
+# `tempfile.gettempdir()` call, which caches the result process-wide.
+if "TEST_TMPDIR" in os.environ:
+    for _tmp_env in ("TMPDIR", "TMP", "TEMP"):
+        os.environ[_tmp_env] = os.environ["TEST_TMPDIR"]
+
 try:
     import pytest
 except ModuleNotFoundError as e:


### PR DESCRIPTION
## Problem

Bazel's default test setup exports `TMPDIR=$TEST_TMPDIR` (see `tools/test/test-setup.sh`) so a test's temp files land in its private, writable, per-test `TEST_TMPDIR`. The `rules_py` `pytest_main` launcher never sets it, so pytest's `tmp_path`/`tmpdir` fixtures and the stdlib `tempfile` module fall back to the system temp dir (usually `/tmp`).

That has two consequences:

1. **Non-hermetic** — temp files leak into a shared `/tmp` across parallel tests and runs, instead of the isolated `TEST_TMPDIR` Bazel cleans up per test.
2. **Broken on remote execution** — RE workers commonly mount `/tmp` `noexec`. A test that writes an executable helper into `tmp_path` and runs it fails with `EACCES`/`PermissionError`, even though the same test passes locally and on RE workers whose `/tmp` is exec-able. We hit this running a `pytest`-based suite on a BuildBarn RE cluster: a test that installs a fake CLI into `tmp_path` and `subprocess`-execs it failed only there, and a probe confirmed `tmp_path` was under `/tmp` (not `TEST_TMPDIR`) with `TMPDIR` unset, and that `/tmp` was `noexec` while `TEST_TMPDIR` was exec-able.

## Fix

Set `TMPDIR`/`TMP`/`TEMP` to `TEST_TMPDIR` at the top of `pytest_main`, before pytest or `tempfile` resolve (and cache) the temp dir — mirroring Bazel's own test setup. Only applied when `TEST_TMPDIR` is present (i.e. under `bazel test`).

## Notes

- `TMP`/`TEMP` are set alongside `TMPDIR` so `tempfile` resolves consistently on Windows too.
- Must run before the first `tempfile.gettempdir()` call, which caches the result process-wide — hence placement immediately after the imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)