### PR TITLE
chore: bump benchmark base version

### DIFF
--- a/benchmark/analysis/compare.py
+++ b/benchmark/analysis/compare.py
@@ -149,7 +149,7 @@ def main() -> None:
         return line
 
     table += row(
-        "BCR 2.0.0-alpha.4 (baseline)", bcr, "—", "—", bcr_aux
+        "BCR 2.0.0-alpha.5 (baseline)", bcr, "—", "—", bcr_aux
     )
     table += row(
         "HEAD main",
@@ -191,7 +191,7 @@ def main() -> None:
                 return f"| {label} | — | — |\n"
             return f"| {label} | {aux.get('packages', '—')} | {aux.get('targets', '—')} |\n"
 
-        table += aux_row("BCR 2.0.0-alpha.4 (baseline)", bcr_aux)
+        table += aux_row("BCR 2.0.0-alpha.5 (baseline)", bcr_aux)
         table += aux_row("HEAD main", main_aux)
         table += aux_row("This PR", pr_aux)
 

--- a/benchmark/analysis/generate_module.py
+++ b/benchmark/analysis/generate_module.py
@@ -32,8 +32,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--version",
-        default="2.0.0-alpha.4",
-        help="BCR version to pin when mode=bcr (default: 2.0.0-alpha.4)",
+        default="2.0.0-alpha.5",
+        help="BCR version to pin when mode=bcr (default: 2.0.0-alpha.5)",
     )
     parser.add_argument(
         "--path",


### PR DESCRIPTION
bump benchmark base version to v2 alpha 5

---

### Changes are visible to end-users: no


