### PR TITLE
fix: provide rules_python providers from py_binary when --@aspect_rules_py//py:emit_rules_python_providers

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -40,8 +40,8 @@ rules_py library fails analysis with `does not have mandatory providers:
 common --@aspect_rules_py//py:emit_rules_python_providers
 ```
 
-`py_library` then also emits the rules_python providers. Temporary scaffolding:
-only `py_library` participates, [virtual deps](/docs/virtual_deps.md) are not
+`py_library`, `py_binary`, and `py_test` then also emit the rules_python
+providers. Temporary scaffolding: [virtual deps](/docs/virtual_deps.md) are not
 expressible in those providers (resolve them concretely in `deps`), and the
 flag belongs in `.bazelrc` only until the last rules_python target is gone.
 

--- a/e2e/rules-python-provider-compat/BUILD.bazel
+++ b/e2e/rules-python-provider-compat/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_library", rules_py_test = "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library", rules_py_test = "py_test")
 load("@rules_python//python:py_test.bzl", rules_python_test = "py_test")
 
 # One converted library, two consumers: the @rules_python test stands in
@@ -49,4 +49,22 @@ rules_python_test(
     srcs = ["transitive_consumer_test.py"],
     main = "transitive_consumer_test.py",
     deps = [":middle"],
+)
+
+# A converted binary as a dependency: the launcher rule (not just
+# py_library) must carry rules_python's PyInfo, surfacing the sibling
+# venv's imports and sources to an @rules_python consumer.
+py_binary(
+    name = "tool",
+    testonly = True,
+    srcs = ["tool.py"],
+    imports = ["."],
+    deps = [":lib"],
+)
+
+rules_python_test(
+    name = "rules_python_binary_consumer_test",
+    srcs = ["binary_consumer_test.py"],
+    main = "binary_consumer_test.py",
+    deps = [":tool"],
 )

--- a/e2e/rules-python-provider-compat/binary_consumer_test.py
+++ b/e2e/rules-python-provider-compat/binary_consumer_test.py
@@ -1,0 +1,11 @@
+"""Asserts a rules_py binary's venv sources and imports reached this target.
+
+Run by an @rules_python py_test that depends on the rules_py binary: the
+launcher rule must surface the sibling venv's imports and transitive
+sources (the binary's own srcs and its deps) through rules_python's PyInfo.
+"""
+
+import tool
+
+assert tool.TOOL_NAME == "rules_py tool", tool.TOOL_NAME
+assert tool.GREETING == "hello from rules_py", tool.GREETING

--- a/e2e/rules-python-provider-compat/test.sh
+++ b/e2e/rules-python-provider-compat/test.sh
@@ -2,8 +2,8 @@
 
 # `//...` covers the compatibility layer turned on (see .bazelrc). This asserts
 # the other half: with the layer off, an @rules_python consumer of a
-# rules_py library fails analysis, so the passing tests above prove the flag
-# and not some incidental interop.
+# rules_py library or binary fails analysis, so the passing tests above prove
+# the flag and not some incidental interop.
 
 set -uo pipefail
 
@@ -19,16 +19,18 @@ fail() {
 failure_log="$(mktemp)"
 trap 'rm -f "$failure_log"' EXIT
 
-if "$BAZEL" build \
-    --lockfile_mode=off \
-    --@aspect_rules_py//py:emit_rules_python_providers=false \
-    -- //:rules_python_consumer_test >"$failure_log" 2>&1; then
-    fail "a rules_python target consumed a rules_py library without the compatibility layer"
-fi
+for target in //:rules_python_consumer_test //:rules_python_binary_consumer_test; do
+    if "$BAZEL" build \
+        --lockfile_mode=off \
+        --@aspect_rules_py//py:emit_rules_python_providers=false \
+        -- "$target" >"$failure_log" 2>&1; then
+        fail "a rules_python target consumed $target's rules_py dependency without the compatibility layer"
+    fi
 
-if ! grep -q "does not have mandatory providers" "$failure_log"; then
-    cat "$failure_log" >&2
-    fail "the disabled compatibility layer lacked a provider-mismatch diagnostic"
-fi
+    if ! grep -q "does not have mandatory providers" "$failure_log"; then
+        cat "$failure_log" >&2
+        fail "the disabled compatibility layer lacked a provider-mismatch diagnostic for $target"
+    fi
+done
 
 echo "PASS: rules_python providers are emitted only under the compatibility flag"

--- a/e2e/rules-python-provider-compat/tool.py
+++ b/e2e/rules-python-provider-compat/tool.py
@@ -1,0 +1,8 @@
+"""An already-migrated binary: built by rules_py, depended on by an @rules_python test."""
+
+from lib import GREETING
+
+TOOL_NAME = "rules_py tool"
+
+if __name__ == "__main__":
+    print(GREETING)

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -44,9 +44,10 @@ alias(
 )
 
 # Compatibility layer for half-migrated trees: with
-# --@aspect_rules_py//py:emit_rules_python_providers, py_library also emits the
-# @rules_python providers so not-yet-migrated rules_python py_* targets keep
-# building. Turn it off once the tree is on rules_py.
+# --@aspect_rules_py//py:emit_rules_python_providers, py_library, py_binary,
+# and py_test also emit the @rules_python providers so not-yet-migrated
+# rules_python py_* targets keep building. Turn it off once the tree is on
+# rules_py.
 # See docs/migrating.md.
 alias(
     name = "emit_rules_python_providers",

--- a/py/private/py_info_interop.bzl
+++ b/py/private/py_info_interop.bzl
@@ -1,8 +1,8 @@
 """Interop between rules_py's `PyInfo` and `@rules_python`'s.
 
-The `deps` attribute shared by py_library/py_binary/py_test (and rules reusing
-their attrs) accepts targets built by either ruleset. rules_py always emits its
-own `PyInfo` (`//py/private:py_info.bzl`); native `@rules_python` targets (e.g.
+The `deps` attribute on rules_py rules accepts targets built by either
+ruleset. rules_py always emits its own `PyInfo`
+(`//py/private:py_info.bzl`); native `@rules_python` targets (e.g.
 a `py_proto_library`) carry `@rules_python`'s. Both expose `transitive_sources`
 and `imports`, which is everything rules_py reads from a foreign dep.
 
@@ -14,10 +14,10 @@ the other.
 The reverse direction (a `@rules_python` rule consuming a rules_py target) is
 not part of the steady-state design. It exists only as a migration
 compatibility layer: under
-`--@aspect_rules_py//py:emit_rules_python_providers`, `py_library`
-additionally emits the `@rules_python` providers a `py_*` target from that
-ruleset demands, so a half-converted tree keeps building. A fully migrated tree leaves
-the flag off. See py_library.bzl.
+`--@aspect_rules_py//py:emit_rules_python_providers`, rules_py rules
+additionally emit the `@rules_python` providers a `py_*` target from that
+ruleset demands, so a half-converted tree keeps building. A fully migrated
+tree leaves the flag off.
 """
 
 load("@rules_python//python:defs.bzl", _RulesPythonPyInfo = "PyInfo")

--- a/py/private/py_venv/py_venv_exec.bzl
+++ b/py/private/py_venv/py_venv_exec.bzl
@@ -7,9 +7,10 @@ attrs to the auto-generated sibling.
 """
 
 load("@bazel_lib//lib:expand_make_vars.bzl", "expand_locations", "expand_variables")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@hermetic_launcher//launcher:lib.bzl", "launcher")
 load("//py/private:py_info.bzl", "PyInfo")
-load("//py/private:py_info_interop.bzl", "get_py_info", "has_py_info")
+load("//py/private:py_info_interop.bzl", "RulesPythonPyInfo", "get_py_info", "has_py_info")
 load("//py/private:py_semantics.bzl", _py_semantics = "semantics")
 load("//py/private:transitions.bzl", "reset_python_flags_transition")
 load(":types.bzl", "VirtualenvInfo", "venv_root")
@@ -131,7 +132,7 @@ def _py_venv_exec_impl(ctx):
         extensions = ["py"],
     )
 
-    return [
+    providers = [
         DefaultInfo(
             files = depset([executable_launcher, main]),
             executable = executable_launcher,
@@ -154,6 +155,14 @@ def _py_venv_exec_impl(ctx):
             inherited_environment = inherited_env,
         ),
     ]
+
+    if ctx.attr._emit_rules_python_providers[BuildSettingInfo].value:
+        providers.append(RulesPythonPyInfo(
+            imports = vinfo.imports,
+            transitive_sources = vinfo.transitive_sources,
+        ))
+
+    return providers
 
 _attrs = dict({
     "env": attr.string_dict(
@@ -229,6 +238,9 @@ that must match the terminal's Python environment in `deps`.
     ),
     "_allowlist_function_transition": attr.label(
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+    "_emit_rules_python_providers": attr.label(
+        default = "//py/private:emit_rules_python_providers",
     ),
 })
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
