### PR TITLE
refactor: name the pyc cache-to-source mapping in both implementations

### DIFF
--- a/py/tools/unpack/exclude_glob_test_vectors.bzl
+++ b/py/tools/unpack/exclude_glob_test_vectors.bzl
@@ -28,3 +28,21 @@ RECORD_PATH_EXCLUDE_VECTORS = [
     ("ns/__pycache__/.cpython-311.pyc", "ns/*.py", False),
     ("pkg/__pycache__/..pyc", "pkg/..py", False),
 ]
+
+# Cache-to-source mapping shared by every implementation of cache_source_path.
+# A None source means nothing imports the cache, so it stands on its own.
+CACHE_SOURCE_VECTORS = [
+    ("ns/__pycache__/mod.cpython-311.pyc", "ns/mod.py"),
+    ("ns/__pycache__/mod.cpython-311.opt-1.pyc", "ns/mod.py"),
+    ("ns/__pycache__/mod.cpython-311.opt-é.pyc", "ns/mod.py"),
+    ("pkg/__pycache__/api.v1.cpython-311.pyc", "pkg/api.v1.py"),
+    ("pkg/__pycache__/api.v1.cpython-311.opt-2.pyc", "pkg/api.v1.py"),
+    ("ns/legacy.pyc", "ns/legacy.py"),
+    ("ns/.pyc", "ns/.py"),
+    ("ns/__pycache__/mod.cpython-311.opt-.pyc", None),
+    ("ns/__pycache__/mod..pyc", None),
+    ("ns/__pycache__/mod..opt-1.pyc", None),
+    ("ns/__pycache__/.cpython-311.pyc", None),
+    ("ns/__pycache__/..pyc", None),
+    ("ns/mod.py", None),
+]

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -116,29 +116,39 @@ def _import_roots(site_packages: Path) -> Set[str]:
     }
 
 
+def cache_source_path(path: Path) -> Optional[Path]:
+    """Return the source a `.pyc` is reached through, or None if unreachable.
+
+    Cache tags are stripped right to left, so a dotted source such as
+    `mod.v1.py` resolves from `mod.v1.cpython-311.pyc`. Keep in sync with
+    cache_source_path in uv/private/whl_install/metadata.bzl and the shared
+    test vectors.
+    """
+    if not path.name.endswith(".pyc"):
+        return None
+    if path.parent.name != "__pycache__":
+        return path.with_name(path.name[:-len(".pyc")] + ".py")
+    source, separator, tag = path.name[:-len(".pyc")].rpartition(".")
+    if tag.startswith("opt-"):
+        if not tag[len("opt-"):]:
+            return None
+        source, separator, tag = source.rpartition(".")
+    if not source or not separator or not tag:
+        return None
+    return path.parent.parent / (source + ".py")
+
+
 def _path_excluded(
     path: Path, patterns: Sequence[Tuple[str, ...]], is_file: bool
 ) -> bool:
     from exclude_glob import excluded
 
-    # Keep cache-to-source matching in sync with record_path_excluded in
-    # uv/private/whl_install/repository.bzl and the shared test vectors.
     if excluded(path.parts, patterns):
         return True
-    if not is_file or not path.name.endswith(".pyc"):
+    if not is_file:
         return False
-    if path.parent.name == "__pycache__":
-        source, separator, tag = path.name[:-len(".pyc")].rpartition(".")
-        if tag.startswith("opt-"):
-            if not tag[len("opt-"):]:
-                return False
-            source, separator, tag = source.rpartition(".")
-        if not source or not separator or not tag:
-            return False
-        source_path = path.parent.parent / (source + ".py")
-    else:
-        source_path = path.with_name(path.name[:-len(".pyc")] + ".py")
-    return excluded(source_path.parts, patterns)
+    source_path = cache_source_path(path)
+    return source_path is not None and excluded(source_path.parts, patterns)
 
 
 def _native_descendants(

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -931,6 +931,9 @@ else:
                 path,
                 glob,
             )
+        for path, expected in vectors["CACHE_SOURCE_VECTORS"]:
+            source = unpack_module.cache_source_path(Path(path))
+            assert source == (expected and Path(expected)), (path, source)
 
         filter_wheel = root / "demo-1.0-py3-none-any.whl"
         compiled_source = root / "compiled_source.py"

--- a/uv/private/whl_install/metadata.bzl
+++ b/uv/private/whl_install/metadata.bzl
@@ -243,21 +243,29 @@ def exclude_glob_matches(path, pattern):
             states[index + 1] = True
     return len(pattern) in states
 
+def cache_source_path(path):
+    """Return the source segments a `.pyc` is reached through, or None.
+
+    Cache tags are stripped right to left, so a dotted source such as
+    `mod.v1.py` resolves from `mod.v1.cpython-311.pyc`. Keep in sync with
+    cache_source_path in py/tools/unpack/unpack.py and the shared test vectors.
+    """
+    if not path or not path[-1].endswith(".pyc"):
+        return None
+    if len(path) < 2 or path[-2] != "__pycache__":
+        return path[:-1] + [path[-1][:-len(".pyc")] + ".py"]
+    stem, separator, tag = path[-1][:-len(".pyc")].rpartition(".")
+    if tag.startswith("opt-"):
+        if not tag[len("opt-"):]:
+            return None
+        stem, separator, tag = stem.rpartition(".")
+    if not stem or not separator or not tag:
+        return None
+    return path[:-2] + [stem + ".py"]
+
 def record_path_excluded(path, patterns):
     """Return whether installation removes a RECORD path or its source."""
-    source = None
-    if path and path[-1].endswith(".pyc"):
-        if len(path) >= 2 and path[-2] == "__pycache__":
-            stem, separator, tag = path[-1][:-len(".pyc")].rpartition(".")
-            if tag.startswith("opt-"):
-                if tag[len("opt-"):]:
-                    stem, separator, tag = stem.rpartition(".")
-                else:
-                    separator = ""
-            if stem and separator and tag:
-                source = path[:-2] + [stem + ".py"]
-        else:
-            source = path[:-1] + [path[-1][:-len(".pyc")] + ".py"]
+    source = cache_source_path(path)
     return any([
         exclude_glob_matches(path, pattern) or
         (source != None and exclude_glob_matches(source, pattern))

--- a/uv/private/whl_install/test.bzl
+++ b/uv/private/whl_install/test.bzl
@@ -3,9 +3,9 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//py/private:providers.bzl", "PyWheelsInfo")
-load("//py/tools/unpack:exclude_glob_test_vectors.bzl", "EXCLUDE_GLOB_VECTORS", "RECORD_PATH_EXCLUDE_VECTORS")
+load("//py/tools/unpack:exclude_glob_test_vectors.bzl", "CACHE_SOURCE_VECTORS", "EXCLUDE_GLOB_VECTORS", "RECORD_PATH_EXCLUDE_VECTORS")
 load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
-load(":metadata.bzl", "canonical_version", "data_directory_for", "data_scheme_segments", "data_segments_contained", "exclude_glob_matches", "metadata_directory_hint", "native_roots_for_segments", "parse_console_script", "parse_exclude_glob", "parse_record", "parse_record_path", "record_path_excluded", "site_packages_segments")
+load(":metadata.bzl", "cache_source_path", "canonical_version", "data_directory_for", "data_scheme_segments", "data_segments_contained", "exclude_glob_matches", "metadata_directory_hint", "native_roots_for_segments", "parse_console_script", "parse_exclude_glob", "parse_record", "parse_record_path", "record_path_excluded", "site_packages_segments")
 load(":repository.bzl", "compatible_python_tags", "select_key", "sort_select_arms", "source_specificity")
 load(":rule.bzl", "pyc_compile_version_compatible", "source_built_wheel", "whl_dist", "whl_install")
 
@@ -258,6 +258,14 @@ def _exclude_glob_test_impl(ctx):
             expected,
             record_path_excluded(path.split("/"), [parse_exclude_glob(pattern)]),
             "{} against {}".format(path, pattern),
+        )
+
+    for path, expected in CACHE_SOURCE_VECTORS:
+        asserts.equals(
+            env,
+            expected and expected.split("/"),
+            cache_source_path(path.split("/")),
+            path,
         )
 
     return unittest.end(env)


### PR DESCRIPTION
The PEP 3147 tag stripping was inlined in the installer's exclusion predicate and again in the analysis-time RECORD filter, covered only indirectly through exclusion results. Both are now cache_source_path, pinned directly by a shared vector table.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
