### PR TITLE
test(launcher): guard runfiles source selection from the 0.0.13 upgrade

### DIFF
--- a/e2e/cases/README.md
+++ b/e2e/cases/README.md
@@ -26,8 +26,8 @@ bazel test //...
 A few cases ship a `cases/<case>/test.sh` because they can't be an `sh_test` under
 `//...` — they assert a build **failure** or need a real top-level `bazel run`
 (or `bazel coverage`): `coverage-drivers`, `hermetic-launcher-1116`,
-`patch-failure`, `pbs-cc-toolchain`, `uv-invalid-build-overrides`,
-`uv-patched-topology-change`. They still resolve against
+`hermetic-launcher-runfiles-1273`, `patch-failure`, `pbs-cc-toolchain`,
+`uv-invalid-build-overrides`, `uv-patched-topology-change`. They still resolve against
 *this* workspace. `cases/test.sh` is the aggregator that runs every `cases/*/test.sh`;
 CI runs it on the `e2e/cases` matrix job alongside `bazel test //...` (see
 `.github/workflows/ci-workflows.yaml`).

--- a/e2e/cases/hermetic-launcher-runfiles-1273/BUILD.bazel
+++ b/e2e/cases/hermetic-launcher-runfiles-1273/BUILD.bazel
@@ -1,0 +1,24 @@
+# Fixture for the hermetic-launcher runfiles-source-selection regression
+# (driven by ./test.sh).
+#
+# Regression for the 0.0.11 -> 0.0.13 launcher upgrade (rules_py #1273 /
+# hermetic-launcher #59): when Bazel provides BOTH `RUNFILES_DIR` and
+# `RUNFILES_MANIFEST_FILE`, the launcher must prefer the directory. The 0.0.11
+# launcher preferred the manifest, so paths resolved into physical bazel-out
+# outputs (`sys.prefix` off the runfiles tree) and the manifest — not the
+# directory — was exported to the child, breaking layouts that rely on the
+# venv's relative symlinks. Fixed in hermetic-launcher 0.0.13.
+#
+# The mixed-source condition is set up by ./test.sh (it points both env vars at
+# the built binary's own tree + manifest), so this is a `manual` fixture, not
+# part of `//...`.
+#
+# gazelle:ignore
+
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+
+py_binary(
+    name = "check_runfiles_source",
+    srcs = ["check_runfiles_source.py"],
+    tags = ["manual"],
+)

--- a/e2e/cases/hermetic-launcher-runfiles-1273/check_runfiles_source.py
+++ b/e2e/cases/hermetic-launcher-runfiles-1273/check_runfiles_source.py
@@ -1,0 +1,47 @@
+"""Runfiles-source-selection probe for hermetic-launcher >= 0.0.13 (see test.sh).
+
+Driven under a mixed-source environment where BOTH `RUNFILES_DIR` (a real
+runfiles tree, whose venv-python is a *relative* symlink into the interpreter
+repo) and `RUNFILES_MANIFEST_FILE` (the manifest, whose entries point at
+physical bazel-out copies) are exported. hermetic-launcher PR #59 makes the
+directory win in that tie: the launcher must both *resolve* the venv through
+the tree and *export the directory* to this child. The 0.0.11 launcher picked
+the manifest instead, so `sys.prefix` landed on a physical output and
+`RUNFILES_MANIFEST_FILE` (not `RUNFILES_DIR`) reached the child.
+"""
+
+import os
+import sys
+
+failures = []
+
+# The venv must resolve through the logical runfiles tree, not a physical output.
+if ".runfiles" not in sys.prefix:
+    failures.append(
+        "sys.prefix resolved to a physical output instead of the runfiles tree: "
+        + sys.prefix
+    )
+
+# The directory owns the environment exported to the child: RUNFILES_DIR set,
+# RUNFILES_MANIFEST_FILE scrubbed.
+runfiles_dir = os.environ.get("RUNFILES_DIR")
+manifest_file = os.environ.get("RUNFILES_MANIFEST_FILE")
+if not runfiles_dir:
+    failures.append("RUNFILES_DIR was not exported to the child")
+elif ".runfiles" not in runfiles_dir:
+    failures.append("RUNFILES_DIR does not point at a runfiles tree: " + runfiles_dir)
+if manifest_file:
+    failures.append(
+        "RUNFILES_MANIFEST_FILE leaked to the child (manifest won): " + manifest_file
+    )
+
+print("sys.prefix:", sys.prefix)
+print("RUNFILES_DIR:", runfiles_dir)
+print("RUNFILES_MANIFEST_FILE:", manifest_file)
+
+if failures:
+    for f in failures:
+        print("FAIL:", f, file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: runfiles directory won source selection")

--- a/e2e/cases/hermetic-launcher-runfiles-1273/test.sh
+++ b/e2e/cases/hermetic-launcher-runfiles-1273/test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Regression test for the hermetic-launcher 0.0.11 -> 0.0.13 upgrade
+# (rules_py #1273 / hermetic-launcher #59): runfiles source selection.
+#
+# When Bazel exports BOTH `RUNFILES_DIR` (a materialized runfiles tree, whose
+# venv `python` is a *relative* symlink into the interpreter repo) and
+# `RUNFILES_MANIFEST_FILE` (the manifest, whose entries name physical bazel-out
+# copies), the launcher must let the directory win: resolve the venv through
+# the tree and export `RUNFILES_DIR` (not the manifest) to the child. The
+# 0.0.11 launcher picked the manifest, so `sys.prefix` landed on a physical
+# output and the child saw `RUNFILES_MANIFEST_FILE` instead of `RUNFILES_DIR` —
+# breaking any layout that relies on the venv's relative symlinks.
+#
+# This can't be an `sh_test` under `//...`: it must construct the exact
+# mixed-source environment against the binary's *own* tree + manifest, so it
+# builds the target and runs it directly. Run from the e2e/cases workspace
+# root; override bazel with $BAZEL.
+set -uo pipefail
+
+cd "$(dirname "$0")/.."  # e2e/cases workspace root
+
+BAZEL="${BAZEL:-bazel}"
+TARGET="//hermetic-launcher-runfiles-1273:check_runfiles_source"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+echo "== build the probe binary =="
+"$BAZEL" build "$TARGET" >/dev/null 2>&1 \
+    || fail "expected 'bazel build $TARGET' to succeed"
+
+bin="$("$BAZEL" cquery --output=files "$TARGET" 2>/dev/null | head -n1)"
+case "$bin" in /*) ;; *) bin="$PWD/$bin" ;; esac  # cquery paths are workspace-relative
+[ -x "$bin" ] || fail "could not locate built binary for $TARGET (got '$bin')"
+
+runfiles_dir="${bin}.runfiles"
+[ -d "$runfiles_dir" ] || fail "missing runfiles tree: $runfiles_dir"
+
+# Resolve the manifest through the tree's MANIFEST symlink so both env vars name
+# genuine, consistent sources (a tree and its own manifest).
+manifest_link="${runfiles_dir}/MANIFEST"
+manifest_file="$(readlink "$manifest_link" 2>/dev/null || echo "$manifest_link")"
+[ -f "$manifest_file" ] || fail "missing runfiles manifest: $manifest_file"
+
+echo "== both RUNFILES_DIR and RUNFILES_MANIFEST_FILE set: directory must win =="
+# Run from `/` so no ambient runfiles are discovered adjacent to cwd; the env
+# vars are the only sources, exercising the env-tier tie-break directly.
+if ! ( cd / && \
+    RUNFILES_DIR="$runfiles_dir" \
+    RUNFILES_MANIFEST_FILE="$manifest_file" \
+    "$bin" ); then
+    fail "launcher regressed: manifest won source selection (hermetic-launcher #59)"
+fi
+
+echo "PASS: launcher prefers the runfiles directory over the manifest"


### PR DESCRIPTION
Testing the issue that https://github.com/aspect-build/rules_py/pull/1273 fixed

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
