### PR TITLE
feat(uv): detect source-built console scripts

### DIFF
--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -13,7 +13,7 @@ There are three kinds of overrides:
 Additionally, `extra_deps` and `extra_data` allow adding dependencies or data
 files to the generated `py_library` target for a package.
 `console_scripts` overrides the complete script map for a wheel built from an
-sdist when its top-level egg-info metadata is absent or unsuitable. An explicit
+sdist when its egg-info metadata is absent or unsuitable. An explicit
 empty map suppresses all detected scripts.
 
 ## Prerequisites

--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -12,8 +12,8 @@ There are three kinds of overrides:
 
 Additionally, `extra_deps` and `extra_data` allow adding dependencies or data
 files to the generated `py_library` target for a package.
-`console_scripts` declares the complete script map for a wheel built from an
-sdist so venv assembly can create wrappers during analysis.
+`console_scripts` overrides the complete script map for a wheel built from an
+sdist when its top-level egg-info metadata is absent or unsuitable.
 
 ## Prerequisites
 

--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -13,7 +13,8 @@ There are three kinds of overrides:
 Additionally, `extra_deps` and `extra_data` allow adding dependencies or data
 files to the generated `py_library` target for a package.
 `console_scripts` overrides the complete script map for a wheel built from an
-sdist when its top-level egg-info metadata is absent or unsuitable.
+sdist when its top-level egg-info metadata is absent or unsuitable. An explicit
+empty map suppresses all detected scripts.
 
 ## Prerequisites
 

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -353,9 +353,10 @@ markers such as `python_full_version < '3.12.4'` require a full
 ### Declaring source-built console scripts
 
 Downloaded wheels expose their console scripts while repositories are
-generated. A wheel built from an sdist does not exist until execution, after
-analysis has already assembled console-script wrappers. Declare the complete,
-nonempty script map on that package's override:
+generated. For source-built wheels, the default configure tool reads a
+top-level `*.egg-info/entry_points.txt` in the sdist and forwards its console
+scripts to venv assembly. If an sdist has no usable entry-point metadata,
+declare the complete, nonempty script map on that package's override:
 
 ```starlark
 uv.override_package(
@@ -369,7 +370,8 @@ uv.override_package(
 
 The optional `version` on `override_package` follows the existing override
 rules: omit it when the lock resolves one version of the package. The
-declaration is attached only to the source-build select arm. If a prebuilt
+declaration takes precedence over detected scripts and is attached only to the
+source-build select arm. If a prebuilt
 wheel is selected instead, its inspected metadata remains authoritative. The
 package layout remains unknown at analysis time, so the complete source-built
 wheel still participates in the normal `.pth` fallback.
@@ -499,9 +501,9 @@ Set `native = true|false` on a package annotation to override automatic sdist
 native detection and select the native or pure-Python wheel build path.
 
 **Why aren't entrypoints automatically created?** Downloaded-wheel entrypoints
-are discovered while repositories are generated. Source-built wheels do not
-exist until execution, so declare their console scripts with
-`uv.override_package(console_scripts = {...})`.
+and top-level sdist egg-info entrypoints are discovered while repositories are
+generated. For sdists without entry-point metadata, declare console scripts
+with `uv.override_package(console_scripts = {...})`.
 
 If you need a given entrypoint as a Bazel target, it needs to be manually
 declared. In most cases of normal entrypoints this is quite easy. Tools like

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -353,10 +353,10 @@ markers such as `python_full_version < '3.12.4'` require a full
 ### Declaring source-built console scripts
 
 Downloaded wheels expose their console scripts while repositories are
-generated. For source-built wheels, the default configure tool reads a
-top-level `*.egg-info/entry_points.txt` in the sdist and forwards its console
-scripts to venv assembly. If an sdist has no usable entry-point metadata,
-declare the complete script map on that package's override:
+generated. For source-built wheels, the default configure tool reads the
+distribution-owned `*.egg-info/entry_points.txt` in the sdist and forwards its
+console scripts to venv assembly. If an sdist has no usable entry-point
+metadata, declare the complete script map on that package's override:
 
 ```starlark
 uv.override_package(
@@ -371,10 +371,10 @@ uv.override_package(
 The optional `version` on `override_package` follows the existing override
 rules: omit it when the lock resolves one version of the package. The
 declaration takes precedence over detected scripts and is attached only to the
-source-build select arm. If a prebuilt
-wheel is selected instead, its inspected metadata remains authoritative. The
-package layout remains unknown at analysis time, so the complete source-built
-wheel still participates in the normal `.pth` fallback.
+source-build select arm. If a prebuilt wheel is selected instead, its inspected
+metadata remains authoritative. The package layout remains unknown at analysis
+time, so the complete source-built wheel still participates in the normal
+`.pth` fallback.
 
 An explicit `console_scripts = {}` suppresses all detected scripts, which is
 useful when a pre-build patch removes stale entry-point metadata.
@@ -504,9 +504,9 @@ Set `native = true|false` on a package annotation to override automatic sdist
 native detection and select the native or pure-Python wheel build path.
 
 **Why aren't entrypoints automatically created?** Downloaded-wheel entrypoints
-and top-level sdist egg-info entrypoints are discovered while repositories are
-generated. For sdists without entry-point metadata, declare console scripts
-with `uv.override_package(console_scripts = {...})`.
+and distribution-owned sdist egg-info entrypoints are discovered while
+repositories are generated. For sdists without entry-point metadata, declare
+console scripts with `uv.override_package(console_scripts = {...})`.
 
 If you need a given entrypoint as a Bazel target, it needs to be manually
 declared. In most cases of normal entrypoints this is quite easy. Tools like

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -356,7 +356,7 @@ Downloaded wheels expose their console scripts while repositories are
 generated. For source-built wheels, the default configure tool reads a
 top-level `*.egg-info/entry_points.txt` in the sdist and forwards its console
 scripts to venv assembly. If an sdist has no usable entry-point metadata,
-declare the complete, nonempty script map on that package's override:
+declare the complete script map on that package's override:
 
 ```starlark
 uv.override_package(
@@ -375,6 +375,9 @@ source-build select arm. If a prebuilt
 wheel is selected instead, its inspected metadata remains authoritative. The
 package layout remains unknown at analysis time, so the complete source-built
 wheel still participates in the normal `.pth` fallback.
+
+An explicit `console_scripts = {}` suppresses all detected scripts, which is
+useful when a pre-build patch removes stale entry-point metadata.
 
 ## Best practices
 

--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -123,7 +123,8 @@ write_source_files(
         # snapshot also pins that a native-only annotation preserves explicit
         # and configure-discovered build deps. This retains the monitor-only
         # source-build coverage. The runtime //uv-sdist-fallback:test
-        # proves that the forced-native build produces a working wheel.
+        # proves that the forced-native build and its detected console script
+        # produce a working wheel and wrapper.
         "snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel": "@sdist_build__uv_sdist_fallback__cowsay__6_0//:BUILD.bazel",
 
         # @sdist_build for python-geohash with uv.override_package(resource_set)

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
@@ -14,6 +14,7 @@ pep517_native_whl(
     src = "@@aspect_rules_py++uv+sdist__cowsay__47445cb273684618//file:file",
     tool = ":build_tool",
     version = "6.0",
+    console_scripts = ["cowsay=cowsay.__main__:cli"],
     monitor_memory = True,
     visibility = ["//visibility:public"],
 )

--- a/e2e/cases/uv-invalid-build-overrides/custom-complete/MODULE.bazel
+++ b/e2e/cases/uv-invalid-build-overrides/custom-complete/MODULE.bazel
@@ -19,6 +19,7 @@ uv.project(
 )
 uv.override_package(
     name = "cowsay",
+    console_scripts = {},
     env = {"DEMO": "1"},
     lock = "//:uv.lock",
     monitor_memory = True,

--- a/e2e/cases/uv-invalid-build-overrides/wheel-only/MODULE.bazel
+++ b/e2e/cases/uv-invalid-build-overrides/wheel-only/MODULE.bazel
@@ -15,7 +15,7 @@ uv.project(
 )
 uv.override_package(
     name = "demo",
-    console_scripts = {"demo": "demo:main"},
+    console_scripts = {},
     env = {"DEMO": "1"},
     lock = "//:uv.lock",
     monitor_memory = True,

--- a/e2e/cases/uv-sdist-fallback/__test__.py
+++ b/e2e/cases/uv-sdist-fallback/__test__.py
@@ -15,7 +15,7 @@ import cowsay
 
 output = cowsay.get_output_string("cow", "sdist fallback works!")
 assert "sdist fallback works!" in output
-marker = "declared console script works"
+marker = "detected console script works"
 wrapper = shutil.which("cowsay")
 assert wrapper is not None, "cowsay wrapper is absent from PATH"
 expected_wrapper = Path(os.environ["VIRTUAL_ENV"]) / "bin" / "cowsay"

--- a/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-fallback/setup.MODULE.bazel
@@ -26,7 +26,6 @@ uv.unstable_annotate_packages(
 )
 uv.override_package(
     name = "cowsay",
-    console_scripts = {"cowsay": "cowsay.__main__:cli"},
     lock = "//uv-sdist-fallback:uv.lock",
     monitor_memory = True,
 )

--- a/uv/private/BUILD.bazel
+++ b/uv/private/BUILD.bazel
@@ -33,3 +33,8 @@ bzl_library(
     name = "normalize_version",
     srcs = ["normalize_version.bzl"],
 )
+
+bzl_library(
+    name = "source_built_wheel",
+    srcs = ["source_built_wheel.bzl"],
+)

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -71,6 +71,11 @@ load(":graph_utils.bzl", "activate_extras", "collect_sccs")
 load(":lockfile.bzl", "build_marker_graph", "collect_bdists", "collect_configurations", "collect_sdists", "normalize_deps", "url_basename")
 load(":projectfile.bzl", "collate_versions_by_name", "collect_activated_extras", "extract_requirement_marker_pairs")
 
+# attr.string_dict cannot distinguish omission from an explicitly empty map.
+# The empty script name is invalid, so this sentinel cannot collide with a
+# valid console-script declaration.
+_CONSOLE_SCRIPTS_UNSET = {"": ""}
+
 def _dist_sha256(dist):
     """The distribution's sha256 for http_file, or None for other hash algorithms."""
     hash = dist.get("hash", "")
@@ -211,7 +216,7 @@ def _parse_projects(module_ctx, hub_specs):
 
             has_target = override.target != None
             has_modifications = (
-                override.console_scripts or
+                override.console_scripts != _CONSOLE_SCRIPTS_UNSET or
                 override.pre_build_patches or
                 override.post_install_patches or
                 override.extra_deps or
@@ -319,18 +324,20 @@ def _parse_projects(module_ctx, hub_specs):
                 if override.lock == None:
                     unscoped_matches[i] += 1
 
-                console_scripts = []
-                for raw_script_name, raw_entry_point in sorted(override.console_scripts.items()):
-                    console_script = parse_declared_console_script(raw_script_name, raw_entry_point)
-                    if console_script == None:
-                        fail("uv.override_package() for '{}=={}' in lock '{}': `console_scripts` must map valid script names to `module:object` entry points; got {} = {}".format(
-                            override.name,
-                            v,
-                            project.lock,
-                            repr(raw_script_name),
-                            repr(raw_entry_point),
-                        ))
-                    console_scripts.append(console_script)
+                console_scripts = None
+                if override.console_scripts != _CONSOLE_SCRIPTS_UNSET:
+                    console_scripts = []
+                    for raw_script_name, raw_entry_point in sorted(override.console_scripts.items()):
+                        console_script = parse_declared_console_script(raw_script_name, raw_entry_point)
+                        if console_script == None:
+                            fail("uv.override_package() for '{}=={}' in lock '{}': `console_scripts` must map valid script names to `module:object` entry points; got {} = {}".format(
+                                override.name,
+                                v,
+                                project.lock,
+                                repr(raw_script_name),
+                                repr(raw_entry_point),
+                            ))
+                        console_scripts.append(console_script)
 
                 has_target = override.target != None
                 package_overrides[override_key] = override
@@ -449,7 +456,7 @@ def _parse_projects(module_ctx, hub_specs):
                 sdist = sdist_table.get(sbuild_id)
                 override_key = (normalize_name(package["name"]), package["version"])
                 pkg_override = package_overrides.get(override_key)
-                sbuild_console_scripts = package_console_scripts.get(override_key, [])
+                sbuild_console_scripts = package_console_scripts.get(override_key)
 
                 # WARNING: Loop invariant; this flag needs to be False by
                 # default and set if we do a build.
@@ -763,13 +770,15 @@ def _uv_impl(module_ctx):
             "metadata_directory": install_cfg.metadata_directory,
             "name": install_id,
             "sbuild": install_cfg.sbuild,
-            "sbuild_console_scripts": install_cfg.sbuild_console_scripts,
+            "sbuild_console_scripts": install_cfg.sbuild_console_scripts or [],
             "whls": json.encode(install_cfg.whls),
             # Parallel list of the same wheel labels as a real label_list,
             # so the whl_install repo rule can `rctx.path()` them to peek
             # at `*.dist-info/RECORD` for top-level metadata.
             "whl_files": _deduplicate_whl_files(install_cfg.whls.values()),
         }
+        if install_cfg.sbuild_console_scripts != None:
+            install_kwargs["sbuild_console_scripts_override"] = True
         if install_cfg.post_install_patches:
             install_kwargs["post_install_patches"] = json.encode(install_cfg.post_install_patches)
             install_kwargs["post_install_patch_strip"] = install_cfg.post_install_patch_strip
@@ -874,7 +883,8 @@ _override_package_tag = tag_class(
                   "Mutually exclusive with all patch/data modification attributes.",
         ),
         "console_scripts": attr.string_dict(
-            doc = "Complete console scripts for a source-built wheel, mapping script names to module:object entry points.",
+            default = _CONSOLE_SCRIPTS_UNSET,
+            doc = "Complete console scripts for a source-built wheel, mapping script names to module:object entry points. An explicit empty map suppresses all detected scripts.",
         ),
         "monitor_memory": attr.bool(
             default = False,

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -12,6 +12,7 @@ load(
     "hostile_python_env_target",
     "pep517_native_whl_execroot_collision_test",
     "pep517_native_whl_toolchain_env_test",
+    "pep517_whl_console_scripts_test",
 )
 
 package(default_visibility = [
@@ -28,6 +29,7 @@ bzl_library(
     srcs = ["rule.bzl"],
     deps = [
         "//py/private/toolchain:types",
+        "//uv/private:source_built_wheel",
         "@bazel_lib//lib:resource_sets",
         "@rules_cc//cc:action_names_bzl",
         "@rules_cc//cc/common",
@@ -84,6 +86,7 @@ bzl_library(
     visibility = ["//uv:__subpackages__"],
     deps = [
         ":rule",
+        "//uv/private:source_built_wheel",
         "@bazel_skylib//lib:unittest",
     ],
 )
@@ -149,6 +152,7 @@ build_test(
 pep517_native_whl(
     name = "__toolchain_env_fixture",
     src = ":__stub_sdist",
+    console_scripts = ["detected-native=demo.cli:native"],
     env = {
         "JAVA_HOME": "$(JAVABASE)",
         "JAVA": "$(JAVA)",
@@ -165,6 +169,12 @@ pep517_native_whl(
 
 pep517_native_whl_toolchain_env_test(
     name = "toolchain_env_test",
+    target_under_test = ":__toolchain_env_fixture",
+)
+
+pep517_whl_console_scripts_test(
+    name = "console_scripts_native_test",
+    expected_console_scripts = ["detected-native=demo.cli:native"],
     target_under_test = ":__toolchain_env_fixture",
 )
 

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -9,6 +9,7 @@ load("@bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
+load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
 
 _CC_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:toolchain_type")
 _TARGET_EXEC_GROUP = "target"
@@ -173,7 +174,10 @@ def _pep517_whl(ctx):
         resource_set = resource_set(ctx.attr),
     )
 
-    return [DefaultInfo(files = depset([wheel_dir]))]
+    return [
+        DefaultInfo(files = depset([wheel_dir])),
+        SourceBuiltWheelInfo(console_scripts = tuple(ctx.attr.console_scripts)),
+    ]
 
 def _pep517_native_whl(ctx):
     archive = ctx.file.src
@@ -220,7 +224,10 @@ def _pep517_native_whl(ctx):
         resource_set = resource_set(ctx.attr),
     )
 
-    return [DefaultInfo(files = depset([wheel_dir]))]
+    return [
+        DefaultInfo(files = depset([wheel_dir])),
+        SourceBuiltWheelInfo(console_scripts = tuple(ctx.attr.console_scripts)),
+    ]
 
 _PATCH_ATTRS = {
     "pre_build_patches": attr.label_list(
@@ -241,6 +248,9 @@ _pep517_whl_attrs = {
     # https://bazel.build/extending/exec-groups#defining-exec-groups
     "tool": attr.label(executable = True, cfg = config.exec(_TARGET_EXEC_GROUP)),
     "version": attr.string(),
+    "console_scripts": attr.string_list(
+        doc = "Console scripts discovered from the source distribution's entry-point metadata.",
+    ),
     "args": attr.string_list(default = ["--validate-anyarch"]),
     "monitor_memory": attr.bool(
         default = False,

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -21,6 +21,12 @@ _INHERITED_PYTHON_ENV = (
     "PYTHONPLATLIBDIR",
 )
 
+def _wheel_providers(wheel_dir, console_scripts):
+    return [
+        DefaultInfo(files = depset([wheel_dir])),
+        SourceBuiltWheelInfo(console_scripts = tuple(console_scripts)),
+    ]
+
 def _common_env(ctx):
     # pyproject_hooks copies the build process environment and launches its
     # Python executable without -I:
@@ -174,10 +180,7 @@ def _pep517_whl(ctx):
         resource_set = resource_set(ctx.attr),
     )
 
-    return [
-        DefaultInfo(files = depset([wheel_dir])),
-        SourceBuiltWheelInfo(console_scripts = tuple(ctx.attr.console_scripts)),
-    ]
+    return _wheel_providers(wheel_dir, ctx.attr.console_scripts)
 
 def _pep517_native_whl(ctx):
     archive = ctx.file.src
@@ -224,10 +227,7 @@ def _pep517_native_whl(ctx):
         resource_set = resource_set(ctx.attr),
     )
 
-    return [
-        DefaultInfo(files = depset([wheel_dir])),
-        SourceBuiltWheelInfo(console_scripts = tuple(ctx.attr.console_scripts)),
-    ]
+    return _wheel_providers(wheel_dir, ctx.attr.console_scripts)
 
 _PATCH_ATTRS = {
     "pre_build_patches": attr.label_list(

--- a/uv/private/pep517_whl/test.bzl
+++ b/uv/private/pep517_whl/test.bzl
@@ -6,6 +6,7 @@ build to verify the env wiring.
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
 
 _ACTION_ENV = "//command_line_option:action_env"
 _HOST_ENV = [
@@ -100,6 +101,22 @@ def _toolchain_env_test_impl(ctx):
     return analysistest.end(env)
 
 pep517_native_whl_toolchain_env_test = analysistest.make(_toolchain_env_test_impl)
+
+def _console_scripts_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    asserts.true(env, SourceBuiltWheelInfo in target, "source-built wheel metadata is absent")
+    asserts.equals(
+        env,
+        tuple(ctx.attr.expected_console_scripts),
+        target[SourceBuiltWheelInfo].console_scripts,
+    )
+    return analysistest.end(env)
+
+pep517_whl_console_scripts_test = analysistest.make(
+    _console_scripts_test_impl,
+    attrs = {"expected_console_scripts": attr.string_list()},
+)
 
 def _execroot_collision_toolchain_impl(_ctx):
     return [platform_common.TemplateVariableInfo({"EXECROOT": "collision"})]

--- a/uv/private/pep517_whl/tests/console_scripts/pure/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/console_scripts/pure/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("//uv/private/pep517_whl:test.bzl", "pep517_whl_console_scripts_test")
+
+write_file(
+    name = "__stub_sdist",
+    out = "stub.tar.gz",
+    content = [""],
+    tags = ["manual"],
+)
+
+write_file(
+    name = "__stub_tool_sh",
+    out = "stub_tool.sh",
+    content = [
+        "#!/bin/sh",
+        "exit 0",
+    ],
+    is_executable = True,
+    tags = ["manual"],
+)
+
+sh_binary(
+    name = "__stub_tool",
+    srcs = [":__stub_tool_sh"],
+    tags = ["manual"],
+)
+
+pep517_whl(
+    name = "__console_scripts_fixture",
+    testonly = True,
+    src = ":__stub_sdist",
+    console_scripts = ["detected-pure=demo.cli:pure"],
+    tags = ["manual"],
+    tool = ":__stub_tool",
+    version = "0.0.1",
+)
+
+pep517_whl_console_scripts_test(
+    name = "console_scripts_test",
+    expected_console_scripts = ["detected-pure=demo.cli:pure"],
+    target_under_test = ":__console_scripts_fixture",
+)

--- a/uv/private/sdist_build/attrs.bzl
+++ b/uv/private/sdist_build/attrs.bzl
@@ -13,7 +13,7 @@ def validate_build_attrs(
     """Fails when a configured source-build attribute is unsupported.
 
     Args:
-        console_scripts: Additional entry points generated for a source build.
+        console_scripts: Complete source-build entry points, or None when unset.
         resource_set: Resource set name, where "default" means unset.
         env: Environment variables for the wheel-build action.
         monitor_memory: Whether to monitor the wheel-build action's memory.
@@ -24,7 +24,7 @@ def validate_build_attrs(
         error: Failure message with one `{}` slot for unsupported names.
     """
     active = []
-    if console_scripts:
+    if console_scripts != None:
         active.append("console_scripts")
     if resource_set != "default":
         active.append("resource_set")

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -172,7 +172,7 @@ def _sdist_build_impl(repository_ctx):
             # If the tool provided complete build file content, use it directly.
             if build_file_content:
                 validate_build_attrs(
-                    console_scripts = [],
+                    console_scripts = None,
                     resource_set = repository_ctx.attr.resource_set,
                     env = repository_ctx.attr.extra_env,
                     error = "sdist_build for '{}': the configure tool returned complete `build_file_content`, which bypasses the generated `pep517_*whl(...)` call, so these attributes cannot be applied: {{}}. Drop them from the override, or have the configure tool set them in its own `build_file_content`.".format(repository_ctx.name),
@@ -209,7 +209,7 @@ def _sdist_build_impl(repository_ctx):
 
     if not is_native:
         validate_build_attrs(
-            console_scripts = [],
+            console_scripts = None,
             resource_set = repository_ctx.attr.resource_set,
             env = repository_ctx.attr.extra_env,
             error = "sdist_build for '{}': the generated pure-Python `pep517_whl(...)` call cannot apply these native-build attributes: {{}}. Remove them, or configure this source distribution as native.".format(repository_ctx.name),

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -280,6 +280,10 @@ def _sdist_build_impl(repository_ctx):
     if repository_ctx.attr.resource_set != "default":
         resource_set_attr = "\n    resource_set = \"{}\",".format(repository_ctx.attr.resource_set)
 
+    console_scripts_attr = ""
+    if inspection and inspection.get("console_scripts"):
+        console_scripts_attr = "\n    console_scripts = {},".format(repr(inspection["console_scripts"]))
+
     # Leave args unset: the pure rule validates anyarch wheels by default,
     # while the native rule defaults to no validation.
     repository_ctx.file("BUILD.bazel", content = """
@@ -297,7 +301,7 @@ py_binary(
     name = "whl",
     src = "{src}",
     tool = ":build_tool",
-    version = "{version}",{monitor_memory_attr}{resource_set_attr}{patch_attrs}{toolchain_attrs}
+    version = "{version}",{console_scripts_attr}{monitor_memory_attr}{resource_set_attr}{patch_attrs}{toolchain_attrs}
     visibility = ["//visibility:public"],
 )
 
@@ -308,6 +312,7 @@ exports_files(
 """.format(
         src = repository_ctx.attr.src,
         deps = repr(all_deps),
+        console_scripts_attr = console_scripts_attr,
         monitor_memory_attr = monitor_memory_attr,
         rule = "pep517_native_whl" if is_native else "pep517_whl",
         version = repository_ctx.attr.version,

--- a/uv/private/sdist_configure/defs.bzl
+++ b/uv/private/sdist_configure/defs.bzl
@@ -92,6 +92,15 @@ The JSON object MAY contain any of the following fields:
         Normalized package names inferred from file extensions. Informational;
         used for logging.
 
+    "console_scripts": [<string>, ...]
+
+        Complete console-script entry points discovered from the source
+        distribution, encoded as `name=module:object`. These are forwarded to
+        the generated wheel target so venv assembly can create wrappers.
+        When `build_file_content` is present, the custom BUILD content owns
+        attaching this metadata; an explicit console-script override remains
+        available for source producers that cannot expose it.
+
 ## Default implementation
 
 The bundled `detect_native.py` implements this contract. It requires

--- a/uv/private/sdist_configure/detect_native.py
+++ b/uv/private/sdist_configure/detect_native.py
@@ -16,6 +16,7 @@ interpreters [build-system] metadata is skipped with a warning.
 from __future__ import annotations
 
 import configparser
+import email.parser
 import importlib
 import os
 import importlib.abc
@@ -88,6 +89,7 @@ class DetectionResult(_OptionalDetectionResult):
     has_setup_cfg: bool
     setup_py_setup_requires: List[str]
     setup_py_install_requires: List[str]
+    console_scripts: List[str]
 
 
 def _normalize_name(name: str) -> str:
@@ -412,6 +414,41 @@ def _find_config_file(members: Sequence[str], filename: str) -> Optional[str]:
     return None
 
 
+def _parse_console_scripts(content: str) -> List[str]:
+    """Return normalized console scripts from an egg-info entry_points.txt."""
+    scripts: Dict[str, str] = {}
+    in_console_scripts = False
+    for raw_line in content.splitlines():
+        line = raw_line.split(";", 1)[0].split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_console_scripts = line[1:-1].strip() == "console_scripts"
+            continue
+        if not in_console_scripts:
+            continue
+
+        name, separator, target = line.partition("=")
+        name = name.strip()
+        module, colon, function = target.partition(":")
+        module = module.strip()
+        function, extra, extras = function.partition("[")
+        function = function.strip()
+        if (
+            not separator
+            or not colon
+            or name in ("", ".", "..")
+            or any(char in name for char in ("/", "\\", "=", " ", "\t", "\n", "\r"))
+            or not module
+            or not function
+            or (extra and (not extras.endswith("]") or "[" in extras or "]" in extras[:-1]))
+            or any(char in module or char in function for char in ("=", ":", "[", "]", " ", "\t", "\n", "\r"))
+        ):
+            continue
+        scripts[name] = f"{name}={module}:{function}"
+    return sorted(scripts.values())
+
+
 def detect(archive_path: str, context: ConfigureContext) -> DetectionResult:
     """Run detection on an sdist archive.
 
@@ -457,6 +494,22 @@ def detect(archive_path: str, context: ConfigureContext) -> DetectionResult:
             content = read_fn(setup_cfg_path)
             if content:
                 declared.extend(_parse_setup_cfg_build_requires(content))
+
+        # Only a top-level egg-info directory belongs to this sdist. Nested
+        # entry-point metadata may be vendored and must not create wrappers.
+        member_paths = [PurePosixPath(name) for name in members]
+        rooted = len({path.parts[0] for path in member_paths}) == 1
+        entry_points_paths = [
+            str(path) for path in member_paths
+            if len(path.parts) == (3 if rooted else 2)
+            and path.parts[-2].endswith(".egg-info")
+            and path.name == "entry_points.txt"
+        ]
+        console_scripts = []
+        if len(entry_points_paths) == 1:
+            content = read_fn(entry_points_paths[0])
+            if content:
+                console_scripts = _parse_console_scripts(content)
 
         # Parse setup.py for setup_requires / install_requires
         setup_py_path = _find_config_file(members, "setup.py")
@@ -513,6 +566,7 @@ def detect(archive_path: str, context: ConfigureContext) -> DetectionResult:
         "has_setup_cfg": setup_cfg_path is not None,
         "setup_py_setup_requires": setup_py_setup_requires,
         "setup_py_install_requires": setup_py_install_requires,
+        "console_scripts": console_scripts,
     }
     if backend_path is not None:
         result["backend_path"] = backend_path

--- a/uv/private/sdist_configure/detect_native.py
+++ b/uv/private/sdist_configure/detect_native.py
@@ -512,22 +512,24 @@ def detect(archive_path: str, context: ConfigureContext) -> DetectionResult:
                 package_name = email.parser.Parser().parsestr(content, headersonly=True).get("Name")
                 if package_name:
                     package_name = _normalize_name(package_name)
+        egg_info = [
+            (name, path) for name, path in member_paths
+            if len(path.parts) >= 2
+            and path.parts[-2].endswith(".egg-info")
+            and path.name == "entry_points.txt"
+        ]
         if package_name:
             entry_points_paths = [
-                name for name, path in member_paths
-                if len(path.parts) >= 2
-                and path.parts[-2].endswith(".egg-info")
-                and _normalize_name(path.parts[-2][:-len(".egg-info")]) == package_name
-                and path.name == "entry_points.txt"
+                name for name, path in egg_info
+                if _normalize_name(path.parts[-2][:-len(".egg-info")]) == package_name
             ]
         else:
             # Git archives may not carry root PKG-INFO. Preserve the direct
             # egg-info fallback without admitting nested vendored metadata.
+            depth = 3 if rooted else 2
             entry_points_paths = [
-                name for name, path in member_paths
-                if len(path.parts) == (3 if rooted else 2)
-                and path.parts[-2].endswith(".egg-info")
-                and path.name == "entry_points.txt"
+                name for name, path in egg_info
+                if len(path.parts) == depth
             ]
         console_scripts = []
         if len(entry_points_paths) == 1:

--- a/uv/private/sdist_configure/detect_native.py
+++ b/uv/private/sdist_configure/detect_native.py
@@ -495,16 +495,40 @@ def detect(archive_path: str, context: ConfigureContext) -> DetectionResult:
             if content:
                 declared.extend(_parse_setup_cfg_build_requires(content))
 
-        # Only a top-level egg-info directory belongs to this sdist. Nested
-        # entry-point metadata may be vendored and must not create wrappers.
+        # Match the root distribution name rather than path depth: setuptools
+        # src-layout projects place their own egg-info below src/ or another
+        # package directory, while differently named metadata may be vendored.
         member_paths = [(name, PurePosixPath(name)) for name in members]
         rooted = len({path.parts[0] for _, path in member_paths}) == 1
-        entry_points_paths = [
+        pkg_info_paths = [
             name for name, path in member_paths
-            if len(path.parts) == (3 if rooted else 2)
-            and path.parts[-2].endswith(".egg-info")
-            and path.name == "entry_points.txt"
+            if len(path.parts) == (2 if rooted else 1)
+            and path.name == "PKG-INFO"
         ]
+        package_name = None
+        if len(pkg_info_paths) == 1:
+            content = read_fn(pkg_info_paths[0])
+            if content:
+                package_name = email.parser.Parser().parsestr(content, headersonly=True).get("Name")
+                if package_name:
+                    package_name = _normalize_name(package_name)
+        if package_name:
+            entry_points_paths = [
+                name for name, path in member_paths
+                if len(path.parts) >= 2
+                and path.parts[-2].endswith(".egg-info")
+                and _normalize_name(path.parts[-2][:-len(".egg-info")]) == package_name
+                and path.name == "entry_points.txt"
+            ]
+        else:
+            # Git archives may not carry root PKG-INFO. Preserve the direct
+            # egg-info fallback without admitting nested vendored metadata.
+            entry_points_paths = [
+                name for name, path in member_paths
+                if len(path.parts) == (3 if rooted else 2)
+                and path.parts[-2].endswith(".egg-info")
+                and path.name == "entry_points.txt"
+            ]
         console_scripts = []
         if len(entry_points_paths) == 1:
             content = read_fn(entry_points_paths[0])

--- a/uv/private/sdist_configure/detect_native.py
+++ b/uv/private/sdist_configure/detect_native.py
@@ -497,10 +497,10 @@ def detect(archive_path: str, context: ConfigureContext) -> DetectionResult:
 
         # Only a top-level egg-info directory belongs to this sdist. Nested
         # entry-point metadata may be vendored and must not create wrappers.
-        member_paths = [PurePosixPath(name) for name in members]
-        rooted = len({path.parts[0] for path in member_paths}) == 1
+        member_paths = [(name, PurePosixPath(name)) for name in members]
+        rooted = len({path.parts[0] for _, path in member_paths}) == 1
         entry_points_paths = [
-            str(path) for path in member_paths
+            name for name, path in member_paths
             if len(path.parts) == (3 if rooted else 2)
             and path.parts[-2].endswith(".egg-info")
             and path.name == "entry_points.txt"

--- a/uv/private/sdist_configure/detect_native_test.py
+++ b/uv/private/sdist_configure/detect_native_test.py
@@ -385,6 +385,19 @@ def test_console_scripts_from_flat_zip_archive() -> None:
     assert result["console_scripts"] == ["percent=pkg.cli:run_%s"]
 
 
+def test_console_scripts_preserve_prefixed_archive_member_names() -> None:
+    members = {
+        "./pkg-1.0/pkg/__init__.py": "",
+        "./pkg-1.0/pkg.egg-info/entry_points.txt": (
+            "[console_scripts]\nprefixed = pkg.cli:main\n"
+        ),
+    }
+    for make_archive in (_make_tar_gz, _make_zip):
+        assert detect(make_archive(members), {})["console_scripts"] == [
+            "prefixed=pkg.cli:main",
+        ]
+
+
 def test_console_scripts_ignore_nested_and_ambiguous_egg_info() -> None:
     nested = _make_tar_gz({
         "pkg-1.0/pkg/__init__.py": "",

--- a/uv/private/sdist_configure/detect_native_test.py
+++ b/uv/private/sdist_configure/detect_native_test.py
@@ -345,6 +345,75 @@ def test_flat_archive() -> None:
     assert "flit_core" in result["build_requires"]
 
 
+# --- sdist console scripts ---
+
+
+def test_console_scripts_from_egg_info() -> None:
+    archive = _make_tar_gz({
+        "pkg-1.0/": None,
+        "pkg-1.0/pkg/__init__.py": "",
+        "pkg-1.0/pkg.egg-info/entry_points.txt": (
+            "[console_scripts]\n"
+            "Upper-Case = pkg.cli:main [speedups] # legacy extra\n"
+            "plain=pkg:run\n"
+            "../escape = pkg.cli:main\n"
+            "bad name = pkg.cli:main\n"
+            "missing-target = pkg.cli\n"
+            "extra-colon = pkg.cli:main:other\n"
+            "stray-close = pkg.cli:main]\n"
+            "stray-open = pkg.cli:main[extra\n"
+            "[gui_scripts]\n"
+            "ignored = pkg.gui:main\n"
+        ),
+    })
+    result = detect(archive, {})
+    assert result["console_scripts"] == [
+        "Upper-Case=pkg.cli:main",
+        "plain=pkg:run",
+    ]
+
+
+def test_console_scripts_from_flat_zip_archive() -> None:
+    archive = _make_zip({
+        "pkg/__init__.py": "",
+        "pkg.egg-info/entry_points.txt": (
+            "[console_scripts]\n"
+            "percent = pkg.cli:run_%s\n"
+        ),
+    })
+    result = detect(archive, {})
+    assert result["console_scripts"] == ["percent=pkg.cli:run_%s"]
+
+
+def test_console_scripts_ignore_nested_and_ambiguous_egg_info() -> None:
+    nested = _make_tar_gz({
+        "pkg-1.0/pkg/__init__.py": "",
+        "pkg-1.0/vendor/dependency.egg-info/entry_points.txt": (
+            "[console_scripts]\nvendor = dependency:main\n"
+        ),
+    })
+    assert detect(nested, {})["console_scripts"] == []
+
+    flat_nested = _make_tar_gz({
+        "pkg/__init__.py": "",
+        "vendor/dependency.egg-info/entry_points.txt": (
+            "[console_scripts]\nvendor = dependency:main\n"
+        ),
+    })
+    assert detect(flat_nested, {})["console_scripts"] == []
+
+    ambiguous = _make_tar_gz({
+        "pkg-1.0/pkg/__init__.py": "",
+        "pkg-1.0/first.egg-info/entry_points.txt": (
+            "[console_scripts]\nfirst = pkg:first\n"
+        ),
+        "pkg-1.0/second.egg-info/entry_points.txt": (
+            "[console_scripts]\nsecond = pkg:second\n"
+        ),
+    })
+    assert detect(ambiguous, {})["console_scripts"] == []
+
+
 # --- setup.py partial evaluator ---
 
 

--- a/uv/private/sdist_configure/detect_native_test.py
+++ b/uv/private/sdist_configure/detect_native_test.py
@@ -409,6 +409,7 @@ def test_console_scripts_ignore_nested_and_ambiguous_egg_info() -> None:
 
     flat_nested = _make_tar_gz({
         "pkg/__init__.py": "",
+        "vendor/PKG-INFO": "Metadata-Version: 2.1\nName: dependency\nVersion: 1.0\n",
         "vendor/dependency.egg-info/entry_points.txt": (
             "[console_scripts]\nvendor = dependency:main\n"
         ),
@@ -416,15 +417,60 @@ def test_console_scripts_ignore_nested_and_ambiguous_egg_info() -> None:
     assert detect(flat_nested, {})["console_scripts"] == []
 
     ambiguous = _make_tar_gz({
+        "pkg-1.0/PKG-INFO": "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n",
         "pkg-1.0/pkg/__init__.py": "",
-        "pkg-1.0/first.egg-info/entry_points.txt": (
+        "pkg-1.0/src/pkg.egg-info/entry_points.txt": (
             "[console_scripts]\nfirst = pkg:first\n"
         ),
-        "pkg-1.0/second.egg-info/entry_points.txt": (
+        "pkg-1.0/lib/pkg.egg-info/entry_points.txt": (
             "[console_scripts]\nsecond = pkg:second\n"
         ),
     })
     assert detect(ambiguous, {})["console_scripts"] == []
+
+
+def test_console_scripts_from_distribution_owned_nested_egg_info() -> None:
+    rooted = _make_tar_gz({
+        "pkg-1.0/PKG-INFO": "Metadata-Version: 2.1\nName: pkg-name\nVersion: 1.0\n",
+        "pkg-1.0/src/pkg/__init__.py": "",
+        "pkg-1.0/src/Pkg_Name.egg-info/entry_points.txt": (
+            "[console_scripts]\nrooted = pkg.cli:main\n"
+        ),
+        "pkg-1.0/vendor/other.egg-info/entry_points.txt": (
+            "[console_scripts]\nvendor = other:main\n"
+        ),
+    })
+    assert detect(rooted, {})["console_scripts"] == [
+        "rooted=pkg.cli:main",
+    ]
+
+    prefixed_zip = _make_zip({
+        "./pkg-1.0/PKG-INFO": "Metadata-Version: 2.1\nName: pkg_name\nVersion: 1.0\n",
+        "./pkg-1.0/lib/pkg/__init__.py": "",
+        "./pkg-1.0/lib/pkg-name.egg-info/entry_points.txt": (
+            "[console_scripts]\nlib = pkg.cli:main\n"
+        ),
+        "./pkg-1.0/vendor/other.egg-info/entry_points.txt": (
+            "[console_scripts]\nvendor = other:main\n"
+        ),
+    })
+    assert detect(prefixed_zip, {})["console_scripts"] == [
+        "lib=pkg.cli:main",
+    ]
+
+    flat = _make_tar_gz({
+        "./PKG-INFO": "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n",
+        "./src/pkg/__init__.py": "",
+        "./src/pkg.egg-info/entry_points.txt": (
+            "[console_scripts]\nflat = pkg.cli:main\n"
+        ),
+        "./vendor/other.egg-info/entry_points.txt": (
+            "[console_scripts]\nvendor = other:main\n"
+        ),
+    })
+    assert detect(flat, {})["console_scripts"] == [
+        "flat=pkg.cli:main",
+    ]
 
 
 # --- setup.py partial evaluator ---

--- a/uv/private/source_built_wheel.bzl
+++ b/uv/private/source_built_wheel.bzl
@@ -1,0 +1,8 @@
+"""Provider for metadata discovered while configuring a source-built wheel."""
+
+SourceBuiltWheelInfo = provider(
+    doc = "Analysis-time metadata for a source-built wheel.",
+    fields = {
+        "console_scripts": "Complete tuple[str] encoded as name=module:object.",
+    },
+)

--- a/uv/private/whl_install/BUILD.bazel
+++ b/uv/private/whl_install/BUILD.bazel
@@ -9,7 +9,10 @@ package(default_visibility = [
 bzl_library(
     name = "rule",
     srcs = ["rule.bzl"],
-    deps = ["//py/private:py_info"],
+    deps = [
+        "//py/private:py_info",
+        "//uv/private:source_built_wheel",
+    ],
 )
 
 bzl_library(
@@ -41,6 +44,7 @@ bzl_library(
     deps = [
         ":repository",
         ":rule",
+        "//uv/private:source_built_wheel",
         "@bazel_skylib//lib:unittest",
         "@bazel_skylib//rules:write_file",
     ],

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -612,17 +612,21 @@ def _whl_install_impl(repository_ctx):
     sbuild_target = str(repository_ctx.attr.sbuild) if repository_ctx.attr.sbuild else None
     default_target = ":source_built_wheel" if sbuild_target else None
     if sbuild_target:
+        console_scripts_override_attr = ""
+        if repository_ctx.attr.sbuild_console_scripts_override:
+            console_scripts_override_attr = "\n    console_scripts_override = True,"
         content.append(
             """
 source_built_wheel(
     name = "source_built_wheel",
     src = {src},
-    console_scripts = {console_scripts},
+    console_scripts = {console_scripts},{console_scripts_override_attr}
     visibility = ["//visibility:private"],
 )
 """.format(
                 src = repr(sbuild_target),
                 console_scripts = repr(repository_ctx.attr.sbuild_console_scripts),
+                console_scripts_override_attr = console_scripts_override_attr,
             ),
         )
 
@@ -914,6 +918,7 @@ whl_install = repository_rule(
         "whl_files": attr.label_list(allow_files = [".whl"]),
         "sbuild": attr.label(),
         "sbuild_console_scripts": attr.string_list(),
+        "sbuild_console_scripts_override": attr.bool(),
         "post_install_patches": attr.string(default = ""),
         "post_install_patch_strip": attr.int(default = 0),
         "extra_deps": attr.string(default = ""),

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -9,7 +9,7 @@ load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
 def _source_built_wheel_impl(ctx):
     source = ctx.attr.src[DefaultInfo]
     console_scripts = ctx.attr.console_scripts
-    if not console_scripts and SourceBuiltWheelInfo in ctx.attr.src:
+    if not ctx.attr.console_scripts_override and not console_scripts and SourceBuiltWheelInfo in ctx.attr.src:
         console_scripts = ctx.attr.src[SourceBuiltWheelInfo].console_scripts
     return [
         # whl_install consumes this target as a single file. Reconstruct
@@ -30,6 +30,7 @@ source_built_wheel = rule(
             mandatory = True,
         ),
         "console_scripts": attr.string_list(),
+        "console_scripts_override": attr.bool(),
     },
     provides = [SourceBuiltWheelInfo],
 )

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -9,7 +9,7 @@ load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
 def _source_built_wheel_impl(ctx):
     source = ctx.attr.src[DefaultInfo]
     console_scripts = ctx.attr.console_scripts
-    if not ctx.attr.console_scripts_override and not console_scripts and SourceBuiltWheelInfo in ctx.attr.src:
+    if not ctx.attr.console_scripts_override and SourceBuiltWheelInfo in ctx.attr.src:
         console_scripts = ctx.attr.src[SourceBuiltWheelInfo].console_scripts
     return [
         # whl_install consumes this target as a single file. Reconstruct

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -4,23 +4,20 @@
 load("//py/private:providers.bzl", "PyWheelsInfo", "make_wheel_record")
 load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "PY_TOOLCHAIN")
-
-SourceBuiltWheelInfo = provider(
-    doc = "Analysis-time metadata declared for a source-built wheel.",
-    fields = {
-        "console_scripts": "Complete tuple[str] encoded as name=module:object.",
-    },
-)
+load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
 
 def _source_built_wheel_impl(ctx):
     source = ctx.attr.src[DefaultInfo]
+    console_scripts = ctx.attr.console_scripts
+    if not console_scripts and SourceBuiltWheelInfo in ctx.attr.src:
+        console_scripts = ctx.attr.src[SourceBuiltWheelInfo].console_scripts
     return [
         # whl_install consumes this target as a single file. Reconstruct
         # DefaultInfo instead of forwarding the source target's executable,
         # which Bazel requires to be created by the rule that advertises it.
         DefaultInfo(files = source.files),
         SourceBuiltWheelInfo(
-            console_scripts = tuple(ctx.attr.console_scripts),
+            console_scripts = tuple(console_scripts),
         ),
     ]
 

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -3,6 +3,7 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//py/private:providers.bzl", "PyWheelsInfo")
+load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
 load(":repository.bzl", "compatible_python_tags", "native_roots_for_segments", "parse_console_script", "parse_record_path", "select_key", "site_packages_segments", "sort_select_arms", "source_specificity")
 load(":rule.bzl", "pyc_compile_version_compatible", "source_built_wheel", "whl_install")
 
@@ -252,6 +253,21 @@ _MACOS_WHL = "demo-1.0.0-cp311-cp311-macosx_11_0_arm64.whl"
 # no metadata entry exists for it.
 _SBUILD_WHL = "demo-1.0.0-py3-none-any.whl"
 _DECLARED_SBUILD_CONSOLE_SCRIPTS = ["declared=demo.cli:main"]
+_DETECTED_SBUILD_CONSOLE_SCRIPTS = ["detected=demo.cli:main"]
+
+def _detected_source_built_wheel_impl(ctx):
+    return [
+        DefaultInfo(files = ctx.attr.src[DefaultInfo].files),
+        SourceBuiltWheelInfo(console_scripts = tuple(ctx.attr.console_scripts)),
+    ]
+
+_detected_source_built_wheel = rule(
+    implementation = _detected_source_built_wheel_impl,
+    attrs = {
+        "src": attr.label(allow_single_file = True, mandatory = True),
+        "console_scripts": attr.string_list(),
+    },
+)
 
 _TOP_LEVELS = {
     _LINUX_WHL: [
@@ -419,10 +435,39 @@ def metadata_selection_test_suite(name):
         tags = ["manual"],
     )
 
+    native.config_setting(
+        name = "__metadata_select_sbuild",
+        define_values = {"metadata_select_sbuild": "true"},
+    )
+
+    native.alias(
+        name = "__metadata_prebuilt_or_sbuild",
+        actual = select({
+            ":__metadata_select_sbuild": ":__metadata_detected_sbuild_wheel",
+            "//conditions:default": _LINUX_WHL,
+        }),
+        tags = ["manual"],
+    )
+
+    _detected_source_built_wheel(
+        name = "__metadata_detected_sbuild_source",
+        testonly = True,
+        src = _LINUX_WHL,
+        console_scripts = _DETECTED_SBUILD_CONSOLE_SCRIPTS,
+        tags = ["manual"],
+    )
+
+    source_built_wheel(
+        name = "__metadata_detected_sbuild_wheel",
+        testonly = True,
+        src = ":__metadata_detected_sbuild_source",
+        tags = ["manual"],
+    )
+
     source_built_wheel(
         name = "__metadata_declared_sbuild_wheel",
         testonly = True,
-        src = _LINUX_WHL,
+        src = ":__metadata_detected_sbuild_source",
         console_scripts = _DECLARED_SBUILD_CONSOLE_SCRIPTS,
         tags = ["manual"],
     )
@@ -464,6 +509,30 @@ def metadata_selection_test_suite(name):
             console_scripts = _CONSOLE_SCRIPTS,
             tags = ["manual"],
         )
+
+    whl_install(
+        name = "__metadata_active_prebuilt_fixture",
+        testonly = True,
+        src = ":__metadata_prebuilt_or_sbuild",
+        top_levels = _TOP_LEVELS,
+        top_level_dirs = _TOP_LEVEL_DIRS,
+        namespace_top_levels = _NAMESPACE_TOP_LEVELS,
+        native_roots = _NATIVE_ROOTS,
+        console_scripts = _CONSOLE_SCRIPTS,
+        tags = ["manual"],
+    )
+
+    whl_install(
+        name = "__metadata_detected_sbuild_fixture",
+        testonly = True,
+        src = ":__metadata_detected_sbuild_wheel",
+        top_levels = _TOP_LEVELS,
+        top_level_dirs = _TOP_LEVEL_DIRS,
+        namespace_top_levels = _NAMESPACE_TOP_LEVELS,
+        native_roots = _NATIVE_ROOTS,
+        console_scripts = _CONSOLE_SCRIPTS,
+        tags = ["manual"],
+    )
 
     whl_install(
         name = "__metadata_declared_sbuild_fixture",
@@ -517,6 +586,32 @@ def metadata_selection_test_suite(name):
         leaked_top_levels = [],
         leaked_native_roots = [],
         leaked_console_scripts = [],
+    )
+
+    _metadata_selection_test(
+        name = name + "_active_prebuilt_test",
+        target_under_test = ":__metadata_active_prebuilt_fixture",
+        expected_top_levels = _TOP_LEVELS[_LINUX_WHL],
+        expected_top_level_dirs = _TOP_LEVEL_DIRS[_LINUX_WHL],
+        expected_namespace_top_levels = [],
+        expected_native_roots = _NATIVE_ROOTS[_LINUX_WHL],
+        expected_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
+        leaked_top_levels = [],
+        leaked_native_roots = [],
+        leaked_console_scripts = _DETECTED_SBUILD_CONSOLE_SCRIPTS,
+    )
+
+    _metadata_selection_test(
+        name = name + "_detected_sbuild_test",
+        target_under_test = ":__metadata_detected_sbuild_fixture",
+        expected_top_levels = [],
+        expected_top_level_dirs = [],
+        expected_namespace_top_levels = [],
+        expected_native_roots = [],
+        expected_console_scripts = _DETECTED_SBUILD_CONSOLE_SCRIPTS,
+        leaked_top_levels = _TOP_LEVELS[_LINUX_WHL],
+        leaked_native_roots = _NATIVE_ROOTS[_LINUX_WHL],
+        leaked_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
     )
 
     _metadata_selection_test(

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -469,6 +469,17 @@ def metadata_selection_test_suite(name):
         testonly = True,
         src = ":__metadata_detected_sbuild_source",
         console_scripts = _DECLARED_SBUILD_CONSOLE_SCRIPTS,
+        console_scripts_override = True,
+        tags = ["manual"],
+    )
+
+    # A pre-build patch can remove every entry point after inspection. An
+    # explicitly empty override must suppress the stale detected metadata.
+    source_built_wheel(
+        name = "__metadata_cleared_sbuild_wheel",
+        testonly = True,
+        src = ":__metadata_detected_sbuild_source",
+        console_scripts_override = True,
         tags = ["manual"],
     )
 
@@ -526,6 +537,18 @@ def metadata_selection_test_suite(name):
         name = "__metadata_detected_sbuild_fixture",
         testonly = True,
         src = ":__metadata_detected_sbuild_wheel",
+        top_levels = _TOP_LEVELS,
+        top_level_dirs = _TOP_LEVEL_DIRS,
+        namespace_top_levels = _NAMESPACE_TOP_LEVELS,
+        native_roots = _NATIVE_ROOTS,
+        console_scripts = _CONSOLE_SCRIPTS,
+        tags = ["manual"],
+    )
+
+    whl_install(
+        name = "__metadata_cleared_sbuild_fixture",
+        testonly = True,
+        src = ":__metadata_cleared_sbuild_wheel",
         top_levels = _TOP_LEVELS,
         top_level_dirs = _TOP_LEVEL_DIRS,
         namespace_top_levels = _NAMESPACE_TOP_LEVELS,
@@ -612,6 +635,19 @@ def metadata_selection_test_suite(name):
         leaked_top_levels = _TOP_LEVELS[_LINUX_WHL],
         leaked_native_roots = _NATIVE_ROOTS[_LINUX_WHL],
         leaked_console_scripts = _CONSOLE_SCRIPTS[_LINUX_WHL],
+    )
+
+    _metadata_selection_test(
+        name = name + "_cleared_sbuild_test",
+        target_under_test = ":__metadata_cleared_sbuild_fixture",
+        expected_top_levels = [],
+        expected_top_level_dirs = [],
+        expected_namespace_top_levels = [],
+        expected_native_roots = [],
+        expected_console_scripts = [],
+        leaked_top_levels = _TOP_LEVELS[_LINUX_WHL],
+        leaked_native_roots = _NATIVE_ROOTS[_LINUX_WHL],
+        leaked_console_scripts = _DETECTED_SBUILD_CONSOLE_SCRIPTS + _CONSOLE_SCRIPTS[_LINUX_WHL],
     )
 
     _metadata_selection_test(


### PR DESCRIPTION
Read console scripts from a source distribution's top-level egg-info
metadata and forward them to venv assembly, removing the need for
handwritten overrides. Explicit overrides remain authoritative and inactive
platform wheels cannot leak scripts.