### PR TITLE
fix: drop bytecode orphaned by a site-packages merge

### DIFF
--- a/py/tools/site_merge/BUILD.bazel
+++ b/py/tools/site_merge/BUILD.bazel
@@ -11,6 +11,7 @@ py_test(
         "site_merge.py",
         "site_merge_test.py",
     ],
+    data = ["//py/tools/unpack:exclude_glob_test_vectors.bzl"],
     imports = ["."],
     main = "site_merge_test.py",
 )

--- a/py/tools/site_merge/site_merge.py
+++ b/py/tools/site_merge/site_merge.py
@@ -65,6 +65,7 @@ def _remove(path: Path) -> None:
 def merge(into: Path, sources: Sequence[Path]) -> List[Tuple[Path, Optional[Path], Path]]:
     into.mkdir(parents=True, exist_ok=True)
     owners: Dict[Path, Path] = {}
+    caches: Dict[Path, List[Path]] = {}
     conflicts: List[Tuple[Path, Optional[Path], Path]] = []
 
     for src in sources:
@@ -104,10 +105,39 @@ def merge(into: Path, sources: Sequence[Path]) -> List[Tuple[Path, Optional[Path
                         continue
                     conflicts.append((rel, prior, src))
                     _remove(dest)
+                # Bytecode belongs to whoever wrote the source; a wheel that
+                # replaces `mod.py` invalidates caches merged before it.
+                for cache in caches.pop(rel, ()):
+                    _remove(into / cache)
                 shutil.copy(str(src_file), str(dest))
                 owners[rel] = src
+                if rel.parent.name == "__pycache__" and rel.name.endswith(".pyc"):
+                    source = cache_source_path(rel)
+                    if source is not None:
+                        caches.setdefault(source, []).append(rel)
 
     return conflicts
+
+
+def cache_source_path(path: Path) -> Optional[Path]:
+    """Return the source a `.pyc` is reached through, or None if unreachable.
+
+    Cache tags are stripped right to left, so a dotted source such as
+    `mod.v1.py` resolves from `mod.v1.cpython-311.pyc`. Keep in sync with
+    cache_source_path in py/tools/unpack/unpack.py and the shared test vectors.
+    """
+    if not path.name.endswith(".pyc"):
+        return None
+    if path.parent.name != "__pycache__":
+        return path.with_name(path.name[:-len(".pyc")] + ".py")
+    source, separator, tag = path.name[:-len(".pyc")].rpartition(".")
+    if tag.startswith("opt-"):
+        if not tag[len("opt-"):]:
+            return None
+        source, separator, tag = source.rpartition(".")
+    if not source or not separator or not tag:
+        return None
+    return path.parent.parent / (source + ".py")
 
 
 def main() -> None:

--- a/py/tools/site_merge/site_merge_test.py
+++ b/py/tools/site_merge/site_merge_test.py
@@ -1,3 +1,4 @@
+import runpy
 import stat
 import subprocess
 import sys
@@ -6,6 +7,7 @@ import unittest
 from pathlib import Path
 from typing import Optional
 
+import site_merge
 from site_merge import merge
 
 
@@ -79,6 +81,117 @@ class SiteMergeTest(unittest.TestCase):
                 (first / "directory_to_file/child.py").read_text(), "first"
             )
             self.assertEqual(stat.S_IMODE((first / "distinct").stat().st_mode), 0o444)
+
+    def test_cache_source_path_matches_the_shared_vectors(self) -> None:
+        vectors = runpy.run_path(
+            str(Path(site_merge.__file__).parents[1] / "unpack" / "exclude_glob_test_vectors.bzl")
+        )
+        for path, expected in vectors["CACHE_SOURCE_VECTORS"]:
+            source = site_merge.cache_source_path(Path(path))
+            self.assertEqual(source, expected and Path(expected), path)
+
+    def test_bytecode_orphaned_by_an_overlay_is_dropped(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            first = root / "first"
+            second = root / "second"
+            output = root / "output"
+
+            _write(first / "pkg/overlaid.py", "first")
+            _write(first / "pkg/__pycache__/overlaid.cpython-311.pyc", "first bytecode")
+            _write(first / "pkg/kept.py", "first")
+            _write(first / "pkg/__pycache__/kept.cpython-311.pyc", "kept bytecode")
+            _write(first / "pkg/__pycache__/sourceless.cpython-311.pyc", "no source")
+            _write(first / "pkg/dotted.v1.py", "first")
+            _write(
+                first / "pkg/__pycache__/dotted.v1.cpython-311.pyc", "dotted bytecode"
+            )
+            _write(first / "pkg/optimized.py", "first")
+            _write(
+                first / "pkg/__pycache__/optimized.cpython-311.opt-2.pyc",
+                "optimized bytecode",
+            )
+
+            _write(second / "pkg/overlaid.py", "second")
+            _write(second / "pkg/dotted.v1.py", "second")
+            _write(second / "pkg/optimized.py", "second")
+            _write(second / "pkg/recompiled.py", "second")
+            _write(
+                second / "pkg/__pycache__/recompiled.cpython-311.pyc",
+                "second bytecode",
+            )
+
+            merge(output, [first, second])
+
+            self.assertFalse(
+                (output / "pkg/__pycache__/overlaid.cpython-311.pyc").exists()
+            )
+            self.assertFalse(
+                (output / "pkg/__pycache__/dotted.v1.cpython-311.pyc").exists()
+            )
+            self.assertFalse(
+                (output / "pkg/__pycache__/optimized.cpython-311.opt-2.pyc").exists()
+            )
+            self.assertEqual(
+                (output / "pkg/__pycache__/kept.cpython-311.pyc").read_text(),
+                "kept bytecode",
+            )
+            self.assertEqual(
+                (output / "pkg/__pycache__/sourceless.cpython-311.pyc").read_text(),
+                "no source",
+            )
+            self.assertEqual(
+                (output / "pkg/__pycache__/recompiled.cpython-311.pyc").read_text(),
+                "second bytecode",
+            )
+
+    def test_bytecode_survives_an_identical_source_from_another_wheel(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            first = root / "first"
+            second = root / "second"
+            output = root / "output"
+
+            _write(first / "pkg/shared.py", "same")
+            _write(first / "pkg/__pycache__/shared.cpython-311.pyc", "first bytecode")
+            _write(second / "pkg/shared.py", "same")
+
+            merge(output, [first, second])
+
+            self.assertEqual(
+                (output / "pkg/__pycache__/shared.cpython-311.pyc").read_text(),
+                "first bytecode",
+            )
+
+    def test_bytecode_from_a_later_wheel_survives_an_earlier_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            first = root / "first"
+            second = root / "second"
+            output = root / "output"
+
+            _write(first / "pkg/source_only.py", "first")
+            _write(first / "pkg/replaced.py", "first")
+            _write(first / "pkg/__pycache__/replaced.cpython-311.pyc", "first bytecode")
+
+            _write(
+                second / "pkg/__pycache__/source_only.cpython-311.pyc",
+                "second bytecode",
+            )
+            _write(
+                second / "pkg/__pycache__/replaced.cpython-311.pyc", "second bytecode"
+            )
+
+            merge(output, [first, second])
+
+            self.assertEqual(
+                (output / "pkg/__pycache__/source_only.cpython-311.pyc").read_text(),
+                "second bytecode",
+            )
+            self.assertEqual(
+                (output / "pkg/__pycache__/replaced.cpython-311.pyc").read_text(),
+                "second bytecode",
+            )
 
     def test_collision_policy_controls_reporting_and_status(self) -> None:
         for policy in ("warning", "ignore", "error"):

--- a/py/tools/unpack/BUILD.bazel
+++ b/py/tools/unpack/BUILD.bazel
@@ -11,6 +11,11 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
+exports_files(
+    ["exclude_glob_test_vectors.bzl"],
+    visibility = ["//py/tools/site_merge:__pkg__"],
+)
+
 py_test(
     name = "unpack_test",
     size = "small",


### PR DESCRIPTION
A wheel can overlay another wheel's `mod.py` without supplying its `__pycache__/mod.*.pyc`, leaving the earlier wheel's bytecode beside the winning source. Bytecode now follows the same overlay order as every other merged file: a cache is dropped only when its wheel precedes the one that supplied the source.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
