### PR TITLE
perf: avoid unnecessary unpack.py imports, lazy load

### DIFF
--- a/py/private/py_unpacked_wheel.bzl
+++ b/py/private/py_unpacked_wheel.bzl
@@ -19,8 +19,10 @@ def _py_unpacked_wheel_impl(ctx):
     args.add(unpack_script)
     args.add_all([unpack_directory], expand_directories = False, before_each = "--into")
     args.add("--wheel", ctx.file.src)
-    args.add("--python-version-major", py_toolchain.interpreter_version_info.major)
-    args.add("--python-version-minor", py_toolchain.interpreter_version_info.minor)
+    args.add("--python-version", "{}.{}".format(
+        py_toolchain.interpreter_version_info.major,
+        py_toolchain.interpreter_version_info.minor,
+    ))
 
     ctx.actions.run(
         outputs = [unpack_directory],

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -12,20 +12,22 @@ Invoked by Bazel as::
     <exec_python> unpack.py --into <dir> --wheel <file> --python-version-major N --python-version-minor M [...]
 """
 
-import argparse
-import configparser
+from __future__ import annotations
+
+# Module-level imports are the bulk of this tool's per-action startup cost;
+# anything conditional (subprocess, configparser, urllib.parse, exclude_glob)
+# is imported where it's needed instead.
 import csv
 import hashlib
 import io
 import os
 import re
 import shutil
-import subprocess
+import sys
 import zipfile
 from base64 import urlsafe_b64encode
-from pathlib import Path
 from collections.abc import Sequence
-from urllib.parse import unquote
+from pathlib import Path
 
 _RELOCATABLE_SHEBANG = """\
 #!/bin/sh
@@ -254,6 +256,8 @@ def _data_prefix(basename: str, record_dir: str | None) -> str:
     """
     if record_dir and record_dir.endswith(".dist-info") and "/" not in record_dir:
         return record_dir[: -len(".dist-info")] + ".data/"
+    from urllib.parse import unquote
+
     return "-".join(unquote(basename).split("-")[:2]) + ".data/"
 
 
@@ -387,6 +391,8 @@ def install_wheel(
                 installed[dest] = reusable_record
 
     for ep_path in site_packages.glob("*.dist-info/entry_points.txt"):
+        import configparser
+
         cp = configparser.ConfigParser(strict=False, delimiters=("=",))
         setattr(cp, "optionxform", str)
         cp.read(str(ep_path), encoding="utf-8")
@@ -447,30 +453,82 @@ def install_wheel(
     return original_import_roots
 
 
+class _Args:
+    into: Path
+    wheel: Path
+    python_version_major: int
+    python_version_minor: int
+
+    def __init__(self) -> None:
+        self.patches: list[Path] = []
+        self.patch_strip = 0
+        self.patch_tool = Path("patch")
+        self.preserve_path: list[str] = []
+        self.expected_data_files_manifest: Path | None = None
+        # Raw glob strings from argv, replaced by parsed patterns in main().
+        self.exclude_glob: list = []
+        self.compile_pyc = False
+        self.pyc_invalidation_mode = "unchecked-hash"
+        self.python: Path | None = None
+
+
+def _parse_args(argv: Sequence[str]) -> _Args:
+    """Parse the Bazel-generated argv by hand; argparse's import chain would
+    dominate this tool's startup time."""
+    args = _Args()
+    flags = iter(argv)
+    for flag in flags:
+        if flag == "--compile-pyc":
+            args.compile_pyc = True
+            continue
+        flag, equals, value = flag.partition("=")
+        if not equals:
+            value = next(flags, None)
+            if value is None:
+                raise SystemExit("Missing value for flag: {}".format(flag))
+        if flag == "--into":
+            args.into = Path(value)
+        elif flag == "--wheel":
+            args.wheel = Path(value)
+        elif flag == "--python-version-major":
+            args.python_version_major = int(value)
+        elif flag == "--python-version-minor":
+            args.python_version_minor = int(value)
+        elif flag == "--patch":
+            args.patches.append(Path(value))
+        elif flag == "--patch-strip":
+            args.patch_strip = int(value)
+        elif flag == "--patch-tool":
+            args.patch_tool = Path(value)
+        elif flag == "--preserve-path":
+            args.preserve_path.append(value)
+        elif flag == "--expected-data-files-manifest":
+            # Newline-separated prefix-relative `.data/data/` paths; presence
+            # enables the post-patch data-file check (an empty manifest is a
+            # meaningful expectation). A file rather than repeated flags: a
+            # wheel like jupyterlab ships thousands of prefix paths, enough to
+            # risk ARG_MAX.
+            args.expected_data_files_manifest = Path(value)
+        elif flag == "--exclude-glob":
+            args.exclude_glob.append(value)
+        elif flag == "--pyc-invalidation-mode":
+            if value not in ("checked-hash", "unchecked-hash", "timestamp"):
+                raise SystemExit("Invalid --pyc-invalidation-mode: {}".format(value))
+            args.pyc_invalidation_mode = value
+        elif flag == "--python":
+            args.python = Path(value)
+        else:
+            raise SystemExit("Unknown flag: {}".format(flag))
+    for required in ("into", "wheel", "python_version_major", "python_version_minor"):
+        if not hasattr(args, required):
+            raise SystemExit(
+                "Missing required flag: --{}".format(required.replace("_", "-"))
+            )
+    return args
+
+
 def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--into", required=True, type=Path)
-    ap.add_argument("--wheel", required=True, type=Path)
-    ap.add_argument("--python-version-major", required=True, type=int)
-    ap.add_argument("--python-version-minor", required=True, type=int)
-    ap.add_argument("--patch", dest="patches", action="append", default=[], type=Path)
-    ap.add_argument("--patch-strip", type=int, default=0)
-    ap.add_argument("--patch-tool", type=Path, default=Path("patch"))
-    ap.add_argument("--preserve-path", action="append", default=[])
-    # Passing this enables the post-patch data-file check; an empty manifest is a
-    # meaningful expectation (any shipped data file reads as added), so presence
-    # alone is the switch. A file rather than repeated flags: a wheel like
-    # jupyterlab ships thousands of prefix paths, enough to risk ARG_MAX.
-    ap.add_argument("--expected-data-files-manifest", type=Path,
-                    help="Newline-separated prefix-relative `.data/data/` paths. When "
-                         "given, require the post-patch prefix files to match them "
-                         "exactly (venv assembly projects that pre-patch set).")
-    ap.add_argument("--exclude-glob", action="append", default=[])
-    ap.add_argument("--compile-pyc", action="store_true")
-    ap.add_argument("--pyc-invalidation-mode", default="unchecked-hash",
-                    choices=["checked-hash", "unchecked-hash", "timestamp"])
-    ap.add_argument("--python", type=Path)
-    args = ap.parse_args()
+    args = _parse_args(sys.argv[1:])
     if args.exclude_glob:
         from exclude_glob import parse
 
@@ -515,6 +573,8 @@ def main() -> None:
             raise SystemExit("Preserved wheel path does not exist: {}".format(relative))
 
     for patch_file in args.patches:
+        import subprocess
+
         # --no-backup-if-mismatch: a fuzz/offset apply otherwise drops a
         # `<file>.orig` into the install tree, leaking into every consuming venv.
         with patch_file.open("rb") as patch_stream:
@@ -626,6 +686,8 @@ def main() -> None:
     if args.compile_pyc:
         if not args.python:
             raise SystemExit("--python is required when --compile-pyc is set")
+        import subprocess
+
         # Wheels may retain source for older Python versions. Match pip by
         # retaining compileall's diagnostics while ignoring its aggregate
         # false result; check=True still rejects abnormal interpreter exits.

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -508,8 +508,6 @@ def _parse_args(argv: Sequence[str]) -> _Args:
         elif flag == "--compile-pyc":
             args.compile_pyc = Path(value)
         elif flag == "--pyc-invalidation-mode":
-            if value not in ("checked-hash", "unchecked-hash", "timestamp"):
-                raise SystemExit("Invalid --pyc-invalidation-mode: {}".format(value))
             args.pyc_invalidation_mode = value
         else:
             raise SystemExit("Unknown flag: {}".format(flag))

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -475,11 +475,9 @@ def _parse_args(argv: Sequence[str]) -> _Args:
     args = _Args()
     flags = iter(argv)
     for flag in flags:
-        flag, equals, value = flag.partition("=")
-        if not equals:
-            value = next(flags, None)
-            if value is None:
-                raise SystemExit("Missing value for flag: {}".format(flag))
+        value = next(flags, None)
+        if value is None:
+            raise SystemExit("Missing value for flag: {}".format(flag))
         if flag == "--into":
             args.into = Path(value)
         elif flag == "--wheel":

--- a/py/tools/unpack/unpack.py
+++ b/py/tools/unpack/unpack.py
@@ -9,7 +9,7 @@ Optionally applies patch files and pre-compiles ``.pyc`` bytecode.
 
 Invoked by Bazel as::
 
-    <exec_python> unpack.py --into <dir> --wheel <file> --python-version-major N --python-version-minor M [...]
+    <exec_python> unpack.py --into <dir> --wheel <file> --python-version M.m [...]
 """
 
 from __future__ import annotations
@@ -280,8 +280,7 @@ def _relative_path(value: str, what: str) -> Path:
 
 
 def install_wheel(
-    version_major: int,
-    version_minor: int,
+    python_version: str,
     into: Path,
     wheel_path: Path,
     exclude_patterns: Sequence[tuple[str, ...]],
@@ -300,7 +299,7 @@ def install_wheel(
             )
         wheel_path = whls[0]
 
-    site_packages = into / "lib" / "python{}.{}".format(version_major, version_minor) / "site-packages"
+    site_packages = into / "lib" / ("python" + python_version) / "site-packages"
     bin_dir = into / "bin"
     site_packages.mkdir(parents=True, exist_ok=True)
     bin_dir.mkdir(parents=True, exist_ok=True)
@@ -456,8 +455,7 @@ def install_wheel(
 class _Args:
     into: Path
     wheel: Path
-    python_version_major: int
-    python_version_minor: int
+    python_version: str
 
     def __init__(self) -> None:
         self.patches: list[Path] = []
@@ -465,11 +463,10 @@ class _Args:
         self.patch_tool = Path("patch")
         self.preserve_path: list[str] = []
         self.expected_data_files_manifest: Path | None = None
-        # Raw glob strings from argv, replaced by parsed patterns in main().
-        self.exclude_glob: list = []
-        self.compile_pyc = False
+        self.exclude_glob: list[tuple[str, ...]] = []
+        # Interpreter that compiles the bytecode; presence enables compilation.
+        self.compile_pyc: Path | None = None
         self.pyc_invalidation_mode = "unchecked-hash"
-        self.python: Path | None = None
 
 
 def _parse_args(argv: Sequence[str]) -> _Args:
@@ -478,9 +475,6 @@ def _parse_args(argv: Sequence[str]) -> _Args:
     args = _Args()
     flags = iter(argv)
     for flag in flags:
-        if flag == "--compile-pyc":
-            args.compile_pyc = True
-            continue
         flag, equals, value = flag.partition("=")
         if not equals:
             value = next(flags, None)
@@ -490,10 +484,8 @@ def _parse_args(argv: Sequence[str]) -> _Args:
             args.into = Path(value)
         elif flag == "--wheel":
             args.wheel = Path(value)
-        elif flag == "--python-version-major":
-            args.python_version_major = int(value)
-        elif flag == "--python-version-minor":
-            args.python_version_minor = int(value)
+        elif flag == "--python-version":
+            args.python_version = value
         elif flag == "--patch":
             args.patches.append(Path(value))
         elif flag == "--patch-strip":
@@ -510,16 +502,18 @@ def _parse_args(argv: Sequence[str]) -> _Args:
             # risk ARG_MAX.
             args.expected_data_files_manifest = Path(value)
         elif flag == "--exclude-glob":
-            args.exclude_glob.append(value)
+            from exclude_glob import parse
+
+            args.exclude_glob.append(parse(value))
+        elif flag == "--compile-pyc":
+            args.compile_pyc = Path(value)
         elif flag == "--pyc-invalidation-mode":
             if value not in ("checked-hash", "unchecked-hash", "timestamp"):
                 raise SystemExit("Invalid --pyc-invalidation-mode: {}".format(value))
             args.pyc_invalidation_mode = value
-        elif flag == "--python":
-            args.python = Path(value)
         else:
             raise SystemExit("Unknown flag: {}".format(flag))
-    for required in ("into", "wheel", "python_version_major", "python_version_minor"):
+    for required in ("into", "wheel", "python_version"):
         if not hasattr(args, required):
             raise SystemExit(
                 "Missing required flag: --{}".format(required.replace("_", "-"))
@@ -529,25 +523,18 @@ def _parse_args(argv: Sequence[str]) -> _Args:
 
 def main() -> None:
     args = _parse_args(sys.argv[1:])
-    if args.exclude_glob:
-        from exclude_glob import parse
-
-        args.exclude_glob = [parse(pattern) for pattern in args.exclude_glob]
 
     original_import_roots = install_wheel(
-        args.python_version_major,
-        args.python_version_minor,
+        args.python_version,
         args.into,
         args.wheel,
         args.exclude_glob if not args.patches else (),
         # Supplied bytecode outlives the source it was built from.
-        args.compile_pyc or bool(args.patches),
+        bool(args.compile_pyc or args.patches),
     )
 
     site_packages = (
-        args.into / "lib"
-        / "python{}.{}".format(args.python_version_major, args.python_version_minor)
-        / "site-packages"
+        args.into / "lib" / ("python" + args.python_version) / "site-packages"
     )
     # Analysis uses these paths for collision and merge planning. Snapshot their
     # installed shape here, where both the before and after states are available.
@@ -684,8 +671,6 @@ def main() -> None:
                 ])
 
     if args.compile_pyc:
-        if not args.python:
-            raise SystemExit("--python is required when --compile-pyc is set")
         import subprocess
 
         # Wheels may retain source for older Python versions. Match pip by
@@ -694,7 +679,7 @@ def main() -> None:
         # https://github.com/pypa/pip/blob/c8651d86d2d080c1936974873ab162f9c2507666/src/pip/_internal/operations/install/wheel.py#L623-L639
         subprocess.run(
             [
-                str(args.python),
+                str(args.compile_pyc),
                 "-c",
                 "import compileall; compileall.main()",
                 "-q",

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -161,13 +161,9 @@ def _run_unpack(
         str(output),
         "--wheel",
         str(wheel),
-        "--python-version-major",
-        str(sys.version_info.major),
-        "--python-version-minor",
-        str(sys.version_info.minor),
-        *(("--compile-pyc",) if compile_pyc else ()),
-        "--python",
-        str(python),
+        "--python-version",
+        f"{sys.version_info.major}.{sys.version_info.minor}",
+        *(("--compile-pyc", str(python)) if compile_pyc else ()),
         *extra_args,
     ]
     return subprocess.run(
@@ -216,8 +212,7 @@ def main() -> None:
 
         unpack_module._sha256 = recording_sha256
         unpack_module.install_wheel(
-            sys.version_info.major,
-            sys.version_info.minor,
+            f"{sys.version_info.major}.{sys.version_info.minor}",
             record_out,
             record_wheel,
             (),
@@ -252,8 +247,7 @@ def main() -> None:
             fallback_out = root / name
             hashed_names.clear()
             unpack_module.install_wheel(
-                sys.version_info.major,
-                sys.version_info.minor,
+                f"{sys.version_info.major}.{sys.version_info.minor}",
                 fallback_out,
                 fallback_wheel,
                 (),
@@ -274,8 +268,7 @@ def main() -> None:
         duplicate_out = root / "duplicate"
         hashed_names.clear()
         unpack_module.install_wheel(
-            sys.version_info.major,
-            sys.version_info.minor,
+            f"{sys.version_info.major}.{sys.version_info.minor}",
             duplicate_out,
             duplicate_wheel,
             (),
@@ -295,8 +288,7 @@ def main() -> None:
         duplicate_member_out = root / "duplicate_member"
         hashed_names.clear()
         unpack_module.install_wheel(
-            sys.version_info.major,
-            sys.version_info.minor,
+            f"{sys.version_info.major}.{sys.version_info.minor}",
             duplicate_member_out,
             duplicate_member_wheel,
             (),
@@ -321,12 +313,9 @@ def main() -> None:
             str(good_out),
             "--wheel",
             str(good_wheel),
-            "--python-version-major",
-            str(sys.version_info.major),
-            "--python-version-minor",
-            str(sys.version_info.minor),
+            "--python-version",
+            f"{sys.version_info.major}.{sys.version_info.minor}",
             "--compile-pyc",
-            "--python",
             sys.executable,
         ]
         try:

--- a/py/tools/unpack/unpack_test.py
+++ b/py/tools/unpack/unpack_test.py
@@ -424,7 +424,7 @@ def main() -> None:
             good_wheel,
             filtered_bytecode_out,
             Path(sys.executable),
-            ("--exclude-glob=fixture/__pycache__/mod.*.pyc",),
+            ("--exclude-glob", "fixture/__pycache__/mod.*.pyc",),
         )
         assert filtered_bytecode.returncode == 0, (
             filtered_bytecode.stdout + filtered_bytecode.stderr
@@ -470,7 +470,7 @@ def main() -> None:
             corrupt_wheel,
             corrupt_out,
             Path(sys.executable),
-            ("--exclude-glob=fixture/**/tests/**",),
+            ("--exclude-glob", "fixture/**/tests/**",),
         )
         assert skipped.returncode == 0, skipped.stdout + skipped.stderr
         assert not (
@@ -548,7 +548,7 @@ def main() -> None:
             excluded_invalid_wheel,
             root / "excluded-invalid-out",
             Path(sys.executable),
-            ("--exclude-glob=**",),
+            ("--exclude-glob", "**",),
         )
         assert excluded_invalid.returncode != 0, (
             excluded_invalid.stdout + excluded_invalid.stderr
@@ -719,7 +719,7 @@ else:
                 str(mutation_tool),
                 "--preserve-path",
                 "fixture",
-                "--exclude-glob=fixture/**/tests/**",
+                "--exclude-glob", "fixture/**/tests/**",
             ),
         )
         assert accepted.returncode == 0, accepted.stdout + accepted.stderr
@@ -739,7 +739,7 @@ else:
                 str(mutation_tool),
                 "--preserve-path",
                 "fixture",
-                "--exclude-glob=fixture/__init__.py",
+                "--exclude-glob", "fixture/__init__.py",
             ),
         )
         assert accepted.returncode == 0, accepted.stdout + accepted.stderr
@@ -928,7 +928,7 @@ else:
             good_wheel,
             excluded_data_dir,
             Path(sys.executable),
-            ("--exclude-glob=**/*.pyc",),
+            ("--exclude-glob", "**/*.pyc",),
         )
         assert excluded_data.returncode == 0, excluded_data.stdout + excluded_data.stderr
         assert (excluded_data_dir / "share" / "supplied.pyc").is_file()
@@ -1031,14 +1031,14 @@ else:
                 "demo",
                 "--preserve-path",
                 "demo-1.0.dist-info",
-                "--exclude-glob=demo/**/tests/**",
-                "--exclude-glob=demo/file_tests/test_*.py",
-                "--exclude-glob=demo/sdk-core",
-                "--exclude-glob=pkg/test_*.py",
-                "--exclude-glob=pkg/.py",
-                "--exclude-glob=pkg/..py",
-                "--exclude-glob=google/**/*.proto",
-                "--exclude-glob=demo-1.0.dist-info/helper.py",
+                "--exclude-glob", "demo/**/tests/**",
+                "--exclude-glob", "demo/file_tests/test_*.py",
+                "--exclude-glob", "demo/sdk-core",
+                "--exclude-glob", "pkg/test_*.py",
+                "--exclude-glob", "pkg/.py",
+                "--exclude-glob", "pkg/..py",
+                "--exclude-glob", "google/**/*.proto",
+                "--exclude-glob", "demo-1.0.dist-info/helper.py",
             ),
         )
         assert filtered.returncode == 0, filtered.stdout + filtered.stderr
@@ -1155,7 +1155,7 @@ else:
             filter_wheel,
             root / "removed-metadata",
             Path(sys.executable),
-            ("--exclude-glob=demo-1.0.dist-info/METADATA",),
+            ("--exclude-glob", "demo-1.0.dist-info/METADATA",),
         )
         assert removed_metadata.returncode != 0, removed_metadata.stderr
         assert "wheel exclusions removed installed METADATA" in removed_metadata.stderr
@@ -1378,7 +1378,7 @@ else:
             entry_point_wheel,
             entry_point_out,
             Path(sys.executable),
-            ("--exclude-glob=entry_point-1.0.dist-info/entry_points.txt",),
+            ("--exclude-glob", "entry_point-1.0.dist-info/entry_points.txt",),
         )
         assert entry_point.returncode == 0, entry_point.stderr
         assert {entry.name for entry in (entry_point_out / "bin").iterdir()} == {

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -221,7 +221,7 @@ def _whl_install(ctx):
         exec_runtime.files,
     ]
     if ctx.attr.exclude_glob:
-        arguments.add_all(ctx.attr.exclude_glob, format_each = "--exclude-glob=%s")
+        arguments.add_all(ctx.attr.exclude_glob, before_each = "--exclude-glob")
         transitive_inputs.append(depset([ctx.file._exclude_glob_script]))
 
     # Patch application (happens before pyc compilation).

--- a/uv/private/whl_install/rule.bzl
+++ b/uv/private/whl_install/rule.bzl
@@ -211,8 +211,10 @@ def _whl_install(ctx):
     arguments.add(unpack_script)
     arguments.add_all([install_dir], expand_directories = False, before_each = "--into")
     arguments.add_all([archive], expand_directories = False, before_each = "--wheel")
-    arguments.add("--python-version-major", py_toolchain.interpreter_version_info.major)
-    arguments.add("--python-version-minor", py_toolchain.interpreter_version_info.minor)
+    arguments.add("--python-version", "{}.{}".format(
+        py_toolchain.interpreter_version_info.major,
+        py_toolchain.interpreter_version_info.minor,
+    ))
 
     transitive_inputs = [
         depset([archive, unpack_script, exec_runtime.interpreter]),
@@ -270,9 +272,8 @@ def _whl_install(ctx):
         py_toolchain.interpreter_version_info,
     )
     if ctx.attr.compile_pyc and exec_matches_target:
-        arguments.add("--compile-pyc")
+        arguments.add("--compile-pyc", exec_runtime.interpreter)
         arguments.add("--pyc-invalidation-mode", ctx.attr.pyc_invalidation_mode)
-        arguments.add("--python", exec_runtime.interpreter)
 
     ctx.actions.run(
         mnemonic = "WhlInstall",


### PR DESCRIPTION
Python interpreter start is a fixed 12.2ms floor, so the script-attributable overhead went 39.5 → 24.6ms — 38% cut. Remaining 24.6ms is mostly zipfile (plus its bz2/lzma/zstd/shutil pulls), _hashlib, re, csv — not removable without vendoring an unzip.

- Saving is per `PyUnpackedWheel`/`WhlInstall` action, fixed regardless of wheel size. Small wheels (majority of a lockfile) it's ~30% of the action; for `numpy`-sized wheels extraction dominates and this change is only noise.
- top-500-wheel graph: ~7.5s CPU shaved; wall-clock gain smaller since actions run parallel, but these fire in bulk on cold builds / lockfile bumps.
- Numbers are host-python 3.14; hermetic exec toolchain will differ slightly in absolute ms (argparse's _colorize→inspect chain is 3.14-specific, older versions save a bit less there) — same shape though.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
