### PR TITLE
perf(uv): reuse wheel RECORD metadata

### DIFF
--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -16,7 +16,9 @@ import argparse
 import configparser
 import csv
 import hashlib
+import io
 import os
+import re
 import shutil
 import subprocess
 import zipfile
@@ -70,6 +72,37 @@ def _write_executable(path, content):
     path.chmod(0o755)
 
 
+def _record_metadata(zf):
+    """Return reusable sha256/size metadata from one well-formed RECORD."""
+    record_members = [
+        info.filename
+        for info in zf.infolist()
+        if info.filename.endswith("/RECORD")
+    ]
+    if len(record_members) != 1:
+        return None, {}
+
+    record_member = record_members[0]
+    record_dir = record_member.rsplit("/", 1)[0]
+    rows = {}
+    try:
+        with zf.open(record_member) as raw:
+            with io.TextIOWrapper(raw, encoding="utf-8", newline="") as text:
+                for path, digest, size in csv.reader(text):
+                    if path in rows:
+                        return record_dir, {}
+                    rows[path] = (digest, size)
+    except (ValueError, csv.Error, UnicodeDecodeError):
+        return record_dir, {}
+    return record_dir, {
+        path: values
+        for path, values in rows.items()
+        # The final unpadded base64 character carries only four digest bits.
+        if re.fullmatch(r"sha256=[A-Za-z0-9_-]{42}[AEIMQUYcgkosw048]", values[0])
+        and values[1].isdecimal()
+    }
+
+
 def _relative_path(value, what):
     """Return a safe host path for a wheel-controlled POSIX path."""
     parts = value.split("/")
@@ -113,6 +146,13 @@ def install_wheel(version_major, version_minor, into, wheel_path):
     installed = []
 
     with zipfile.ZipFile(wheel_path, "r") as zf:
+        record_dir, record_metadata = _record_metadata(zf)
+        regenerated_markers = ()
+        if record_dir:
+            regenerated_markers = (
+                f"{record_dir}/INSTALLER",
+                f"{record_dir}/REQUESTED",
+            )
         for info in zf.infolist():
             member = info.filename
             member_path = _relative_path(
@@ -144,11 +184,13 @@ def install_wheel(version_major, version_minor, into, wheel_path):
                 dest = site_packages / member_path
 
             dest.parent.mkdir(parents=True, exist_ok=True)
+            reusable_record = record_metadata.get(member)
             if is_script:
                 data = zf.read(member)
                 if _has_python_shebang(data):
                     _, _, body = data.partition(b"\n")
                     data = _RELOCATABLE_SHEBANG.encode() + body
+                    reusable_record = None
                 dest.write_bytes(data)
             else:
                 with zf.open(info, "r") as source, dest.open("wb") as output:
@@ -158,8 +200,10 @@ def install_wheel(version_major, version_minor, into, wheel_path):
             if unix_mode & 0o111 or is_script:
                 dest.chmod(dest.stat().st_mode | 0o111)
 
-            if not member.endswith("/RECORD"):
-                installed.append(dest)
+            if not member.endswith("/RECORD") and member not in regenerated_markers:
+                if reusable_record is not None and reusable_record[1] != str(info.file_size):
+                    reusable_record = None
+                installed.append((dest, reusable_record))
 
     for ep_path in site_packages.glob("*.dist-info/entry_points.txt"):
         cp = configparser.ConfigParser(strict=False, delimiters=("=",))
@@ -193,7 +237,7 @@ def install_wheel(version_major, version_minor, into, wheel_path):
                     )
                 )
                 _write_executable(script_path, wrapper.encode())
-                installed.append(script_path)
+                installed.append((script_path, None))
 
     for record_path in site_packages.glob("*.dist-info/RECORD"):
         dist_info = record_path.parent
@@ -204,10 +248,17 @@ def install_wheel(version_major, version_minor, into, wheel_path):
         requested_path = dist_info / "REQUESTED"
         requested_path.write_bytes(b"")
 
+        destination_counts = {}
+        for f, _ in installed:
+            destination_counts[f] = destination_counts.get(f, 0) + 1
+
         rows = []
-        for f in installed:
+        for f, reusable_record in installed:
             rel = os.path.relpath(str(f), str(site_packages)).replace("\\", "/")
-            rows.append((rel, _sha256(f), str(f.stat().st_size)))
+            if reusable_record is not None and destination_counts[f] == 1:
+                rows.append((rel, reusable_record[0], reusable_record[1]))
+            else:
+                rows.append((rel, _sha256(f), str(f.stat().st_size)))
         for meta_file in (installer_path, requested_path):
             rel = os.path.relpath(str(meta_file), str(site_packages)).replace("\\", "/")
             rows.append((rel, _sha256(meta_file), str(meta_file.stat().st_size)))

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -1,4 +1,6 @@
+import csv
 import hashlib
+import importlib.util
 import shutil
 import subprocess
 import sys
@@ -6,6 +8,7 @@ import tempfile
 import zipfile
 from base64 import urlsafe_b64encode
 from pathlib import Path
+from typing import Optional
 
 
 def _write_member(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
@@ -14,7 +17,13 @@ def _write_member(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
     archive.writestr(info, data)
 
 
-def _write_wheel(path: Path, distribution: str, members: dict[str, bytes]) -> None:
+def _write_wheel(
+    path: Path,
+    distribution: str,
+    members: dict[str, bytes],
+    record_overrides: Optional[dict[str, tuple[str, str]]] = None,
+    leading_record_rows: tuple[tuple[str, str, str], ...] = (),
+) -> None:
     dist_info = f"{distribution}-1.0.dist-info"
     members = dict(members)
     members[f"{dist_info}/METADATA"] = (
@@ -29,16 +38,58 @@ def _write_wheel(path: Path, distribution: str, members: dict[str, bytes]) -> No
         "Tag: py3-none-any\n"
     ).encode()
     record_path = f"{dist_info}/RECORD"
-    record = []
+    record = [",".join(row) for row in leading_record_rows]
+    record_overrides = record_overrides or {}
     for name, data in sorted(members.items()):
         digest = urlsafe_b64encode(hashlib.sha256(data).digest()).decode().rstrip("=")
-        record.append(f"{name},sha256={digest},{len(data)}")
+        hash_value, size = record_overrides.get(
+            name, (f"sha256={digest}", str(len(data)))
+        )
+        record.append(f"{name},{hash_value},{size}")
     record.append(f"{record_path},,")
     members[record_path] = ("\n".join(record) + "\n").encode()
 
     with zipfile.ZipFile(path, "w") as archive:
         for name, data in members.items():
             _write_member(archive, name, data)
+
+
+def _load_unpack(path: Path):
+    spec = importlib.util.spec_from_file_location("rules_py_unpack_test_module", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _record_rows(site_packages: Path) -> list[tuple[str, str, str]]:
+    record_path = next(site_packages.glob("*.dist-info/RECORD"))
+    with record_path.open(newline="", encoding="utf-8") as record:
+        return list(csv.reader(record))
+
+
+def _site_packages(output: Path) -> Path:
+    return (
+        output
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+
+
+def _assert_record_matches_installed_files(site_packages: Path) -> None:
+    seen = set()
+    for relative, digest, size in _record_rows(site_packages):
+        assert relative not in seen, relative
+        seen.add(relative)
+        if not digest and not size:
+            continue
+        path = site_packages / relative
+        expected_digest = urlsafe_b64encode(
+            hashlib.sha256(path.read_bytes()).digest()
+        ).decode().rstrip("=")
+        assert digest == f"sha256={expected_digest}", relative
+        assert size == str(path.stat().st_size), relative
 
 
 def _build_wheel(path: Path, *, legacy_syntax: bool) -> None:
@@ -91,6 +142,101 @@ def main() -> None:
     unpack = Path(sys.argv[1])
     with tempfile.TemporaryDirectory() as temp_dir:
         root = Path(temp_dir)
+
+        record_wheel = root / "record_fixture-1.0-py3-none-any.whl"
+        _write_wheel(
+            record_wheel,
+            "record_fixture",
+            {
+                "fixture/__init__.py": b"VALUE = 1\n",
+                "record_fixture-1.0.data/purelib/fixture/pure.py": b"PURE = 1\n",
+                "record_fixture-1.0.data/scripts/plain": b"#!/bin/sh\nexit 0\n",
+                "record_fixture-1.0.data/scripts/python-script": (
+                    b"#!/usr/bin/env python3\nprint('fixture')\n"
+                ),
+                "record_fixture-1.0.data/data/share/snapshot.dist-info/INSTALLER": b"snapshot\n",
+                "record_fixture-1.0.dist-info/entry_points.txt": (
+                    b"[console_scripts]\nfixture-cli = fixture:main\n"
+                ),
+                "record_fixture-1.0.dist-info/INSTALLER": b"wheel-installer\n",
+                "record_fixture-1.0.dist-info/REQUESTED": b"wheel-requested\n",
+            },
+        )
+        record_out = root / "record"
+        record_site_packages = _site_packages(record_out)
+        unpack_module = _load_unpack(unpack)
+        original_sha256 = unpack_module._sha256
+        hashed_names = set()
+
+        def recording_sha256(path: Path) -> str:
+            hashed_names.add(path.name)
+            return original_sha256(path)
+
+        unpack_module._sha256 = recording_sha256
+        unpack_module.install_wheel(
+            sys.version_info.major,
+            sys.version_info.minor,
+            record_out,
+            record_wheel,
+        )
+        assert not {"__init__.py", "pure.py", "plain"} & hashed_names
+        assert {"python-script", "fixture-cli", "INSTALLER", "REQUESTED"} <= hashed_names
+        assert (
+            record_site_packages / "record_fixture-1.0.dist-info" / "INSTALLER"
+        ).read_bytes() == b"aspect_rules_py"
+        assert (
+            record_site_packages / "record_fixture-1.0.dist-info" / "REQUESTED"
+        ).read_bytes() == b""
+        assert any(
+            relative.endswith("snapshot.dist-info/INSTALLER")
+            for relative, _, _ in _record_rows(record_site_packages)
+        )
+        _assert_record_matches_installed_files(record_site_packages)
+
+        for name, digest in [
+            ("empty-sha", "sha256="),
+            ("invalid-sha", "sha256=not-a-digest"),
+            ("noncanonical-sha", "sha256=" + "A" * 42 + "B"),
+        ]:
+            fallback_wheel = root / f"{name}-1.0-py3-none-any.whl"
+            _write_wheel(
+                fallback_wheel,
+                name,
+                {"fixture/__init__.py": b"VALUE = 1\n"},
+                {"fixture/__init__.py": (digest, str(len(b"VALUE = 1\n")))},
+            )
+            fallback_out = root / name
+            hashed_names.clear()
+            unpack_module.install_wheel(
+                sys.version_info.major,
+                sys.version_info.minor,
+                fallback_out,
+                fallback_wheel,
+            )
+            fallback_site_packages = _site_packages(fallback_out)
+            assert "__init__.py" in hashed_names, name
+            _assert_record_matches_installed_files(fallback_site_packages)
+
+        duplicate_wheel = root / "duplicate-1.0-py3-none-any.whl"
+        stale_digest = urlsafe_b64encode(hashlib.sha256(b"stale").digest()).decode().rstrip("=")
+        _write_wheel(
+            duplicate_wheel,
+            "duplicate",
+            {"fixture/__init__.py": b"VALUE = 1\n"},
+            {"fixture/__init__.py": (f"sha256={stale_digest}", str(len(b"VALUE = 1\n")))},
+            (("fixture/__init__.py", "", ""),),
+        )
+        duplicate_out = root / "duplicate"
+        hashed_names.clear()
+        unpack_module.install_wheel(
+            sys.version_info.major,
+            sys.version_info.minor,
+            duplicate_out,
+            duplicate_wheel,
+        )
+        duplicate_site_packages = _site_packages(duplicate_out)
+        assert "__init__.py" in hashed_names
+        _assert_record_matches_installed_files(duplicate_site_packages)
 
         # A wheel that compiles cleanly installs successfully (exit 0) and
         # produces bytecode.
@@ -261,8 +407,10 @@ def main() -> None:
         # file. Use a controlled patch executable for topology transitions that
         # must behave identically on every test host.
         mutation_tool = root / "mutate_tree.py"
+        mutation_python = root / "python"
+        mutation_python.symlink_to(sys.executable)
         mutation_tool.write_text(
-            f"""#!{sys.executable}
+            f"""#!{mutation_python}
 import shutil
 import sys
 from pathlib import Path


### PR DESCRIPTION
Summary
- Parse reusable sha256 and size values from a well-formed wheel RECORD.
- Reuse metadata for untouched installed files and recompute it for rewritten or synthesized files.
- Fall back to hashing when RECORD data is malformed, duplicated, or non-canonical.

Validation
- bazel test //py/tools/unpack:unpack_test