### PR TITLE
ci: enable macos runners

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -112,6 +112,44 @@ jobs:
                 if [ -f test.sh ]; then
                     bash test.sh
                 fi
+    # macOS minutes are billed at 10X, so it only covers the root and e2e consumer
+    # workspaces, on main plus branches whose name contains 'macos'.
+    # https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
+    smoke:
+        name: smoke (${{ matrix.workspace.path }}, macos)
+        if: >-
+            ${{ github.ref_name == 'main'
+                || contains(github.head_ref || github.ref_name, 'macos') }}
+        runs-on: macos-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                workspace:
+                - { path: ".", slug: "root" }
+                - { path: "e2e/cases", slug: "e2e" }
+        defaults:
+            run:
+                working-directory: ${{ matrix.workspace.path }}
+        steps:
+            - uses: actions/checkout@v6
+            - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+              with:
+                  bazelisk-cache: true
+                  disk-cache: macos-${{ matrix.workspace.slug }}
+                  repository-cache: true
+            # Images still build; only the tests that need a Linux container daemon are
+            # dropped, since the GitHub-hosted macOS runners have none.
+            # Run `test //...`, then the workspace's test.sh if it has one
+            - name: Test
+              shell: bash
+              run: |
+                  bazel test --config=ci --keep_going \
+                    --test_tag_filters=-skip-on-bazel8,-requires-docker \
+                    --build_tag_filters=-skip-on-bazel8 \
+                    //...
+                  if [ -f test.sh ]; then
+                      bash test.sh
+                  fi
     test-all:
         name: test-all
         runs-on: ubuntu-latest

--- a/e2e/cases/pbs-cc-toolchain/test.sh
+++ b/e2e/cases/pbs-cc-toolchain/test.sh
@@ -21,7 +21,7 @@ check_toolchain() {
         --lockfile_mode=off \
         "--@aspect_rules_py//py:python_version=${version}" \
         "--@aspect_rules_py//py/private/interpreter:freethreaded=${freethreaded}" \
-        "${platform_flags[@]}" \
+        ${platform_flags[@]+"${platform_flags[@]}"} \
         "--platforms=//pbs-cc-toolchain:${platform}" \
         -- "$@"
 }
@@ -60,5 +60,5 @@ fi
     --lockfile_mode=off \
     --@aspect_rules_py//py:python_version=3.13 \
     --@aspect_rules_py//py/private/interpreter:freethreaded=true \
-    "${host_flags[@]}" \
+    ${host_flags[@]+"${host_flags[@]}"} \
     -- @aspect_rules_py//py/tests/cc-deps:test_smoke

--- a/e2e/cases/uv-toolchain/BUILD.bazel
+++ b/e2e/cases/uv-toolchain/BUILD.bazel
@@ -1,10 +1,18 @@
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
+# The uv_custom and uv_bazel_fork hubs pin sha256s per platform, and the fork
+# release publishes no Windows archive at all, so none of this resolves there.
+NOT_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
 [
     genrule(
         name = "{}_version".format(hub),
         outs = ["{}_version.txt".format(hub)],
         cmd = "$(execpath @{}//:uv) --version > $@".format(hub),
+        target_compatible_with = NOT_WINDOWS,
         tools = ["@{}//:uv".format(hub)],
     )
     for hub in [
@@ -26,4 +34,5 @@ sh_test(
         ":uv_mirror_version.txt",
         ":uv_version.txt",
     ],
+    target_compatible_with = NOT_WINDOWS,
 )

--- a/py/private/toolchain/tools.bzl
+++ b/py/private/toolchain/tools.bzl
@@ -25,6 +25,18 @@ TOOLCHAIN_PLATFORMS = {
             "@platforms//cpu:aarch64",
         ],
     ),
+    "windows_amd64": struct(
+        compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:x86_64",
+        ],
+    ),
+    "windows_arm64": struct(
+        compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:aarch64",
+        ],
+    ),
 }
 
 def _dummy_toolchain_impl(ctx):

--- a/uv/private/host/repository.bzl
+++ b/uv/private/host/repository.bzl
@@ -56,7 +56,10 @@ def _platform(rctx):
         else:
             fail("Unknown libc from ldd --version %r" % res.stdout)
 
-    # TODO: Windows
+    elif os == "windows":
+        # Windows wheel tags encode no runtime version, so only the libc slot is meaningful.
+        return "msvc", "0.0"
+
     # TODO: Other
 
     fail("Unsupported platform {}".format(os))


### PR DESCRIPTION
For proper cross-compilation I think we need these main tests run on all OSs?

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
