### PR TITLE
docs: clarify nested virtualenv migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,10 @@ the link target on a subset of binaries.
 
 > **Migrating from v1.x?** `py_binary` no longer auto-emits a `.venv` sibling.
 > Add `expose_venv_link = True` for the equivalent IDE-symlink behavior,
-> or use the explicit two-target form when you want fine-grained control.
+> or use the explicit two-target form when you want fine-grained control. The
+> workspace link now points to the complete runfiles tree, so update IDE,
+> shell, direnv, and automation paths such as `.venv/bin` to use the nested
+> virtualenv path printed by `bazel run :<name>.venv_link`.
 
 ### Debugger Support (VSCode/PyCharm)
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -10,6 +10,25 @@ The rest of the BUILD file can remain the same.
 
 If using Gazelle, see the note on [using with Gazelle](/README.md#gazelle-integration)
 
+## Update virtualenv paths
+
+In rules_py v2.0, `py_venv_link` links the target's complete runfiles tree into
+the workspace and prints the virtualenv's nested path below that link. Keeping
+the runfiles layout intact preserves relative `.pth` entries and symlinks from
+the virtualenv to its dependencies.
+
+Paths that previously assumed the workspace link was the virtualenv root, such
+as `.venv/bin`, must use the nested path instead. This includes IDE settings,
+shell `PATH` entries, direnv configuration, and other automation. Run the link
+target and use the path it prints rather than hard-coding a universal layout:
+
+```sh
+bazel run //path/to/package:target.venv_link
+```
+
+See [IDE Integration](/README.md#ide-integration) for target declarations and
+editor configuration.
+
 ## Remaining notes
 
 Users are encouraged to send a Pull Request to add more documentation as they uncover issues during migrations.


### PR DESCRIPTION
AI written, human reviewed.

## Summary

- document that `py_venv_link` exposes the complete runfiles tree and prints a nested virtualenv path
- call out migration of IDE, shell, direnv, and automation references from paths such as `.venv/bin`
- recommend consuming the printed path rather than hard-coding a runfiles layout

Closes #1368.

## Test plan

- `git diff --check`
- reviewed the Markdown changes against the existing IDE integration guidance