### PR TITLE
perf: default whl pyc precompile check default to unchecked

### DIFF
--- a/e2e/cases/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
+++ b/e2e/cases/snapshots/abi3_compat.whl_install.cffi.BUILD.bazel
@@ -48,9 +48,9 @@ whl_install(
         "//conditions:default": False,
     }),
     pyc_invalidation_mode = select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     }),
     visibility = ["//visibility:private"],
 )

--- a/e2e/cases/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
+++ b/e2e/cases/snapshots/abi3_compat.whl_install.cryptography.BUILD.bazel
@@ -217,9 +217,9 @@ whl_install(
         "//conditions:default": False,
     }),
     pyc_invalidation_mode = select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     }),
     visibility = ["//visibility:private"],
 )

--- a/e2e/cases/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
+++ b/e2e/cases/snapshots/whl_install.azure_overlap.azure_core.BUILD.bazel
@@ -36,9 +36,9 @@ whl_install(
         "//conditions:default": False,
     }),
     pyc_invalidation_mode = select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     }),
     visibility = ["//visibility:private"],
 )

--- a/e2e/cases/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
+++ b/e2e/cases/snapshots/whl_install.azure_overlap.azure_core_tracing_opentelemetry.BUILD.bazel
@@ -36,9 +36,9 @@ whl_install(
         "//conditions:default": False,
     }),
     pyc_invalidation_mode = select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     }),
     visibility = ["//visibility:private"],
 )

--- a/e2e/cases/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
+++ b/e2e/cases/snapshots/whl_install.bare_linux_wheels.grpcio.BUILD.bazel
@@ -75,9 +75,9 @@ whl_install(
         "//conditions:default": False,
     }),
     pyc_invalidation_mode = select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     }),
     visibility = ["//visibility:private"],
 )

--- a/e2e/cases/snapshots/whl_install.exclusions.cowsay.BUILD.bazel
+++ b/e2e/cases/snapshots/whl_install.exclusions.cowsay.BUILD.bazel
@@ -37,9 +37,9 @@ whl_install(
         "//conditions:default": False,
     }),
     pyc_invalidation_mode = select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     }),
     patches = ["@@//uv-exclusions/patches:nested_test.patch"],
     patch_strip = 1,

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -470,7 +470,7 @@ def main() -> None:
                          "exactly (venv assembly projects that pre-patch set).")
     ap.add_argument("--exclude-glob", action="append", default=[])
     ap.add_argument("--compile-pyc", action="store_true")
-    ap.add_argument("--pyc-invalidation-mode", default="checked-hash",
+    ap.add_argument("--pyc-invalidation-mode", default="unchecked-hash",
                     choices=["checked-hash", "unchecked-hash", "timestamp"])
     ap.add_argument("--python", type=Path)
     args = ap.parse_args()

--- a/uv/private/pyc/BUILD.bazel
+++ b/uv/private/pyc/BUILD.bazel
@@ -12,18 +12,19 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-# Controls the PEP 552 invalidation mode for pre-compiled .pyc files.
+# Controls the PEP 552 invalidation mode for `whl_install`-compiled `.pyc`
+# files.
 #
 # Supported values:
-#   "checked-hash"   (default) — Python validates the .pyc hash against the
-#                     source at import time. Safe when sources may be modified
-#                     after compilation (e.g. the runfiles __init__.py shim).
-#   "unchecked-hash" — Python trusts the .pyc unconditionally. Faster imports
-#                     but stale .pyc files will silently shadow source changes.
+#   "unchecked-hash" (default) — Python trusts the .pyc unconditionally. Wheel
+#                     sources are immutable build outputs, so there is nothing
+#                     to re-validate; skips a source hash per import.
+#   "checked-hash"   — Python validates the .pyc hash against the source at
+#                     import time.
 #   "timestamp"      — Classic mtime-based invalidation.
 string_flag(
-    name = "invalidation_mode",
-    build_setting_default = "checked-hash",
+    name = "whl_install_pyc_invalidation_mode",
+    build_setting_default = "unchecked-hash",
     values = [
         "checked-hash",
         "unchecked-hash",
@@ -33,13 +34,13 @@ string_flag(
 )
 
 config_setting(
-    name = "is_unchecked_hash",
-    flag_values = {":invalidation_mode": "unchecked-hash"},
+    name = "is_whl_install_checked_hash",
+    flag_values = {":whl_install_pyc_invalidation_mode": "checked-hash"},
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "is_timestamp",
-    flag_values = {":invalidation_mode": "timestamp"},
+    name = "is_whl_install_timestamp",
+    flag_values = {":whl_install_pyc_invalidation_mode": "timestamp"},
     visibility = ["//visibility:public"],
 )

--- a/uv/private/uv_hub/snapshots/whl_install.attrs.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/whl_install.attrs.BUILD.bazel
@@ -36,9 +36,9 @@ whl_install(
         "//conditions:default": False,
     }),
     pyc_invalidation_mode = select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     }),
     visibility = ["//visibility:private"],
 )

--- a/uv/private/uv_hub/snapshots/whl_install.numpy.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/whl_install.numpy.BUILD.bazel
@@ -59,9 +59,9 @@ whl_install(
         "//conditions:default": False,
     }),
     pyc_invalidation_mode = select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     }),
     visibility = ["//visibility:private"],
 )

--- a/uv/private/whl_install/repository.bzl
+++ b/uv/private/whl_install/repository.bzl
@@ -282,10 +282,10 @@ filegroup(
         "//conditions:default": False,
     })"""
 
-    pyc_invalidation_mode_select = """select({
-        "@aspect_rules_py//uv/private/pyc:is_unchecked_hash": "unchecked-hash",
-        "@aspect_rules_py//uv/private/pyc:is_timestamp": "timestamp",
-        "//conditions:default": "checked-hash",
+    whl_install_pyc_invalidation_mode_select = """select({
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_checked_hash": "checked-hash",
+        "@aspect_rules_py//uv/private/pyc:is_whl_install_timestamp": "timestamp",
+        "//conditions:default": "unchecked-hash",
     })"""
 
     # The selected wheel is a `whl_dist` (or the source-built fallback) that
@@ -293,9 +293,9 @@ filegroup(
     install_attrs = """
     src = ":whl",
     compile_pyc = {compile_pyc},
-    pyc_invalidation_mode = {pyc_invalidation_mode},""".format(
+    pyc_invalidation_mode = {whl_install_pyc_invalidation_mode},""".format(
         compile_pyc = compile_pyc_select,
-        pyc_invalidation_mode = pyc_invalidation_mode_select,
+        whl_install_pyc_invalidation_mode = whl_install_pyc_invalidation_mode_select,
     )
 
     if post_install_patches:

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -394,9 +394,9 @@ lighter weight since the toolchain's files aren't inputs.
             doc = "Pre-compile .pyc bytecode after unpacking and patching.",
         ),
         "pyc_invalidation_mode": attr.string(
-            default = "checked-hash",
+            default = "unchecked-hash",
             values = ["checked-hash", "unchecked-hash", "timestamp"],
-            doc = "PEP 552 invalidation mode for pre-compiled .pyc files.",
+            doc = "PEP 552 invalidation mode for .pyc files compiled by whl_install.",
         ),
     },
     toolchains = [


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Default `pyc_invalidation_mode` changed to `unchecked-hash` for third-party wheels.

### Test plan

- Covered by existing test cases
