### PR TITLE
fix(uv): use C++ mode for clang wrapper drivers

### DIFF
--- a/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
+++ b/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
@@ -15,6 +15,8 @@ _CONFIGURED_CC_TOOLCHAIN = "//pep517-frontend-exec-group:configured_cc_toolchain
 
 _CLANG_CC_TOOLCHAIN = "//pep517-frontend-exec-group:clang_cc_toolchain"
 
+_MINIMAL_CLANG_CC_TOOLCHAIN = "//pep517-frontend-exec-group:minimal_clang_cc_toolchain"
+
 _LEGACY_CC_TOOLCHAIN = "//pep517-frontend-exec-group:legacy_cc_toolchain"
 
 _DIRECT_CXX_TOOLCHAIN = "//pep517-frontend-exec-group:direct_cxx_toolchain"
@@ -159,6 +161,19 @@ platform(
         "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
         "--extra_execution_platforms=@platforms//host,//pep517-frontend-exec-group:linux_wrapped_cxx",
         "--extra_toolchains=" + _WRAPPED_CXX_TOOLCHAIN,
+    ],
+)
+
+platform(
+    name = "linux_minimal_clang",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    flags = [
+        "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
+        "--extra_execution_platforms=@platforms//host,//pep517-frontend-exec-group:linux_minimal_clang",
+        "--extra_toolchains=" + _MINIMAL_CLANG_CC_TOOLCHAIN,
     ],
 )
 
@@ -498,6 +513,18 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
+fake_cc_toolchain(
+    name = "minimal_clang_cc",
+    compiler = ":clang_wrapper_script",
+    compiler_kind = "clang",
+)
+
+toolchain(
+    name = "minimal_clang_cc_toolchain",
+    toolchain = ":minimal_clang_cc",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
 filegroup(
     name = "legacy_tools",
     srcs = [
@@ -803,6 +830,12 @@ platform_transition_filegroup(
     target_platform = ":linux_wrapped_cxx",
 )
 
+platform_transition_filegroup(
+    name = "wheel_linux_minimal_clang",
+    srcs = [":clang_wheel"],
+    target_platform = ":linux_minimal_clang",
+)
+
 build_test(
     name = "frontend_exec_platform_test",
     targets = [
@@ -835,4 +868,9 @@ build_test(
         ":wheel_linux_plain_cxx",
         ":wheel_linux_wrapped_cxx",
     ],
+)
+
+build_test(
+    name = "minimal_clang_cxx_driver_test",
+    targets = [":wheel_linux_minimal_clang"],
 )

--- a/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
+++ b/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
@@ -13,6 +13,8 @@ _CC_TOOLCHAIN = "//pep517-frontend-exec-group:cc_toolchain"
 
 _CONFIGURED_CC_TOOLCHAIN = "//pep517-frontend-exec-group:configured_cc_toolchain"
 
+_CLANG_CC_TOOLCHAIN = "//pep517-frontend-exec-group:clang_cc_toolchain"
+
 _LEGACY_CC_TOOLCHAIN = "//pep517-frontend-exec-group:legacy_cc_toolchain"
 
 _DIRECT_CXX_TOOLCHAIN = "//pep517-frontend-exec-group:direct_cxx_toolchain"
@@ -66,6 +68,19 @@ platform(
         "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
         "--extra_execution_platforms=@platforms//host,//pep517-frontend-exec-group:linux_configured",
         "--extra_toolchains=" + _CONFIGURED_CC_TOOLCHAIN,
+    ],
+)
+
+platform(
+    name = "linux_clang",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    flags = [
+        "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
+        "--extra_execution_platforms=@platforms//host,//pep517-frontend-exec-group:linux_clang",
+        "--extra_toolchains=" + _CLANG_CC_TOOLCHAIN,
     ],
 )
 
@@ -441,6 +456,48 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
+write_file(
+    name = "clang_wrapper_script",
+    out = "clang_wrapper.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "if [[ \"${1-}\" == --driver-mode=g++ ]]; then",
+        "  shift",
+        "  exec /usr/bin/c++ \"$@\"",
+        "fi",
+        "exec /usr/bin/cc \"$@\"",
+    ],
+    is_executable = True,
+)
+
+cc_tool(
+    name = "clang_wrapper_tool",
+    src = ":clang_wrapper_script",
+)
+
+cc_tool_map(
+    name = "clang_tool_map",
+    tools = {
+        "@rules_cc//cc/toolchains/actions:c_compile": ":clang_wrapper_tool",
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions": ":clang_wrapper_tool",
+        "@rules_cc//cc/toolchains/actions:link_actions": ":clang_wrapper_tool",
+        "@rules_cc//cc/toolchains/actions:strip": ":clang_wrapper_tool",
+        "@rules_cc//cc/toolchains/actions:ar_actions": ":clang_wrapper_tool",
+    },
+)
+
+cc_toolchain(
+    name = "clang_cc",
+    compiler = "clang",
+    tool_map = ":clang_tool_map",
+)
+
+toolchain(
+    name = "clang_cc_toolchain",
+    toolchain = ":clang_cc",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
 filegroup(
     name = "legacy_tools",
     srcs = [
@@ -597,6 +654,19 @@ pep517_native_whl(
 )
 
 pep517_native_whl(
+    name = "clang_wheel",
+    src = ":stub_sdist",
+    args = [
+        "*/clang_wrapper.sh",
+        "*/clang_wrapper.sh --driver-mode=g++",
+        "1",
+    ],
+    tags = ["manual"],
+    tool = ":cxx_frontend",
+    version = "0.0.0",
+)
+
+pep517_native_whl(
     name = "legacy_wheel",
     src = ":stub_sdist",
     tags = ["manual"],
@@ -692,6 +762,12 @@ platform_transition_filegroup(
 )
 
 platform_transition_filegroup(
+    name = "wheel_linux_clang",
+    srcs = [":clang_wheel"],
+    target_platform = ":linux_clang",
+)
+
+platform_transition_filegroup(
     name = "wheel_linux_legacy",
     srcs = [":legacy_wheel"],
     target_platform = ":linux_legacy",
@@ -738,6 +814,11 @@ build_test(
 build_test(
     name = "configured_compiler_tools_test",
     targets = [":wheel_linux_configured"],
+)
+
+build_test(
+    name = "clang_cxx_driver_test",
+    targets = [":wheel_linux_clang"],
 )
 
 build_test(

--- a/e2e/cases/pep517-frontend-exec-group/cxx_frontend.sh
+++ b/e2e/cases/pep517-frontend-exec-group/cxx_frontend.sh
@@ -38,6 +38,8 @@ EOF
     read -r -a cxx <<<"${CXX}"
     "${cxx[@]}" -std=c++11 "${wheel_dir}/probe.cc" -o "${wheel_dir}/probe"
     "${wheel_dir}/probe"
-    "${cxx[@]}" -std=c++11 -shared -fPIC "${wheel_dir}/probe.cc" -o "${wheel_dir}/probe.so"
+    link_flags=(-std=c++11 -shared -fPIC)
+    if [[ $(uname -s) == Linux ]]; then link_flags+=(-Wl,--as-needed); fi
+    "${cxx[@]}" "${link_flags[@]}" "${wheel_dir}/probe.cc" -o "${wheel_dir}/probe.so"
     /usr/bin/python3 -c 'import ctypes, sys; probe = ctypes.CDLL(sys.argv[1]).probe; probe.restype = ctypes.c_char_p; assert probe() == b"rules_py"' "${wheel_dir}/probe.so"
 fi

--- a/e2e/cases/pep517-frontend-exec-group/toolchain.bzl
+++ b/e2e/cases/pep517-frontend-exec-group/toolchain.bzl
@@ -9,6 +9,7 @@ def _fake_cc_toolchain_impl(ctx):
     return [
         platform_common.ToolchainInfo(
             all_files = depset([compiler] + ctx.files.tools),
+            compiler = ctx.attr.compiler_kind,
             compiler_executable = compiler.path,
         ),
     ]
@@ -21,6 +22,7 @@ fake_cc_toolchain = rule(
             mandatory = True,
         ),
         "tools": attr.label_list(allow_files = True),
+        "compiler_kind": attr.string(),
     },
 )
 

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -109,6 +109,8 @@ def _cc_toolchain_inputs_and_tools(ctx):
         compiler = getattr(cc_toolchain, "compiler_executable", None)
         if not compiler:
             return files, {}, False
+        if getattr(cc_toolchain, "compiler", None) == "clang":
+            return files, {"CC": compiler, "CXX": compiler + " --driver-mode=g++"}, False
         return files, {"CC": compiler, "CXX": compiler}, True
 
     feature_configuration = cc_common.configure_features(
@@ -158,6 +160,7 @@ def _cc_toolchain_inputs_and_tools(ctx):
     # https://github.com/llvm/llvm-project/blob/llvmorg-22.1.2/clang/lib/Driver/ToolChains/Gnu.cpp#L452-L471
     if tools.get("CXX") and tools["CXX"] == tools.get("CC") and getattr(cc_toolchain, "compiler", None) == "clang":
         tools["CXX"] += " --driver-mode=g++"
+        infer_cxx = False
 
     infer_cxx = infer_cxx or tools.get("CXX") == tools.get("CC")
     return files, {key: value for key, value in tools.items() if value}, infer_cxx

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -153,6 +153,12 @@ def _cc_toolchain_inputs_and_tools(ctx):
         }
         tools.update({key: legacy_tools[key] for key in missing if legacy_tools[key] in file_paths})
 
+    # A shared clang wrapper needs C++ driver mode so its runtime libraries
+    # follow object files instead of being dropped by --as-needed:
+    # https://github.com/llvm/llvm-project/blob/llvmorg-22.1.2/clang/lib/Driver/ToolChains/Gnu.cpp#L452-L471
+    if tools.get("CXX") and tools["CXX"] == tools.get("CC") and getattr(cc_toolchain, "compiler", None) == "clang":
+        tools["CXX"] += " --driver-mode=g++"
+
     infer_cxx = infer_cxx or tools.get("CXX") == tools.get("CC")
     return files, {key: value for key, value in tools.items() if value}, infer_cxx
 

--- a/uv/private/pep517_whl/test.bzl
+++ b/uv/private/pep517_whl/test.bzl
@@ -91,10 +91,14 @@ def _toolchain_env_test_impl(ctx):
     asserts.equals(env, "{}/relative/libdep.a".format(marker), action_env.get("LDFLAGS"))
 
     action_inputs = [f.path for f in build_actions[0].inputs.to_list()]
+    cxx_driver_mode = " --driver-mode=g++"
     for key in _CC_ENV_KEYS:
+        tool = action_env.get(key)
+        if key == "CXX" and tool.endswith(cxx_driver_mode):
+            tool = tool[:-len(cxx_driver_mode)]
         asserts.true(
             env,
-            action_env.get(key) in action_inputs,
+            tool in action_inputs,
             "{} should select a declared C++ action tool".format(key),
         )
 


### PR DESCRIPTION
FastText wheels built through a shared clang compiler wrapper fail to import because C++ RTTI and standard-library symbols are missing.

Use --driver-mode=g++ when the configured C and C++ action tools share a clang wrapper, preserving its toolchain configuration and explicit CXX overrides.