### PR TITLE
fix: set tempdir vars to a shorter symlink to TEST_TMPDIR to prevent long path issues

### DIFF
--- a/py/private/launcher_env/aspect_rules_py_launcher_env.py
+++ b/py/private/launcher_env/aspect_rules_py_launcher_env.py
@@ -5,7 +5,10 @@ Both pytest_main.py and unittest_main.py import this before anything else
 resolves the environment they set up, so the two drivers cannot drift apart.
 """
 
+import atexit
+import hashlib
 import os
+import stat
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
@@ -15,6 +18,70 @@ if TYPE_CHECKING:
 # coveragepy resolves manifest entries through symlinks; Bazel wants the
 # original spelling back in the LCOV (coveragepy#963).
 _absfile_mapping: Dict[str, str] = {}
+
+
+def _alias_dir() -> Optional[str]:
+    """A short directory to hold temp dir aliases, or None if this host won't
+    give us one only we can write to.
+
+    Traversable by others (0711) so a test that drops privileges can still
+    reach its own TMPDIR; planting an alias needs write, which they lack.
+    """
+    path = "/tmp/rpy-%d" % os.getuid()
+    try:
+        os.mkdir(path, 0o711)
+        return path
+    except FileExistsError:
+        pass
+    except OSError:
+        return None
+    # Only reuse an existing entry nobody else can write to; otherwise the
+    # aliases inside it are attacker-controlled.
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return None
+    if not stat.S_ISDIR(st.st_mode) or st.st_uid != os.getuid():
+        return None
+    return path if not stat.S_IMODE(st.st_mode) & 0o022 else None
+
+
+def _unlink_alias(path: str, owner_pid: int) -> None:
+    # A fork inherits atexit callbacks, so a child exiting normally would take
+    # away the TMPDIR its parent is still using.
+    if os.getpid() != owner_pid:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _short_tmpdir(real: str) -> str:
+    """A short alias for `real`, or `real` itself if none can be made."""
+    if os.name != "posix":
+        return real
+    directory = _alias_dir()
+    if directory is None:
+        return real
+    # Named for the target, not the invocation: a run killed before its exit
+    # hook leaves one entry, which its next run reuses instead of adding another.
+    # fsencode, not encode: a path holding non-UTF-8 bytes reaches us as
+    # surrogate escapes, which UTF-8 refuses to encode.
+    link = os.path.join(directory, hashlib.sha256(os.fsencode(real)).hexdigest()[:16])
+    try:
+        os.symlink(real, link)
+    except FileExistsError:
+        # Left by another run of this target; reuse without taking ownership.
+        # A still-live creator exiting first takes the alias with it.
+        try:
+            return link if os.readlink(link) == real else real
+        except OSError:
+            return real
+    except OSError:
+        return real
+    atexit.register(_unlink_alias, link, os.getpid())
+    return link
 
 
 def set_test_tmpdir() -> None:
@@ -29,11 +96,19 @@ def set_test_tmpdir() -> None:
     `noexec` — a test that writes an executable helper into pytest's `tmp_path`
     and runs it gets EACCES. TMP/TEMP are set too so `tempfile` resolves
     consistently on Windows.
+
+    TEST_TMPDIR is itself too deep to hold an AF_UNIX socket, whose address is
+    capped at 104 bytes of sun_path (issues/1387) — `multiprocessing`'s spawn
+    Manager binds one and dies with "AF_UNIX path too long". bind() measures the
+    string it is handed, not the resolved path, so TMPDIR gets a short symlink
+    and the files still land in TEST_TMPDIR.
     """
     if "TEST_TMPDIR" not in os.environ:
         return
+
+    tmpdir = _short_tmpdir(os.path.abspath(os.environ["TEST_TMPDIR"]))
     for var in ("TMPDIR", "TMP", "TEMP"):
-        os.environ[var] = os.environ["TEST_TMPDIR"]
+        os.environ[var] = tmpdir
 
 
 def shard_info() -> Optional[Tuple[int, int]]:

--- a/py/tests/tmpdir-af-unix/BUILD.bazel
+++ b/py/tests/tmpdir-af-unix/BUILD.bazel
@@ -1,0 +1,32 @@
+load("//py:defs.bzl", "py_library", "py_pytest_test", "py_test", "py_unittest_test")
+
+package(default_testonly = True)
+
+py_library(
+    name = "af_unix_probe",
+    srcs = ["af_unix_probe.py"],
+    imports = ["."],
+    deps = ["//py/private/launcher_env"],
+)
+
+py_pytest_test(
+    name = "pytest_af_unix_test",
+    srcs = ["pytest_af_unix_test.py"],
+    deps = [
+        ":af_unix_probe",
+        "@pypi//pytest",
+    ],
+)
+
+py_unittest_test(
+    name = "unittest_af_unix_test",
+    srcs = ["unittest_af_unix_test.py"],
+    deps = [":af_unix_probe"],
+)
+
+py_test(
+    name = "raw_af_unix_test",
+    srcs = ["raw_af_unix_test.py"],
+    main = "raw_af_unix_test.py",
+    deps = [":af_unix_probe"],
+)

--- a/py/tests/tmpdir-af-unix/af_unix_probe.py
+++ b/py/tests/tmpdir-af-unix/af_unix_probe.py
@@ -1,0 +1,184 @@
+"""Shared assertions for https://github.com/aspect-build/rules_py/issues/1387.
+
+The generated pytest/unittest launchers point TMPDIR at TEST_TMPDIR, a deeply
+nested path under the bazel output base. An AF_UNIX socket created there
+overflows sun_path (108 bytes on Linux, 104 on macOS), so
+`multiprocessing.get_context("spawn").Manager()` -- which binds one via
+`connection.arbitrary_address()` -- dies with "OSError: AF_UNIX path too long".
+"""
+
+import atexit
+import hashlib
+import multiprocessing
+import os
+import socket
+import stat
+import tempfile
+
+import aspect_rules_py_launcher_env as launcher_env
+
+# multiprocessing.connection.arbitrary_address() builds
+# <tmp>/pymp-XXXXXXXX/listener-XXXXXXXX
+SOCKET_OVERHEAD = len("/pymp-abcd1234/listener-abcd1234")
+
+# The smaller of the two sun_path limits, so the assertion means the same thing
+# on every platform.
+SUN_PATH_MAX = 104
+
+# Mirrors the launcher's own guard: it only shortens TMPDIR on POSIX, so the
+# sun_path budget and the alias scheme are only asserted there.
+IS_UNIX = os.name == "posix"
+NOT_UNIX_REASON = "no AF_UNIX"
+
+
+def check_tmpdir_leaves_room_for_a_socket() -> None:
+    tmp = tempfile.gettempdir()
+    assert len(tmp) + SOCKET_OVERHEAD < SUN_PATH_MAX, f"temp dir too deep for AF_UNIX: {tmp}"
+
+
+def check_tmpdir_alias_is_stable() -> None:
+    """The alias is named for TEST_TMPDIR, not for the invocation, so a test
+    killed by a timeout or a signal -- which runs no exit hook -- leaves at most
+    the single entry its next run reuses.
+    """
+    real = os.path.abspath(os.environ["TEST_TMPDIR"])
+    digest = hashlib.sha256(os.fsencode(real)).hexdigest()[:16]
+    assert tempfile.gettempdir() == "/tmp/rpy-%d/%s" % (os.getuid(), digest)
+
+
+def check_alias_handles_non_utf8_path() -> None:
+    """A POSIX path may hold any non-NUL bytes, which arrive as surrogate
+    escapes; naming the alias with `str.encode()` would raise UnicodeEncodeError
+    before the launcher could run a single test.
+    """
+    real = os.path.join(os.environ["TEST_TMPDIR"], os.fsdecode(b"\xff-1387"))
+    alias = launcher_env._short_tmpdir(real)
+    assert alias != real, "non-UTF-8 path fell back to the long path"
+    assert os.readlink(alias) == real
+
+
+def check_alias_survives_forked_child_exit() -> None:
+    """A fork inherits the creator's atexit callbacks, so a child exiting
+    normally would unlink the alias its parent still has in TMPDIR.
+
+    The child runs its inherited callbacks explicitly and then `os._exit`s:
+    that is what interpreter shutdown would do, without unwinding SystemExit
+    back through the test framework.
+    """
+    real = os.path.join(os.environ["TEST_TMPDIR"], "fork-1387")
+    os.makedirs(real, exist_ok=True)
+    alias = launcher_env._short_tmpdir(real)
+    assert alias != real, "no alias to test"
+
+    pid = os.fork()
+    if pid == 0:
+        try:
+            atexit._run_exitfuncs()
+        finally:
+            os._exit(0)
+    _, status = os.waitpid(pid, 0)
+
+    assert status == 0, status
+    assert os.readlink(alias) == real, "child removed its parent's alias"
+
+
+def check_alias_dir_rejects_writable_modes() -> None:
+    """The directory is the trust boundary: anyone who can write to it can swap
+    the aliases inside, so a group/other-writable one is refused. A 0700 dir
+    from an earlier version stays usable."""
+    alias_dir = os.path.dirname(tempfile.gettempdir())
+    mode = stat.S_IMODE(os.lstat(alias_dir).st_mode)
+    try:
+        for writable in (0o777, 0o733, 0o722):
+            os.chmod(alias_dir, writable)
+            assert launcher_env._alias_dir() is None, oct(writable)
+        os.chmod(alias_dir, 0o700)
+        assert launcher_env._alias_dir() == alias_dir, "0700 must stay usable"
+    finally:
+        os.chmod(alias_dir, mode)
+
+
+def check_alias_dir_traversable_after_dropping_privileges() -> None:
+    """A test that drops privileges must still reach its own TMPDIR: reading
+    the alias needs only search permission on the directory."""
+    if os.getuid() != 0:
+        return  # Not root, so there is nothing to drop.
+    import pwd
+
+    nobody = pwd.getpwnam("nobody")
+    alias = tempfile.gettempdir()
+
+    pid = os.fork()
+    if pid == 0:
+        code = 0
+        try:
+            os.setgid(nobody.pw_gid)
+            os.setuid(nobody.pw_uid)
+            os.readlink(alias)
+        except OSError:
+            code = 1
+        os._exit(code)
+    _, status = os.waitpid(pid, 0)
+    assert status == 0, "dropped-privilege child could not reach TMPDIR"
+
+
+def check_alias_is_removed_on_exit() -> None:
+    """A normally exiting process takes its own alias with it."""
+    real = os.path.join(os.environ["TEST_TMPDIR"], "exit-1387")
+    os.makedirs(real, exist_ok=True)
+
+    pid = os.fork()
+    if pid == 0:
+        code = 0 if launcher_env._short_tmpdir(real) != real else 1
+        try:
+            atexit._run_exitfuncs()
+        finally:
+            os._exit(code)
+    _, status = os.waitpid(pid, 0)
+    assert status == 0, status
+
+    digest = hashlib.sha256(os.fsencode(real)).hexdigest()[:16]
+    alias = os.path.join(os.path.dirname(tempfile.gettempdir()), digest)
+    assert not os.path.lexists(alias), alias
+
+
+def check_reused_alias_survives_reuser_exit() -> None:
+    """A second process that finds the alias already there reuses it without
+    taking ownership, so its exit leaves the creator's alias alone."""
+    real = os.path.join(os.environ["TEST_TMPDIR"], "reuse-1387")
+    os.makedirs(real, exist_ok=True)
+    alias = launcher_env._short_tmpdir(real)
+    assert launcher_env._short_tmpdir(real) == alias
+
+    pid = os.fork()
+    if pid == 0:
+        # A launcher starting in this process reuses the existing alias; its
+        # normal exit must not remove it.
+        code = 0 if launcher_env._short_tmpdir(real) == alias else 1
+        try:
+            atexit._run_exitfuncs()
+        finally:
+            os._exit(code)
+    _, status = os.waitpid(pid, 0)
+
+    assert status == 0, status
+    assert os.readlink(alias) == real, "reuser removed the creator's alias"
+
+
+def check_tmpdir_resolves_into_test_tmpdir() -> None:
+    """The short path is an alias, not an escape: files still land in TEST_TMPDIR."""
+    real = os.path.realpath(tempfile.gettempdir())
+    assert real == os.path.realpath(os.environ["TEST_TMPDIR"]), real
+
+
+def check_bind_unix_socket_under_tmpdir() -> None:
+    addr = os.path.join(tempfile.mkdtemp(prefix="pymp-"), "listener-abcd1234")
+    with socket.socket(socket.AF_UNIX) as sock:
+        sock.bind(addr)
+
+
+def check_spawn_sync_manager() -> None:
+    with multiprocessing.get_context("spawn").Manager() as mgr:
+        d = mgr.dict()
+        d["k"] = "v"
+        assert d["k"] == "v"

--- a/py/tests/tmpdir-af-unix/pytest_af_unix_test.py
+++ b/py/tests/tmpdir-af-unix/pytest_af_unix_test.py
@@ -1,0 +1,81 @@
+"""Issue 1387 under the py_pytest_test launcher (pytest_main.py)."""
+
+import os
+from pathlib import Path
+
+import af_unix_probe
+import pytest
+
+unix_only = pytest.mark.skipif(
+    not af_unix_probe.IS_UNIX, reason=af_unix_probe.NOT_UNIX_REASON
+)
+
+
+@unix_only
+def test_tmpdir_leaves_room_for_a_socket() -> None:
+    af_unix_probe.check_tmpdir_leaves_room_for_a_socket()
+
+
+@unix_only
+def test_tmpdir_alias_is_stable() -> None:
+    af_unix_probe.check_tmpdir_alias_is_stable()
+
+
+@unix_only
+def test_alias_handles_non_utf8_path() -> None:
+    af_unix_probe.check_alias_handles_non_utf8_path()
+
+
+@unix_only
+def test_alias_survives_forked_child_exit() -> None:
+    af_unix_probe.check_alias_survives_forked_child_exit()
+
+
+@unix_only
+def test_reused_alias_survives_reuser_exit() -> None:
+    af_unix_probe.check_reused_alias_survives_reuser_exit()
+
+
+@unix_only
+def test_alias_is_removed_on_exit() -> None:
+    af_unix_probe.check_alias_is_removed_on_exit()
+
+
+@unix_only
+def test_alias_dir_rejects_writable_modes() -> None:
+    af_unix_probe.check_alias_dir_rejects_writable_modes()
+
+
+@unix_only
+def test_alias_dir_traversable_after_dropping_privileges() -> None:
+    af_unix_probe.check_alias_dir_traversable_after_dropping_privileges()
+
+
+def test_tmpdir_resolves_into_test_tmpdir() -> None:
+    af_unix_probe.check_tmpdir_resolves_into_test_tmpdir()
+
+
+@unix_only
+def test_bind_unix_socket_under_tmpdir() -> None:
+    af_unix_probe.check_bind_unix_socket_under_tmpdir()
+
+
+@unix_only
+def test_spawn_sync_manager() -> None:
+    af_unix_probe.check_spawn_sync_manager()
+
+
+def test_tmp_path_bypasses_the_short_tmpdir(tmp_path: Path) -> None:
+    """Known limitation: the short TMPDIR does not reach pytest's own fixtures.
+
+    `_pytest/tmpdir.py` resolves the temp root unconditionally
+    (`Path(from_env or tempfile.gettempdir()).resolve()`), and does the same to
+    an explicit `--basetemp`, so `tmp_path` lands on the long TEST_TMPDIR path.
+    A socket bound directly under `tmp_path` can therefore still overflow
+    sun_path -- unchanged from before the issues/1387 fix, which only covers
+    consumers that read TMPDIR without resolving it (`tempfile`,
+    `multiprocessing`). Asserted by shape, not by length, so it holds on any
+    output base; it turns red if pytest ever stops resolving.
+    """
+    assert not str(tmp_path).startswith(os.environ["TMPDIR"])
+    assert str(tmp_path).startswith(os.path.realpath(os.environ["TEST_TMPDIR"]))

--- a/py/tests/tmpdir-af-unix/raw_af_unix_test.py
+++ b/py/tests/tmpdir-af-unix/raw_af_unix_test.py
@@ -1,0 +1,14 @@
+"""Issue 1387 under a plain py_test with its own main.
+
+No generated launcher runs here, so TMPDIR keeps its system value and the
+socket path stays short. This target guards that: it fails if the TMPDIR
+override ever reaches the native launcher.
+"""
+
+import af_unix_probe
+
+if __name__ == "__main__":
+    if af_unix_probe.IS_UNIX:
+        af_unix_probe.check_tmpdir_leaves_room_for_a_socket()
+        af_unix_probe.check_bind_unix_socket_under_tmpdir()
+        af_unix_probe.check_spawn_sync_manager()

--- a/py/tests/tmpdir-af-unix/unittest_af_unix_test.py
+++ b/py/tests/tmpdir-af-unix/unittest_af_unix_test.py
@@ -1,0 +1,52 @@
+"""Issue 1387 under the py_unittest_test launcher (unittest_main.py)."""
+
+import unittest
+
+import af_unix_probe
+
+unix_only = unittest.skipIf(not af_unix_probe.IS_UNIX, af_unix_probe.NOT_UNIX_REASON)
+
+
+class AfUnixTmpdirTest(unittest.TestCase):
+    @unix_only
+    def test_tmpdir_leaves_room_for_a_socket(self) -> None:
+        af_unix_probe.check_tmpdir_leaves_room_for_a_socket()
+
+    @unix_only
+    def test_tmpdir_alias_is_stable(self) -> None:
+        af_unix_probe.check_tmpdir_alias_is_stable()
+
+    @unix_only
+    def test_alias_handles_non_utf8_path(self) -> None:
+        af_unix_probe.check_alias_handles_non_utf8_path()
+
+    @unix_only
+    def test_alias_survives_forked_child_exit(self) -> None:
+        af_unix_probe.check_alias_survives_forked_child_exit()
+
+    @unix_only
+    def test_reused_alias_survives_reuser_exit(self) -> None:
+        af_unix_probe.check_reused_alias_survives_reuser_exit()
+
+    @unix_only
+    def test_alias_is_removed_on_exit(self) -> None:
+        af_unix_probe.check_alias_is_removed_on_exit()
+
+    @unix_only
+    def test_alias_dir_rejects_writable_modes(self) -> None:
+        af_unix_probe.check_alias_dir_rejects_writable_modes()
+
+    @unix_only
+    def test_alias_dir_traversable_after_dropping_privileges(self) -> None:
+        af_unix_probe.check_alias_dir_traversable_after_dropping_privileges()
+
+    def test_tmpdir_resolves_into_test_tmpdir(self) -> None:
+        af_unix_probe.check_tmpdir_resolves_into_test_tmpdir()
+
+    @unix_only
+    def test_bind_unix_socket_under_tmpdir(self) -> None:
+        af_unix_probe.check_bind_unix_socket_under_tmpdir()
+
+    @unix_only
+    def test_spawn_sync_manager(self) -> None:
+        af_unix_probe.check_spawn_sync_manager()


### PR DESCRIPTION
Fix #1387 

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
