### PR TITLE
perf(py_venv): reuse addpackage's known_paths in the venv .pth addsitedir lines

### DIFF
--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -185,6 +185,15 @@ write_source_files(
         # * wheel_root_pth — `py_unpacked_wheel` without `top_levels`;
         #   pins the `site.addsitedir(...)` shape so wheel-root `.pth`
         #   shims keep running.
+        # * multi_addsitedir — the same branch at N=4. Every `addsitedir`
+        #   line shares one `known_paths` set, declared once by the prologue
+        #   line ahead of them, so the file stays O(N) in emitted bytes and
+        #   `site` does one `_init_pathinfo()` for the whole file instead of
+        #   one per line. The interleaved plain `_main` entry pins that
+        #   sharing did not reorder `sys.path`. Read against
+        #   `wheel_root_pth` above: the prologue line is identical in both
+        #   while the per-wheel lines multiply, so inlining it back into
+        #   each line shows up as a diff that grows with N.
         # * pth_install_tree_fallback — two install_tree wheels colliding
         #   on a REGULAR top-level; the collision loser stays on the
         #   fallback (an extend_path winner can still graft from it).
@@ -198,6 +207,7 @@ write_source_files(
         "snapshots/pth_namespace_547.test.venv.pth": "//pth-namespace-547:test.venv.pth",
         "snapshots/firebase_admin.test_tool.venv.pth": "//firebase-admin-import:test_tool.venv.pth",
         "snapshots/wheel_root_pth.venv.pth": "//uv-include-group:wheel_root_pth_test.venv.pth",
+        "snapshots/multi_addsitedir.venv.pth": "//uv-include-group:multi_addsitedir_test.venv.pth",
         "snapshots/pth_install_tree_fallback.venv.pth": "//pth-install-tree-fallback:test.venv.pth",
         "snapshots/pth_install_tree_fallback_namespace.venv.pth": "//pth-install-tree-fallback:namespace_test.venv.pth",
 

--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -186,14 +186,12 @@ write_source_files(
         #   pins the `site.addsitedir(...)` shape so wheel-root `.pth`
         #   shims keep running.
         # * multi_addsitedir — the same branch at N=4. Every `addsitedir`
-        #   line shares one `known_paths` set, declared once by the prologue
-        #   line ahead of them, so the file stays O(N) in emitted bytes and
-        #   `site` does one `_init_pathinfo()` for the whole file instead of
-        #   one per line. The interleaved plain `_main` entry pins that
-        #   sharing did not reorder `sys.path`. Read against
-        #   `wheel_root_pth` above: the prologue line is identical in both
-        #   while the per-wheel lines multiply, so inlining it back into
-        #   each line shows up as a diff that grows with N.
+        #   line reuses the `known_paths` set owned by the enclosing
+        #   `site.addpackage`, so the file costs one `_init_pathinfo()` in
+        #   total rather than one per line. The plain `_main` entry sits
+        #   between two of those lines, pinning both that the reuse did not
+        #   reorder `sys.path` and that a plain entry landing mid-file is
+        #   one the later lines can see.
         # * pth_install_tree_fallback — two install_tree wheels colliding
         #   on a REGULAR top-level; the collision loser stays on the
         #   fallback (an extend_path winner can still graft from it).

--- a/e2e/cases/snapshots/multi_addsitedir.venv.pth
+++ b/e2e/cases/snapshots/multi_addsitedir.venv.pth
@@ -1,7 +1,6 @@
 ../../../../../..
-import site; site._aspect_rules_py_known_paths = getattr(site, "_aspect_rules_py_known_paths", None) or getattr(site, "_init_pathinfo", lambda: None)()
-import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/iniconfig_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/iniconfig_no_top_levels/lib/python3.11/site-packages")), vars().get("known_paths"))
 ../../../../../../_main
-import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/packaging_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
-import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/pluggy_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
-import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/pygments_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/packaging_no_top_levels/lib/python3.11/site-packages")), vars().get("known_paths"))
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/pluggy_no_top_levels/lib/python3.11/site-packages")), vars().get("known_paths"))
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/pygments_no_top_levels/lib/python3.11/site-packages")), vars().get("known_paths"))

--- a/e2e/cases/snapshots/multi_addsitedir.venv.pth
+++ b/e2e/cases/snapshots/multi_addsitedir.venv.pth
@@ -1,0 +1,7 @@
+../../../../../..
+import site; site._aspect_rules_py_known_paths = getattr(site, "_aspect_rules_py_known_paths", None) or getattr(site, "_init_pathinfo", lambda: None)()
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/iniconfig_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
+../../../../../../_main
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/packaging_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/pluggy_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/pygments_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))

--- a/e2e/cases/snapshots/wheel_root_pth.venv.pth
+++ b/e2e/cases/snapshots/wheel_root_pth.venv.pth
@@ -1,3 +1,4 @@
 ../../../../../..
-import os, sys, site; _kp = getattr(site, "_aspect_rules_py_known_paths", None) or getattr(site, "_init_pathinfo", lambda: None)(); site._aspect_rules_py_known_paths = _kp; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/setuptools_no_top_levels/lib/python3.11/site-packages")), _kp)
+import site; site._aspect_rules_py_known_paths = getattr(site, "_aspect_rules_py_known_paths", None) or getattr(site, "_init_pathinfo", lambda: None)()
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/setuptools_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
 ../../../../../../_main

--- a/e2e/cases/snapshots/wheel_root_pth.venv.pth
+++ b/e2e/cases/snapshots/wheel_root_pth.venv.pth
@@ -1,4 +1,3 @@
 ../../../../../..
-import site; site._aspect_rules_py_known_paths = getattr(site, "_aspect_rules_py_known_paths", None) or getattr(site, "_init_pathinfo", lambda: None)()
-import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/setuptools_no_top_levels/lib/python3.11/site-packages")), getattr(site, "_aspect_rules_py_known_paths", None))
+import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/setuptools_no_top_levels/lib/python3.11/site-packages")), vars().get("known_paths"))
 ../../../../../../_main

--- a/e2e/cases/snapshots/wheel_root_pth.venv.pth
+++ b/e2e/cases/snapshots/wheel_root_pth.venv.pth
@@ -1,3 +1,3 @@
 ../../../../../..
-import os, sys, site; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/setuptools_no_top_levels/lib/python3.11/site-packages")))
+import os, sys, site; _kp = getattr(site, "_aspect_rules_py_known_paths", None) or getattr(site, "_init_pathinfo", lambda: None)(); site._aspect_rules_py_known_paths = _kp; site.addsitedir(os.path.normpath(os.path.join(sys.prefix, "../../..", "_main/uv-include-group/setuptools_no_top_levels/lib/python3.11/site-packages")), _kp)
 ../../../../../../_main

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -77,9 +77,8 @@ extract_venv_pth(
 )
 
 # Four unknown-layout wheels, so the venv emits four `site.addsitedir` lines
-# against the one above. That contrast is what makes the shared `known_paths`
-# set legible: the prologue is emitted once no matter the wheel count, and
-# each `addsitedir` line carries only a `getattr` reference to it.
+# against the one above — enough for the snapshot to show the reused
+# `known_paths` set, and for a plain path entry to land between two of them.
 MULTI_ADDSITEDIR_PKGS = [
     "iniconfig",
     "packaging",

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -75,3 +75,41 @@ extract_venv_pth(
     name = "wheel_root_pth_test.venv.pth",
     venv = ":wheel_root_pth_test.venv",
 )
+
+# Four unknown-layout wheels, so the venv emits four `site.addsitedir` lines
+# against the one above. That contrast is what makes the shared `known_paths`
+# set legible: the prologue is emitted once no matter the wheel count, and
+# each `addsitedir` line carries only a `getattr` reference to it.
+MULTI_ADDSITEDIR_PKGS = [
+    "iniconfig",
+    "packaging",
+    "pluggy",
+    "pygments",
+]
+
+[
+    py_unpacked_wheel(
+        name = "{}_no_top_levels".format(pkg),
+        src = "@pypi_uv_include_group//{}:whl".format(pkg),
+    )
+    for pkg in MULTI_ADDSITEDIR_PKGS
+]
+
+py_test(
+    name = "multi_addsitedir_test",
+    srcs = ["multi_addsitedir_test.py"],
+    # These four are pytest's transitive deps, so they resolve in the `test`
+    # group; `dep_group` gates which hub wheels are compatible at all.
+    dep_group = "test",
+    expose_venv = True,
+    isolated = False,
+    main = "multi_addsitedir_test.py",
+    # Pin the interpreter so the snapshot's `lib/pythonX.Y` paths are stable.
+    python_version = "3.11",
+    deps = ["{}_no_top_levels".format(pkg) for pkg in MULTI_ADDSITEDIR_PKGS],
+)
+
+extract_venv_pth(
+    name = "multi_addsitedir_test.venv.pth",
+    venv = ":multi_addsitedir_test.venv",
+)

--- a/e2e/cases/uv-include-group/multi_addsitedir_test.py
+++ b/e2e/cases/uv-include-group/multi_addsitedir_test.py
@@ -1,0 +1,29 @@
+"""Four unknown-layout wheels, four `site.addsitedir` lines, one prologue.
+
+The companion snapshot (`snapshots/multi_addsitedir.venv.pth`) pins the file
+shape; this pins that the shape still works — every wheel on sys.path exactly
+once, sharing one `known_paths` set across all four lines.
+"""
+
+import sys
+
+PACKAGES = ("iniconfig", "packaging", "pluggy", "pygments")
+
+
+def main() -> None:
+    site_packages = [p for p in sys.path if p.endswith("site-packages")]
+    if len(site_packages) != len(set(site_packages)):
+        duplicates = sorted({p for p in site_packages if site_packages.count(p) > 1})
+        raise SystemExit("duplicate site-packages on sys.path: {}".format(duplicates))
+
+    for pkg in PACKAGES:
+        owned = [p for p in site_packages if "/{}_no_top_levels/".format(pkg) in p]
+        if len(owned) != 1:
+            raise SystemExit(
+                "expected exactly one sys.path entry for {}, got {}".format(pkg, owned)
+            )
+        __import__(pkg)
+
+
+if __name__ == "__main__":
+    main()

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -43,31 +43,28 @@ load(":virtuals_resolvers.bzl", "enforce_collision_policy", "resolve_wheel_colli
 # `site.addsitedir(dir)` called without `known_paths` builds that set from
 # scratch via `site._init_pathinfo()`, which stats every entry already on
 # `sys.path` — so N such lines cost O(N^2) stats and dominate interpreter
-# startup once N reaches the hundreds. `site.addpackage` runs each line with
-# `exec(line)` under the `site` module's globals, and a `.pth` line's own
-# locals do not survive to the next line, so the set is stashed on the `site`
-# module: one `_init_pathinfo()` for the whole file, kept current by
-# `addsitedir` as it appends. Emitted once, ahead of the first line that reads
-# it, so its ~150 bytes aren't repeated N times.
-_KNOWN_PATHS_PROLOGUE = (
-    "import site; site._aspect_rules_py_known_paths = " +
-    "getattr(site, \"_aspect_rules_py_known_paths\", None) or " +
-    "getattr(site, \"_init_pathinfo\", lambda: None)()"
-)
-
+# startup once N reaches the hundreds.
+#
+# The set to reuse is the one `site.addpackage` is already holding: threaded
+# down from `site.main()`, and updated in place as it appends this file's own
+# plain path entries. `exec(line)` hands each line `addpackage`'s locals as
+# its own, so `vars()` reaches that set directly. A set of our own would go
+# stale against those plain entries and re-append a directory a wheel-root
+# `.pth` also names.
+#
 # Deliberately per-line rather than one combined loop: the lines stay
 # interleaved with the plain path entries in `imports_depset` order, so
 # `sys.path` precedence is byte-for-byte what it was.
 #
-# `getattr(..., None)` keeps every line total — no prologue, or a `site`
-# without `_init_pathinfo`, yields `None` and `addsitedir` rebuilds the set
-# itself: slower, never wrong. Totality is load-bearing, since `addpackage`
-# abandons the remainder of the file on the first line that raises.
+# `.get` keeps every line total — anything but `addpackage` as the caller
+# yields `None`, and `addsitedir` rebuilds the set itself: slower, never
+# wrong. Totality is load-bearing, since `addpackage` abandons the remainder
+# of the file on the first line that raises.
 _ADDSITEDIR_LINE = (
     "import os, sys, site; " +
     "site.addsitedir(os.path.normpath(os.path.join(" +
     "sys.prefix, \"{venv_escape}\", \"{imp}\")), " +
-    "getattr(site, \"_aspect_rules_py_known_paths\", None))"
+    "vars().get(\"known_paths\"))"
 )
 
 def _dict_to_exports(env):
@@ -157,16 +154,6 @@ def assemble_venv(
     # scripts) leave `top_levels` empty: nothing is projected for them, so their
     # `.pth` line must use `site.addsitedir` (see `_format_imp`).
     known_layout_site_pkgs = {w.site_packages_rfpath: True for w in wheels if w.top_levels}
-
-    # Whether any wheel will take the `site.addsitedir` fallback in
-    # `_format_imp`, and so needs `_KNOWN_PATHS_PROLOGUE`. A site-packages
-    # import reaching `imports_depset` from outside `wheels` would miss the
-    # prologue and fall back to a per-line `_init_pathinfo()` — correct, just
-    # not the fast path.
-    any_addsitedir = any([
-        not w.top_levels and w.site_packages_rfpath not in fully_covered_site_pkgs
-        for w in wheels
-    ])
 
     declared = []  # accumulator for all outputs
 
@@ -278,12 +265,6 @@ def assemble_venv(
     pth_lines.use_param_file("%s", use_always = True)
     pth_lines.set_param_file_format("multiline")
     pth_lines.add(escape)
-
-    # Import lines touch nothing in `sys.path`, so only the prologue's position
-    # relative to the first `addsitedir` line matters, not its position among
-    # the plain path entries.
-    if any_addsitedir:
-        pth_lines.add(_KNOWN_PATHS_PROLOGUE)
 
     # allow_closure lets _format_imp capture fully_covered_site_pkgs /
     # known_layout_site_pkgs so we don't have to materialise imports_depset

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -40,6 +40,26 @@ load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
 load(":toolchains_resolver.bzl", "resolve_venv_toolchain")
 load(":virtuals_resolvers.bzl", "enforce_collision_policy", "resolve_wheel_collisions")
 
+# `site.addsitedir(dir)` called without `known_paths` builds that set from
+# scratch via `site._init_pathinfo()`, which stats every entry already on
+# `sys.path` — so N such lines cost O(N^2) stats and dominate interpreter
+# startup once N reaches the hundreds. `site.addpackage` runs each line with
+# `exec(line)` under the `site` module's globals, so stashing the set on the
+# module carries it across lines: one `_init_pathinfo()` for the whole file,
+# and `addsitedir` keeps the set current as it appends.
+#
+# Deliberately per-line rather than one combined loop: the lines stay
+# interleaved with the plain path entries in `imports_depset` order, so
+# `sys.path` precedence is byte-for-byte what it was.
+_ADDSITEDIR_LINE = (
+    "import os, sys, site; " +
+    "_kp = getattr(site, \"_aspect_rules_py_known_paths\", None) or " +
+    "getattr(site, \"_init_pathinfo\", lambda: None)(); " +
+    "site._aspect_rules_py_known_paths = _kp; " +
+    "site.addsitedir(os.path.normpath(os.path.join(" +
+    "sys.prefix, \"{venv_escape}\", \"{imp}\")), _kp)"
+)
+
 def _dict_to_exports(env):
     return ["export %s=\"%s\"" % (k, v) for (k, v) in env.items()]
 
@@ -228,9 +248,7 @@ def assemble_venv(
         if imp in fully_covered_site_pkgs:
             return None
         if imp.endswith("site-packages") and imp not in known_layout_site_pkgs:
-            return ("import os, sys, site; " +
-                    "site.addsitedir(os.path.normpath(os.path.join(" +
-                    "sys.prefix, \"{venv_escape}\", \"{imp}\")))").format(
+            return _ADDSITEDIR_LINE.format(
                 venv_escape = venv_to_runfiles_escape,
                 imp = imp,
             )

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -44,20 +44,30 @@ load(":virtuals_resolvers.bzl", "enforce_collision_policy", "resolve_wheel_colli
 # scratch via `site._init_pathinfo()`, which stats every entry already on
 # `sys.path` — so N such lines cost O(N^2) stats and dominate interpreter
 # startup once N reaches the hundreds. `site.addpackage` runs each line with
-# `exec(line)` under the `site` module's globals, so stashing the set on the
-# module carries it across lines: one `_init_pathinfo()` for the whole file,
-# and `addsitedir` keeps the set current as it appends.
-#
+# `exec(line)` under the `site` module's globals, and a `.pth` line's own
+# locals do not survive to the next line, so the set is stashed on the `site`
+# module: one `_init_pathinfo()` for the whole file, kept current by
+# `addsitedir` as it appends. Emitted once, ahead of the first line that reads
+# it, so its ~150 bytes aren't repeated N times.
+_KNOWN_PATHS_PROLOGUE = (
+    "import site; site._aspect_rules_py_known_paths = " +
+    "getattr(site, \"_aspect_rules_py_known_paths\", None) or " +
+    "getattr(site, \"_init_pathinfo\", lambda: None)()"
+)
+
 # Deliberately per-line rather than one combined loop: the lines stay
 # interleaved with the plain path entries in `imports_depset` order, so
 # `sys.path` precedence is byte-for-byte what it was.
+#
+# `getattr(..., None)` keeps every line total — no prologue, or a `site`
+# without `_init_pathinfo`, yields `None` and `addsitedir` rebuilds the set
+# itself: slower, never wrong. Totality is load-bearing, since `addpackage`
+# abandons the remainder of the file on the first line that raises.
 _ADDSITEDIR_LINE = (
     "import os, sys, site; " +
-    "_kp = getattr(site, \"_aspect_rules_py_known_paths\", None) or " +
-    "getattr(site, \"_init_pathinfo\", lambda: None)(); " +
-    "site._aspect_rules_py_known_paths = _kp; " +
     "site.addsitedir(os.path.normpath(os.path.join(" +
-    "sys.prefix, \"{venv_escape}\", \"{imp}\")), _kp)"
+    "sys.prefix, \"{venv_escape}\", \"{imp}\")), " +
+    "getattr(site, \"_aspect_rules_py_known_paths\", None))"
 )
 
 def _dict_to_exports(env):
@@ -147,6 +157,16 @@ def assemble_venv(
     # scripts) leave `top_levels` empty: nothing is projected for them, so their
     # `.pth` line must use `site.addsitedir` (see `_format_imp`).
     known_layout_site_pkgs = {w.site_packages_rfpath: True for w in wheels if w.top_levels}
+
+    # Whether any wheel will take the `site.addsitedir` fallback in
+    # `_format_imp`, and so needs `_KNOWN_PATHS_PROLOGUE`. A site-packages
+    # import reaching `imports_depset` from outside `wheels` would miss the
+    # prologue and fall back to a per-line `_init_pathinfo()` — correct, just
+    # not the fast path.
+    any_addsitedir = any([
+        not w.top_levels and w.site_packages_rfpath not in fully_covered_site_pkgs
+        for w in wheels
+    ])
 
     declared = []  # accumulator for all outputs
 
@@ -258,6 +278,12 @@ def assemble_venv(
     pth_lines.use_param_file("%s", use_always = True)
     pth_lines.set_param_file_format("multiline")
     pth_lines.add(escape)
+
+    # Import lines touch nothing in `sys.path`, so only the prologue's position
+    # relative to the first `addsitedir` line matters, not its position among
+    # the plain path entries.
+    if any_addsitedir:
+        pth_lines.add(_KNOWN_PATHS_PROLOGUE)
 
     # allow_closure lets _format_imp capture fully_covered_site_pkgs /
     # known_layout_site_pkgs so we don't have to materialise imports_depset

--- a/py/tests/wheel-root-pth-double/BUILD.bazel
+++ b/py/tests/wheel-root-pth-double/BUILD.bazel
@@ -111,3 +111,24 @@ py_test(
     main = "unknown_layout_pth_test.py",
     deps = [":pthtest_unknown_layout"],
 )
+
+# A second unknown-layout wheel, so the venv emits more than one
+# `site.addsitedir` line and the `known_paths` set those lines share is
+# actually exercised (see shared_known_paths_test.py). Distinct console-script
+# name so the two targets don't collide in bin/.
+py_unpacked_wheel(
+    name = "pthtest_unknown_layout_b",
+    src = ":pthtest_b-1.0-py3-none-any.whl",
+    console_scripts = ["pthtestb=bpkg:main"],
+)
+
+py_test(
+    name = "shared_known_paths_test",
+    srcs = ["shared_known_paths_test.py"],
+    isolated = False,
+    main = "shared_known_paths_test.py",
+    deps = [
+        ":pthtest_unknown_layout",
+        ":pthtest_unknown_layout_b",
+    ],
+)

--- a/py/tests/wheel-root-pth-double/shared_known_paths_test.py
+++ b/py/tests/wheel-root-pth-double/shared_known_paths_test.py
@@ -1,28 +1,35 @@
 """Two unknown-layout wheels must each reach sys.path exactly once.
 
 `_format_imp` emits one `site.addsitedir(...)` line per unknown-layout wheel,
-and those lines share a single `known_paths` set stashed on the `site` module
-by `_KNOWN_PATHS_PROLOGUE`, so N of them cost O(N) rather than O(N^2). Sharing
-that set is what could go wrong: a stale set would let a directory be appended
-twice, and an over-eager one would make the second `addsitedir` believe a
-directory was already present and silently skip it.
+and each passes the `known_paths` set that the enclosing `site.addpackage` is
+already maintaining, so N of them cost O(N) rather than O(N^2). Reusing a set
+is what could go wrong: a stale one lets a directory be appended twice, and an
+over-eager one makes a later `addsitedir` believe a directory was already
+present and silently skip it.
 
 The launcher processes the venv site-packages as a site dir twice (see
 double_pth_test.py), so the whole `.pth` — every `addsitedir` line in it — runs
 twice. Deduplication across those two passes is precisely what `known_paths`
-is for, which makes this the case a shared set has to get right.
+is for, which makes this the case a reused set has to get right.
 
-The tail of the test pins the emitted file's shape rather than its effect: one
-prologue, ahead of the lines that read it, and an `addsitedir` line that still
-behaves when the stash is missing.
+The tail of the test pins the emitted file's shape rather than its effect,
+plus the two ways the reused set could be wrong: staleness against the plain
+path entries interleaved with these lines, and the set not being in scope at
+all.
 """
 
 import os
+import shutil
+import site
 import sys
+import tempfile
 
 WHEELS = ("pthtest_unknown_layout", "pthtest_unknown_layout_b")
 
-STASH = "_aspect_rules_py_known_paths"
+# What every emitted `addsitedir` line must pass as `known_paths`: the live set
+# owned by the enclosing `addpackage`, not one of our own. `exec` hands a .pth
+# line that frame's locals as its own, so `vars()` reaches it.
+KNOWN_PATHS_EXPR = 'vars().get("known_paths")'
 
 
 def find_venv_pth() -> str:
@@ -34,9 +41,9 @@ def find_venv_pth() -> str:
                 continue
             path = os.path.join(root, name)
             with open(path) as fh:
-                if STASH in fh.read():
+                if "site.addsitedir(" in fh.read():
                     return path
-    raise SystemExit("no venv .pth referencing {} under {}".format(STASH, sys.prefix))
+    raise SystemExit("no venv .pth calling site.addsitedir under {}".format(sys.prefix))
 
 
 def check_sys_path() -> None:
@@ -62,7 +69,7 @@ def check_sys_path() -> None:
         raise SystemExit("a wheel root .pth did not execute: {}".format(counts))
     if counts[0] != counts[1]:
         raise SystemExit(
-            "wheel-root .pth executions are asymmetric {} — the shared "
+            "wheel-root .pth executions are asymmetric {} — the reused "
             "known_paths set made one addsitedir re-scan or skip".format(counts)
         )
 
@@ -74,57 +81,86 @@ def check_sys_path() -> None:
 
 
 def check_pth_shape(lines: list[str]) -> list[str]:
-    """One prologue for the whole file, ahead of every line that reads it."""
-    prologues = [i for i, ln in enumerate(lines) if ln.startswith("import site;")]
-    add_lines = [i for i, ln in enumerate(lines) if "site.addsitedir(" in ln]
+    """Every addsitedir line reuses the caller's set.
 
-    if len(prologues) != 1:
-        raise SystemExit(
-            "expected exactly one known_paths prologue, got {}".format(len(prologues))
-        )
+    Dropping the reuse costs only startup time and is invisible from sys.path,
+    so pin the expression rather than an effect.
+    """
+    add_lines = [i for i, ln in enumerate(lines) if "site.addsitedir(" in ln]
     if len(add_lines) < 2:
         raise SystemExit(
             "expected at least two addsitedir lines, got {}".format(len(add_lines))
         )
-    if prologues[0] > add_lines[0]:
-        raise SystemExit(
-            "prologue on line {} follows an addsitedir line on {}".format(
-                prologues[0] + 1, add_lines[0] + 1
-            )
-        )
 
-    # Losing the shared set costs only startup time, so nothing observable
-    # from sys.path catches it. Pin the reference instead.
-    unshared = [i + 1 for i in add_lines if STASH not in lines[i]]
+    unshared = [i + 1 for i in add_lines if KNOWN_PATHS_EXPR not in lines[i]]
     if unshared:
         raise SystemExit(
-            "addsitedir lines {} do not read {} — back to a per-line "
-            "_init_pathinfo()".format(unshared, STASH)
+            "addsitedir lines {} do not pass `{}` — back to a per-line "
+            "_init_pathinfo()".format(unshared, KNOWN_PATHS_EXPR)
         )
     return [lines[i] for i in add_lines]
 
 
-def check_missing_stash_degrades(add_line: str) -> None:
+def check_stale_set_regression() -> None:
+    """A plain path entry landing between the addsitedir lines must be visible
+    to them.
+
+    `addpackage` adds plain lines to the set it owns. A set of our own would
+    not see them, so a wheel-root `.pth` naming that same directory would
+    append it a second time. Built here rather than assembled by the venv
+    rules, because no fixture wheel ships a root `.pth` pointing back out at a
+    venv import root.
+    """
+    root = tempfile.mkdtemp(prefix="rules-py-stale-")
+    try:
+        shared_dir = os.path.join(root, "shared_dir")
+        wheel_sp = os.path.join(root, "wheel", "site-packages")
+        os.makedirs(shared_dir)
+        os.makedirs(wheel_sp)
+        with open(os.path.join(wheel_sp, "w.pth"), "w") as fh:
+            fh.write(os.path.relpath(shared_dir, wheel_sp) + "\n")
+
+        sitedir = os.path.join(root, "sitedir")
+        os.makedirs(sitedir)
+        with open(os.path.join(sitedir, "venv.pth"), "w") as fh:
+            fh.write(shared_dir + "\n")
+            fh.write(
+                "import os, sys, site; site.addsitedir({!r}, {})\n".format(
+                    wheel_sp, KNOWN_PATHS_EXPR
+                )
+            )
+
+        saved = list(sys.path)
+        try:
+            site.addpackage(sitedir, "venv.pth", None)
+            hits = [p for p in sys.path if os.path.realpath(p) == os.path.realpath(shared_dir)]
+        finally:
+            sys.path[:] = saved
+    finally:
+        shutil.rmtree(root)
+
+    if len(hits) != 1:
+        raise SystemExit(
+            "plain path entry landed on sys.path {} times — the addsitedir "
+            "line is reusing a set that is stale against it".format(len(hits))
+        )
+
+
+def check_foreign_caller_degrades(add_line: str) -> None:
     """`addpackage` abandons the rest of the file on the first line that
-    raises, so an `addsitedir` line must be total with no stash present. It
-    falls back to rebuilding `known_paths`, which still finds the directory
-    already on sys.path and appends nothing."""
-    site = sys.modules["site"]
-    saved = site.__dict__.pop(STASH, None)
+    raises, so an `addsitedir` line must be total when it runs anywhere else —
+    no `known_paths` in scope, `.get` yields None, and `addsitedir` rebuilds
+    the set itself, still finding the directory on sys.path and appending
+    nothing. A bare `known_paths` reference would raise here instead."""
     before = len(sys.path)
     try:
         exec(add_line, {})
     except Exception as exc:
-        raise SystemExit(
-            "addsitedir line raised without the {} stash: {!r}".format(STASH, exc)
-        )
-    finally:
-        if saved is not None:
-            setattr(site, STASH, saved)
+        raise SystemExit("addsitedir line raised outside addpackage: {!r}".format(exc))
 
     readded = [p for p in sys.path[before:] if p.endswith("site-packages")]
     if readded:
-        raise SystemExit("addsitedir re-appended {} after losing the stash".format(readded))
+        raise SystemExit("addsitedir re-appended {} outside addpackage".format(readded))
 
 
 def main() -> None:
@@ -134,8 +170,9 @@ def main() -> None:
         lines = [ln for ln in fh.read().splitlines() if ln.strip()]
 
     add_lines = check_pth_shape(lines)
+    check_stale_set_regression()
     # Last: re-running an addsitedir line re-fires that wheel's root `.pth`.
-    check_missing_stash_degrades(add_lines[0])
+    check_foreign_caller_degrades(add_lines[0])
 
 
 if __name__ == "__main__":

--- a/py/tests/wheel-root-pth-double/shared_known_paths_test.py
+++ b/py/tests/wheel-root-pth-double/shared_known_paths_test.py
@@ -1,0 +1,56 @@
+"""Two unknown-layout wheels must each reach sys.path exactly once.
+
+`_format_imp` emits one `site.addsitedir(...)` line per unknown-layout wheel,
+and those lines thread a single `known_paths` set through the `site` module so
+N of them cost O(N) rather than O(N^2). Sharing that set is what could go
+wrong: a stale set would let a directory be appended twice, and an over-eager
+one would make the second `addsitedir` believe a directory was already present
+and silently skip it.
+
+The launcher processes the venv site-packages as a site dir twice (see
+double_pth_test.py), so the whole `.pth` — every `addsitedir` line in it — runs
+twice. Deduplication across those two passes is precisely what `known_paths`
+is for, which makes this the case a shared set has to get right.
+"""
+
+import sys
+
+WHEELS = ("pthtest_unknown_layout", "pthtest_unknown_layout_b")
+
+
+def main() -> None:
+    site_packages = [p for p in sys.path if p.endswith("site-packages")]
+
+    for name in WHEELS:
+        owned = [p for p in site_packages if "/{}/".format(name) in p]
+        if len(owned) != 1:
+            raise SystemExit(
+                "expected exactly one sys.path entry for {}, got {}".format(name, owned)
+            )
+
+    if len(site_packages) != len(set(site_packages)):
+        duplicates = sorted({p for p in site_packages if site_packages.count(p) > 1})
+        raise SystemExit("duplicate site-packages on sys.path: {}".format(duplicates))
+
+    # Both wheel-root `.pth` shims must still fire — `addsitedir` runs them as
+    # it scans each directory it appends. Counts are asserted symmetric rather
+    # than absolute, for the same reason double_pth_test.py does: the launcher's
+    # per-site-dir scan count is a pre-existing, uniform multiplier.
+    counts = [sys.path.count(s) for s in ("rules_py_pth_sentinel_a", "rules_py_pth_sentinel_b")]
+    if counts[0] < 1 or counts[1] < 1:
+        raise SystemExit("a wheel root .pth did not execute: {}".format(counts))
+    if counts[0] != counts[1]:
+        raise SystemExit(
+            "wheel-root .pth executions are asymmetric {} — the shared "
+            "known_paths set made one addsitedir re-scan or skip".format(counts)
+        )
+
+    import apkg
+    import bpkg
+
+    if (apkg.VALUE, bpkg.VALUE) != ("apkg", "bpkg"):
+        raise SystemExit("unknown-layout wheel packages did not import")
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tests/wheel-root-pth-double/shared_known_paths_test.py
+++ b/py/tests/wheel-root-pth-double/shared_known_paths_test.py
@@ -1,24 +1,45 @@
 """Two unknown-layout wheels must each reach sys.path exactly once.
 
 `_format_imp` emits one `site.addsitedir(...)` line per unknown-layout wheel,
-and those lines thread a single `known_paths` set through the `site` module so
-N of them cost O(N) rather than O(N^2). Sharing that set is what could go
-wrong: a stale set would let a directory be appended twice, and an over-eager
-one would make the second `addsitedir` believe a directory was already present
-and silently skip it.
+and those lines share a single `known_paths` set stashed on the `site` module
+by `_KNOWN_PATHS_PROLOGUE`, so N of them cost O(N) rather than O(N^2). Sharing
+that set is what could go wrong: a stale set would let a directory be appended
+twice, and an over-eager one would make the second `addsitedir` believe a
+directory was already present and silently skip it.
 
 The launcher processes the venv site-packages as a site dir twice (see
 double_pth_test.py), so the whole `.pth` — every `addsitedir` line in it — runs
 twice. Deduplication across those two passes is precisely what `known_paths`
 is for, which makes this the case a shared set has to get right.
+
+The tail of the test pins the emitted file's shape rather than its effect: one
+prologue, ahead of the lines that read it, and an `addsitedir` line that still
+behaves when the stash is missing.
 """
 
+import os
 import sys
 
 WHEELS = ("pthtest_unknown_layout", "pthtest_unknown_layout_b")
 
+STASH = "_aspect_rules_py_known_paths"
 
-def main() -> None:
+
+def find_venv_pth() -> str:
+    """The venv's own `.pth`. `os.walk` does not follow the site-packages
+    symlinks out into runfiles, so this stays within the venv tree."""
+    for root, _dirs, files in os.walk(sys.prefix):
+        for name in sorted(files):
+            if not name.endswith(".pth"):
+                continue
+            path = os.path.join(root, name)
+            with open(path) as fh:
+                if STASH in fh.read():
+                    return path
+    raise SystemExit("no venv .pth referencing {} under {}".format(STASH, sys.prefix))
+
+
+def check_sys_path() -> None:
     site_packages = [p for p in sys.path if p.endswith("site-packages")]
 
     for name in WHEELS:
@@ -50,6 +71,71 @@ def main() -> None:
 
     if (apkg.VALUE, bpkg.VALUE) != ("apkg", "bpkg"):
         raise SystemExit("unknown-layout wheel packages did not import")
+
+
+def check_pth_shape(lines: list[str]) -> list[str]:
+    """One prologue for the whole file, ahead of every line that reads it."""
+    prologues = [i for i, ln in enumerate(lines) if ln.startswith("import site;")]
+    add_lines = [i for i, ln in enumerate(lines) if "site.addsitedir(" in ln]
+
+    if len(prologues) != 1:
+        raise SystemExit(
+            "expected exactly one known_paths prologue, got {}".format(len(prologues))
+        )
+    if len(add_lines) < 2:
+        raise SystemExit(
+            "expected at least two addsitedir lines, got {}".format(len(add_lines))
+        )
+    if prologues[0] > add_lines[0]:
+        raise SystemExit(
+            "prologue on line {} follows an addsitedir line on {}".format(
+                prologues[0] + 1, add_lines[0] + 1
+            )
+        )
+
+    # Losing the shared set costs only startup time, so nothing observable
+    # from sys.path catches it. Pin the reference instead.
+    unshared = [i + 1 for i in add_lines if STASH not in lines[i]]
+    if unshared:
+        raise SystemExit(
+            "addsitedir lines {} do not read {} — back to a per-line "
+            "_init_pathinfo()".format(unshared, STASH)
+        )
+    return [lines[i] for i in add_lines]
+
+
+def check_missing_stash_degrades(add_line: str) -> None:
+    """`addpackage` abandons the rest of the file on the first line that
+    raises, so an `addsitedir` line must be total with no stash present. It
+    falls back to rebuilding `known_paths`, which still finds the directory
+    already on sys.path and appends nothing."""
+    site = sys.modules["site"]
+    saved = site.__dict__.pop(STASH, None)
+    before = len(sys.path)
+    try:
+        exec(add_line, {})
+    except Exception as exc:
+        raise SystemExit(
+            "addsitedir line raised without the {} stash: {!r}".format(STASH, exc)
+        )
+    finally:
+        if saved is not None:
+            setattr(site, STASH, saved)
+
+    readded = [p for p in sys.path[before:] if p.endswith("site-packages")]
+    if readded:
+        raise SystemExit("addsitedir re-appended {} after losing the stash".format(readded))
+
+
+def main() -> None:
+    check_sys_path()
+
+    with open(find_venv_pth()) as fh:
+        lines = [ln for ln in fh.read().splitlines() if ln.strip()]
+
+    add_lines = check_pth_shape(lines)
+    # Last: re-running an addsitedir line re-fires that wheel's root `.pth`.
+    check_missing_stash_degrades(add_lines[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`site.addsitedir(dir)` called without `known_paths` builds that set from
scratch via `site._init_pathinfo()`, which stats every entry already on
`sys.path`. Emitting one such line per unknown-layout wheel therefore costs
O(N^2) stats and dominates interpreter startup once N reaches the hundreds:
at N=2000, 10.2s on 3.9 and 4.7s on 3.14, against 0.11s and 0.09s once the
set is reused. The line grows by 27 bytes to carry the argument.

The set to reuse is the one `site.addpackage` already holds -- threaded down
from `site.main()` and updated in place as it appends this file's own plain
path entries. `exec(line)` hands each `.pth` import line that frame's locals
as its own, so `vars().get("known_paths")` reaches it directly.

Reusing that set rather than one of our own is what makes it correct, not
just fast. A set built once by the file itself would not see the plain path
entries interleaved between these lines, so a wheel-root `.pth` naming one of
those directories would append it a second time. Threading `addpackage`'s set
also closes the reverse hole, which predates this change: `addsitedir` with no
`known_paths` built a throwaway set, so the enclosing `addpackage` never
learned about the wheel dir and a later plain line for it duplicated.

`.get` keeps every line total -- run anywhere but under `addpackage` it
yields `None` and `addsitedir` rebuilds the set itself: slower, never wrong.
Totality is load-bearing, because `addpackage` abandons the remainder of the
file on the first line that raises rather than skipping it.

Kept per-line rather than collapsed into one loop so the addsitedir entries
stay interleaved with the plain path entries in imports_depset order and
sys.path precedence is unchanged.

Fix #1376.

Test plan:
- New `shared_known_paths_test` builds a venv with two unknown-layout wheels
  and asserts each reaches sys.path exactly once, with both wheel-root .pth
  shims still firing symmetrically. It also pins the emitted expression --
  losing the reuse costs only startup time and is invisible from sys.path --
  reproduces the stale-set case directly (plain path line, then an addsitedir
  for a wheel whose root .pth names that same directory), and checks the line
  is total with no `known_paths` in scope.
- New `multi_addsitedir` e2e case and snapshot: four unknown-layout wheels, so
  the shape is pinned at N>1 and a plain `_main` entry lands between two of
  the addsitedir lines. `wheel_root_pth.venv.pth` re-pinned.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
