### PR TITLE
refactor: separate Python sources from library runfiles

### DIFF
--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -354,6 +354,16 @@ container_structure_test(
 
 image_layer_analysis_test_suite()
 
+# Snapshot the same binary's ordinary image layer to prove explicitly declared
+# runtime data remains packaged even when the collision fixture uses a custom
+# layer root.
+assert_tar_listing(
+    name = "scalar_data_layers_snapshot",
+    actual = [":_scalar_data_layers"],
+    exclude = ["python_interpreters"],
+    expected = "scalar_data_layers_listing.yaml",
+)
+
 platform_transition_filegroup(
     name = "platform_layers",
     srcs = [":my_app_layers"],

--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -359,9 +359,15 @@ image_layer_analysis_test_suite()
 # layer root.
 assert_tar_listing(
     name = "scalar_data_layers_snapshot",
-    actual = [":_scalar_data_layers"],
+    actual = [":platform_scalar_data_layers"],
     exclude = ["python_interpreters"],
     expected = "scalar_data_layers_listing.yaml",
+)
+
+platform_transition_filegroup(
+    name = "platform_scalar_data_layers",
+    srcs = [":_scalar_data_layers"],
+    target_platform = ":x86_64_linux",
 )
 
 platform_transition_filegroup(

--- a/e2e/cases/oci/py_image_layer/image_layer_analysis_tests.bzl
+++ b/e2e/cases/oci/py_image_layer/image_layer_analysis_tests.bzl
@@ -402,6 +402,10 @@ touch $@
         binary = ":_scalar_strip_collision",
         layer_tier = ":_scalar_strip_collision_tier",
     )
+    py_image_layer(
+        name = "_scalar_data_layers",
+        binary = ":_scalar_strip_collision",
+    )
 
     py_layer_tier(
         name = "_scalar_default_tier",

--- a/e2e/cases/oci/py_image_layer/snapshots/scalar_data_layers_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/scalar_data_layers_listing.yaml
@@ -1,0 +1,14 @@
+---
+layer: 0
+files:
+  - -rwxr-xr-x  0 0      0       22800 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0        2128 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/bin/activate
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/bin/python3 -> python
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/bin/python3.11 -> python
+  - -rwxr-xr-x  0 0      0          48 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/lib/python3.11/site-packages/__scalar_strip_collision.venv.pth
+  - -rwxr-xr-x  0 0      0          19 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/lib/python3.11/site-packages/_virtualenv.pth
+  - -rwxr-xr-x  0 0      0        4932 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/lib/python3.11/site-packages/_virtualenv.py
+  - -rwxr-xr-x  0 0      0         111 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0          50 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/server.py
+  - -rwxr-xr-x  0 0      0 * Jan  1  2023 ./app.runfiles/_repo_mapping
+  - -rwxr-xr-x  0 0      0           5 Jan  1  2023 ./app/data.txt

--- a/e2e/cases/oci/py_image_layer/snapshots/scalar_data_layers_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/scalar_data_layers_listing.yaml
@@ -1,7 +1,7 @@
 ---
 layer: 0
 files:
-  - -rwxr-xr-x  0 0      0       22800 Jan  1  2023 ./app
+  - -rwxr-xr-x  0 0      0       18856 Jan  1  2023 ./app
   - -rwxr-xr-x  0 0      0        2128 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/bin/activate
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/bin/python3 -> python
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_collision.venv/bin/python3.11 -> python

--- a/e2e/cases/oci/test.sh
+++ b/e2e/cases/oci/test.sh
@@ -51,7 +51,6 @@ if "$BAZEL" build --keep_going --output_groups=_validation -- \
     cat "$output_log" >&2
     fail "expected remapped destinations to fail validation"
 fi
-expect_diagnostic "py_image_layer runfile collision at ./app.runfiles/_main/oci/py_image_layer/_scalar_strip_collision/data.txt:"
 expect_diagnostic "py_image_layer runfile collision at ./app.runfiles/_main/oci/py_image_layer/server.py:"
 
 echo "PASS: expanded and remapped destinations validate correctly"

--- a/e2e/cases/oci/test.sh
+++ b/e2e/cases/oci/test.sh
@@ -45,13 +45,14 @@ if ! "$BAZEL" build --output_groups=_validation -- \
 fi
 
 echo "== remapped destinations must fail validation =="
-if "$BAZEL" build --keep_going --output_groups=_validation -- \
-    "${PKG}:_scalar_strip_collision_layers" \
-    "${PKG}:_scalar_root_collision_layers" >"$output_log" 2>&1; then
-    cat "$output_log" >&2
-    fail "expected remapped destinations to fail validation"
-fi
-expect_diagnostic "py_image_layer runfile collision at ./app.runfiles/_main/oci/py_image_layer/server.py:"
+for target in _scalar_strip_collision_layers _scalar_root_collision_layers; do
+    if "$BAZEL" build --output_groups=_validation -- \
+        "${PKG}:$target" >"$output_log" 2>&1; then
+        cat "$output_log" >&2
+        fail "expected ${target} to fail validation"
+    fi
+    expect_diagnostic "py_image_layer runfile collision at ./app.runfiles/_main/oci/py_image_layer/server.py:"
+done
 
 echo "PASS: expanded and remapped destinations validate correctly"
 

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -21,7 +21,7 @@ def _make_instrumented_files_info(ctx):
         extensions = ["py"],
     )
 
-def _make_srcs_depset(ctx):
+def _make_srcs_depset(ctx, extra_depsets = []):
     # `deps` may carry rules_py's PyInfo or native @rules_python's; both expose
     # `transitive_sources`. See py_info_interop.bzl.
     return depset(
@@ -31,7 +31,7 @@ def _make_srcs_depset(ctx):
             get_py_info(target).transitive_sources
             for target in ctx.attr.deps
             if has_py_info(target)
-        ],
+        ] + extra_depsets,
     )
 
 def _make_virtual_depset(ctx):
@@ -156,7 +156,7 @@ def _py_library_impl(ctx):
     imports = _make_imports_depset(ctx)
     virtuals = _make_virtual_depset(ctx)
     resolutions = _make_virtual_resolutions_depset(ctx)
-    runfiles = _make_merged_runfiles(ctx, extra_runfiles = ctx.files.srcs)
+    runfiles = _make_merged_runfiles(ctx)
     instrumented_files_info = _make_instrumented_files_info(ctx)
     wheels = _make_wheels_depset(ctx)
 

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -83,13 +83,15 @@ def _assemble_shared(ctx):
         venv_name = ".{}".format(safe_name),
     )
 
-    srcs_depset = _py_library.make_srcs_depset(ctx)
+    srcs_depset = _py_library.make_srcs_depset(
+        ctx,
+        extra_depsets = virtual_resolution.srcs,
+    )
     runfiles = _py_library.make_merged_runfiles(
         ctx,
         extra_depsets = [
             py_toolchain.files,
-            srcs_depset,
-        ] + virtual_resolution.srcs + virtual_resolution.runfiles,
+        ] + virtual_resolution.runfiles,
         extra_runfiles = venv.all_files,
         extra_runfiles_depsets = [
             ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
@@ -104,13 +106,16 @@ def _assemble_shared(ctx):
         srcs_depset = srcs_depset,
     )
 
-def _common_providers(ctx, shared, executable = None):
+def _common_providers(ctx, shared, executable = None, include_sources = False):
     """Providers emitted by both the executable and lib variants."""
+    runfiles = shared.runfiles
+    if include_sources:
+        runfiles = runfiles.merge(ctx.runfiles(transitive_files = shared.srcs_depset))
     return [
         DefaultInfo(
             files = depset([executable]) if executable != None else None,
             executable = executable,
-            runfiles = shared.runfiles,
+            runfiles = runfiles,
         ),
         # Deliberately no PyInfo: a venv is a terminal artifact, not a source of imports.
         VirtualenvInfo(
@@ -160,7 +165,7 @@ def _py_venv_rule_impl(ctx):
     # overrides with its own absolute value when invoked directly.
     passed_env["VIRTUAL_ENV"] = venv_root(shared.venv.bin_python)
 
-    return _common_providers(ctx, shared, executable = ctx.outputs.executable) + [
+    return _common_providers(ctx, shared, executable = ctx.outputs.executable, include_sources = True) + [
         # Read by the sibling `expose_venv = True` py_binary/py_test;
         # the binary's own `env` wins on key conflicts (py_venv_exec.bzl).
         RunEnvironmentInfo(

--- a/py/private/py_venv/py_venv_exec.bzl
+++ b/py/private/py_venv/py_venv_exec.bzl
@@ -9,6 +9,7 @@ attrs to the auto-generated sibling.
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
 load("@hermetic_launcher//launcher:lib.bzl", "launcher")
 load("//py/private:py_info.bzl", "PyInfo")
+load("//py/private:py_info_interop.bzl", "get_py_info", "has_py_info")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "reset_python_flags_transition")
 load(":types.bzl", "VirtualenvInfo", "venv_root")
@@ -108,8 +109,16 @@ def _py_venv_exec_impl(ctx):
     )
 
     # Merge runfiles, supporting `py_venv_exec(main)` not being in the `py_venv` runfiles.
+    data_sources = [
+        get_py_info(target).transitive_sources
+        for target in ctx.attr.data
+        if has_py_info(target)
+    ]
     runfiles = ctx.runfiles(
         files = ctx.files.data + [main],
+        transitive_files = depset(
+            transitive = [vinfo.transitive_sources] + data_sources,
+        ),
     ).merge_all(
         [target[DefaultInfo].default_runfiles for target in ctx.attr.data] +
         [venv[DefaultInfo].default_runfiles],
@@ -173,8 +182,9 @@ user-facing attribute — direct settings on the rule are blocked at
 the macro layer in `//py:defs.bzl`.
 
 The binary's launcher exec's the referenced venv's `bin/python`; its
-runfiles inherit the venv's default_runfiles so all wheels and first-
-party sources land at their usual rlocation paths.
+runfiles inherit the venv's default_runfiles for wheels and runtime data,
+and add first-party sources from `VirtualenvInfo.transitive_sources` at
+their usual rlocation paths.
 """,
     ),
     "interpreter_options": attr.string_list(

--- a/py/private/py_venv/types.bzl
+++ b/py/private/py_venv/types.bzl
@@ -22,6 +22,6 @@ binary's launcher exec's the venv's `bin_python`.
     fields = {
         "bin_python": "File — the venv's bin/python symlink. Callers needing a launcher target point here.",
         "imports": "depset[str] — rlocation-root-relative import paths covered by this venv. Mirrors `PyInfo.imports` of the venv's dep closure.",
-        "transitive_sources": "depset[File] — first-party Python sources carried by this venv (its own `srcs` plus those of any `deps` that emit `PyInfo`). Surfaced by py_binary as `PyInfo.transitive_sources` so downstream consumers see the same source closure they'd see if srcs/deps lived on the binary directly.",
+        "transitive_sources": "depset[File] — source artifacts carried by this venv: its own `srcs`, sources from `deps` that emit `PyInfo`, and files contributed by virtual-resolution targets. Surfaced by py_binary as `PyInfo.transitive_sources` so downstream consumers see the same source closure they'd see if srcs/deps lived on the binary directly.",
     },
 )

--- a/py/tests/py-library-runfiles/BUILD.bazel
+++ b/py/tests/py-library-runfiles/BUILD.bazel
@@ -1,0 +1,60 @@
+load("//py:defs.bzl", "py_library", "py_test", "py_venv")
+load(":runfiles_test.bzl", "py_library_runfiles_test", "py_venv_runfiles_test")
+
+package(default_testonly = True)
+
+py_library(
+    name = "library",
+    srcs = ["library.py"],
+    data = ["runtime_data.py"],
+    imports = ["."],
+)
+
+py_library_runfiles_test(
+    name = "library_runfiles_test",
+    target_under_test = ":library",
+)
+
+py_venv(
+    name = "public_venv",
+    srcs = ["main.py"],
+    imports = ["."],
+    deps = [":library"],
+)
+
+py_venv_runfiles_test(
+    name = "public_venv_sources_test",
+    expected_sources = [
+        "main.py",
+        "library.py",
+    ],
+    target_under_test = ":public_venv",
+)
+
+py_test(
+    name = "library_runtime_test",
+    srcs = ["main.py"],
+    main = "main.py",
+    deps = [":library"],
+)
+
+py_library(
+    name = "data_helper",
+    srcs = ["data_helper.py"],
+    imports = ["."],
+)
+
+py_library(
+    name = "data_plugin",
+    srcs = ["data_plugin.py"],
+    imports = ["."],
+    deps = [":data_helper"],
+)
+
+py_test(
+    name = "data_python_dependency_runtime_test",
+    srcs = ["data_main.py"],
+    data = [":data_plugin"],
+    imports = ["."],
+    main = "data_main.py",
+)

--- a/py/tests/py-library-runfiles/data_helper.py
+++ b/py/tests/py-library-runfiles/data_helper.py
@@ -1,0 +1,1 @@
+VALUE = "helper"

--- a/py/tests/py-library-runfiles/data_main.py
+++ b/py/tests/py-library-runfiles/data_main.py
@@ -1,0 +1,9 @@
+import data_plugin
+
+
+def test_data_python_dependency_sources_are_available() -> None:
+    assert data_plugin.VALUE == "plugin-helper"
+
+
+if __name__ == "__main__":
+    test_data_python_dependency_sources_are_available()

--- a/py/tests/py-library-runfiles/data_plugin.py
+++ b/py/tests/py-library-runfiles/data_plugin.py
@@ -1,0 +1,3 @@
+from data_helper import VALUE
+
+VALUE = "plugin-" + VALUE

--- a/py/tests/py-library-runfiles/library.py
+++ b/py/tests/py-library-runfiles/library.py
@@ -1,0 +1,3 @@
+"""Import source for runfiles provenance coverage."""
+
+VALUE = "source-runfiles-ok"

--- a/py/tests/py-library-runfiles/main.py
+++ b/py/tests/py-library-runfiles/main.py
@@ -1,0 +1,9 @@
+import library
+
+
+def test_library_source_is_available() -> None:
+    assert library.VALUE == "source-runfiles-ok"
+
+
+if __name__ == "__main__":
+    test_library_source_is_available()

--- a/py/tests/py-library-runfiles/runfiles_test.bzl
+++ b/py/tests/py-library-runfiles/runfiles_test.bzl
@@ -1,0 +1,29 @@
+"""Analysis coverage for py_library's source-free default runfiles."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _has(paths, suffix):
+    return any([path.endswith(suffix) for path in paths])
+
+def _py_library_runfiles_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    paths = [f.short_path for f in target[DefaultInfo].default_runfiles.files.to_list()]
+    asserts.false(env, _has(paths, "/library.py"), "library sources stay in PyInfo")
+    asserts.true(env, _has(paths, "/runtime_data.py"), "library data remains in runfiles")
+    return analysistest.end(env)
+
+py_library_runfiles_test = analysistest.make(_py_library_runfiles_test_impl)
+
+def _py_venv_runfiles_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    paths = [f.short_path for f in target[DefaultInfo].default_runfiles.files.to_list()]
+    for source in ctx.attr.expected_sources:
+        asserts.true(env, _has(paths, "/" + source), "public py_venv retains source " + source)
+    return analysistest.end(env)
+
+py_venv_runfiles_test = analysistest.make(
+    _py_venv_runfiles_test_impl,
+    attrs = {"expected_sources": attr.string_list(mandatory = True)},
+)

--- a/py/tests/py-library-runfiles/runtime_data.py
+++ b/py/tests/py-library-runfiles/runtime_data.py
@@ -1,0 +1,1 @@
+"""Runtime data that intentionally remains in default runfiles."""


### PR DESCRIPTION
Avoid adding `.py` files to `DefaultInfo.default_runfiles` until absolutely necessary in terminal runnable rules such as `py_venv_exec[_test]` (which `py_binary|test` wrap).

This reduces confusion about providers vs runfiles.
This way the `.py` can more easily be swapped out for `.pyc` files in the future.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
