### PR TITLE
refactor!: require a PyInfo provider on resolution targets

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -39,7 +39,9 @@ The `resolutions` helper struct is gone: delete the
 `resolutions.from_requirements(all_whl_requirements_by_package, requirement)`
 with `{pkg: requirement(pkg) for pkg in all_whl_requirements_by_package.keys()}`,
 and replace `.override({...})` with the dict union operator (`base | {...}`).
-See [virtual deps](/docs/virtual_deps.md).
+Resolution targets must now provide a `PyInfo` (rules_py's or rules_python's);
+to remove a dependency entirely, resolve it to an empty `py_library` instead of
+a `filegroup`. See [virtual deps](/docs/virtual_deps.md).
 
 ## rules_python provider compatibility layer
 

--- a/docs/virtual_deps.md
+++ b/docs/virtual_deps.md
@@ -45,6 +45,7 @@ load("@my_deps//:requirements.bzl", "all_whl_requirements_by_package", "requirem
 
 These can be used to resolve a virtual dependency. The `resolutions` attribute is a plain dict
 mapping each virtual dependency's package name to the label of an installed package that provides it.
+Resolution targets must provide a `PyInfo` (rules_py's or rules_python's).
 Continuing the Django example above, a binary rule can specify which external repository to resolve to:
 
 ```

--- a/e2e/rules-python-interop/virtual-deps/django/BUILD.bazel
+++ b/e2e/rules-python-interop/virtual-deps/django/BUILD.bazel
@@ -60,9 +60,10 @@ py_binary(
 )
 
 ## Use case 3
-# It's possible to completely remove a dependency.
-# For example, to reduce the size of an image when a transitive dep is known to be unused.
-filegroup(
+# It's possible to completely remove a dependency by resolving it to an empty
+# py_library. For example, to reduce the size of an image when a transitive dep
+# is known to be unused.
+py_library(
     name = "empty",
 )
 

--- a/py/private/py_library.bzl
+++ b/py/private/py_library.bzl
@@ -224,6 +224,7 @@ _attrs = dict({
         doc = """Satisfy a virtual_dep with a mapping from external package name to the label of an installed package that provides it.
         See virtual_deps.
         """,
+        providers = [[PyInfo], [RulesPythonPyInfo]],
     ),
 })
 


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

All `requirements` attributes must now provide a valid python target and no longer accept generic `DefaultInfo` such as `filegroup`. Normally basic `DefaultInfo` outputting targets can be replaced or wrapped with `py_library`.

### Test plan

- Covered by existing test cases
