### PR TITLE
ci: force LF checkout so Windows text comparisons work

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,12 @@
+# Windows runners default to core.autocrlf=true. CRLF breaks shell script
+# templates and makes text comparisons against checked-in expectations fail.
+* text=auto eol=lf
+
+# Windows-native scripts are the exception: batch label/goto handling needs CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
 # Configuration for 'git archive'
 # see https://git-scm.com/docs/git-archive/2.40.0#ATTRIBUTES
 # Don't include examples in the distribution artifact, just to reduce size


### PR DESCRIPTION
Windows runners default to core.autocrlf=true, so .bzl string literals and checked-in snapshots arrive with CRLF and compare unequal against generated LF output, and .sh templates become unrunnable. The index is already all-LF, so this only changes checkout behaviour.

This fixes 4 failures on windows.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
