### PR TITLE
test: provision dev interpreters with our own toolchains instead of rules_python

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,9 @@ common --define=SOME_VAR=SOME_VALUE
 # Set the default virtualenv to 'default'
 common --@pypi//dep_group=aspect_rules_py
 
+# Default python version
+common --@aspect_rules_py//py:python_version=3.13
+
 # Uncomment to enable verbose diagnostics for uv repository rules (sdist builds, git archives)
 # common --repo_env=RULES_PY_UV_VERBOSE=1
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -119,16 +119,9 @@ multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitoo
 multitool.hub(lockfile = "//tools:tools.lock.json")
 use_repo(multitool, "multitool")
 
-# rules_oci and friends
-
-# rules_python and friends
-python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
-python.toolchain(
-    is_default = True,
-    python_version = "3.9",
-)
-python.toolchain(
-    is_default = False,
+# Second interpreter version for multi-version test coverage.
+dev_interpreters = use_extension("//py:extensions.bzl", "python_interpreters", dev_dependency = True)
+dev_interpreters.toolchain(
     python_version = "3.12",
 )
 

--- a/py/private/py_venv/tests/BUILD.bazel
+++ b/py/private/py_venv/tests/BUILD.bazel
@@ -44,6 +44,9 @@ platform(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
+    # The libc flag defaults to the host's; pin it so the PBS linux-gnu
+    # toolchain matches regardless of host.
+    flags = ["--//uv/private/constraints/platform:platform_libc=glibc"],
 )
 
 venv_tree(

--- a/py/private/py_venv/tests/snapshots/venv.tree.snap
+++ b/py/private/py_venv/tests/snapshots/venv.tree.snap
@@ -84,14 +84,14 @@ case $0 in
 esac
 exec "${script_dir}/python" -c 'import sys; from importlib import import_module; from operator import attrgetter; sys.argv[0] = "cowsay"; sys.exit(attrgetter("cli")(import_module("cowsay.__main__"))())' "$@"
 ---
-LINK bin/python -> ../../../../../../../rules_python++python+python_3_9_x86_64-unknown-linux-gnu/bin/python3
+LINK bin/python -> ../../../../../../../+python_interpreters+python_3_13_x86_64_unknown_linux_gnu/bin/python3
 LINK bin/python3 -> python
-LINK bin/python3.9 -> python
-FILE lib/python3.9/site-packages/_virtualenv.pth
+LINK bin/python3.13 -> python
+FILE lib/python3.13/site-packages/_virtualenv.pth
 ---
 import _virtualenv
 ---
-FILE lib/python3.9/site-packages/_virtualenv.py
+FILE lib/python3.13/site-packages/_virtualenv.py
 ---
 """Patches that are applied at runtime to the virtual environment."""
 
@@ -211,9 +211,9 @@ class _Finder:
 
 sys.meta_path.insert(0, _Finder())
 ---
-LINK lib/python3.9/site-packages/cowsay -> ../../../../../../../../../+uv+whl_install__aspect_rules_py__cowsay__6_1/actual_install.install/lib/python3.9/site-packages/cowsay
-LINK lib/python3.9/site-packages/cowsay-6.1.dist-info -> ../../../../../../../../../+uv+whl_install__aspect_rules_py__cowsay__6_1/actual_install.install/lib/python3.9/site-packages/cowsay-6.1.dist-info
-FILE lib/python3.9/site-packages/venv.pth
+LINK lib/python3.13/site-packages/cowsay -> ../../../../../../../../../+uv+whl_install__aspect_rules_py__cowsay__6_1/actual_install.install/lib/python3.13/site-packages/cowsay
+LINK lib/python3.13/site-packages/cowsay-6.1.dist-info -> ../../../../../../../../../+uv+whl_install__aspect_rules_py__cowsay__6_1/actual_install.install/lib/python3.13/site-packages/cowsay-6.1.dist-info
+FILE lib/python3.13/site-packages/venv.pth
 ---
 ../../../../../../../../..
 ../../../../../../../../../_main
@@ -221,9 +221,9 @@ FILE lib/python3.9/site-packages/venv.pth
 ---
 FILE pyvenv.cfg
 ---
-home = ../../../../../../rules_python++python+python_3_9_x86_64-unknown-linux-gnu/bin
+home = ../../../../../../+python_interpreters+python_3_13_x86_64_unknown_linux_gnu/bin
 implementation = CPython
-version_info = 3.9.25
+version_info = 3.13.12
 include-system-site-packages = false
 relocatable = true
 ---

--- a/py/tests/py-pex-binary/BUILD.bazel
+++ b/py/tests/py-pex-binary/BUILD.bazel
@@ -98,6 +98,9 @@ platform(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
+    # The libc flag defaults to the host's; pin it so the PBS linux-gnu
+    # toolchain matches regardless of host.
+    flags = ["--//uv/private/constraints/platform:platform_libc=glibc"],
 )
 
 platform_transition_binary(

--- a/py/tests/py-pex-binary/pex_info_test.py
+++ b/py/tests/py-pex-binary/pex_info_test.py
@@ -19,7 +19,9 @@ PKG = "_main/py/tests/py-pex-binary"
 
 
 def read_pex(name: str) -> tuple[str, dict[str, object]]:
-    path = r.Rlocation("{}/{}.pex".format(PKG, name))
+    # source_repo skips CurrentRepository's caller-frame inspection, which
+    # cannot see through the venv's site-packages indirection.
+    path = r.Rlocation("{}/{}.pex".format(PKG, name), source_repo="")
     with open(path, "rb") as f:
         shebang = f.readline().rstrip(b"\r\n").decode()
     with zipfile.ZipFile(path) as zf:
@@ -64,7 +66,7 @@ assert info.get("inherit_path", "false") == "false", info
 # structural exclusions: the sibling venv's `.pth`/`pyvenv.cfg` plumbing and the
 # interpreter must be filtered out, while first-party `data` files are kept.
 def pex_names(name: str) -> list[str]:
-    path = r.Rlocation("{}/{}.pex".format(PKG, name))
+    path = r.Rlocation("{}/{}.pex".format(PKG, name), source_repo="")
     with zipfile.ZipFile(path) as zf:
         return zf.namelist()
 

--- a/py/tests/reset-data-edges/BUILD.bazel
+++ b/py/tests/reset-data-edges/BUILD.bazel
@@ -49,7 +49,7 @@ terminal(
     name = "nested_terminal",
     data = [":probe"],
     dep_group = "nested",
-    python_version = "3.9",
+    python_version = "3.13",
     tags = ["manual"],
 )
 

--- a/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/python_interpreters.BUILD.bazel
@@ -3,6 +3,30 @@ load("@aspect_rules_py//py/private/interpreter:current_py_toolchain.bzl", "curre
 package(default_visibility = ["//visibility:public"])
 
 config_setting(
+    name = "_python_version_is_3_12_our_major_minor",
+    flag_values = {"@aspect_rules_py//py/private/interpreter:python_version": "3.12"},
+)
+
+# rules_python's flag is a fallback: it selects only when our own flag is
+# unset, so setting our flag always wins and rpy's default can't shadow it.
+config_setting(
+    name = "_python_version_is_3_12_rpy_fallback",
+    flag_values = {
+        "@aspect_rules_py//py/private/interpreter:python_version": "",
+        "@rules_python//python/config_settings:python_version": "3.12",
+    },
+)
+
+selects.config_setting_group(
+    name = "python_version_is_3_12",
+    match_any = [
+        ":_python_version_is_3_12_our_major_minor",
+        ":_python_version_is_3_12_rpy_fallback",
+    ],
+)
+
+
+config_setting(
     name = "_python_version_is_3_13_our_major_minor",
     flag_values = {"@aspect_rules_py//py/private/interpreter:python_version": "3.13"},
 )
@@ -47,6 +71,306 @@ config_setting(
 config_setting(
     name = "platform_libc_is_musl",
     flag_values = {"@aspect_rules_py//uv/private/constraints/platform:platform_libc": "musl"},
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_aarch64_apple_darwin",
+    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_aarch64_apple_darwin//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_aarch64_apple_darwin_py_cc",
+    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_aarch64_apple_darwin//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+# Exec tools toolchain: selected by exec platform (not target platform) so
+# that build actions using the interpreter (e.g. compileall) get a runnable
+# binary on the build host regardless of the target platform being built for.
+# Version-gated so the exec interpreter follows the version flags.
+toolchain(
+    name = "python_3_12_aarch64_apple_darwin_exec_tools",
+    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12"],
+    toolchain = "@python_3_12_aarch64_apple_darwin//:runtime",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_aarch64_unknown_linux_gnu",
+    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false", ":platform_libc_is_glibc"],
+    toolchain = "@python_3_12_aarch64_unknown_linux_gnu//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_aarch64_unknown_linux_gnu_py_cc",
+    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false", ":platform_libc_is_glibc"],
+    toolchain = "@python_3_12_aarch64_unknown_linux_gnu//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+# Exec tools toolchain: selected by exec platform (not target platform) so
+# that build actions using the interpreter (e.g. compileall) get a runnable
+# binary on the build host regardless of the target platform being built for.
+# Version-gated so the exec interpreter follows the version flags.
+toolchain(
+    name = "python_3_12_aarch64_unknown_linux_gnu_exec_tools",
+    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12"],
+    toolchain = "@python_3_12_aarch64_unknown_linux_gnu//:runtime",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_aarch64_unknown_linux_musl",
+    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false", ":platform_libc_is_musl"],
+    toolchain = "@python_3_12_aarch64_unknown_linux_musl//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_aarch64_unknown_linux_musl_py_cc",
+    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false", ":platform_libc_is_musl"],
+    toolchain = "@python_3_12_aarch64_unknown_linux_musl//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_x86_64_apple_darwin",
+    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_x86_64_apple_darwin//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_x86_64_apple_darwin_py_cc",
+    target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_x86_64_apple_darwin//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+# Exec tools toolchain: selected by exec platform (not target platform) so
+# that build actions using the interpreter (e.g. compileall) get a runnable
+# binary on the build host regardless of the target platform being built for.
+# Version-gated so the exec interpreter follows the version flags.
+toolchain(
+    name = "python_3_12_x86_64_apple_darwin_exec_tools",
+    exec_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12"],
+    toolchain = "@python_3_12_x86_64_apple_darwin//:runtime",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_x86_64_unknown_linux_gnu",
+    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false", ":platform_libc_is_glibc"],
+    toolchain = "@python_3_12_x86_64_unknown_linux_gnu//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_x86_64_unknown_linux_gnu_py_cc",
+    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false", ":platform_libc_is_glibc"],
+    toolchain = "@python_3_12_x86_64_unknown_linux_gnu//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+# Exec tools toolchain: selected by exec platform (not target platform) so
+# that build actions using the interpreter (e.g. compileall) get a runnable
+# binary on the build host regardless of the target platform being built for.
+# Version-gated so the exec interpreter follows the version flags.
+toolchain(
+    name = "python_3_12_x86_64_unknown_linux_gnu_exec_tools",
+    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12"],
+    toolchain = "@python_3_12_x86_64_unknown_linux_gnu//:runtime",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_x86_64_unknown_linux_musl",
+    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false", ":platform_libc_is_musl"],
+    toolchain = "@python_3_12_x86_64_unknown_linux_musl//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_x86_64_unknown_linux_musl_py_cc",
+    target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false", ":platform_libc_is_musl"],
+    toolchain = "@python_3_12_x86_64_unknown_linux_musl//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_x86_64_pc_windows_msvc",
+    target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_x86_64_pc_windows_msvc//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_x86_64_pc_windows_msvc_py_cc",
+    target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_x86_64_pc_windows_msvc//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+# Exec tools toolchain: selected by exec platform (not target platform) so
+# that build actions using the interpreter (e.g. compileall) get a runnable
+# binary on the build host regardless of the target platform being built for.
+# Version-gated so the exec interpreter follows the version flags.
+toolchain(
+    name = "python_3_12_x86_64_pc_windows_msvc_exec_tools",
+    exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    target_settings = [":python_version_is_3_12"],
+    toolchain = "@python_3_12_x86_64_pc_windows_msvc//:runtime",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_aarch64_pc_windows_msvc",
+    target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_aarch64_pc_windows_msvc//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_aarch64_pc_windows_msvc_py_cc",
+    target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_aarch64_pc_windows_msvc//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+# Exec tools toolchain: selected by exec platform (not target platform) so
+# that build actions using the interpreter (e.g. compileall) get a runnable
+# binary on the build host regardless of the target platform being built for.
+# Version-gated so the exec interpreter follows the version flags.
+toolchain(
+    name = "python_3_12_aarch64_pc_windows_msvc_exec_tools",
+    exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
+    target_settings = [":python_version_is_3_12"],
+    toolchain = "@python_3_12_aarch64_pc_windows_msvc//:runtime",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
+)
+
+
+# The Python interpreter toolchain has no exec_compatible_with: the interpreter
+# runs on the TARGET platform (inside the virtualenv), not on the exec host.
+# Setting exec_compatible_with = platform_constraints would prevent this
+# toolchain from being selected during cross-compilation (e.g. building an
+# arm64 image on an amd64 host), because the exec platform (amd64) would not
+# satisfy the arm64 exec constraint.  The target_compatible_with constraint is
+# sufficient to pick the right interpreter for the target.
+toolchain(
+    name = "python_3_12_i686_pc_windows_msvc",
+    target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_i686_pc_windows_msvc//:runtime",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+toolchain(
+    name = "python_3_12_i686_pc_windows_msvc_py_cc",
+    target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
+    target_settings = [":python_version_is_3_12", ":freethreaded_is_false"],
+    toolchain = "@python_3_12_i686_pc_windows_msvc//:py_cc_toolchain",
+    toolchain_type = "@rules_python//python/cc:toolchain_type",
+)
+
+# Exec tools toolchain: selected by exec platform (not target platform) so
+# that build actions using the interpreter (e.g. compileall) get a runnable
+# binary on the build host regardless of the target platform being built for.
+# Version-gated so the exec interpreter follows the version flags.
+toolchain(
+    name = "python_3_12_i686_pc_windows_msvc_exec_tools",
+    exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_32"],
+    target_settings = [":python_version_is_3_12"],
+    toolchain = "@python_3_12_i686_pc_windows_msvc//:runtime",
+    toolchain_type = "@aspect_rules_py//py/private/toolchain:exec_tools_toolchain_type",
 )
 
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
