### PR TITLE
fix(oci): make py_image_layer gzip output deterministic

### DIFF
--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -824,7 +824,15 @@ def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, 
     tar_args = ctx.actions.args()
     tar_args.add("--create")
     tar_args.add("--" + compress)
-    tar_args.add("--options", "{}:compression-level={}".format(compress, level))
+    options = "{}:compression-level={}".format(compress, level)
+    if compress == "gzip":
+        # libarchive's gzip filter stores the current wall-clock time in the gzip
+        # header's MTIME field, so two executions of this action over byte-identical
+        # inputs emit different bytes — and therefore a different layer digest, which
+        # propagates into the oci_image manifest. `!timestamp` zeroes that field.
+        # zstd has no equivalent field, so this is gzip-only.
+        options += ",gzip:!timestamp"
+    tar_args.add("--options", options)
     tar_args.add("--file", tar_out)
 
     # `@<file>` tells bsdtar to read the named file as an mtree archive


### PR DESCRIPTION
## Problem

libarchive's gzip filter stores the current wall-clock time in the gzip header's MTIME field. `_run_tar_action` passes only `gzip:compression-level=N`, so every execution of a `PyImageLayer` action writes a different MTIME and emits different bytes for byte-identical inputs.

The layer content is unaffected — the digest isn't, and that digest is what `oci_image` records in the image manifest. Anything downstream that treats an image manifest as a content identity therefore sees a "new" image after every cache miss.

That's how we found it. A CI job skips republishing an image when its `cquery --output=files` outputs hash the same as the previous delivery; for an `oci_image` those files are `image_config.json` and `image_manifest.json`. Four of our images republished on essentially every build of an otherwise unchanged tree, each one also triggering a downstream deployment commit.

## Diagnosis

Two builds in separate output bases with `--noremote_accept_cached`, same machine, same commit. All seven layer `.tar.gz` outputs of one `py_image_layer` differed — including layers built purely from third-party wheels and the interpreter layer, whose contents cannot have changed. Every uncompressed tar was byte-identical, and the gzip headers differed only in MTIME:

```
A: 1f8b0800 90d26c6a 0003   MTIME=1785516688  (16:51:28)
B: 1f8b0800 d5d26c6a 0003   MTIME=1785516757  (16:52:37)
gunzip A == gunzip B        (identical sha256)
```

## Fix

`gzip:!timestamp` tells libarchive to leave the field zero. Confirmed against the same bsdtar the toolchain ships (3.8.1 / libarchive 3.8.1):

```
--options gzip:compression-level=6                  ->  1f8b0800 b1d76c6a
--options gzip:compression-level=6,gzip:!timestamp  ->  1f8b0800 00000000
```

Applied to gzip only — zstd has no equivalent header field, and passing the option to its filter is an error.

## Notes

- No behavior change beyond the header field; compression level is untouched.
- The `@@`/canonical-repository buildifier warnings in this file are pre-existing on `main` (lines 63/83/157) and unrelated to this change, so I left them alone rather than widen the diff.