### PR TITLE
refactor: extract shared test launcher env setup

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -45,6 +45,7 @@ jobs:
             - name: Typecheck maintained Python
               run: |
                 runtime39=(
+                  py/private/launcher_env/aspect_rules_py_launcher_env.py
                   py/private/py_image_layer_validator.py
                   py/private/py_venv/templates/_virtualenv.py
                   py/private/py_venv/templates/link.py

--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -22,7 +22,10 @@ py_library(
     srcs = ["pytest_main.py"],
     imports = ["."],
     visibility = ["//visibility:public"],
-    deps = ["//py/private/pytest_shard"],
+    deps = [
+        "//py/private/launcher_env",
+        "//py/private/pytest_shard",
+    ],
 )
 
 _py_binary_rule(

--- a/py/private/launcher_env/BUILD.bazel
+++ b/py/private/launcher_env/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+
+py_library(
+    name = "launcher_env",
+    # Prefixed module name: `imports` puts this on sys.path as a top-level
+    # module, where a plain name could be shadowed by a user dep.
+    srcs = ["aspect_rules_py_launcher_env.py"],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/py/private/launcher_env/aspect_rules_py_launcher_env.py
+++ b/py/private/launcher_env/aspect_rules_py_launcher_env.py
@@ -1,0 +1,112 @@
+# -*- mode: python -*-
+"""Bazel test-environment setup shared by the generated test launchers.
+
+Both pytest_main.py and unittest_main.py import this before anything else
+resolves the environment they set up, so the two drivers cannot drift apart.
+"""
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
+
+if TYPE_CHECKING:
+    from coverage import Coverage
+
+# coveragepy resolves manifest entries through symlinks; Bazel wants the
+# original spelling back in the LCOV (coveragepy#963).
+_absfile_mapping: Dict[str, str] = {}
+
+
+def set_test_tmpdir() -> None:
+    """Point the temp dir env vars at Bazel's per-test TEST_TMPDIR.
+
+    Call before anything resolves a temp dir: `tempfile.gettempdir()` caches
+    process-wide.
+
+    Temp files then land in the test's private, writable temp directory instead
+    of the system one, which is non-hermetic (leaks across parallel tests and
+    runs) and unwritable-for-exec on remote-execution workers that mount /tmp
+    `noexec` — a test that writes an executable helper into pytest's `tmp_path`
+    and runs it gets EACCES. TMP/TEMP are set too so `tempfile` resolves
+    consistently on Windows.
+    """
+    if "TEST_TMPDIR" not in os.environ:
+        return
+    for var in ("TMPDIR", "TMP", "TEMP"):
+        os.environ[var] = os.environ["TEST_TMPDIR"]
+
+
+def shard_info() -> Optional[Tuple[int, int]]:
+    """https://bazel.build/reference/test-encyclopedia#initial-conditions"""
+    index = os.environ.get("TEST_SHARD_INDEX")
+    total = os.environ.get("TEST_TOTAL_SHARDS")
+    if not (index and total and int(total) > 1):
+        return None
+    return int(index), int(total)
+
+
+def advertise_sharding() -> None:
+    """Call before any early return, else Bazel masks the real error with 'the
+    test runner did not advertise support for test sharding'."""
+    status = os.environ.get("TEST_SHARD_STATUS_FILE")
+    if status and shard_info():
+        Path(status).touch()
+
+
+def start_coverage() -> Optional["Coverage"]:
+    """Start a coverage session over the files Bazel asked to instrument.
+
+    Bazel sets COVERAGE_MANIFEST for a target carrying InstrumentedFilesInfo
+    (https://bazel.build/rules/lib/providers/InstrumentedFilesInfo); its lines
+    are the files that matched --instrumentation_filter. Returns None when
+    coverage is not enabled or the `coverage` package is not a dependency.
+    """
+    global _absfile_mapping
+
+    if "COVERAGE_MANIFEST" not in os.environ:
+        return None
+    try:
+        import coverage
+        import coverage.files
+    except ModuleNotFoundError as e:
+        print("WARNING: python coverage setup failed. Do you need to include the 'coverage' package as a dependency of the test target?", e)
+        return None
+
+    with open(os.environ["COVERAGE_MANIFEST"], "r") as mf:
+        manifest_entries = mf.read().splitlines()
+    cov = coverage.Coverage(include=manifest_entries)
+    _absfile_mapping = {coverage.files.abs_file(mfe): mfe for mfe in manifest_entries}
+    cov.start()
+    return cov
+
+
+def write_lcov(cov: "Coverage") -> None:
+    """Stop `cov` and write Bazel's LCOV output file.
+
+    https://bazel.build/configure/coverage
+    """
+    cov.stop()
+    output_file = os.getenv("COVERAGE_OUTPUT_FILE")
+    assert output_file is not None
+
+    unfixed = output_file + ".tmp"
+    cov.lcov_report(outfile=unfixed)
+    cov.save()
+
+    with open(unfixed, "r") as src, open(output_file, "w") as dst:
+        for line in src:
+            # Undo coveragepy's symlink-following of source paths
+            # (coveragepy#963).
+            if line.startswith("SF:"):
+                sourcefile = line[3:].rstrip()
+                if sourcefile in _absfile_mapping:
+                    dst.write("SF:%s\n" % _absfile_mapping[sourcefile])
+                    continue
+            # Drop the 'end line number' field Bazel rejects (bazel#25118).
+            if line.startswith("FN:"):
+                parts = line[3:].split(",")
+                if len(parts) == 3:
+                    dst.write("FN:%s,%s" % (parts[0], parts[2]))
+                    continue
+            dst.write(line)
+    os.unlink(unfixed)

--- a/py/private/py_pytest_main.bzl
+++ b/py/private/py_pytest_main.bzl
@@ -137,6 +137,9 @@ def py_pytest_main(name, py_library = default_py_library, deps = [], data = [], 
         srcs = [test_main],
         tags = tags,
         visibility = visibility,
-        deps = deps + [Label("//py/private/pytest_shard")],
+        deps = deps + [
+            Label("//py/private/launcher_env"),
+            Label("//py/private/pytest_shard"),
+        ],
         data = data,
     )

--- a/py/private/py_unittest_test.bzl
+++ b/py/private/py_unittest_test.bzl
@@ -93,6 +93,7 @@ def py_unittest_test(
         imports = ["."],
         testonly = True,
         tags = tags,
+        deps = [Label("//py/private/launcher_env")],
     )
 
     py_binary_with_venv(

--- a/py/private/pytest_main.py
+++ b/py/private/pytest_main.py
@@ -15,25 +15,11 @@
 
 import sys
 import os
-from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import List
 
-if TYPE_CHECKING:
-    from coverage import Coverage
+import aspect_rules_py_launcher_env as launcher_env
 
-# Point the temp dir at Bazel's per-test TEST_TMPDIR before pytest or the stdlib
-# `tempfile` module resolve it. Bazel's default test setup exports
-# TMPDIR=$TEST_TMPDIR so a test's temp files land in its private, writable temp
-# directory; rules_py's launcher didn't, so pytest's `tmp_path`/`tmpdir` fixtures
-# and `tempfile` fell back to the system temp dir (usually /tmp). That is
-# non-hermetic (temp files leak across parallel tests / runs) and outright breaks
-# on remote-execution workers that mount /tmp `noexec` — e.g. a test that writes an
-# executable helper into `tmp_path` and runs it gets EACCES. TMP/TEMP are set too so
-# `tempfile` resolves consistently on Windows. Must run before the first
-# `tempfile.gettempdir()` call, which caches the result process-wide.
-if "TEST_TMPDIR" in os.environ:
-    for _tmp_env in ("TMPDIR", "TMP", "TEMP"):
-        os.environ[_tmp_env] = os.environ["TEST_TMPDIR"]
+launcher_env.set_test_tmpdir()
 
 try:
     import pytest
@@ -41,30 +27,7 @@ except ModuleNotFoundError as e:
     print("ERROR: pytest must be included in the deps of the py_pytest_main or py_test target")
     raise e
 
-# None means coverage wasn't enabled
-cov: Optional["Coverage"] = None
-# For workaround of https://github.com/nedbat/coveragepy/issues/963
-coveragepy_absfile_mapping: Dict[str, str] = {}
-
-# Since our py_test had InstrumentedFilesInfo, we know Bazel will hand us this environment variable.
-# https://bazel.build/rules/lib/providers/InstrumentedFilesInfo
-if "COVERAGE_MANIFEST" in os.environ:
-    try:
-        import coverage
-        import coverage.files
-        # The lines are files that matched the --instrumentation_filter flag
-        coverage_manifest = os.getenv("COVERAGE_MANIFEST")
-        assert coverage_manifest is not None
-        with open(coverage_manifest, "r") as mf:
-            manifest_entries = mf.read().splitlines()
-            cov = coverage.Coverage(include = manifest_entries)
-            # coveragepy incorrectly converts our entries by following symlinks
-            # record a mapping of their conversion so we can undo it later in reporting the coverage
-            coveragepy_absfile_mapping = {coverage.files.abs_file(mfe): mfe for mfe in manifest_entries}
-        cov.start()
-    except ModuleNotFoundError as e:
-        print("WARNING: python coverage setup failed. Do you need to include the 'coverage' package as a dependency of py_pytest_main?", e)
-        pass
+cov = launcher_env.start_coverage()
 
 from pytest_shard import ShardPlugin
 
@@ -114,20 +77,14 @@ def main() -> int:
         if suite_name:
             args.extend(["-o", f"junit_suite_name={suite_name}"])
 
-    test_shard_index = os.environ.get("TEST_SHARD_INDEX")
-    test_total_shards = os.environ.get("TEST_TOTAL_SHARDS")
-    test_shard_status_file = os.environ.get("TEST_SHARD_STATUS_FILE")
-    if (
-        test_shard_index
-        and test_total_shards
-        and test_shard_status_file
-        and int(test_total_shards) > 1
-    ):
+    shard = launcher_env.shard_info()
+    if shard is not None:
+        shard_index, total_shards = shard
         args.extend([
-            f"--shard-id={test_shard_index}",
-            f"--num-shards={test_total_shards}",
+            f"--shard-id={shard_index}",
+            f"--num-shards={total_shards}",
         ])
-        Path(test_shard_status_file).touch()
+        launcher_env.advertise_sharding()
         plugins.append(ShardPlugin())
 
     test_filter = os.environ.get("TESTBRIDGE_TEST_ONLY")
@@ -154,34 +111,7 @@ def main() -> int:
         print("Pytest exit code: " + str(exit_code), file=sys.stderr)
         print("Ran pytest.main with " + str(args), file=sys.stderr)
     elif cov:
-        cov.stop()
-        # https://bazel.build/configure/coverage
-        coverage_output_file = os.getenv("COVERAGE_OUTPUT_FILE")
-        assert coverage_output_file is not None
-
-        unfixed_dat = coverage_output_file + ".tmp"
-        cov.lcov_report(outfile = unfixed_dat)
-        cov.save()
-        
-        with open(unfixed_dat, "r") as unfixed:
-          with open(coverage_output_file, "w") as output_file:
-            for line in unfixed:
-              # Workaround https://github.com/nedbat/coveragepy/issues/963
-              # by mapping SF: records to un-do the symlink-following
-              if line.startswith('SF:'):
-                sourcefile = line[3:].rstrip()
-                if sourcefile in coveragepy_absfile_mapping:
-                    output_file.write(f"SF:{coveragepy_absfile_mapping[sourcefile]}\n")
-                    continue
-              # Workaround https://github.com/bazelbuild/bazel/issues/25118
-              # by removing 'end line number' from FN: records
-              if line.startswith('FN:'):
-                parts = line[3:].split(",")  # Remove 'FN:' and split by commas
-                if len(parts) == 3:
-                  output_file.write(f"FN:{parts[0]},{parts[2]}")
-                  continue
-              output_file.write(line)
-        os.unlink(unfixed_dat)
+        launcher_env.write_lcov(cov)
 
     return exit_code
 

--- a/py/private/unittest_main.py
+++ b/py/private/unittest_main.py
@@ -13,10 +13,11 @@ import time
 import traceback
 import unittest
 from dataclasses import dataclass
-from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional
+from typing import Any, Dict, Iterator, List, Literal, Optional
 from xml.sax.saxutils import escape, quoteattr
+
+import aspect_rules_py_launcher_env as launcher_env
 
 # The closed set of JUnit outcomes the writer understands.
 _Status = Literal["passed", "failure", "error", "skipped"]
@@ -31,34 +32,8 @@ class _Record:
     message: str
     detail: str
 
-if TYPE_CHECKING:
-    from coverage import Coverage
-
-# Point temp dirs at Bazel's per-test TEST_TMPDIR before anything resolves it
-# (see the long rationale in pytest_main.py). Must run before the first
-# tempfile.gettempdir(), which caches process-wide.
-if "TEST_TMPDIR" in os.environ:
-    for _tmp_env in ("TMPDIR", "TMP", "TEMP"):
-        os.environ[_tmp_env] = os.environ["TEST_TMPDIR"]
-
-# Coverage: Bazel hands us COVERAGE_MANIFEST when the target has
-# InstrumentedFilesInfo. Same coveragepy symlink workaround as pytest_main.py.
-cov: Optional["Coverage"] = None
-coveragepy_absfile_mapping: Dict[str, str] = {}
-if "COVERAGE_MANIFEST" in os.environ:
-    try:
-        import coverage
-        import coverage.files
-
-        with open(os.environ["COVERAGE_MANIFEST"]) as mf:
-            manifest_entries = mf.read().splitlines()
-            cov = coverage.Coverage(include=manifest_entries)
-            coveragepy_absfile_mapping = {
-                coverage.files.abs_file(mfe): mfe for mfe in manifest_entries
-            }
-        cov.start()
-    except ModuleNotFoundError as e:
-        print("WARNING: coverage requested but the 'coverage' package is not a dep", e)
+launcher_env.set_test_tmpdir()
+cov = launcher_env.start_coverage()
 
 
 def _import_test_modules(test_files: List[str]) -> List[ModuleType]:
@@ -118,24 +93,12 @@ def _filter_by_substring(suite: unittest.TestSuite, needle: str) -> unittest.Tes
     return matched
 
 
-def _advertise_sharding() -> None:
-    """Touch TEST_SHARD_STATUS_FILE up front so Bazel sees sharding support
-    even if the run later exits early (empty discovery / no filter match).
-    Otherwise Bazel masks the real error with 'the test runner did not
-    advertise support for test sharding'."""
-    status = os.environ.get("TEST_SHARD_STATUS_FILE")
-    total = os.environ.get("TEST_TOTAL_SHARDS")
-    if status and total and int(total) > 1:
-        Path(status).touch()
-
-
 def _shard(suite: unittest.TestSuite) -> unittest.TestSuite:
     """Keep every Nth test by stable-sorted id for Bazel sharding."""
-    idx = os.environ.get("TEST_SHARD_INDEX")
-    total = os.environ.get("TEST_TOTAL_SHARDS")
-    if not (idx and total and int(total) > 1):
+    shard = launcher_env.shard_info()
+    if shard is None:
         return suite
-    i, n = int(idx), int(total)
+    i, n = shard
     sharded = unittest.TestSuite()
     for pos, test in enumerate(sorted(_iter_tests(suite), key=lambda t: t.id())):
         if pos % n == i:
@@ -274,37 +237,6 @@ def _write_junit_xml(path: str, records: List[_Record], suite_name: str) -> None
         f.write("\n".join(lines) + "\n")
 
 
-def _finalize_coverage() -> None:
-    """Write Bazel's lcov output, applying the same SF:/FN: fixups as
-    pytest_main.py (coveragepy #963, bazel #25118)."""
-    assert cov is not None
-    cov.stop()
-    cov.save()
-
-    out = os.environ.get("COVERAGE_OUTPUT_FILE")
-    if not out:
-        return
-
-    unfixed = out + ".tmp"
-    cov.lcov_report(outfile=unfixed)
-    with open(unfixed) as src, open(out, "w") as dst:
-        for line in src:
-            # Undo coveragepy's symlink-following of source paths.
-            if line.startswith("SF:"):
-                sourcefile = line[3:].rstrip()
-                if sourcefile in coveragepy_absfile_mapping:
-                    dst.write("SF:%s\n" % coveragepy_absfile_mapping[sourcefile])
-                    continue
-            # Drop the 'end line number' from FN: records that Bazel rejects.
-            if line.startswith("FN:"):
-                parts = line[3:].split(",")
-                if len(parts) == 3:
-                    dst.write("FN:%s,%s" % (parts[0], parts[2]))
-                    continue
-            dst.write(line)
-    os.unlink(unfixed)
-
-
 def _parse_args(argv: List[str]) -> argparse.Namespace:
     """Parse the runtime args forwarded from the `args` attribute / command
     line. Errors (exit 2) on anything unrecognized rather than dropping it, so
@@ -334,8 +266,7 @@ def main() -> int:
 
     opts = _parse_args(sys.argv[1:])
 
-    # Advertise sharding before any early return (see _advertise_sharding).
-    _advertise_sharding()
+    launcher_env.advertise_sharding()
 
     # The next assignment is rewritten at analysis time by py_unittest_test with
     # the target's own-repo source files. Keep it on its own line exactly as
@@ -406,7 +337,7 @@ def main() -> int:
         _write_junit_xml(xml_out, result.records, os.environ.get("BAZEL_TARGET", "unittest"))
 
     if cov is not None and exit_code == 0:
-        _finalize_coverage()
+        launcher_env.write_lcov(cov)
 
     return exit_code
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ select = [
 
 [tool.pyright]
 typeCheckingMode = "standard"
-extraPaths = ["py/private/pytest_shard"]
+extraPaths = ["py/private/launcher_env", "py/private/pytest_shard"]
 
 [tool.ty.environment]
-extra-paths = ["py/private/pytest_shard"]
+extra-paths = ["py/private/launcher_env", "py/private/pytest_shard"]
 
 [tool.ty.rules]
 missing-type-argument = "error"


### PR DESCRIPTION
pytest_main.py and unittest_main.py each carried their own copy of the bazel setup for tempdir, coverage etc, so a change to one silently diverged from the other. Move it to `//py/private/launcher_env`, imported by both.

No functional change.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
