### PR TITLE
perf: run the wheel unpack tool with an isolated interpreter

### DIFF
--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -15,6 +15,7 @@ def _py_unpacked_wheel_impl(ctx):
     unpack_directory = ctx.actions.declare_directory("{}".format(ctx.attr.name))
 
     args = ctx.actions.args()
+    args.add_all(["-S", "-E", "-s", "-B"])
     args.add(unpack_script)
     args.add_all([unpack_directory], expand_directories = False, before_each = "--into")
     args.add("--wheel", ctx.file.src)

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -207,6 +207,7 @@ def _whl_install(ctx):
     data_files = meta.data_files
 
     arguments = ctx.actions.args()
+    arguments.add_all(["-S", "-E", "-s", "-B"])
     arguments.add(unpack_script)
     arguments.add_all([install_dir], expand_directories = False, before_each = "--into")
     arguments.add_all([archive], expand_directories = False, before_each = "--wheel")


### PR DESCRIPTION
- -S — skip site module import. No site-packages setup, faster startup.
- -E — ignore PYTHON* env vars (PYTHONPATH, PYTHONHOME, etc).
- -s — skip user site-packages (~/.local/lib/...).
- -B — no .pyc writes

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
