### PR TITLE
perf: defer source-layer exclusions to the mtree action

### DIFF
--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_amd64_layers_listing.yaml
@@ -31,7 +31,6 @@ files:
   - -rwxr-xr-x  0 0      0         522 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0         111 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        1272 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/my_app_bin.venv
   - -rwxr-xr-x  0 0      0        6709 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - -rwxr-xr-x  0 0      0 * Jan  1  2023 ./app.runfiles/_repo_mapping
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_x86_64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11

--- a/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
+++ b/e2e/cases/oci/py_venv_image_layer/snapshots/my_app_arm64_layers_listing.yaml
@@ -31,7 +31,6 @@ files:
   - -rwxr-xr-x  0 0      0         522 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/lib/python3.11/site-packages/my_app_bin.venv.pth
   - -rwxr-xr-x  0 0      0         111 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/.my_app_bin.venv/pyvenv.cfg
   - -rwxr-xr-x  0 0      0         463 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/__main__.py
-  - -rwxr-xr-x  0 0      0        1272 Jan  1  2023 ./app.runfiles/_main/oci/py_venv_image_layer/my_app_bin.venv
   - -rwxr-xr-x  0 0      0        6709 Jan  1  2023 ./app.runfiles/_main/tools/verify_venv/verify_venv.py
   - -rwxr-xr-x  0 0      0 * Jan  1  2023 ./app.runfiles/_repo_mapping
   - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/aspect_rules_py++python_interpreters+python_3_11_aarch64_unknown_linux_gnu/bin/2to3 -> 2to3-3.11

--- a/py/private/modify_mtree.awk
+++ b/py/private/modify_mtree.awk
@@ -85,6 +85,33 @@ function decode_mtree_path(path) {
     return path
 }
 
+# Record one path-set entry: a trailing "/" marks a directory recorded by
+# root (tree artifacts are never expanded), anything else an exact path.
+function add_set_entry(entry, exact, dirs) {
+    entry = decode_mtree_path(entry)
+    if (entry ~ /\/$/) {
+        dirs[substr(entry, 1, length(entry) - 1)] = 1
+    } else {
+        exact[entry] = 1
+    }
+}
+
+# True when `path` is an exact entry of `exact` or a descendant of a `dirs`
+# directory.
+function path_in_set(path, exact, dirs, prefix) {
+    if (path in exact) {
+        return 1
+    }
+    prefix = path
+    while (match(prefix, /\/[^\/]*$/)) {
+        prefix = substr(prefix, 1, RSTART - 1)
+        if (prefix in dirs) {
+            return 1
+        }
+    }
+    return 0
+}
+
 function replace_metadata_field(row, pattern, replacement) {
     if (!match(row, pattern)) {
         return row
@@ -93,6 +120,17 @@ function replace_metadata_field(row, pattern, replacement) {
 }
 
 {
+    # Optional path sets, read before the source rows: skip drops matching
+    # source rows; chmod forces them to mode=0755.
+    if (skip_argind && ARGIND == skip_argind) {
+        add_set_entry($0, skip_set, skip_dirs)
+        next
+    }
+    if (chmod_argind && ARGIND == chmod_argind) {
+        add_set_entry($0, chmod_set, chmod_dirs)
+        next
+    }
+
     source_field = ""
     source_type = ""
     source_path = ""
@@ -112,6 +150,15 @@ function replace_metadata_field(row, pattern, replacement) {
             symlink_map[source_path] = $1
         }
         next
+    }
+
+    if (skip_argind && source_path != "" && path_in_set(source_path, skip_set, skip_dirs)) {
+        next
+    }
+
+    # Files also present in the binaries' source closure keep 0755.
+    if (chmod_argind && source_path != "" && path_in_set(source_path, chmod_set, chmod_dirs)) {
+        $0 = replace_metadata_field($0, "[[:space:]]mode=[^ ]+", "mode=0755")
     }
 
     symlink = ""

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -33,7 +33,7 @@ Sharing model:
 load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private:py_info_interop.bzl", "has_py_info")
-load("//py/private/py_venv:types.bzl", "PY_VENV_KINDS")
+load("//py/private/py_venv:types.bzl", "VirtualenvInfo")
 load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN", "interpreter_files_and_version")
 
 _TAR_TOOLCHAIN = "@tar.bzl//tar/toolchain:type"
@@ -206,10 +206,10 @@ py_layer_tier = rule(
 _LayerInfo = provider(
     doc = "Private: aggregated source files + pip package layers produced by _layer_aspect.",
     fields = {
-        "source_files": "depset[File] — ungrouped first-party Python source files.",
+        "source_files": "depset[File] — default source layer candidates, collected from venv providers, binary outputs, and opaque runtime deps; bytes owned by other layers are dropped by the source tar's skip set.",
         "pip_packages": "depset[struct] — fully transitive pip packages with per-package layers.",
         "first_party_layers": "depset[struct(label, files, group)] — first-party PyInfo targets matched by py_layer_tier.groups.",
-        "interpreter_layer": "struct(tar, group, interpreter_files) | None — prebuilt interpreter layer tar + its group name + the files used to build it, declared at the toolchain target's namespace so the tar action-shares across every py_image_layer using that toolchain config.",
+        "interpreter_layer": "struct(tar, group, interpreter_files) | None — prebuilt interpreter layer tar + its group name + the files used to build it, declared at the toolchain target's namespace so the tar action-shares across every py_image_layer using that toolchain config. tar=None at the toolchain node when no interpreter group is configured.",
     },
 )
 
@@ -239,6 +239,22 @@ def _collect_from_deps(ctx, provider):
         if provider in dep:
             results.append(dep[provider])
     return results
+
+def _runtime_files(dep):
+    """Return an opaque runtime target's outputs plus its transitive runfiles."""
+    return depset(transitive = [
+        dep[DefaultInfo].files,
+        dep[DefaultInfo].default_runfiles.files,
+    ])
+
+def _opaque_dep_files(rule_attr, attr_names):
+    # PyInfo deps (including wheel leaves) self-capture via the aspect.
+    parts = []
+    for attr_name in attr_names:
+        for dep in getattr(rule_attr, attr_name, None) or []:
+            if not has_py_info(dep) and DefaultInfo in dep:
+                parts.append(_runtime_files(dep))
+    return parts
 
 def _compression_for(plan, group_name):
     comp = plan.compression.get(group_name, None) if group_name else None
@@ -345,7 +361,9 @@ def _layer_aspect_impl(target, ctx):
             return []
         plan = ctx.attr._layer_tier[PyLayerTierInfo]
         interp_group = plan.interpreter_group
-        interp_layer = None
+
+        # tar=None: no interpreter layer configured; files go to the source layer.
+        interp_layer = struct(tar = None, group = None, interpreter_files = interp_depset)
         if interp_group:
             bsdtar, bsdtar_files = _tar_toolchain(ctx)
             algorithm, level, ext = _compression_for(plan, interp_group)
@@ -425,20 +443,8 @@ def _layer_aspect_impl(target, ctx):
             interpreter_layer = interp,
         )]
 
-    # Skip PyInfo deps (including wheel-leaf targets, which also emit PyInfo) —
-    # they self-capture via the aspect.
-    if kind not in PY_VENV_KINDS and has_py_info(target) and not is_binary:
-        own_parts = [target[DefaultInfo].files]
-        for attr_name in ("data", "deps"):
-            attr_val = getattr(ctx.rule.attr, attr_name, None)
-            if not attr_val:
-                continue
-            for dep in attr_val:
-                if has_py_info(dep):
-                    continue
-                if DefaultInfo in dep:
-                    own_parts.append(dep[DefaultInfo].files)
-        own_depset = depset(transitive = own_parts)
+    if VirtualenvInfo not in target and has_py_info(target) and not is_binary:
+        own_depset = depset(transitive = [target[DefaultInfo].files] + _opaque_dep_files(ctx.rule.attr, ("data", "deps")))
 
         plan = ctx.attr._layer_tier[PyLayerTierInfo]
         label_str = normalize_label(str(target.label))
@@ -452,41 +458,32 @@ def _layer_aspect_impl(target, ctx):
         else:
             own_source.append(own_depset)
 
-    if kind in PY_VENV_KINDS:
+    if VirtualenvInfo in target:
+        # Own srcs and opaque dep closures, not transitive_sources or runfiles:
+        # wheel install trees must stay out of the source layer's inputs.
+        own_source.append(target[VirtualenvInfo].runtime_files)
+        own_source.append(depset(ctx.rule.files.srcs))
+        own_source.extend(_opaque_dep_files(ctx.rule.attr, ("data", "deps")))
         if PY_TOOLCHAIN in ctx.rule.toolchains:
             py_tc = ctx.rule.toolchains[PY_TOOLCHAIN]
             if _LayerInfo in py_tc:
-                interpreter_layer = py_tc[_LayerInfo].interpreter_layer
+                tc_layer = py_tc[_LayerInfo].interpreter_layer
+                if tc_layer.tar != None:
+                    interpreter_layer = tc_layer
+                else:
+                    own_source.append(tc_layer.interpreter_files)
 
-    # Binaries walk their runfiles for the source layer, filtering out bytes already
-    # shipping in their own pip / fp-group / interpreter layers.
+    # Venv sources arrive via the sibling venv's provider; the binary adds
+    # only its own outputs and launcher-local opaque `data`.
     if is_binary:
-        skip_paths = {}
-        for pkg_depset in transitive_pkgs:
-            for pkg in pkg_depset.to_list():
-                for f in pkg.files.to_list():
-                    skip_paths[f.path] = True
-        for fp_depset in transitive_fp:
-            for entry in fp_depset.to_list():
-                for f in entry.files.to_list():
-                    skip_paths[f.path] = True
-
-        # Opt-in interpreter layer. The aspect fires on the py toolchain via
-        # `toolchains_aspects` and declares the tar there; the venv propagates
-        # that layer (and its file list) so the binary uses the exact interpreter
-        # that built the venv rather than relying on its own toolchain resolution.
-        interp_paths = {}
-        for interp_layer in transitive_interp:
-            for f in interp_layer.interpreter_files.to_list():
-                interp_paths[f.path] = True
+        # The venv propagates the interpreter layer declared at its toolchain so
+        # the binary uses the exact interpreter that built the venv.
         venv = getattr(ctx.rule.attr, "venv", None)
         if venv != None and _LayerInfo in venv:
             interpreter_layer = venv[_LayerInfo].interpreter_layer
 
-        runfiles_files = target[DefaultInfo].default_runfiles.files.to_list()
-        filtered = [f for f in runfiles_files if f.path not in skip_paths and f.path not in interp_paths]
-        if filtered:
-            own_source.append(depset(direct = filtered))
+        own_source.append(target[DefaultInfo].files)
+        own_source.extend(_opaque_dep_files(ctx.rule.attr, ("data",)))
 
     return [_LayerInfo(
         source_files = depset(transitive = transitive_source + own_source),
@@ -635,8 +632,8 @@ def _source_destination(sp, strip_prefix, root, executable_dsts):
         return _apply_strip_prefix(sp, sp, root)
     return "./app.runfiles/_main/" + sp
 
-# mtree escapes spaces as \040; must stay byte-identical across every row
-# emitter or awk's path matching silently misses.
+# mtree escapes spaces as \040; must stay byte-identical between row emitters
+# and the skip/chmod path sets or awk's set matching silently misses.
 def _encode_mtree_path(path):
     return path.replace(" ", "\\040")
 
@@ -714,16 +711,16 @@ def _source_file_to_mtree(
         ),
     ]
 
-def _user_file_to_mtree(f, dir_expander, source_owned_paths, owner = "0", group = "0"):
+def _user_file_to_mtree(f, dir_expander, owner = "0", group = "0"):
     # Rule-level groups may contain declared symlinks that File.is_symlink
     # doesn't expose, so every grouped file needs the readlink fallback.
+    # Source-closure files get 0755 via the tar action's chmod set.
     if f.is_directory:
         return [
             _file_to_mtree_entry(child, "0755", maybe_symlink = True, owner = owner, group = group)
             for child in dir_expander.expand(f)
         ]
-    mode = "0755" if f.path in source_owned_paths else "0644"
-    return _file_to_mtree_entry(f, mode, maybe_symlink = True, owner = owner, group = group)
+    return _file_to_mtree_entry(f, "0644", maybe_symlink = True, owner = owner, group = group)
 
 def _should_skip_pkg_path(p):
     return (
@@ -826,6 +823,20 @@ _platform_cfg = transition(
     outputs = ["//command_line_option:platforms", "@aspect_rules_py//py:layer_tier"],
 )
 
+def _skip_path(f):
+    # Trailing "/" marks a directory; consumers prefix-match its children.
+    path = _encode_mtree_path(f.path)
+    return path + "/" if f.is_directory else path
+
+def _path_set_args(ctx, files_depsets):
+    # One path per line, consumed by the awk path-set readers.
+    args = ctx.actions.args()
+    args.set_param_file_format("multiline")
+    args.use_param_file("%s", use_always = True)
+    for files in files_depsets:
+        args.add_all(files, map_each = _skip_path, expand_directories = False)
+    return args
+
 def _declare_symlink_mapping(ctx, mappings):
     """Expand every mapping set's mtree rows into one shared file.
 
@@ -858,7 +869,7 @@ def _declare_symlink_mapping(ctx, mappings):
     )
     return mapping_out
 
-def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, compress, level, reqs, mnemonic, progress_msg, symlink_mappings = None):
+def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, compress, level, reqs, mnemonic, progress_msg, symlink_mappings = None, skip_files = None, chmod_files = None):
     # mtree (param file) → gawk (readlinks `type=link`/`type=file content=`
     # rows; `contents=` rows pass through; END buffers, asort-sorts, and
     # writes the sorted mtree to a file) → bsdtar consumes the file.
@@ -875,10 +886,23 @@ def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, 
 
     gawk_args = ctx.actions.args()
     gawk_args.add("-v", sorted_mtree, format = "outfile=%s")
-    gawk_args.add("-v", "1", format = "source_argind=%s")
-    gawk_args.add("-f", awk_script)
-    gawk_arguments = [gawk_args, mtree_args]
+
+    # Skip drops matching source rows; chmod forces them to 0755. Entries are
+    # path strings only, so the referenced files are never action inputs.
+    gawk_arguments = [gawk_args]
     gawk_inputs = [files_depset]
+    next_argind = 1
+    if skip_files != None:
+        gawk_args.add("-v", str(next_argind), format = "skip_argind=%s")
+        gawk_arguments.append(_path_set_args(ctx, [skip_files]))
+        next_argind += 1
+    if chmod_files != None:
+        gawk_args.add("-v", str(next_argind), format = "chmod_argind=%s")
+        gawk_arguments.append(_path_set_args(ctx, [chmod_files]))
+        next_argind += 1
+    gawk_args.add("-v", str(next_argind), format = "source_argind=%s")
+    gawk_args.add("-f", awk_script)
+    gawk_arguments.append(mtree_args)
     if symlink_mappings != None:
         # Own Args so the file lands in argv after the mtree param file: awk
         # treats files past source_argind as destination registrations only.
@@ -927,7 +951,7 @@ def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, 
         use_default_shell_env = False,
     )
 
-def _declare_group_tar(ctx, bsdtar, bsdtar_files, out_name, group_name, files, map_each, progress, symlink_mappings = None):
+def _declare_group_tar(ctx, bsdtar, bsdtar_files, out_name, group_name, files, map_each, progress, symlink_mappings = None, skip_files = None, chmod_files = None):
     tar_out = ctx.actions.declare_file(out_name)
     level = ctx.attr.group_compress_levels.get(group_name, "6")
     reqs = _parse_exec_requirements(ctx.attr.group_execution_requirements.get(group_name, []))
@@ -944,6 +968,8 @@ def _declare_group_tar(ctx, bsdtar, bsdtar_files, out_name, group_name, files, m
         "PyImageLayer",
         progress,
         symlink_mappings,
+        skip_files = skip_files,
+        chmod_files = chmod_files,
     )
     return tar_out
 
@@ -1063,7 +1089,6 @@ def _py_image_layer_impl(ctx):
 
     rule_group_names = {gname: True for gname in ctx.attr.groups.values()}
     rule_group_files = []
-    rule_group_paths = {}
     rule_groups = []
     for dep, group_name in ctx.attr.groups.items():
         dep_label = normalize_label(str(dep.label))
@@ -1071,27 +1096,13 @@ def _py_image_layer_impl(ctx):
             continue
         files = dep[DefaultInfo].files
         rule_group_files.append(files)
-        for f in files.to_list():
-            rule_group_paths[f.path] = True
         rule_groups.append((group_name, files))
 
     source_files = depset(transitive = [info.source_files for info in infos])
     if repo_mapping != None:
         source_files = depset(direct = [repo_mapping], transitive = [source_files])
-    source_owned_group_paths = {}
-    if rule_group_paths:
-        # The aspect cannot see rule-level groups, so decide ownership from the
-        # source closure once, then remove grouped bytes from the source tar.
-        ungrouped_source_files = []
-        for f in source_files.to_list():
-            if f.path in rule_group_paths:
-                source_owned_group_paths[f.path] = True
-            else:
-                ungrouped_source_files.append(f)
-        source_files = depset(direct = ungrouped_source_files)
-
     rule_group_map = lambda f, d: (
-        source_map(f, d) if f.short_path in executable_dsts else _user_file_to_mtree(f, d, source_owned_group_paths, owner, group)
+        source_map(f, d) if f.short_path in executable_dsts else _user_file_to_mtree(f, d, owner, group)
     )
 
     first_party_reference_files = []
@@ -1107,19 +1118,22 @@ def _py_image_layer_impl(ctx):
             layer = info.interpreter_layer
             interpreter_layers[layer.tar.path] = layer
 
+    # Non-default-layer file sets with their mtree mappers, lowest-priority
+    # first (awk last-row-wins); the same sets feed the source tar's skip set.
+    owned_sets = (
+        [(files, source_map) for files in first_party_reference_files] +
+        [(pkg.files, pkg_map) for pkg in all_pkgs] +
+        [(layer.interpreter_files, interpreter_map) for layer in interpreter_layers.values()] +
+        [(files, rule_group_map) for files in rule_group_files]
+    )
+    source_exclusion_files = [files for files, _ in owned_sets]
+
     # Each source-owned tier may contain a symlink whose target is emitted by
     # another tier. Share destination-only rows so every tar can rewrite those
     # links without copying the target bytes into that tar.
     symlink_mappings = None
     if rule_group_files or first_party_reference_files:
-        # awk's symlink_map is last-row-wins, so emit lowest-priority sets first:
-        # source/first-party, then interpreter, then rule groups.
-        reference_mappings = (
-            [(files, source_map) for files in [source_files] + first_party_reference_files] +
-            [(layer.interpreter_files, interpreter_map) for layer in interpreter_layers.values()] +
-            [(files, rule_group_map) for files in rule_group_files]
-        )
-        symlink_mappings = _declare_symlink_mapping(ctx, reference_mappings)
+        symlink_mappings = _declare_symlink_mapping(ctx, [(source_files, source_map)] + owned_sets)
 
     for group_name, files in rule_groups:
         tar_out = _declare_group_tar(
@@ -1132,6 +1146,7 @@ def _py_image_layer_impl(ctx):
             rule_group_map,
             "Creating image layer %s[%s]" % (ctx.label, group_name),
             symlink_mappings,
+            chmod_files = source_files,
         )
         all_tars.append(tar_out)
 
@@ -1240,6 +1255,7 @@ def _py_image_layer_impl(ctx):
         source_map,
         "Creating source layer for %s" % ctx.label,
         symlink_mappings,
+        skip_files = depset(transitive = source_exclusion_files) if source_exclusion_files else None,
     )
     all_tars.append(source_tar)
 
@@ -1258,28 +1274,25 @@ def _py_image_layer_impl(ctx):
         # Validate expanded rows whenever source destinations can be shared or remapped.
         # TreeArtifact roots can contain disjoint versioned children, so only
         # the production mappers' expanded destinations are authoritative.
-        source_files = depset(transitive = [source_files] + [
-            files
-            for group_name, file_sets in fp_by_group.items()
-            if group_name not in prebuilt_group_tars
-            for files in file_sets
-        ])
-        owned_sets = (
-            [(files, rule_group_map) for files in rule_group_files] +
-            [(pkg.files, pkg_map) for pkg in all_pkgs] +
-            [(layer.interpreter_files, interpreter_map) for layer in interpreter_layers.values()]
-        )
-
         mtree_args = ctx.actions.args()
         mtree_args.set_param_file_format("multiline")
         mtree_args.use_param_file("%s", use_always = True)
         mtree_args.add("#mtree")
         mtree_args.add_all(source_files, map_each = source_map, expand_directories = False, allow_closure = True)
+
+        # --skip applies only to the source rows above; owning-layer rows
+        # below stay visible for collision checks.
+        mtree_args.add("#end-source")
         for files, map_each in owned_sets:
             mtree_args.add_all(files, map_each = map_each, expand_directories = False, allow_closure = True)
         validation_args.add("--mtree")
         validation_arguments.append(mtree_args)
-        validation_inputs.extend([source_files] + [files for files, _ in owned_sets])
+
+        validation_skip_args = _path_set_args(ctx, source_exclusion_files)
+        validation_flag_args = ctx.actions.args()
+        validation_flag_args.add("--skip")
+        validation_arguments.extend([validation_flag_args, validation_skip_args])
+        validation_inputs.extend([source_files] + source_exclusion_files)
 
     ctx.actions.run(
         executable = ctx.executable._validator,

--- a/py/private/py_image_layer_validator.py
+++ b/py/private/py_image_layer_validator.py
@@ -10,6 +10,9 @@ Usage:
     label=path  — one entry per ungrouped pip package; `label` is the canonical pip label
                   (e.g. @pip//numpy), `path` is its install directory / file.
     --mtree FILE  — expanded mtree rows for shared or remapped source destinations.
+    --skip FILE   — source paths shipping in other layers; their rows before the
+                  `#end-source` marker are ignored. A trailing `/` marks a
+                  directory whose children are all excluded.
 """
 
 from __future__ import annotations
@@ -25,6 +28,7 @@ import sys
 from collections.abc import Iterable, Sequence
 
 _OCI_LAYER_HARD_LIMIT = 127
+_END_SOURCE_MARKER = "#end-source"
 _BINARY_GLOBS = {"*.so", "*.so.*", "*.pyd", "*.dylib", "*.dll"}
 _LAYER_TIER_TARGET = "@aspect_rules_py//py:layer_tier"
 _DEFAULT_LAYER_TIER_TARGET = "@aspect_rules_py//py/private:default_layer_tier"
@@ -279,12 +283,42 @@ def _comparable_symlink_target(source_kind: str, encoded_source: str) -> str | N
         return None
 
 
-def _mtree_collision(rows: Iterable[str]) -> str | None:
-    """Return the first conflicting expanded mtree destination, or None."""
+def _skip_match(source: str, skip_paths: frozenset[str], skip_dirs: frozenset[str]) -> bool:
+    """True when source is excluded: an exact skip_paths entry, or a
+    descendant of a skip_dirs directory (tree artifacts are recorded by
+    root, never expanded)."""
+    if source in skip_paths:
+        return True
+    idx = source.rfind("/")
+    while idx > 0:
+        if source[:idx] in skip_dirs:
+            return True
+        idx = source.rfind("/", 0, idx)
+    return False
+
+
+def _mtree_collision(
+    rows: Iterable[str],
+    skip_paths: frozenset[str] = frozenset(),
+    skip_dirs: frozenset[str] = frozenset(),
+) -> str | None:
+    """Return the first conflicting expanded mtree destination, or None.
+
+    skip_paths/skip_dirs drop source-layer rows whose bytes ship in another
+    layer, mirroring the source tar's own exclusion. They apply only to rows
+    before the `#end-source` marker: rows after it belong to the owning layers
+    and must stay visible so their destinations still participate in collisions.
+    """
+    had_skip = bool(skip_paths or skip_dirs)
+    marker_seen = False
     paths: dict[str, tuple[str, str, str, tuple[str, ...]]] = {}
     descendants: dict[str, tuple[str, str]] = {}
     for row in rows:
         if not row or row.startswith("#"):
+            if row.strip() == _END_SOURCE_MARKER:
+                marker_seen = True
+                skip_paths = frozenset()
+                skip_dirs = frozenset()
             continue
         fields = row.split()
         destination_parts: list[str] = []
@@ -309,6 +343,11 @@ def _mtree_collision(rows: Iterable[str]) -> str | None:
         if entry_type is None or source_field is None:
             return "invalid py_image_layer mtree row (missing source): {}".format(row)
         source_kind, _, source = source_field.partition("=")
+        if (skip_paths or skip_dirs) and _skip_match(
+            _decode_mtree_path(source), skip_paths, skip_dirs
+        ):
+            # Ships in another layer; the source tar drops it the same way.
+            continue
         metadata = tuple(sorted(field for field in fields[1:] if field != source_field))
         entry = (entry_type, source_kind, source, metadata)
 
@@ -349,6 +388,10 @@ def _mtree_collision(rows: Iterable[str]) -> str | None:
             parent = "/".join(parts[:end])
             descendants.setdefault(parent, (destination, source))
 
+    if had_skip and not marker_seen:
+        return "py_image_layer validator: --skip given but mtree has no {} marker".format(
+            _END_SOURCE_MARKER
+        )
     return None
 
 
@@ -359,6 +402,7 @@ def main() -> None:
     parser.add_argument("--warn_layer_count", type=int, default=90)
     parser.add_argument("--output", required=True)
     parser.add_argument("--mtree")
+    parser.add_argument("--skip")
     parser.add_argument("pkg_paths", nargs="*", metavar="label=path")
     args = parser.parse_args()
 
@@ -376,9 +420,26 @@ def main() -> None:
     pkg_binary = {label: _pkg_is_binary(paths) for label, paths in pkg_path_map.items()}
 
     messages: list[str] = []
+    skip_paths: frozenset[str] = frozenset()
+    skip_dirs: frozenset[str] = frozenset()
+    if args.skip:
+        exact: set[str] = set()
+        dirs: set[str] = set()
+        with open(args.skip) as skip:
+            for line in skip:
+                entry = line.strip()
+                if not entry:
+                    continue
+                entry = _decode_mtree_path(entry)
+                if entry.endswith("/"):
+                    dirs.add(entry[:-1])
+                else:
+                    exact.add(entry)
+        skip_paths = frozenset(exact)
+        skip_dirs = frozenset(dirs)
     if args.mtree:
         with open(args.mtree) as mtree:
-            collision = _mtree_collision(mtree)
+            collision = _mtree_collision(mtree, skip_paths, skip_dirs)
         if collision:
             messages.append("ERROR: " + collision)
     suggestions = _Suggestions()

--- a/py/private/py_image_layer_validator_test.py
+++ b/py/private/py_image_layer_validator_test.py
@@ -23,11 +23,15 @@ from py.private.py_image_layer_validator import (
 
 
 def _mtree_row(destination: str, source: str, marker: str = "contents") -> str:
-    return "{} type=file mode=0755 {}={}".format(destination, marker, source.replace(" ", "\\040"))
+    return "{} type=file mode=0755 {}={}".format(
+        destination.replace(" ", "\\040"), marker, source.replace(" ", "\\040")
+    )
 
 
 def _mtree_link_row(destination: str, source: str, mode: str = "0755") -> str:
-    return "{} type=link mode={} link={}".format(destination, mode, source.replace(" ", "\\040"))
+    return "{} type=link mode={} link={}".format(
+        destination.replace(" ", "\\040"), mode, source.replace(" ", "\\040")
+    )
 
 
 def test_mtree_identical_link_source_coalesces() -> None:
@@ -103,6 +107,90 @@ def test_mtree_conflicting_source_fails() -> None:
     ])
     assert collision is not None
     assert "py_image_layer runfile collision at ./app.runfiles/pkg/module.py:" in collision
+
+
+def test_mtree_skip_drops_source_layer_duplicate() -> None:
+    # The wheel file appears once as a source-layer row and once (different
+    # destination) as its owning-layer row; only the source row is dropped.
+    assert _mtree_collision(
+        [
+            "#mtree",
+            _mtree_row("./app.runfiles/pip/pkg/module.py", "wheel/module.py"),
+            "#end-source",
+            _mtree_row("./site-packages/pkg/module.py", "wheel/module.py"),
+        ],
+        skip_paths=frozenset(["wheel/module.py"]),
+    ) is None
+
+
+def test_mtree_skip_keeps_owning_layer_row_for_collisions() -> None:
+    # A first-party file colliding with a wheel's owning-layer destination
+    # must still fail: the skip set only hides rows before #end-source.
+    collision = _mtree_collision(
+        [
+            "#mtree",
+            _mtree_row("./site-packages/pkg/module.py", "first_party/module.py"),
+            _mtree_row("./elsewhere/module.py", "wheel/module.py"),
+            "#end-source",
+            _mtree_row("./site-packages/pkg/module.py", "wheel/module.py"),
+        ],
+        skip_paths=frozenset(["wheel/module.py"]),
+    )
+    assert collision is not None
+    assert "py_image_layer runfile collision at ./site-packages/pkg/module.py:" in collision
+
+
+def test_mtree_skip_directory_prefix_drops_children() -> None:
+    # A skip directory excludes its children without listing them.
+    assert _mtree_collision(
+        [
+            "#mtree",
+            _mtree_row("./app.runfiles/pip/pkg/module.py", "wheel_dir/pkg/module.py"),
+            "#end-source",
+            _mtree_row("./site-packages/pkg/module.py", "wheel_dir/pkg/module.py"),
+        ],
+        skip_dirs=frozenset(["wheel_dir"]),
+    ) is None
+
+
+def test_mtree_skip_directory_prefix_ignores_similar_names() -> None:
+    # "wheel_dir" must not exclude "wheel_dirx/..." rows.
+    collision = _mtree_collision(
+        [
+            "#mtree",
+            _mtree_row("./app.runfiles/pkg/module.py", "wheel_dirx/module.py"),
+            _mtree_row("./app.runfiles/pkg/module.py", "other/module.py"),
+            "#end-source",
+        ],
+        skip_dirs=frozenset(["wheel_dir"]),
+    )
+    assert collision is not None
+    assert "py_image_layer runfile collision at ./app.runfiles/pkg/module.py:" in collision
+
+
+def test_mtree_skip_decodes_encoded_spaces() -> None:
+    # Without decoding, neither row matches the skip set and they collide.
+    assert _mtree_collision(
+        [
+            _mtree_row("./app.runfiles/pip/pkg/data file", "wheel/data file"),
+            _mtree_row("./app.runfiles/pip/pkg/data file", "other/data file"),
+            "#end-source",
+        ],
+        skip_paths=frozenset(["wheel/data file", "other/data file"]),
+    ) is None
+
+
+def test_mtree_skip_without_end_source_marker_fails() -> None:
+    # A skip set without the marker would silently hide owning-layer rows too.
+    collision = _mtree_collision(
+        [
+            "#mtree",
+            _mtree_row("./app.runfiles/pip/pkg/module.py", "wheel/module.py"),
+        ],
+        skip_paths=frozenset(["wheel/module.py"]),
+    )
+    assert collision is not None
+    assert "#end-source" in collision
 
 
 def test_mtree_identical_regular_files_coalesce_across_markers() -> None:

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -85,6 +85,12 @@ def _assemble_venv_target(ctx):
         ctx,
         extra_depsets = virtual_resolution.srcs,
     )
+    runtime_files = depset(
+        direct = assembled.declared_outputs,
+        transitive = [
+            ctx.attr._runfiles_lib[DefaultInfo].default_runfiles.files,
+        ],
+    )
     runfiles = _py_library.make_merged_runfiles(
         ctx,
         extra_depsets = [py_toolchain.files] + virtual_resolution.runfiles,
@@ -99,6 +105,7 @@ def _assemble_venv_target(ctx):
             bin_python = assembled.bin_python,
             imports = imports_depset,
             transitive_sources = srcs_depset,
+            runtime_files = runtime_files,
         ),
         runfiles = runfiles,
     )

--- a/py/private/py_venv/types.bzl
+++ b/py/private/py_venv/types.bzl
@@ -23,5 +23,6 @@ binary's launcher exec's the venv's `bin_python`.
         "bin_python": "File — the venv's bin/python symlink. Callers needing a launcher target point here.",
         "imports": "depset[str] — rlocation-root-relative import paths covered by this venv. Mirrors `PyInfo.imports` of the venv's dep closure.",
         "transitive_sources": "depset[File] — source artifacts carried by this venv: its own `srcs`, sources from `deps` that emit `PyInfo`, and files contributed by virtual-resolution targets. Surfaced by py_binary as `PyInfo.transitive_sources` so downstream consumers see the same source closure they'd see if srcs/deps lived on the binary directly.",
+        "runtime_files": "depset[File] — generated venv support files and the runfiles library; excludes dependency and interpreter runfiles.",
     },
 )


### PR DESCRIPTION
The pip, first-party-group, interpreter and runfiles depsets are no longer pre-filtered in the rule but instead by the awk script. This means the awk script has more inputs, may be invoked more often, but actions depending on the output (such as actually deploying an image) should not be effected.

The gain is the analysis for that action should be significantly simpler and faster.

This should also allow the filtering of `pyc` files to be done in a similar way.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
