### PR TITLE
refactor: split pep517_whl rule.bzl into one module per rule

### DIFF
--- a/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
+++ b/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
@@ -1,5 +1,5 @@
 
-load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
@@ -1,5 +1,5 @@
 
-load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
@@ -1,5 +1,5 @@
 
-load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -1,18 +1,36 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
-load("//py:defs.bzl", "py_library")
 
 package(default_visibility = [
     "//uv/private:__subpackages__",
 ])
 
 bzl_library(
-    name = "rule",
-    srcs = ["rule.bzl"],
+    name = "pep517_whl",
+    srcs = ["pep517_whl.bzl"],
     deps = [
+        ":common",
         "//py/private/toolchain:types",
-        "//uv/private:source_built_wheel",
+        "@bazel_lib//lib:resource_sets",
+    ],
+)
+
+bzl_library(
+    name = "pep517_native_whl",
+    srcs = ["pep517_native_whl.bzl"],
+    deps = [
+        ":common",
+        "//py/private/toolchain:types",
         "@bazel_lib//lib:resource_sets",
         "@rules_cc//cc:action_names_bzl",
         "@rules_cc//cc/common",
+    ],
+)
+
+bzl_library(
+    name = "common",
+    srcs = ["common.bzl"],
+    deps = [
+        "//uv/private:source_built_wheel",
+        "@bazel_lib//lib:resource_sets",
     ],
 )

--- a/uv/private/pep517_whl/common.bzl
+++ b/uv/private/pep517_whl/common.bzl
@@ -1,0 +1,81 @@
+"""Shared helpers and attrs for the PEP 517 sdist-to-wheel rules."""
+
+load("@bazel_lib//lib:resource_sets.bzl", "resource_set_attr")
+load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
+
+TARGET_EXEC_GROUP = "target"
+
+_INHERITED_PYTHON_ENV = (
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "PYTHONPLATLIBDIR",
+)
+
+def wheel_providers(wheel_file, console_scripts):
+    return [
+        DefaultInfo(files = depset([wheel_file])),
+        SourceBuiltWheelInfo(console_scripts = tuple(console_scripts)),
+    ]
+
+def common_env(ctx):
+    # pyproject_hooks copies the build process environment and launches its
+    # Python executable without -I:
+    # https://github.com/pypa/pyproject-hooks/blob/4b7c6d113fb89b755d762a88712c8a6873cddd47/src/pyproject_hooks/_impl.py#L70-L83
+    # https://github.com/pypa/pyproject-hooks/blob/4b7c6d113fb89b755d762a88712c8a6873cddd47/src/pyproject_hooks/_impl.py#L378-L396
+    # Host settings therefore must not replace that child's venv or stdlib.
+    # https://docs.python.org/3/using/cmdline.html#environment-variables
+    default_shell_env = {
+        key: value
+        for key, value in ctx.configuration.default_shell_env.items()
+        if key.upper() not in _INHERITED_PYTHON_ENV
+    }
+    return {
+        "SETUPTOOLS_SCM_PRETEND_VERSION": ctx.attr.version,
+        # Determinism: fix hash seed so dict/set iteration order is stable
+        "PYTHONHASHSEED": "0",
+        # Determinism: reproducible timestamps in archives
+        "SOURCE_DATE_EPOCH": "0",
+    } | default_shell_env
+
+def patch_args_and_inputs(ctx):
+    patch_args = []
+    patch_inputs = []
+    if ctx.attr.pre_build_patches:
+        patch_args.extend(["--patch-strip", str(ctx.attr.pre_build_patch_strip)])
+        for target in ctx.attr.pre_build_patches:
+            for f in target[DefaultInfo].files.to_list():
+                patch_args.extend(["--patch", f.path])
+                patch_inputs.append(f)
+    return patch_args, patch_inputs
+
+def memory_args(ctx):
+    return ["--monitor-memory"] if ctx.attr.monitor_memory else []
+
+_PATCH_ATTRS = {
+    "pre_build_patches": attr.label_list(
+        default = [],
+        allow_files = [".patch", ".diff"],
+        doc = "Patch files to apply to the extracted source before building.",
+    ),
+    "pre_build_patch_strip": attr.int(
+        default = 0,
+        doc = "Strip count for pre-build patches (-p flag to patch).",
+    ),
+}
+
+PEP517_WHL_ATTRS = {
+    "src": attr.label(allow_single_file = True),
+    # The wheel action uses the named group below, so its frontend must use the
+    # same execution platform:
+    # https://bazel.build/extending/exec-groups#defining-exec-groups
+    "tool": attr.label(executable = True, cfg = config.exec(TARGET_EXEC_GROUP)),
+    "version": attr.string(),
+    "console_scripts": attr.string_list(
+        doc = "Console scripts discovered from the source distribution's entry-point metadata.",
+    ),
+    "args": attr.string_list(default = ["--validate-anyarch"]),
+    "monitor_memory": attr.bool(
+        default = False,
+        doc = "Report approximate Linux process-tree RSS while building the wheel.",
+    ),
+} | _PATCH_ATTRS | resource_set_attr

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -1,66 +1,26 @@
-"""
-PEP 517 sdist-to-wheel build rules.
+"""PEP 517 sdist to platform-specific whl build rule.
 
 Uses `python -m build` (the pypa/build frontend) which delegates to whatever
 build backend the sdist declares in its `[build-system]` table.
 """
 
-load("@bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
+load("@bazel_lib//lib:resource_sets.bzl", "resource_set")
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
-load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
-
-_CC_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:toolchain_type")
-_TARGET_EXEC_GROUP = "target"
-_EXECROOT_MARKER = "__ASPECT_RULES_PY_EXECROOT__"
-_INFER_CXX_COMPANION = "ASPECT_RULES_PY_INFER_CXX_COMPANION"
-
-_INHERITED_PYTHON_ENV = (
-    "PYTHONHOME",
-    "PYTHONPATH",
-    "PYTHONPLATLIBDIR",
+load(
+    ":common.bzl",
+    "PEP517_WHL_ATTRS",
+    "TARGET_EXEC_GROUP",
+    "common_env",
+    "memory_args",
+    "patch_args_and_inputs",
+    "wheel_providers",
 )
 
-def _wheel_providers(wheel_file, console_scripts):
-    return [
-        DefaultInfo(files = depset([wheel_file])),
-        SourceBuiltWheelInfo(console_scripts = tuple(console_scripts)),
-    ]
-
-def _common_env(ctx):
-    # pyproject_hooks copies the build process environment and launches its
-    # Python executable without -I:
-    # https://github.com/pypa/pyproject-hooks/blob/4b7c6d113fb89b755d762a88712c8a6873cddd47/src/pyproject_hooks/_impl.py#L70-L83
-    # https://github.com/pypa/pyproject-hooks/blob/4b7c6d113fb89b755d762a88712c8a6873cddd47/src/pyproject_hooks/_impl.py#L378-L396
-    # Host settings therefore must not replace that child's venv or stdlib.
-    # https://docs.python.org/3/using/cmdline.html#environment-variables
-    default_shell_env = {
-        key: value
-        for key, value in ctx.configuration.default_shell_env.items()
-        if key.upper() not in _INHERITED_PYTHON_ENV
-    }
-    return {
-        "SETUPTOOLS_SCM_PRETEND_VERSION": ctx.attr.version,
-        # Determinism: fix hash seed so dict/set iteration order is stable
-        "PYTHONHASHSEED": "0",
-        # Determinism: reproducible timestamps in archives
-        "SOURCE_DATE_EPOCH": "0",
-    } | default_shell_env
-
-def _patch_args_and_inputs(ctx):
-    patch_args = []
-    patch_inputs = []
-    if ctx.attr.pre_build_patches:
-        patch_args.extend(["--patch-strip", str(ctx.attr.pre_build_patch_strip)])
-        for target in ctx.attr.pre_build_patches:
-            for f in target[DefaultInfo].files.to_list():
-                patch_args.extend(["--patch", f.path])
-                patch_inputs.append(f)
-    return patch_args, patch_inputs
-
-def _memory_args(ctx):
-    return ["--monitor-memory"] if ctx.attr.monitor_memory else []
+_CC_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:toolchain_type")
+_EXECROOT_MARKER = "__ASPECT_RULES_PY_EXECROOT__"
+_INFER_CXX_COMPANION = "ASPECT_RULES_PY_INFER_CXX_COMPANION"
 
 def _collect_toolchain_inputs_and_vars(ctx):
     """Gather files + Make-variable substitutions from `ctx.attr.toolchains`.
@@ -96,7 +56,7 @@ def _collect_toolchain_inputs_and_vars(ctx):
 
 def _cc_toolchain_inputs_and_tools(ctx):
     """Return the target execution group's C++ files and selected build tools."""
-    cc_toolchain = ctx.exec_groups[_TARGET_EXEC_GROUP].toolchains[_CC_TOOLCHAIN_TYPE]
+    cc_toolchain = ctx.exec_groups[TARGET_EXEC_GROUP].toolchains[_CC_TOOLCHAIN_TYPE]
     if hasattr(cc_toolchain, "cc_provider_in_toolchain") and hasattr(cc_toolchain, "cc"):
         cc_toolchain = cc_toolchain.cc
     if not cc_toolchain or not hasattr(cc_toolchain, "all_files"):
@@ -156,44 +116,12 @@ def _cc_toolchain_inputs_and_tools(ctx):
     infer_cxx = infer_cxx or tools.get("CXX") == tools.get("CC")
     return files, {key: value for key, value in tools.items() if value}, infer_cxx
 
-def _pep517_whl(ctx):
-    archive = ctx.file.src
-
-    # Fixed name; the backend picks the real filename at build time and the
-    # helper renames onto this. Consumers read identity from dist-info only.
-    wheel_file = ctx.actions.declare_file(ctx.label.name + ".whl")
-    patch_args, patch_inputs = _patch_args_and_inputs(ctx)
-
-    # The build tool is a py_binary wrapping build_helper.py. Using it as
-    # a tool (not just an input) causes Bazel to materialize its runfiles in
-    # the action sandbox, which means the venv shim can find the interpreter
-    # via the standard runfiles mechanism regardless of whether the interpreter
-    # comes from an external repo or the main workspace.
-    ctx.actions.run(
-        mnemonic = "PySdistBuild",
-        progress_message = "Source compiling {} to a whl".format(archive.basename),
-        executable = ctx.executable.tool,
-        toolchain = None,
-        arguments = ctx.attr.args + patch_args + _memory_args(ctx) + [
-            archive.path,
-            wheel_file.path,
-        ],
-        inputs = [archive] + patch_inputs,
-        tools = [ctx.attr.tool[DefaultInfo].files_to_run],
-        outputs = [wheel_file],
-        env = _common_env(ctx),
-        exec_group = _TARGET_EXEC_GROUP,
-        resource_set = resource_set(ctx.attr),
-    )
-
-    return _wheel_providers(wheel_file, ctx.attr.console_scripts)
-
 def _pep517_native_whl(ctx):
     archive = ctx.file.src
     wheel_file = ctx.actions.declare_file(ctx.label.name + ".whl")
-    patch_args, patch_inputs = _patch_args_and_inputs(ctx)
+    patch_args, patch_inputs = patch_args_and_inputs(ctx)
 
-    env = _common_env(ctx)
+    env = common_env(ctx)
     extra_inputs, known_variables = _collect_toolchain_inputs_and_vars(ctx)
 
     if "EXECROOT" in known_variables:
@@ -221,7 +149,7 @@ def _pep517_native_whl(ctx):
         progress_message = "Native source compiling {} to a whl".format(archive.basename),
         executable = ctx.executable.tool,
         toolchain = None,
-        arguments = ctx.attr.args + patch_args + _memory_args(ctx) + [
+        arguments = ctx.attr.args + patch_args + memory_args(ctx) + [
             "--execroot-marker",
             _EXECROOT_MARKER,
             archive.path,
@@ -234,58 +162,11 @@ def _pep517_native_whl(ctx):
         tools = [ctx.attr.tool[DefaultInfo].files_to_run],
         outputs = [wheel_file],
         env = env,
-        exec_group = _TARGET_EXEC_GROUP,
+        exec_group = TARGET_EXEC_GROUP,
         resource_set = resource_set(ctx.attr),
     )
 
-    return _wheel_providers(wheel_file, ctx.attr.console_scripts)
-
-_PATCH_ATTRS = {
-    "pre_build_patches": attr.label_list(
-        default = [],
-        allow_files = [".patch", ".diff"],
-        doc = "Patch files to apply to the extracted source before building.",
-    ),
-    "pre_build_patch_strip": attr.int(
-        default = 0,
-        doc = "Strip count for pre-build patches (-p flag to patch).",
-    ),
-}
-
-_pep517_whl_attrs = {
-    "src": attr.label(allow_single_file = True),
-    # The wheel action uses the named group below, so its frontend must use the
-    # same execution platform:
-    # https://bazel.build/extending/exec-groups#defining-exec-groups
-    "tool": attr.label(executable = True, cfg = config.exec(_TARGET_EXEC_GROUP)),
-    "version": attr.string(),
-    "console_scripts": attr.string_list(
-        doc = "Console scripts discovered from the source distribution's entry-point metadata.",
-    ),
-    "args": attr.string_list(default = ["--validate-anyarch"]),
-    "monitor_memory": attr.bool(
-        default = False,
-        doc = "Report approximate Linux process-tree RSS while building the wheel.",
-    ),
-} | _PATCH_ATTRS | resource_set_attr
-
-pep517_whl = rule(
-    implementation = _pep517_whl,
-    doc = """PEP 517 sdist to anyarch whl build rule.
-
-Consumes a sdist artifact and performs a build of that artifact with the
-specified Python dependencies under the configured Python toolchain.
-
-""",
-    attrs = _pep517_whl_attrs,
-    exec_groups = {
-        _TARGET_EXEC_GROUP: exec_group(
-            toolchains = [
-                PY_TOOLCHAIN,
-            ],
-        ),
-    },
-)
+    return wheel_providers(wheel_file, ctx.attr.console_scripts)
 
 pep517_native_whl = rule(
     implementation = _pep517_native_whl,
@@ -306,7 +187,7 @@ The build is guaranteed to occur on an execution platform matching the
 constraints of the target platform.
 
 """,
-    attrs = _pep517_whl_attrs | {
+    attrs = PEP517_WHL_ATTRS | {
         "args": attr.string_list(),
         "env": attr.string_dict(
             doc = "Environment variables to set on the build action. Values may " +
@@ -334,7 +215,7 @@ constraints of the target platform.
         # would need to encode the target platform with no upstream tooling
         # support. Packages that need cross-compiled native extensions should
         # publish pre-built wheels for their target platforms instead.
-        _TARGET_EXEC_GROUP: exec_group(
+        TARGET_EXEC_GROUP: exec_group(
             toolchains = [
                 PY_TOOLCHAIN,
                 NATIVE_BUILD_TOOLCHAIN,

--- a/uv/private/pep517_whl/pep517_whl.bzl
+++ b/uv/private/pep517_whl/pep517_whl.bzl
@@ -1,0 +1,67 @@
+"""PEP 517 sdist to anyarch whl build rule.
+
+Uses `python -m build` (the pypa/build frontend) which delegates to whatever
+build backend the sdist declares in its `[build-system]` table.
+"""
+
+load("@bazel_lib//lib:resource_sets.bzl", "resource_set")
+load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
+load(
+    ":common.bzl",
+    "PEP517_WHL_ATTRS",
+    "TARGET_EXEC_GROUP",
+    "common_env",
+    "memory_args",
+    "patch_args_and_inputs",
+    "wheel_providers",
+)
+
+def _pep517_whl(ctx):
+    archive = ctx.file.src
+
+    # Fixed name; the backend picks the real filename at build time and the
+    # helper renames onto this. Consumers read identity from dist-info only.
+    wheel_file = ctx.actions.declare_file(ctx.label.name + ".whl")
+    patch_args, patch_inputs = patch_args_and_inputs(ctx)
+
+    # The build tool is a py_binary wrapping build_helper.py. Using it as
+    # a tool (not just an input) causes Bazel to materialize its runfiles in
+    # the action sandbox, which means the venv shim can find the interpreter
+    # via the standard runfiles mechanism regardless of whether the interpreter
+    # comes from an external repo or the main workspace.
+    ctx.actions.run(
+        mnemonic = "PySdistBuild",
+        progress_message = "Source compiling {} to a whl".format(archive.basename),
+        executable = ctx.executable.tool,
+        toolchain = None,
+        arguments = ctx.attr.args + patch_args + memory_args(ctx) + [
+            archive.path,
+            wheel_file.path,
+        ],
+        inputs = [archive] + patch_inputs,
+        tools = [ctx.attr.tool[DefaultInfo].files_to_run],
+        outputs = [wheel_file],
+        env = common_env(ctx),
+        exec_group = TARGET_EXEC_GROUP,
+        resource_set = resource_set(ctx.attr),
+    )
+
+    return wheel_providers(wheel_file, ctx.attr.console_scripts)
+
+pep517_whl = rule(
+    implementation = _pep517_whl,
+    doc = """PEP 517 sdist to anyarch whl build rule.
+
+Consumes a sdist artifact and performs a build of that artifact with the
+specified Python dependencies under the configured Python toolchain.
+
+""",
+    attrs = PEP517_WHL_ATTRS,
+    exec_groups = {
+        TARGET_EXEC_GROUP: exec_group(
+            toolchains = [
+                PY_TOOLCHAIN,
+            ],
+        ),
+    },
+)

--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -4,7 +4,8 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@tar.bzl//tar:mtree.bzl", "mtree_mutate", "mtree_spec")
 load("@tar.bzl//tar:tar.bzl", "tar_rule")
 load("//py:defs.bzl", "py_binary", "py_test")
-load("//uv/private/pep517_whl:rule.bzl", "pep517_native_whl", "pep517_whl")
+load("//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
+load("//uv/private/pep517_whl:pep517_whl.bzl", "pep517_whl")
 load(
     ":pep517_whl_test.bzl",
     "execroot_collision_toolchain",

--- a/uv/private/pep517_whl/tests/console_scripts/pure/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/console_scripts/pure/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("//uv/private/pep517_whl:pep517_whl.bzl", "pep517_whl")
 load("//uv/private/pep517_whl/tests:pep517_whl_test.bzl", "pep517_whl_console_scripts_test")
 
 package(default_testonly = True)

--- a/uv/private/pep517_whl/tests/explicit_env/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/explicit_env/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 load("//uv/private/pep517_whl/tests:pep517_whl_test.bzl", "hostile_python_env_target")
 
 package(default_testonly = True)

--- a/uv/private/pep517_whl/tests/native_dep/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/native_dep/BUILD.bazel
@@ -4,7 +4,7 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@tar.bzl//tar:mtree.bzl", "mtree_mutate", "mtree_spec")
 load("@tar.bzl//tar:tar.bzl", "tar_rule")
-load("//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 load(":defs.bzl", "dep_makevars")
 
 package(default_testonly = True)

--- a/uv/private/pep517_whl/tests/native_dep/tool_names/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/native_dep/tool_names/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 
 package(default_testonly = True)
 

--- a/uv/private/pep517_whl/tests/native_dep/tool_names/bare/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/native_dep/tool_names/bare/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//uv/private/pep517_whl:rule.bzl", "pep517_native_whl")
+load("//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 
 package(default_testonly = True)
 

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -258,7 +258,7 @@ def _sdist_build_impl(repository_ctx):
     # Leave args unset: the pure rule validates anyarch wheels by default,
     # while the native rule defaults to no validation.
     repository_ctx.file("BUILD.bazel", content = """
-load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{rule}")
+load("@aspect_rules_py//uv/private/pep517_whl:{rule}.bzl", "{rule}")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(

--- a/uv/private/uv_hub/snapshots/sdist_build.bravado_core.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/sdist_build.bravado_core.BUILD.bazel
@@ -1,5 +1,5 @@
 
-load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "pep517_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:pep517_whl.bzl", "pep517_whl")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(


### PR DESCRIPTION
Mechanical, behavior-preserving split of `uv/private/pep517_whl/rule.bzl`, extracted from #1434 to shrink it into reviewable pieces:

- `common.bzl` — shared helpers (`wheel_providers`, `common_env`, `patch_args_and_inputs`, `memory_args`) and `PEP517_WHL_ATTRS`
- `pep517_whl.bzl` — the pure (anyarch) rule
- `pep517_native_whl.bzl` — the native rule with its cc-toolchain plumbing (git tracks this as a rename of `rule.bzl`)

Shared helpers lose their underscore prefix on export; every function body is otherwise verbatim — a normalized line diff of the old file against the union of the three new ones shows only the module docstrings differing. Load sites, the `sdist_build` repository template, and the generated-BUILD snapshots now load each rule from its own file.

### Changes are visible to end-users: no

All files remain under `uv/private`; the public `uv:defs.bzl` surface is untouched.

### Test plan

- `bazel test //uv/...`: 163 passed, 2 skipped (platform-incompatible on the darwin dev host)
- Existing generated-BUILD snapshot tests cover the repository template change