### PR TITLE
perf(py_venv): drop the whole-wheel .pth fallback for shadowed collision losers

### DIFF
--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -186,14 +186,21 @@ write_source_files(
         #   pins the `site.addsitedir(...)` shape so wheel-root `.pth`
         #   shims keep running.
         # * pth_install_tree_fallback — two install_tree wheels colliding
-        #   on a top-level; the collision loser reaches `_format_imp`'s
+        #   on a REGULAR top-level. The loser is shadowed by the winner's
+        #   venv symlink, so it needs no whole-wheel fallback and this
+        #   snapshot carries no site-packages line; re-introducing the
+        #   fallback adds one.
+        # * pth_install_tree_fallback_namespace — two install_tree wheels
+        #   colliding on an entryless PEP 420 namespace, which DOES need
+        #   both wheels on the fallback. Those lines reach `_format_imp`'s
         #   site-packages branch and must emit a PLAIN escape path (not
-        #   `site.addsitedir`, which would re-run its already-projected
+        #   `site.addsitedir`, which would re-run an already-projected
         #   root `.pth`). Reverting that branch changes this snapshot.
         "snapshots/pth_namespace_547.test.venv.pth": "//pth-namespace-547:test.venv.pth",
         "snapshots/firebase_admin.test_tool.venv.pth": "//firebase-admin-import:test_tool.venv.pth",
         "snapshots/wheel_root_pth.venv.pth": "//uv-include-group:wheel_root_pth_test.venv.pth",
         "snapshots/pth_install_tree_fallback.venv.pth": "//pth-install-tree-fallback:test.venv.pth",
+        "snapshots/pth_install_tree_fallback_namespace.venv.pth": "//pth-install-tree-fallback:namespace_test.venv.pth",
 
         # PBS pyvenv.cfg home handling (cases/pbs-symlink-prefix-1048).
         # 3.11 is inside the narrow empty-home gate; 3.13 proves the normal

--- a/e2e/cases/pth-install-tree-fallback/BUILD.bazel
+++ b/e2e/cases/pth-install-tree-fallback/BUILD.bazel
@@ -1,17 +1,24 @@
 load("@aspect_rules_py//py:defs.bzl", "py_test", "py_unpacked_wheel")
 load("//tools:pth_snapshot.bzl", "extract_venv_pth")
 
-# Snapshot fixture for assemble_venv's `_format_imp` install_tree branch.
+# Snapshot fixtures for assemble_venv's `_format_imp` install_tree branch.
+# Two independent pairs, pinning the two outcomes a collision can have.
 #
-# Two hand-built wheels, each carrying PyWheelsInfo (they set `top_levels`,
-# so each gets an `install_tree`) and each shipping a distinct root `.pth`.
-# Both claim the top-level `shared`, so the collision loser is NOT fully
-# covered and surfaces as a site-packages line in the venv `.pth`.
+# itfa / itfb — REGULAR collision, no fallback expected. Each carries
+# PyWheelsInfo (they set `top_levels`, so each gets an `install_tree`) and
+# ships a distinct root `.pth`; both claim the regular top-level `shared`.
+# The loser's `shared` is shadowed by the winner's symlink in the venv
+# site-packages, which precedes every `.pth` entry, so the loser needs no
+# whole-wheel fallback and its snapshot carries no site-packages line.
+# Re-introducing the fallback adds one.
 #
-# That line is exactly the one `_format_imp` must emit as a PLAIN escape
-# path, not `site.addsitedir(...)`: the loser's root `.pth` was already
-# projected into the venv site-packages by the per-top-level symlinks, so
-# `addsitedir` would re-run it (see the runtime guard at
+# itfc / itfd — NAMESPACE collision, fallback required. Both claim the PEP
+# 420 namespace `nspkg` and declare no `namespace_entries`, so venv assembly
+# cannot materialise per-entry symlinks and both wheels must stay reachable
+# through `.pth` for the namespace to union at runtime. Those lines are what
+# `_format_imp` must emit as PLAIN escape paths, not `site.addsitedir(...)`:
+# a wheel root already projected into the venv site-packages would have its
+# root `.pth` re-run (see the runtime guard at
 # @aspect_rules_py//py/tests/wheel-root-pth-double). The pinned snapshot
 # makes that line shape visible — reverting to `addsitedir` changes it.
 
@@ -102,4 +109,82 @@ py_test(
 extract_venv_pth(
     name = "test.venv.pth",
     venv = ":test.venv",
+)
+
+# The namespace pair. `nspkg` carries no `__init__.py` on either side, and
+# neither wheel declares `namespace_entries`, so there is nothing to project
+# per-entry and both wheels must reach sys.path for `nspkg` to union.
+genrule(
+    name = "wheel_c",
+    srcs = [
+        "c/cpkg/__init__.py",
+        "c/nspkg/mod_c.py",
+        "c/METADATA",
+    ],
+    outs = ["itfc-1.0-py3-none-any.whl"],
+    cmd = " ".join([
+        "$(execpath @bazel_tools//tools/zip:zipper) c $@",
+        "cpkg/__init__.py=$(execpath c/cpkg/__init__.py)",
+        "nspkg/mod_c.py=$(execpath c/nspkg/mod_c.py)",
+        "itfc-1.0.dist-info/METADATA=$(execpath c/METADATA)",
+    ]),
+    tools = ["@bazel_tools//tools/zip:zipper"],
+)
+
+genrule(
+    name = "wheel_d",
+    srcs = [
+        "d/dpkg/__init__.py",
+        "d/nspkg/mod_d.py",
+        "d/METADATA",
+    ],
+    outs = ["itfd-1.0-py3-none-any.whl"],
+    cmd = " ".join([
+        "$(execpath @bazel_tools//tools/zip:zipper) c $@",
+        "dpkg/__init__.py=$(execpath d/dpkg/__init__.py)",
+        "nspkg/mod_d.py=$(execpath d/nspkg/mod_d.py)",
+        "itfd-1.0.dist-info/METADATA=$(execpath d/METADATA)",
+    ]),
+    tools = ["@bazel_tools//tools/zip:zipper"],
+)
+
+py_unpacked_wheel(
+    name = "itfc",
+    src = ":itfc-1.0-py3-none-any.whl",
+    namespace_top_levels = ["nspkg"],
+    top_levels = [
+        "cpkg",
+        "itfc-1.0.dist-info",
+        "nspkg",
+    ],
+)
+
+py_unpacked_wheel(
+    name = "itfd",
+    src = ":itfd-1.0-py3-none-any.whl",
+    namespace_top_levels = ["nspkg"],
+    top_levels = [
+        "dpkg",
+        "itfd-1.0.dist-info",
+        "nspkg",
+    ],
+)
+
+py_test(
+    name = "namespace_test",
+    srcs = ["namespace_test.py"],
+    expose_venv = True,
+    isolated = False,
+    main = "namespace_test.py",
+    # Pin the interpreter so the snapshot's `lib/pythonX.Y` path is stable.
+    python_version = "3.11",
+    deps = [
+        ":itfc",
+        ":itfd",
+    ],
+)
+
+extract_venv_pth(
+    name = "namespace_test.venv.pth",
+    venv = ":namespace_test.venv",
 )

--- a/e2e/cases/pth-install-tree-fallback/c/METADATA
+++ b/e2e/cases/pth-install-tree-fallback/c/METADATA
@@ -1,0 +1,3 @@
+Metadata-Version: 2.1
+Name: itfc
+Version: 1.0

--- a/e2e/cases/pth-install-tree-fallback/c/cpkg/__init__.py
+++ b/e2e/cases/pth-install-tree-fallback/c/cpkg/__init__.py
@@ -1,0 +1,1 @@
+VALUE = "cpkg"

--- a/e2e/cases/pth-install-tree-fallback/c/nspkg/mod_c.py
+++ b/e2e/cases/pth-install-tree-fallback/c/nspkg/mod_c.py
@@ -1,0 +1,1 @@
+VALUE = "ns_c"

--- a/e2e/cases/pth-install-tree-fallback/d/METADATA
+++ b/e2e/cases/pth-install-tree-fallback/d/METADATA
@@ -1,0 +1,3 @@
+Metadata-Version: 2.1
+Name: itfd
+Version: 1.0

--- a/e2e/cases/pth-install-tree-fallback/d/dpkg/__init__.py
+++ b/e2e/cases/pth-install-tree-fallback/d/dpkg/__init__.py
@@ -1,0 +1,1 @@
+VALUE = "dpkg"

--- a/e2e/cases/pth-install-tree-fallback/d/nspkg/mod_d.py
+++ b/e2e/cases/pth-install-tree-fallback/d/nspkg/mod_d.py
@@ -1,0 +1,1 @@
+VALUE = "ns_d"

--- a/e2e/cases/pth-install-tree-fallback/namespace_test.py
+++ b/e2e/cases/pth-install-tree-fallback/namespace_test.py
@@ -1,0 +1,16 @@
+"""An entryless PEP 420 namespace must still union across both wheels.
+
+Neither wheel declares `namespace_entries`, so venv assembly has nothing to
+project per-entry and both wheel roots have to stay on the `.pth` fallback.
+If either were dropped, only one contributor's module would import.
+"""
+
+import cpkg
+import dpkg
+import nspkg.mod_c
+import nspkg.mod_d
+
+assert cpkg.VALUE == "cpkg"
+assert dpkg.VALUE == "dpkg"
+assert nspkg.mod_c.VALUE == "ns_c"
+assert nspkg.mod_d.VALUE == "ns_d"

--- a/e2e/cases/snapshots/pth_install_tree_fallback.venv.pth
+++ b/e2e/cases/snapshots/pth_install_tree_fallback.venv.pth
@@ -1,3 +1,2 @@
 ../../../../../..
-../../../../../../_main/pth-install-tree-fallback/itfa/lib/python3.11/site-packages
 ../../../../../../_main

--- a/e2e/cases/snapshots/pth_install_tree_fallback_namespace.venv.pth
+++ b/e2e/cases/snapshots/pth_install_tree_fallback_namespace.venv.pth
@@ -1,0 +1,4 @@
+../../../../../..
+../../../../../../_main/pth-install-tree-fallback/itfc/lib/python3.11/site-packages
+../../../../../../_main
+../../../../../../_main/pth-install-tree-fallback/itfd/lib/python3.11/site-packages

--- a/py/private/py_venv/tests/virtuals_resolvers_test.bzl
+++ b/py/private/py_venv/tests/virtuals_resolvers_test.bzl
@@ -136,9 +136,84 @@ def _console_script_collision_test_impl(ctx):
     asserts.equals(env, "pkg_b.cli", cs_map["tool"].module)
     return unittest.end(env)
 
+def _regular_collision_covers_loser_test_impl(ctx):
+    """A non-namespace collision loser needs no whole-wheel fallback.
+
+    Both wheels claim the file top-level `mod.py`. The winner's entry is
+    projected into the venv site-packages, which precedes every `.pth` entry
+    on sys.path, so the loser's copy is unreachable regardless. Leaving the
+    loser on the fallback would only lengthen sys.path and expose a second
+    `.dist-info` to `importlib.metadata`.
+    """
+    env = unittest.begin(ctx)
+    mock_ctx = _mock_ctx(ctx.label)
+    sp_a = "external/pypi_a/site-packages"
+    sp_b = "external/pypi_b/site-packages"
+    wheels = [
+        _make_wheel(
+            site_packages_rfpath = sp_a,
+            tl_claims = [
+                ("mod.py", _claim(sp_a)),
+                ("only_a", _claim(sp_a, is_dir = True)),
+            ],
+            top_levels = ["mod.py", "only_a"],
+        ),
+        _make_wheel(
+            site_packages_rfpath = sp_b,
+            tl_claims = [("mod.py", _claim(sp_b))],
+            top_levels = ["mod.py"],
+        ),
+    ]
+    top_level, fully_covered, _, _, _ = resolve_wheel_collisions(mock_ctx, wheels)
+
+    # Last distinct claimant wins the contested name.
+    asserts.equals(env, sp_b, top_level["mod.py"])
+
+    # The loser keeps its uncontested top-level projected...
+    asserts.equals(env, sp_a, top_level["only_a"])
+
+    # ...and both wheels drop off the `.pth` fallback entirely.
+    asserts.true(env, sp_a in fully_covered, "collision loser must not need a fallback")
+    asserts.true(env, sp_b in fully_covered)
+    return unittest.end(env)
+
+def _entryless_namespace_keeps_fallback_test_impl(ctx):
+    """An entryless PEP 420 namespace still needs both wheels on `.pth`.
+
+    Neither claimant declares `ns_entries`, so there is nothing to project
+    per-entry and the namespace can only union by having both wheel roots on
+    sys.path. This is the case the regular-collision suppression must not
+    swallow.
+    """
+    env = unittest.begin(ctx)
+    mock_ctx = _mock_ctx(ctx.label)
+    sp_a = "external/pypi_a/site-packages"
+    sp_b = "external/pypi_b/site-packages"
+    wheels = [
+        _make_wheel(
+            site_packages_rfpath = sp_a,
+            tl_claims = [("ns", _claim(sp_a, is_ns = True, is_dir = True))],
+            namespace_dirs = ["ns"],
+            top_levels = ["ns"],
+        ),
+        _make_wheel(
+            site_packages_rfpath = sp_b,
+            tl_claims = [("ns", _claim(sp_b, is_ns = True, is_dir = True))],
+            namespace_dirs = ["ns"],
+            top_levels = ["ns"],
+        ),
+    ]
+    _, fully_covered, _, _, _ = resolve_wheel_collisions(mock_ctx, wheels)
+
+    asserts.false(env, sp_a in fully_covered, "entryless namespace must keep its fallback")
+    asserts.false(env, sp_b in fully_covered, "entryless namespace must keep its fallback")
+    return unittest.end(env)
+
 _single_wheel_test = unittest.make(_single_wheel_test_impl)
 _namespace_merge_test = unittest.make(_namespace_merge_test_impl)
 _console_script_collision_test = unittest.make(_console_script_collision_test_impl)
+_regular_collision_covers_loser_test = unittest.make(_regular_collision_covers_loser_test_impl)
+_entryless_namespace_keeps_fallback_test = unittest.make(_entryless_namespace_keeps_fallback_test_impl)
 
 def virtuals_resolvers_test_suite(name):
     unittest.suite(
@@ -146,4 +221,6 @@ def virtuals_resolvers_test_suite(name):
         _single_wheel_test,
         _namespace_merge_test,
         _console_script_collision_test,
+        _regular_collision_covers_loser_test,
+        _entryless_namespace_keeps_fallback_test,
     )

--- a/py/private/py_venv/virtuals_resolvers.bzl
+++ b/py/private/py_venv/virtuals_resolvers.bzl
@@ -329,8 +329,13 @@ def _resolve_directory_collision(
         winner = [c for c in distinct_claimants if not c.is_ns][-1]
         state.top_level_to_site_pkgs[tl] = winner.site_packages
         for c in distinct_claimants:
+            # With no namespace claimant the winner's projected directory is a
+            # regular package, so Python binds `<tl>.__path__` to it alone and
+            # a loser on the fallback contributes nothing. Only a namespace
+            # unions across sys.path entries and needs the fallback kept.
             if (c.site_packages == winner.site_packages or
-                c.site_packages in duplicate_metadata_loser_sps):
+                c.site_packages in duplicate_metadata_loser_sps or
+                not any_namespace):
                 _cover(state, c.site_packages, tl)
             else:
                 _skip(state, c.site_packages, tl)
@@ -401,10 +406,17 @@ def _resolve_top_level(
         )
         return
 
+    # Reached only when `all_directories` is False, which implies
+    # `any_namespace` is False. `tl` is therefore projected into the venv
+    # site-packages as the winner's entry, and that directory precedes every
+    # `.pth` entry on sys.path — so a loser's copy is unreachable whether or
+    # not its wheel root stays on the fallback. Cover it: a fallback that
+    # cannot be reached only lengthens sys.path and exposes a second
+    # `.dist-info` to `importlib.metadata` scans.
     winner = distinct_claimants[-1]
     for c in distinct_claimants:
         if c.site_packages != winner.site_packages:
-            _skip(state, c.site_packages, tl)
+            _cover(state, c.site_packages, tl)
     state.top_level_to_site_pkgs[tl] = winner.site_packages
 
 def _fold_merge_groups(wheels, wheel_by_sp, state):


### PR DESCRIPTION
A wheel that lost a top-level collision was demoted to the whole-wheel `.pth` fallback for its entire root, even when the contested name was a regular package or module. In that case the winner's entry is projected into the venv site-packages, which precedes every `.pth` entry on sys.path, so the loser's copy is unreachable whether or not its wheel root is on the path. The fallback line was dead weight: one more sys.path entry for every import to walk, and a second `.dist-info` for `importlib.metadata` to find.

Cover those losers instead, at the two sites where the collision is provably non-namespace:

  * `_resolve_top_level`'s tail, reached only when `all_directories` is false, which implies no claimant is a namespace.
  * `_resolve_directory_collision`'s native branch, guarded on `not any_namespace`.

A namespace claimant still keeps its fallback -- PEP 420 unions across sys.path entries, so dropping one loses a contributor. The entryless namespace path (`_skip_entryless_and_split`), the nested-namespace prefix conflict (`_dedupe_prefix_conflicts`) and the duplicate-entry path (`_resolve_entry_owners`) are untouched.

Refs #1376.

Test plan:
- Two resolver unit tests: a regular collision covers its loser, an entryless namespace keeps both wheels on the fallback. Reverting either guard fails the matching test.
- e2e `pth-install-tree-fallback` gains a namespace pair (itfc/itfd) so `_format_imp`'s plain-escape-path branch keeps its snapshot coverage; the existing regular pair now pins the absence of a fallback line.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
