### PR TITLE
feat: add oci layer owner/group api

### DIFF
--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -3,7 +3,7 @@ load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
-load("//tools:asserts.bzl", "assert_tar_listing")
+load("//tools:asserts.bzl", "assert_tar_listing", "assert_tar_ownership")
 load(":image_layer_analysis_tests.bzl", "image_layer_analysis_test_suite")
 
 platform(
@@ -96,6 +96,72 @@ py_image_layer(
     name = "my_app_layers_fp",
     binary = ":my_app_bin",
     layer_tier = ":my_app_tier",
+)
+
+# Ownership coverage. Every layer kind has its own mtree emitter, so the binary
+# and tier below are shaped to produce one of each: pip whole-group (colorama
+# rest), pip subpath split (colorama_code), first-party group (branding),
+# interpreter, squashed ungrouped pip (pyproject_hooks), rule-level group
+# (assets), and the default source layer.
+py_binary(
+    name = "my_app_owner_bin",
+    srcs = ["__main__.py"],
+    dep_group = "images",
+    deps = [
+        "//oci/py_image_layer/branding",
+        "//tools/verify_venv",
+        "@aspect_rules_py//py/tests/internal-deps/adder",
+        "@pypi_oci_py_image_layer//colorama",
+        "@pypi_oci_py_image_layer//pyproject_hooks",
+    ],
+)
+
+filegroup(
+    name = "my_app_owner_assets",
+    srcs = ["my_app_peer_bin/config.json"],
+)
+
+py_layer_tier(
+    name = "my_app_owner_tier",
+    group = "2000",
+    groups = {
+        "//oci/py_image_layer/branding": "branding",
+        "@pip//colorama": "colorama",
+        "@pip//colorama:**/*.py": "colorama_code",
+    },
+    interpreter_group = "interpreter",
+    owner = "1000",
+)
+
+py_image_layer(
+    name = "my_app_owner_layers",
+    binary = ":my_app_owner_bin",
+    groups = {":my_app_owner_assets": "assets"},
+    layer_tier = ":my_app_owner_tier",
+)
+
+platform_transition_filegroup(
+    name = "platform_owner_layers",
+    srcs = [":my_app_owner_layers"],
+    target_platform = ":x86_64_linux",
+)
+
+# The interpreter tree is 2317 of the 2361 rows and shows nothing the other
+# layers don't, so it is excluded to keep the snapshot reviewable.
+assert_tar_listing(
+    name = "my_app_owner_layers_snapshot",
+    actual = [":platform_owner_layers"],
+    exclude = ["python_interpreters"],
+    expected = "my_app_owner_listing.yaml",
+)
+
+# Invariant guard over the same layers: the snapshot only holds if regenerated
+# correctly, this holds regardless.
+assert_tar_ownership(
+    name = "my_app_owner_layers_test",
+    actual = [":platform_owner_layers"],
+    group = "2000",
+    owner = "1000",
 )
 
 # Multi-member group coverage: two pip packages mapped to the same group name
@@ -192,6 +258,15 @@ py_image_layer(
         ":my_app_worker_alias",
     ],
     layer_tier = ":my_app_launchers_tier",
+)
+
+# Multi-binary images run the launcher-ownership loop, whose locals must not
+# collide with the tier's uid/gid. Default tier, so every row stays 0:0.
+assert_tar_ownership(
+    name = "my_app_launchers_layers_ownership_test",
+    actual = [":my_app_launchers_layers"],
+    group = "0",
+    owner = "0",
 )
 
 genrule(

--- a/e2e/cases/oci/py_image_layer/image_layer_analysis_tests.bzl
+++ b/e2e/cases/oci/py_image_layer/image_layer_analysis_tests.bzl
@@ -518,6 +518,17 @@ printf '%s\\n' "$$scalar" > "$@"
             toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
         )
 
+    py_layer_tier(
+        name = "_named_owner_tier",
+        owner = "nobody",
+        tags = ["manual"],
+    )
+    _expected_failure_test(
+        name = "named_owner_test",
+        expected_error = "py_layer_tier.owner must be a numeric id, got \"nobody\"",
+        target_under_test = ":_named_owner_tier",
+    )
+
     _image_layer_failure(
         name = "interpreter_group_collision",
         expected_error = "Group \"interpreter\" is declared in both py_image_layer.groups and the active py_layer_tier",

--- a/e2e/cases/oci/py_image_layer/snapshots/my_app_owner_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/my_app_owner_listing.yaml
@@ -1,0 +1,63 @@
+---
+layer: 0
+files:
+  - -rw-r--r--  0 1000   2000       28 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/my_app_peer_bin/config.json
+---
+layer: 1
+files:
+  - -rwxr-xr-x  0 1000   2000       42 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/branding/__init__.py
+  - -rwxr-xr-x  0 1000   2000       31 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/branding/palette.txt
+---
+layer: 2
+files:
+---
+layer: 3
+files:
+  - -rwxr-xr-x  0 1000   2000      266 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/__init__.py
+  - -rwxr-xr-x  0 1000   2000     2522 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansi.py
+  - -rwxr-xr-x  0 1000   2000    11128 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/ansitowin32.py
+  - -rwxr-xr-x  0 1000   2000     3325 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/initialise.py
+  - -rwxr-xr-x  0 1000   2000       75 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/__init__.py
+  - -rwxr-xr-x  0 1000   2000     2839 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansi_test.py
+  - -rwxr-xr-x  0 1000   2000    10678 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/ansitowin32_test.py
+  - -rwxr-xr-x  0 1000   2000     6741 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/initialise_test.py
+  - -rwxr-xr-x  0 1000   2000     1866 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/isatty_test.py
+  - -rwxr-xr-x  0 1000   2000     1079 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/utils.py
+  - -rwxr-xr-x  0 1000   2000     3709 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/tests/winterm_test.py
+  - -rwxr-xr-x  0 1000   2000     6181 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/win32.py
+  - -rwxr-xr-x  0 1000   2000     7134 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama/winterm.py
+---
+layer: 4
+files:
+  - -rwxr-xr-x  0 1000   2000    17158 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/METADATA
+  - -rwxr-xr-x  0 1000   2000     1491 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info/licenses/LICENSE.txt
+---
+layer: 5
+files:
+  - -rwxr-xr-x  0 1000   2000     1081 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/LICENSE
+  - -rwxr-xr-x  0 1000   2000     1288 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info/METADATA
+  - -rwxr-xr-x  0 1000   2000      691 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/__init__.py
+  - -rwxr-xr-x  0 1000   2000    14936 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/_impl.py
+  - -rwxr-xr-x  0 1000   2000      557 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/_in_process/__init__.py
+  - -rwxr-xr-x  0 1000   2000    12216 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py
+  - -rwxr-xr-x  0 1000   2000        0 Jan  1  2023 ./app.runfiles/aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks/py.typed
+---
+layer: 6
+files:
+  - -rwxr-xr-x  0 1000   2000    18856 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 1000   2000     2114 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/bin/activate
+  - lrwxr-xr-x  0 1000   2000        0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/bin/python3 -> python
+  - lrwxr-xr-x  0 1000   2000        0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/bin/python3.11 -> python
+  - -rwxr-xr-x  0 1000   2000      295 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/lib/python3.11/site-packages/_my_app_owner_bin.venv.pth
+  - -rwxr-xr-x  0 1000   2000       19 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/lib/python3.11/site-packages/_virtualenv.pth
+  - -rwxr-xr-x  0 1000   2000     4932 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/lib/python3.11/site-packages/_virtualenv.py
+  - lrwxr-xr-x  0 1000   2000        0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/lib/python3.11/site-packages/colorama -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama
+  - lrwxr-xr-x  0 1000   2000        0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/lib/python3.11/site-packages/colorama-0.4.6.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__images__colorama__0_4_6/actual_install.install/lib/python3.11/site-packages/colorama-0.4.6.dist-info
+  - lrwxr-xr-x  0 1000   2000        0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/lib/python3.11/site-packages/pyproject_hooks -> ../../../../../../../aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks
+  - lrwxr-xr-x  0 1000   2000        0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info -> ../../../../../../../aspect_rules_py++uv+whl_install__images__pyproject_hooks__1_2_0/actual_install.install/lib/python3.11/site-packages/pyproject_hooks-1.2.0.dist-info
+  - -rwxr-xr-x  0 1000   2000      111 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/._my_app_owner_bin.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 1000   2000      276 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/__main__.py
+  - -rwxr-xr-x  0 1000   2000     6713 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
+  - -rwxr-xr-x  0 1000   2000 * Jan  1  2023 ./app.runfiles/_repo_mapping
+  - -rwxr-xr-x  0 1000   2000        0 Jan  1  2023 ./app.runfiles/aspect_rules_py+/py/tests/internal-deps/adder/__init__.py
+  - -rwxr-xr-x  0 1000   2000       32 Jan  1  2023 ./app.runfiles/aspect_rules_py+/py/tests/internal-deps/adder/add.py

--- a/e2e/cases/tools/BUILD.bazel
+++ b/e2e/cases/tools/BUILD.bazel
@@ -2,4 +2,7 @@
 
 # Consumed cross-package by the `assert_tar_listing` macro (//tools:asserts.bzl),
 # which declares a py_test with this script as `main` in the caller's package.
-exports_files(["assert_absent.py"])
+exports_files([
+    "assert_absent.py",
+    "assert_ownership.py",
+])

--- a/e2e/cases/tools/assert_ownership.py
+++ b/e2e/cases/tools/assert_ownership.py
@@ -1,0 +1,53 @@
+"""Fail if any row in a tar listing has an unexpected numeric uid/gid.
+
+Docker-free guard for `py_layer_tier(owner = ..., group = ...)`: every layer
+kind (pip whole-package, pip subpath split, first-party group, interpreter,
+squashed ungrouped pip, rule-level group, default source) routes through its
+own mtree emitter, so a missed emitter shows up here as rows still owned by
+0/0.
+
+`bsdtar -tv` columns are: mode, nlink, uid, gid, size, month, day, year, path.
+
+Usage (from the macro): assert_ownership.py <listing-file> <uid> <gid>
+"""
+
+import sys
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) != 4:
+        sys.exit("usage: assert_ownership.py <listing-file> <uid> <gid>")
+    listing_path, want_uid, want_gid = argv[1:]
+
+    with open(listing_path, encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    failures = []
+    rows = 0
+    for line in lines:
+        if not line.startswith("  - "):
+            continue
+        fields = line[4:].split()
+        if len(fields) < 9:
+            sys.exit("unparseable listing row: {}".format(line))
+        rows += 1
+        if fields[2] != want_uid or fields[3] != want_gid:
+            failures.append(line.strip())
+
+    if not rows:
+        sys.exit("no listing rows found in {}".format(listing_path))
+
+    if failures:
+        msg = [
+            "{} of {} rows in {} are not owned by {}:{}:".format(
+                len(failures), rows, listing_path, want_uid, want_gid
+            )
+        ]
+        msg.extend("  " + line for line in failures[:20])
+        sys.exit("\n".join(msg))
+
+    print("ok: {} rows owned by {}:{}".format(rows, want_uid, want_gid))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/e2e/cases/tools/asserts.bzl
+++ b/e2e/cases/tools/asserts.bzl
@@ -27,12 +27,15 @@ _VOLATILE_SIZE_PATHS = [
 # @bazel_tools, Bazel 9 routes it through @rules_shell at a different
 # runfiles path — neither this rule nor the user-facing image cares which,
 # so filter the row out so one snapshot works on both.
+#
+# Callers pass `exclude` to drop more, for snapshots that only need to
+# demonstrate one property of the rows they keep.
 _FILTERED_PATHS = [
     "/bazel_tools/tools/bash/runfiles/runfiles.bash",
 ]
 
 # buildifier: disable=function-docstring
-def assert_tar_listing(name, actual, expected, **kwargs):
+def assert_tar_listing(name, actual, expected, exclude = [], **kwargs):
     actual_listing = "{}_listing".format(name)
     native.genrule(
         name = actual_listing,
@@ -80,7 +83,7 @@ for f in $(SRCS); do
 done > $@
 """.format(
             volatile = "|".join(_VOLATILE_SIZE_PATHS),
-            filtered = "|".join(_FILTERED_PATHS),
+            filtered = "|".join(_FILTERED_PATHS + exclude),
         ),
         toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
     )
@@ -104,4 +107,34 @@ done > $@
         args = ["$(rootpath :{})".format(actual_listing)] + _FORBIDDEN_LAYER_PATHS,
         data = [":{}".format(actual_listing)],
         testonly = True,
+    )
+
+# buildifier: disable=function-docstring
+def assert_tar_ownership(name, actual, owner, group, **kwargs):
+    actual_listing = "{}_listing".format(name)
+    native.genrule(
+        name = actual_listing,
+        srcs = actual,
+        testonly = True,
+        outs = ["_{}.listing".format(name)],
+        cmd = """\
+for f in $(SRCS); do
+  TZ="UTC" LC_ALL="en_US.UTF-8" $(BSDTAR_BIN) -tvf $$f | sed "s/^/  - /g"
+done > $@
+""",
+        toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
+    )
+
+    py_test(
+        name = name,
+        srcs = ["//tools:assert_ownership.py"],
+        main = "//tools:assert_ownership.py",
+        args = [
+            "$(rootpath :{})".format(actual_listing),
+            owner,
+            group,
+        ],
+        data = [":{}".format(actual_listing)],
+        testonly = True,
+        **kwargs
     )

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -98,6 +98,8 @@ PyLayerTierInfo = provider(
         "interpreter_group": "str — group name for the Python interpreter layer; '' disables.",
         "root": "str — root path in the image (e.g. '/app').",
         "strip_prefix": "str — prefix stripped from source file paths; empty means use binary short_path.",
+        "owner": "str — numeric uid owning files in the layer.",
+        "group": "str — numeric gid owning files in the layer.",
     },
 )
 
@@ -107,6 +109,12 @@ def _split_glob_key(key):
     if colon_idx > 0 and ("*" in key[colon_idx:] or "?" in key[colon_idx:]):
         return key[:colon_idx], key[colon_idx + 1:]
     return None, None
+
+def _validate_numeric_id(value, attr_name):
+    # mtree's uid=/gid= fields only accept numbers; a name would produce an
+    # unparseable archive at tar time rather than an analysis error.
+    if not value.isdigit():
+        fail("py_layer_tier.%s must be a numeric id, got %r" % (attr_name, value))
 
 def _py_layer_tier_impl(ctx):
     if ctx.attr.testonly:
@@ -129,6 +137,9 @@ def _py_layer_tier_impl(ctx):
         group_counts[group_name] = group_counts.get(group_name, 0) + 1
     multi_member_groups = {name: True for name, count in group_counts.items() if count >= 2}
 
+    _validate_numeric_id(ctx.attr.owner, "owner")
+    _validate_numeric_id(ctx.attr.group, "group")
+
     return [PyLayerTierInfo(
         whole_groups = whole_groups,
         subpath_groups = subpath_groups,
@@ -137,6 +148,8 @@ def _py_layer_tier_impl(ctx):
         interpreter_group = ctx.attr.interpreter_group,
         root = ctx.attr.root,
         strip_prefix = ctx.attr.strip_prefix,
+        owner = ctx.attr.owner,
+        group = ctx.attr.group,
     )]
 
 py_layer_tier = rule(
@@ -177,6 +190,14 @@ py_layer_tier = rule(
         "strip_prefix": attr.string(
             default = "",
             doc = "Prefix stripped from source file paths. Empty means use the binary's short_path.",
+        ),
+        "owner": attr.string(
+            default = "0",
+            doc = "Numeric uid owning every file in every layer this tier produces. Default: '0' (root).",
+        ),
+        "group": attr.string(
+            default = "0",
+            doc = "Numeric gid owning every file in every layer this tier produces. Default: '0' (root).",
         ),
     },
     provides = [PyLayerTierInfo],
@@ -251,6 +272,7 @@ def _build_pip_layers(ctx, plan, label, install_dir):
 
     bsdtar, bsdtar_files = _tar_toolchain(ctx)
     layers = []
+    pkg_map = lambda f, d: _pkg_file_to_mtree(f, d, plan.owner, plan.group)
 
     if subpath_for_this:
         all_patterns = [p for pats in subpath_for_this.values() for p in pats]
@@ -263,7 +285,7 @@ def _build_pip_layers(ctx, plan, label, install_dir):
                 bsdtar_files,
                 tar_out,
                 install_dir,
-                _make_glob_map_each(patterns),
+                _make_glob_map_each(patterns, plan.owner, plan.group),
                 algorithm,
                 level,
                 {},
@@ -280,7 +302,7 @@ def _build_pip_layers(ctx, plan, label, install_dir):
             bsdtar_files,
             rest_tar,
             install_dir,
-            _make_glob_map_each(all_patterns, invert = True),
+            _make_glob_map_each(all_patterns, plan.owner, plan.group, invert = True),
             algorithm,
             level,
             {},
@@ -297,7 +319,7 @@ def _build_pip_layers(ctx, plan, label, install_dir):
             bsdtar_files,
             tar_out,
             install_dir,
-            _pkg_file_to_mtree,
+            pkg_map,
             algorithm,
             level,
             {},
@@ -331,7 +353,7 @@ def _layer_aspect_impl(target, ctx):
                 bsdtar_files,
                 interp_tar,
                 interp_depset,
-                _interpreter_file_to_mtree,
+                lambda f, d: _interpreter_file_to_mtree(f, d, plan.owner, plan.group),
                 algorithm,
                 level,
                 {},
@@ -529,7 +551,7 @@ def _merge_aspect_impl(target, ctx):
             bsdtar_files,
             tar_out,
             depset(transitive = install_dirs),
-            _pkg_file_to_mtree,
+            lambda f, d: _pkg_file_to_mtree(f, d, plan.owner, plan.group),
             algorithm,
             level,
             {},
@@ -609,22 +631,34 @@ def _source_destination(sp, strip_prefix, root, executable_dsts):
         return _apply_strip_prefix(sp, sp, root)
     return "./app.runfiles/_main/" + sp
 
-def _file_to_mtree_entry(f, mode = "0644", strip_prefix = "", root = "/", maybe_symlink = False, executable_dsts = {}):
+def _file_to_mtree_entry(
+        f,
+        mode = "0644",
+        strip_prefix = "",
+        root = "/",
+        maybe_symlink = False,
+        executable_dsts = {},
+        owner = "0",
+        group = "0"):
     dst = _source_destination(f.short_path, strip_prefix, root, executable_dsts)
 
     # `f.is_symlink` emits `type=link` (awk readlinks once); `maybe_symlink=True`
     # emits `type=file content=` (awk readlinks to detect repo-rule-staged
     # symlinks); default emits `type=file contents=` which skips awk entirely.
     if f.is_symlink:
-        return "{} type=link mode={} uid=0 gid=0 time=1672560000 link={}".format(
+        return "{} type=link mode={} uid={} gid={} time=1672560000 link={}".format(
             dst.replace(" ", "\\040"),
             mode,
+            owner,
+            group,
             f.path.replace(" ", "\\040"),
         )
     marker = "content" if maybe_symlink else "contents"
-    return "{} type=file mode={} uid=0 gid=0 time=1672560000 {}={}".format(
+    return "{} type=file mode={} uid={} gid={} time=1672560000 {}={}".format(
         dst.replace(" ", "\\040"),
         mode,
+        owner,
+        group,
         marker,
         f.path.replace(" ", "\\040"),
     )
@@ -637,23 +671,27 @@ def _source_file_to_mtree(
         maybe_symlink,
         executable_dsts,
         runfile_executable_paths,
-        repo_mapping_path):
+        repo_mapping_path,
+        owner = "0",
+        group = "0"):
     if f.path == repo_mapping_path:
         return _file_to_mtree_entry(
             f,
             "0755",
             f.short_path,
             "/app.runfiles/_repo_mapping",
+            owner = owner,
+            group = group,
         )
 
     # 0755 throughout: keeps launcher/interpreter/venv shims executable; Bazel
     # doesn't expose per-input source mode for us to propagate.
     if f.is_directory:
         return [
-            _file_to_mtree_entry(child, "0755", strip_prefix, root, maybe_symlink, executable_dsts)
+            _file_to_mtree_entry(child, "0755", strip_prefix, root, maybe_symlink, executable_dsts, owner, group)
             for child in dir_expander.expand(f)
         ]
-    entry = _file_to_mtree_entry(f, "0755", strip_prefix, root, maybe_symlink, executable_dsts)
+    entry = _file_to_mtree_entry(f, "0755", strip_prefix, root, maybe_symlink, executable_dsts, owner, group)
     if f.path not in runfile_executable_paths:
         return entry
     return [
@@ -662,16 +700,21 @@ def _source_file_to_mtree(
             f,
             "0755",
             maybe_symlink = maybe_symlink,
+            owner = owner,
+            group = group,
         ),
     ]
 
-def _user_file_to_mtree(f, dir_expander, source_owned_paths):
+def _user_file_to_mtree(f, dir_expander, source_owned_paths, owner = "0", group = "0"):
     # Rule-level groups may contain declared symlinks that File.is_symlink
     # doesn't expose, so every grouped file needs the readlink fallback.
     if f.is_directory:
-        return [_file_to_mtree_entry(child, "0755", maybe_symlink = True) for child in dir_expander.expand(f)]
+        return [
+            _file_to_mtree_entry(child, "0755", maybe_symlink = True, owner = owner, group = group)
+            for child in dir_expander.expand(f)
+        ]
     mode = "0755" if f.path in source_owned_paths else "0644"
-    return _file_to_mtree_entry(f, mode, maybe_symlink = True)
+    return _file_to_mtree_entry(f, mode, maybe_symlink = True, owner = owner, group = group)
 
 def _should_skip_pkg_path(p):
     return (
@@ -680,18 +723,18 @@ def _should_skip_pkg_path(p):
         "/__pycache__/" in p or p.endswith(".whl")
     )
 
-def _pkg_file_to_mtree(f, dir_expander):
+def _pkg_file_to_mtree(f, dir_expander, owner = "0", group = "0"):
     if f.is_directory:
         lines = []
         for child in dir_expander.expand(f):
             p = child.path
             if _should_skip_pkg_path(p):
                 continue
-            lines.append(_file_to_mtree_entry(child, "0755"))
+            lines.append(_file_to_mtree_entry(child, "0755", owner = owner, group = group))
         return lines
-    return [_file_to_mtree_entry(f, "0755")]
+    return [_file_to_mtree_entry(f, "0755", owner = owner, group = group)]
 
-def _interpreter_file_to_mtree(f, dir_expander):
+def _interpreter_file_to_mtree(f, dir_expander, owner = "0", group = "0"):
     # Interpreter repo stages `bin/python -> python3.11` symlinks `f.is_symlink`
     # doesn't catch, so opt into awk's readlink scan.
     if f.is_directory:
@@ -700,9 +743,9 @@ def _interpreter_file_to_mtree(f, dir_expander):
             p = child.path
             if _should_skip_pkg_path(p):
                 continue
-            lines.append(_file_to_mtree_entry(child, "0755", maybe_symlink = True))
+            lines.append(_file_to_mtree_entry(child, "0755", maybe_symlink = True, owner = owner, group = group))
         return lines
-    return [_file_to_mtree_entry(f, "0755", maybe_symlink = True)]
+    return [_file_to_mtree_entry(f, "0755", maybe_symlink = True, owner = owner, group = group)]
 
 def _glob_match_chunk(name, chunk):
     if chunk == "*":
@@ -733,7 +776,7 @@ def _glob_match(path, pattern):
             return False
     return True
 
-def _make_glob_map_each(patterns, invert = False):
+def _make_glob_map_each(patterns, owner, group, invert = False):
     def _matches(p):
         hit = any([_glob_match(p, pat) for pat in patterns])
         return hit != invert
@@ -746,10 +789,10 @@ def _make_glob_map_each(patterns, invert = False):
                 if _should_skip_pkg_path(p):
                     continue
                 if _matches(p):
-                    lines.append(_file_to_mtree_entry(child, "0755"))
+                    lines.append(_file_to_mtree_entry(child, "0755", owner = owner, group = group))
             return lines
         if _matches(f.path):
-            return [_file_to_mtree_entry(f, "0755")]
+            return [_file_to_mtree_entry(f, "0755", owner = owner, group = group)]
         return []
 
     return _fn
@@ -894,6 +937,8 @@ def _py_image_layer_impl(ctx):
     plan = ctx.attr._layer_tier[PyLayerTierInfo]
     root = plan.root
     strip_prefix = plan.strip_prefix
+    owner = plan.owner
+    group = plan.group
     launcher_dir = ctx.attr.launcher_dir
     if len(binaries) > 1 and not launcher_dir:
         launcher_dir = "/app/bin"
@@ -926,12 +971,14 @@ def _py_image_layer_impl(ctx):
     if launcher_dir and len(binaries) > 1:
         for index, binary in enumerate(binaries):
             for f in binary[DefaultInfo].default_runfiles.files.to_list():
-                owner = executable_owner_by_path.get(f.path, None)
+                # Distinct from the tier's `owner` (the uid) — this is which
+                # binary declares `f` as its executable.
+                owning_binary = executable_owner_by_path.get(f.path, None)
 
                 # A launcher consumed through another binary's runfiles needs
                 # both its relocated entrypoint and the logical key resolved
                 # by that consumer.
-                if owner != None and owner != index:
+                if owning_binary != None and owning_binary != index:
                     runfile_executable_paths[f.path] = True
 
     # Each manifest describes one launcher's runfiles closure. The image shares
@@ -974,7 +1021,11 @@ def _py_image_layer_impl(ctx):
         executable_dsts,
         runfile_executable_paths,
         repo_mapping.path if repo_mapping != None else "",
+        owner,
+        group,
     )
+    pkg_map = lambda f, d: _pkg_file_to_mtree(f, d, owner, group)
+    interpreter_map = lambda f, d: _interpreter_file_to_mtree(f, d, owner, group)
 
     rule_group_names = {gname: True for gname in ctx.attr.groups.values()}
     rule_group_files = []
@@ -1006,7 +1057,7 @@ def _py_image_layer_impl(ctx):
         source_files = depset(direct = ungrouped_source_files)
 
     rule_group_map = lambda f, d: (
-        source_map(f, d) if f.short_path in executable_dsts else _user_file_to_mtree(f, d, source_owned_group_paths)
+        source_map(f, d) if f.short_path in executable_dsts else _user_file_to_mtree(f, d, source_owned_group_paths, owner, group)
     )
 
     first_party_reference_files = []
@@ -1041,7 +1092,7 @@ def _py_image_layer_impl(ctx):
                 if f.is_directory:
                     reference_tree_files[f.path] = f
         reference_map = lambda f, d: (
-            rule_group_map(f, d) if f.path in rule_group_paths else _interpreter_file_to_mtree(f, d) if f.path in interpreter_reference_paths else source_map(f, d)
+            rule_group_map(f, d) if f.path in rule_group_paths else interpreter_map(f, d) if f.path in interpreter_reference_paths else source_map(f, d)
         )
         symlink_mappings = struct(
             files = depset(transitive = reference_files),
@@ -1131,7 +1182,7 @@ def _py_image_layer_impl(ctx):
                 bsdtar_files,
                 tar_out,
                 depset(transitive = merged[group_name]),
-                _pkg_file_to_mtree,
+                pkg_map,
                 algorithm,
                 level,
                 {},
@@ -1149,7 +1200,7 @@ def _py_image_layer_impl(ctx):
             "{}_squashed.tar.gz".format(ctx.attr.name),
             "packages",
             depset(transitive = [p.files for p in ungrouped_pkgs]),
-            _pkg_file_to_mtree,
+            pkg_map,
             "Creating squashed pip layer (%d ungrouped packages) for %s" % (len(ungrouped_pkgs), ctx.label),
         )
         all_tars.append(squashed_tar)
@@ -1203,9 +1254,9 @@ def _py_image_layer_impl(ctx):
         for files in rule_group_files:
             mtree_args.add_all(files, map_each = rule_group_map, expand_directories = False, allow_closure = True)
         for files in wheel_files:
-            mtree_args.add_all(files, map_each = _pkg_file_to_mtree, expand_directories = False)
+            mtree_args.add_all(files, map_each = pkg_map, expand_directories = False, allow_closure = True)
         for files in interpreter_files:
-            mtree_args.add_all(files, map_each = _interpreter_file_to_mtree, expand_directories = False)
+            mtree_args.add_all(files, map_each = interpreter_map, expand_directories = False, allow_closure = True)
         validation_args.add("--mtree")
         validation_arguments.append(mtree_args)
         validation_inputs.extend([source_files] + rule_group_files + wheel_files + interpreter_files)


### PR DESCRIPTION
This has minor changes compared to the rules_js API such as owner/group being separate attributes instead of a single `":"`-separated attribute. The owner/group must be on the `py_layer_tier` and not the `py_image_layer` etc.

### Changes are visible to end-users: yes

 Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add `py_layer_tier(owner, group)` to assign uid, gid to files in image layers.

### Test plan

- Covered by existing test cases
- New test cases added
