### PR TITLE
test: remove target name vs output file name overlap

### DIFF
--- a/e2e/cases/firebase-admin-import/BUILD.bazel
+++ b/e2e/cases/firebase-admin-import/BUILD.bazel
@@ -98,6 +98,7 @@ build_test(
 # emission shape across many wheels and surfaces any ordering /
 # scale-only regression.
 extract_venv_pth(
-    name = "test_tool.venv.pth",
+    name = "test_tool_venv_pth_snapshot",
+    out = "test_tool.venv.pth",
     venv = ":test_tool.venv",
 )

--- a/e2e/cases/pbs-symlink-prefix-1048/BUILD.bazel
+++ b/e2e/cases/pbs-symlink-prefix-1048/BUILD.bazel
@@ -33,12 +33,14 @@ pbs_action_probe(
 # unchanged retained-home shape. The extractor normalizes platform-dependent
 # PBS interpreter repository names without hiding a retained line.
 pbs_pyvenv_cfg_snapshot(
-    name = "action_probe_311.venv.cfg",
+    name = "action_probe_311_venv_cfg_snapshot",
+    out = "action_probe_311.venv.cfg",
     venv = ":action_probe_311.venv",
 )
 
 pbs_pyvenv_cfg_snapshot(
-    name = "action_probe_313.venv.cfg",
+    name = "action_probe_313_venv_cfg_snapshot",
+    out = "action_probe_313.venv.cfg",
     venv = ":action_probe_313.venv",
 )
 

--- a/e2e/cases/pbs-symlink-prefix-1048/action_probe.bzl
+++ b/e2e/cases/pbs-symlink-prefix-1048/action_probe.bzl
@@ -39,12 +39,12 @@ def pbs_action_probe(name, python_version):
         ],
     )
 
-def pbs_pyvenv_cfg_snapshot(name, venv):
+def pbs_pyvenv_cfg_snapshot(name, out, venv):
     """Copy a PBS-backed py_venv's generated pyvenv.cfg from its runfiles."""
     native.genrule(
         name = name,
         testonly = True,
-        outs = [name],
+        outs = [out],
         cmd = """
             launcher=$(execpath {venv})
             runfiles="$$launcher".runfiles

--- a/e2e/cases/pth-install-tree-fallback/BUILD.bazel
+++ b/e2e/cases/pth-install-tree-fallback/BUILD.bazel
@@ -110,7 +110,8 @@ py_test(
 )
 
 extract_venv_pth(
-    name = "test.venv.pth",
+    name = "test_venv_pth_snapshot",
+    out = "test.venv.pth",
     venv = ":test.venv",
 )
 
@@ -188,6 +189,7 @@ py_test(
 )
 
 extract_venv_pth(
-    name = "namespace_test.venv.pth",
+    name = "namespace_test_venv_pth_snapshot",
+    out = "namespace_test.venv.pth",
     venv = ":namespace_test.venv",
 )

--- a/e2e/cases/pth-namespace-547/BUILD.bazel
+++ b/e2e/cases/pth-namespace-547/BUILD.bazel
@@ -65,6 +65,7 @@ py_test(
 # fully covered by the concrete per-entry namespace merge, so the
 # snapshot pins that NEITHER appears in the .pth fallback.
 extract_venv_pth(
-    name = "test.venv.pth",
+    name = "test_venv_pth_snapshot",
+    out = "test.venv.pth",
     venv = ":test.venv",
 )

--- a/e2e/cases/tools/pth_snapshot.bzl
+++ b/e2e/cases/tools/pth_snapshot.bzl
@@ -1,6 +1,6 @@
 """Snapshot helpers: extract venv artifacts from a `py_venv` launcher."""
 
-def extract_venv_data_tree(name, venv):
+def extract_venv_data_tree(name, out, venv):
     """Snapshot the shape of a venv's PEP 427 prefix data projection.
 
     Emits one line per entry outside the venv-owned roots: `path/` for a real
@@ -19,7 +19,7 @@ def extract_venv_data_tree(name, venv):
     native.genrule(
         name = name,
         testonly = True,
-        outs = [name],
+        outs = [out],
         # Only the prologue is `.format`ed: the loop below contains shell `${}`
         # expansions, which `.format` would read as replacement fields.
         cmd = """
@@ -49,20 +49,21 @@ def extract_venv_data_tree(name, venv):
         visibility = ["//:__pkg__"],
     )
 
-def extract_venv_pth(name, venv):
+def extract_venv_pth(name, out, venv):
     """Copy the site-packages `.pth` out of a `py_venv` launcher's runfiles tree.
 
     The launcher binary is exposed via DefaultInfo; the venv tree (where the
     .pth lives) is only reachable through the launcher's runfiles. Using
     `tools = [venv]` makes Bazel materialise that runfiles tree in the sandbox.
 
-    `name` doubles as the output filename — pick something that reads naturally
-    as the snapshot source (e.g. `test_tool.venv.pth`).
+    Keep `name` distinct from `out`: Bazel warns when a rule and its generated
+    file share a target name. `out` should be the snapshot filename (for
+    example, `test_tool.venv.pth`).
     """
     native.genrule(
         name = name,
         testonly = True,
-        outs = [name],
+        outs = [out],
         cmd = """
             launcher=$(execpath {venv})
             runfiles="$$launcher".runfiles

--- a/e2e/cases/uv-include-group/BUILD.bazel
+++ b/e2e/cases/uv-include-group/BUILD.bazel
@@ -72,7 +72,8 @@ sh_test(
 # plain path entry, this diff surfaces alongside the runtime test
 # failure.
 extract_venv_pth(
-    name = "wheel_root_pth_test.venv.pth",
+    name = "wheel_root_pth_test_venv_pth_snapshot",
+    out = "wheel_root_pth_test.venv.pth",
     venv = ":wheel_root_pth_test.venv",
 )
 
@@ -109,6 +110,7 @@ py_test(
 )
 
 extract_venv_pth(
-    name = "multi_addsitedir_test.venv.pth",
+    name = "multi_addsitedir_test_venv_pth_snapshot",
+    out = "multi_addsitedir_test.venv.pth",
     venv = ":multi_addsitedir_test.venv",
 )

--- a/e2e/cases/venv-data-files-1366/BUILD.bazel
+++ b/e2e/cases/venv-data-files-1366/BUILD.bazel
@@ -30,6 +30,7 @@ py_test(
 # share `share/jupyter/`, so the venv descends through it and binds each wheel's
 # subtree as one symlink instead of one per installed file.
 extract_venv_data_tree(
-    name = "test.venv.data",
+    name = "test_venv_data_snapshot",
+    out = "test.venv.data",
     venv = ":test.venv",
 )


### PR DESCRIPTION
Just removes some warnings when running `bazel test`

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
