### PR TITLE
feat(py): expose PyWheelsInfo

### DIFF
--- a/e2e/cases/uv-console-script-extras/BUILD.bazel
+++ b/e2e/cases/uv-console-script-extras/BUILD.bazel
@@ -1,4 +1,4 @@
-load(":metadata_test.bzl", "console_scripts_metadata_test")
+load(":metadata_test.bzl", "console_scripts_metadata_test", "forward_wheels")
 
 # Each target pins a REAL wheel that ships the legacy console-script extras
 # syntax in its `entry_points.txt`, and asserts `parse_console_script`
@@ -13,13 +13,18 @@ load(":metadata_test.bzl", "console_scripts_metadata_test")
 #   black  = black:patched_main         -> black=black:patched_main      (plain, unchanged)
 #   blackd = blackd:patched_main [d]    -> blackd=blackd:patched_main    ([d] extra stripped)
 # The `[d]` extra gates black's optional HTTP-daemon dependencies (aiohttp).
+forward_wheels(
+    name = "forwarded_black_wheels",
+    deps = ["@whl_install__console_script_extras__black__26_5_1//:install"],
+)
+
 console_scripts_metadata_test(
     name = "black_console_scripts_test",
     expected_console_scripts = [
         "black=black:patched_main",
         "blackd=blackd:patched_main",
     ],
-    target_under_test = "@whl_install__console_script_extras__black__26_5_1//:install",
+    target_under_test = ":forwarded_black_wheels",
 )
 
 # google-auth-oauthlib 1.4.0 — single py3-none-any wheel, one console script:

--- a/e2e/cases/uv-console-script-extras/metadata_test.bzl
+++ b/e2e/cases/uv-console-script-extras/metadata_test.bzl
@@ -7,8 +7,19 @@ legacy `name = module:func [extra]` syntax, so a regression that lets the
 `[extra]` suffix leak back into the value fails here.
 """
 
-load("@aspect_rules_py//py/private:providers.bzl", "PyWheelsInfo")
+load("@aspect_rules_py//py:defs.bzl", "PyWheelsInfo")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _forward_wheels_impl(ctx):
+    return [PyWheelsInfo(wheels = depset(order = "postorder", transitive = [
+        dep[PyWheelsInfo].wheels
+        for dep in ctx.attr.deps
+    ]))]
+
+forward_wheels = rule(
+    implementation = _forward_wheels_impl,
+    attrs = {"deps": attr.label_list(providers = [PyWheelsInfo])},
+)
 
 def _console_scripts_metadata_test_impl(ctx):
     env = analysistest.begin(ctx)

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -55,6 +55,7 @@ bzl_library(
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//py/private:providers",
         "//py/private:py_image_layer",
         "//py/private:py_info",
         "//py/private:py_library",

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -20,6 +20,7 @@ load("@rules_python//python:packaging.bzl", _py_wheel = "py_wheel")
 load("@rules_python//python:pip.bzl", _whl_filegroup = "whl_filegroup")
 load("@rules_python//python:py_runtime.bzl", _py_runtime = "py_runtime")
 load("@rules_python//python:py_runtime_pair.bzl", _py_runtime_pair = "py_runtime_pair")
+load("//py/private:providers.bzl", _PyWheelsInfo = "PyWheelsInfo")
 load(
     "//py/private:py_image_layer.bzl",
     _PyLayerTierInfo = "PyLayerTierInfo",
@@ -63,6 +64,7 @@ PyLayerTierInfo = _PyLayerTierInfo
 
 # The PyInfo provider used by rules_py
 PyInfo = _PyInfo
+PyWheelsInfo = _PyWheelsInfo
 
 # The runtime provider carried by rules_py-provisioned interpreter toolchains:
 # rules_python's public PyRuntimeInfo, the shared standard-toolchain contract.


### PR DESCRIPTION
Expose installed-wheel metadata through the public Python API so custom rules can forward it without a private load path. Preserve postorder wheel aggregation and cover forwarding with a pinned UV wheel.