### PR TITLE
fix: test coverage when chdir is specified

### DIFF
--- a/e2e/cases/coverage-drivers/BUILD.bazel
+++ b/e2e/cases/coverage-drivers/BUILD.bazel
@@ -34,6 +34,24 @@ py_unittest_test(
     ],
 )
 
+# Regression: a baked chdir must not empty the coverage data. COVERAGE_MANIFEST
+# holds execroot-relative paths and coveragepy matches relative include patterns
+# against the CWD, so the pre-chdir `cov.start()` alone isn't enough — the
+# patterns have to be absolute.
+py_pytest_test(
+    name = "coverage_pytest_chdir_test",
+    srcs = ["cov_add_test.py"],
+    chdir = "coverage-drivers/chdir_data",
+    data = ["chdir_data/keep.txt"],
+    dep_group = "coverage-drivers",
+    imports = ["."],
+    deps = [
+        ":lib",
+        "@pypi_coverage_drivers//coverage",
+        "@pypi_coverage_drivers//pytest",
+    ],
+)
+
 # Baked pytest_args route py_pytest_test through its codegen branch, which
 # renders a per-test copy of pytest_main.py (via py_pytest_main) instead of the
 # shared main. Confirms the coverage teardown survives that template rendering.

--- a/e2e/cases/coverage-drivers/chdir_data/keep.txt
+++ b/e2e/cases/coverage-drivers/chdir_data/keep.txt
@@ -1,0 +1,1 @@
+Empty dir for the chdir coverage target to change into.

--- a/e2e/cases/coverage-drivers/test.sh
+++ b/e2e/cases/coverage-drivers/test.sh
@@ -59,6 +59,7 @@ check_coverage() {
 
 check_coverage //coverage-drivers:coverage_pytest_test bazel-testlogs/coverage-drivers/coverage_pytest_test/coverage.dat
 check_coverage //coverage-drivers:coverage_pytest_codegen_test bazel-testlogs/coverage-drivers/coverage_pytest_codegen_test/coverage.dat
+check_coverage //coverage-drivers:coverage_pytest_chdir_test bazel-testlogs/coverage-drivers/coverage_pytest_chdir_test/coverage.dat
 check_coverage //coverage-drivers:coverage_unittest_test bazel-testlogs/coverage-drivers/coverage_unittest_test/coverage.dat
 
 echo "All coverage driver checks passed."

--- a/py/private/launcher_env/aspect_rules_py_launcher_env.py
+++ b/py/private/launcher_env/aspect_rules_py_launcher_env.py
@@ -9,6 +9,7 @@ import atexit
 import hashlib
 import os
 import stat
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
@@ -149,8 +150,11 @@ def start_coverage() -> Optional["Coverage"]:
 
     with open(os.environ["COVERAGE_MANIFEST"], "r") as mf:
         manifest_entries = mf.read().splitlines()
-    cov = coverage.Coverage(include=manifest_entries)
     _absfile_mapping = {coverage.files.abs_file(mfe): mfe for mfe in manifest_entries}
+
+    # Include patterns must be absolute: coveragepy matches relative patterns
+    # against the CWD, so a test with `chdir` set would match nothing.
+    cov = coverage.Coverage(include=list(_absfile_mapping.keys()))
     cov.start()
     return cov
 
@@ -160,12 +164,20 @@ def write_lcov(cov: "Coverage") -> None:
 
     https://bazel.build/configure/coverage
     """
+    import coverage.exceptions
+
     cov.stop()
     output_file = os.getenv("COVERAGE_OUTPUT_FILE")
     assert output_file is not None
 
     unfixed = output_file + ".tmp"
-    cov.lcov_report(outfile=unfixed)
+    try:
+        cov.lcov_report(outfile=unfixed)
+    except coverage.exceptions.NoDataError as e:
+        # An empty report must not fail an otherwise passing test.
+        print("WARNING: no python coverage data collected:", e, file=sys.stderr)
+        open(output_file, "w").close()
+        return
     cov.save()
 
     with open(unfixed, "r") as src, open(output_file, "w") as dst:

--- a/py/private/py_pytest_main.bzl
+++ b/py/private/py_pytest_main.bzl
@@ -86,7 +86,7 @@ _py_pytest_main = rule(
             doc = "Additional arguments to pass to pytest.",
         ),
         "chdir": attr.string(
-            doc = "A path to a directory to chdir when the test starts.",
+            doc = "A path to a directory to chdir when the test starts, relative to the runfiles root.",
             mandatory = False,
         ),
         "out": attr.output(

--- a/py/private/py_pytest_test.bzl
+++ b/py/private/py_pytest_test.bzl
@@ -103,8 +103,8 @@ def py_pytest_test(
         pytest_args: Extra arguments baked into the pytest invocation. Setting
             this renders a private per-test entrypoint instead of reusing the
             shared main.
-        chdir: Optional directory to change into before pytest runs. Also
-            forces a private per-test entrypoint.
+        chdir: Optional directory to change into before pytest runs, relative
+            to the runfiles root. Also forces a private per-test entrypoint.
         resolutions: virtual-dep resolutions, `"string" -> label` (reversed to
             the rule's label-keyed-dict form here).
         **kwargs: forwarded to the underlying test rule and sibling py_venv.


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
