### PR TITLE
perf(uv): stream wheel installs

### DIFF
--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -17,6 +17,7 @@ import configparser
 import csv
 import hashlib
 import os
+import shutil
 import subprocess
 import zipfile
 from base64 import urlsafe_b64encode
@@ -143,13 +144,15 @@ def install_wheel(version_major, version_minor, into, wheel_path):
                 dest = site_packages / member_path
 
             dest.parent.mkdir(parents=True, exist_ok=True)
-            data = zf.read(member)
-
-            if is_script and _has_python_shebang(data):
-                _, _, body = data.partition(b"\n")
-                data = _RELOCATABLE_SHEBANG.encode() + body
-
-            dest.write_bytes(data)
+            if is_script:
+                data = zf.read(member)
+                if _has_python_shebang(data):
+                    _, _, body = data.partition(b"\n")
+                    data = _RELOCATABLE_SHEBANG.encode() + body
+                dest.write_bytes(data)
+            else:
+                with zf.open(info, "r") as source, dest.open("wb") as output:
+                    shutil.copyfileobj(source, output, length=1024 * 1024)
 
             unix_mode = (info.external_attr >> 16) & 0xFFFF
             if unix_mode & 0o111 or is_script:

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -107,6 +107,44 @@ def main() -> None:
         )
         assert next((site_packages / "fixture" / "__pycache__").glob("*.pyc"))
 
+        # Members larger than the streaming copy buffer round-trip byte-for-byte.
+        large_payload = b"rules_py" * (256 * 1024 + 1)
+        assert len(large_payload) > 1024 * 1024
+        large_wheel = root / "large_fixture-1.0-py3-none-any.whl"
+        _write_wheel(large_wheel, "large_fixture", {"fixture/big.bin": large_payload})
+        large_out = root / "large"
+        large = _run_unpack(unpack, large_wheel, large_out, Path(sys.executable))
+        assert large.returncode == 0, large.stderr
+        installed_large = (
+            large_out
+            / "lib"
+            / f"python{sys.version_info.major}.{sys.version_info.minor}"
+            / "site-packages"
+            / "fixture"
+            / "big.bin"
+        )
+        assert installed_large.read_bytes() == large_payload
+
+        # A .data/scripts member with a Python shebang is rewritten to the
+        # relocatable launcher and marked executable.
+        script_wheel = root / "script_fixture-1.0-py3-none-any.whl"
+        _write_wheel(
+            script_wheel,
+            "script_fixture",
+            {"script_fixture-1.0.data/scripts/tool": b"#!/usr/bin/python\nprint('hi')\n"},
+        )
+        script_out = root / "script"
+        script = _run_unpack(unpack, script_wheel, script_out, Path(sys.executable))
+        assert script.returncode == 0, script.stderr
+        installed_script = script_out / "bin" / "tool"
+        assert installed_script.read_bytes() == (
+            "#!/bin/sh\n"
+            "'''exec' \"$(dirname -- \"$(realpath -- \"$0\")\")\"/'python3' \"$0\" \"$@\"\n"
+            "' '''\n"
+            "print('hi')\n"
+        ).encode()
+        assert installed_script.stat().st_mode & 0o111
+
         for case, member in [
             ("roottraversal", "../../../../escaped.py"),
             ("rootabsolute", str(root / "escaped.py")),


### PR DESCRIPTION
Summary
- Stream non-script wheel members from the zip archive to disk with copyfileobj.
- Keep script members in memory only when shebang rewriting may be needed.

Validation
- bazel test //py/tools/unpack:unpack_test