### PR TITLE
refactor(py_venv): clarify assembly boundaries

### DIFF
--- a/py/private/py_venv/BUILD.bazel
+++ b/py/private/py_venv/BUILD.bazel
@@ -46,7 +46,6 @@ bzl_library(
     deps = [
         ":toolchains_resolver",
         ":virtuals_resolvers",
-        "//py/private:py_library",
     ],
 )
 

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -46,10 +46,8 @@ def _interpreter_flags(ctx):
 
     return args
 
-def _assemble_shared(ctx):
-    """Resolve the py toolchain, virtual deps, imports depset — then run
-    the shared venv-assembly helper.
-    """
+def _assemble_venv_target(ctx):
+    """Assemble a venv and its provider-facing runtime metadata."""
     py_toolchain = _py_semantics.resolve_toolchain(ctx)
     virtual_resolution = _py_library.resolve_virtuals(ctx)
     imports_depset = _py_library.make_imports_depset(
@@ -63,12 +61,13 @@ def _assemble_shared(ctx):
         "BAZEL_TARGET_NAME": ctx.attr.name,
     }
 
-    safe_name = ctx.attr.name.replace("/", "_")
-
-    venv = assemble_venv(
+    venv_stem = ctx.attr.name.replace("/", "_")
+    wheels = _py_library.make_wheels_depset(ctx).to_list()
+    assembled = assemble_venv(
         ctx,
-        safe_name = safe_name,
+        venv_stem = venv_stem,
         py_toolchain = py_toolchain,
+        wheels = wheels,
         imports_depset = imports_depset,
         is_windows = ctx.target_platform_has_constraint(
             ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
@@ -79,7 +78,7 @@ def _assemble_shared(ctx):
         venv_activate_tmpl = ctx.file._venv_activate_tmpl,
         site_merge_script_py = ctx.file._site_merge_script,
         console_script_tmpl = ctx.file._console_script_tmpl,
-        venv_name = ".{}".format(safe_name),
+        venv_name = ".{}".format(venv_stem),
     )
 
     srcs_depset = _py_library.make_srcs_depset(
@@ -88,28 +87,27 @@ def _assemble_shared(ctx):
     )
     runfiles = _py_library.make_merged_runfiles(
         ctx,
-        extra_depsets = [
-            py_toolchain.files,
-        ] + virtual_resolution.runfiles,
-        extra_runfiles = venv.all_files,
+        extra_depsets = [py_toolchain.files] + virtual_resolution.runfiles,
+        extra_runfiles = assembled.declared_outputs,
         extra_runfiles_depsets = [
             ctx.attr._runfiles_lib[DefaultInfo].default_runfiles,
         ],
     )
 
     return struct(
-        py_toolchain = py_toolchain,
-        venv = venv,
+        info = VirtualenvInfo(
+            bin_python = assembled.bin_python,
+            imports = imports_depset,
+            transitive_sources = srcs_depset,
+        ),
         runfiles = runfiles,
-        imports_depset = imports_depset,
-        srcs_depset = srcs_depset,
     )
 
-def _common_providers(ctx, shared, executable = None, include_sources = False):
+def _venv_providers(ctx, venv, executable = None, include_sources = False):
     """Providers emitted by both the executable and lib variants."""
-    runfiles = shared.runfiles
+    runfiles = venv.runfiles
     if include_sources:
-        runfiles = runfiles.merge(ctx.runfiles(transitive_files = shared.srcs_depset))
+        runfiles = runfiles.merge(ctx.runfiles(transitive_files = venv.info.transitive_sources))
     return [
         DefaultInfo(
             files = depset([executable]) if executable != None else None,
@@ -117,11 +115,7 @@ def _common_providers(ctx, shared, executable = None, include_sources = False):
             runfiles = runfiles,
         ),
         # Deliberately no PyInfo: a venv is a terminal artifact, not a source of imports.
-        VirtualenvInfo(
-            bin_python = shared.venv.bin_python,
-            imports = shared.imports_depset,
-            transitive_sources = shared.srcs_depset,
-        ),
+        venv.info,
         # `bazel coverage` finds this by walking the consumer's `venv` attr.
         coverage_common.instrumented_files_info(
             ctx,
@@ -135,7 +129,7 @@ def _py_venv_rule_impl(ctx):
     """A virtualenv target whose own executable activates the venv and
     exec's the interpreter — a `bazel run :name`-able venv."""
 
-    shared = _assemble_shared(ctx)
+    venv = _assemble_venv_target(ctx)
 
     ctx.actions.expand_template(
         template = ctx.file._run_tmpl,
@@ -143,7 +137,7 @@ def _py_venv_rule_impl(ctx):
         substitutions = {
             "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION.strip(),
             "{{INTERPRETER_FLAGS}}": " ".join(_interpreter_flags(ctx)),
-            "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, shared.venv.bin_python),
+            "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, venv.info.bin_python),
             "{{DEBUG}}": str(ctx.attr.debug).lower(),
         },
         is_executable = True,
@@ -162,9 +156,9 @@ def _py_venv_rule_impl(ctx):
 
     # `VIRTUAL_ENV` as the venv root's rootpath. `venv.tmpl.sh`
     # overrides with its own absolute value when invoked directly.
-    passed_env["VIRTUAL_ENV"] = venv_root(shared.venv.bin_python)
+    passed_env["VIRTUAL_ENV"] = venv_root(venv.info.bin_python)
 
-    return _common_providers(ctx, shared, executable = ctx.outputs.executable, include_sources = True) + [
+    return _venv_providers(ctx, venv, executable = ctx.outputs.executable, include_sources = True) + [
         # Read by the sibling `expose_venv = True` py_binary/py_test;
         # the binary's own `env` wins on key conflicts (py_venv_exec.bzl).
         RunEnvironmentInfo(
@@ -274,18 +268,20 @@ environment. Forwarded to the sibling py_binary/py_test consumer
     ),
 })
 
+_venv_toolchains = [
+    PY_TOOLCHAIN,
+    # Optional: only consulted when a regular package needs a physical merge
+    # and assemble_venv needs an exec-config interpreter to run the
+    # site_merge action. Optional so venvs keep analyzing in setups
+    # that never registered rules_py's exec-tools toolchain.
+    config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
+]
+
 _py_venv = rule(
     doc = """Build a Python virtual environment and execute its interpreter.""",
     implementation = _py_venv_rule_impl,
     attrs = _attrs,
-    toolchains = [
-        PY_TOOLCHAIN,
-        # Optional: only consulted when a regular package needs a physical merge
-        # and assemble_venv needs an exec-config interpreter to run the
-        # site_merge action. Optional so venvs keep analyzing in setups
-        # that never registered rules_py's exec-tools toolchain.
-        config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
-    ],
+    toolchains = _venv_toolchains,
     executable = True,
     cfg = python_transition,
 )
@@ -295,8 +291,8 @@ def _py_venv_lib_rule_impl(ctx):
     launcher and no RunEnvironmentInfo (Bazel rejects it on
     non-executable targets; py_venv_exec.bzl gates its read on
     `if RunEnvironmentInfo in venv`)."""
-    shared = _assemble_shared(ctx)
-    return _common_providers(ctx, shared)
+    venv = _assemble_venv_target(ctx)
+    return _venv_providers(ctx, venv)
 
 # Internal-only non-executable variant. Uses `_lib_attrs` — the
 # launcher-only attrs (`debug`, `interpreter_options`, `_run_tmpl`,
@@ -304,12 +300,7 @@ def _py_venv_lib_rule_impl(ctx):
 _py_venv_lib = rule(
     implementation = _py_venv_lib_rule_impl,
     attrs = _lib_attrs,
-    toolchains = [
-        PY_TOOLCHAIN,
-        # Same optional exec-tools dependency as `_py_venv`: assemble_venv
-        # needs it to run the site_merge action when a package needs a merge.
-        config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
-    ],
+    toolchains = _venv_toolchains,
     cfg = python_transition,
 )
 

--- a/py/private/py_venv/toolchains_resolver.bzl
+++ b/py/private/py_venv/toolchains_resolver.bzl
@@ -125,7 +125,7 @@ def resolve_venv_toolchain(ctx, *, py_toolchain, is_windows, venv_name):
       ctx: The rule context.
       py_toolchain: Resolved Python toolchain struct from py_semantics.
       is_windows: Whether the venv targets Windows.
-      venv_name: The venv dir basename (e.g. ``.safe_name``).
+      venv_name: The venv dir basename (e.g. ``.venv_stem``).
 
     Returns:
       struct with ``wheel_py_ver``, ``venv_py_ver``, ``escape``,

--- a/py/private/py_venv/venv.bzl
+++ b/py/private/py_venv/venv.bzl
@@ -33,7 +33,6 @@ Bazel's action cache treats each piece independently (no tree-artifact
 + remote-exec materialisation surprises).
 """
 
-load("//py/private:py_library.bzl", _py_library = "py_library_utils")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN")
 load(":toolchains_resolver.bzl", "resolve_venv_toolchain")
 load(":virtuals_resolvers.bzl", "enforce_collision_policy", "resolve_wheel_collisions")
@@ -71,8 +70,9 @@ def _dict_to_exports(env):
 def assemble_venv(
         ctx,
         *,
-        safe_name,
+        venv_stem,
         py_toolchain,
+        wheels,
         imports_depset,
         is_windows,
         package_collisions,
@@ -86,9 +86,11 @@ def assemble_venv(
 
     Args:
       ctx: The rule context.
-      safe_name: Directory-name-safe stem for the venv dir. Slashes in the
+      venv_stem: Directory-name-safe stem for the venv dir. Slashes in the
         target name should be replaced by the caller (e.g. "_").
       py_toolchain: Resolved Python toolchain struct from py_semantics.
+      wheels: Ordered sequence of wheel metadata structs from the venv's
+        resolved dependency graph.
       imports_depset: Depset of first-party + transitive wheel import
         paths (as returned by py_library_utils.make_imports_depset).
       is_windows: Bool — whether the venv targets Windows.
@@ -108,18 +110,16 @@ def assemble_venv(
         EXEC_TOOLS_TOOLCHAIN for an exec-configuration interpreter.
       console_script_tmpl: File — the console-script wrapper template
         (usually `ctx.file._console_script_tmpl`).
-      venv_name: str — the venv dir basename (e.g. "." + safe_name).
+      venv_name: str — the venv dir basename (e.g. "." + venv_stem).
 
     Returns:
       struct with:
         bin_python: File — the venv's bin/python symlink, for launchers
             to rlocation-resolve and exec.
-        all_files: list[File] — every declared output, ready for runfiles
+        declared_outputs: list[File] — every declared output, ready for runfiles
             / DefaultInfo aggregation.
     """
 
-    wheels_depset = _py_library.make_wheels_depset(ctx)
-    wheels = wheels_depset.to_list()
     top_level_to_site_pkgs, fully_covered_site_pkgs, console_scripts_map, merge_groups, data_file_to_site_pkgs, collisions = resolve_wheel_collisions(ctx, wheels)
     enforce_collision_policy(collisions, package_collisions)
 
@@ -309,7 +309,7 @@ def assemble_venv(
     pth_lines.add_all(imports_depset, map_each = _format_imp, allow_closure = True)
 
     site_packages_pth_file = ctx.actions.declare_file(
-        "{}/{}.pth".format(site_packages_rel, safe_name),
+        "{}/{}.pth".format(site_packages_rel, venv_stem),
     )
     ctx.actions.write(
         output = site_packages_pth_file,
@@ -393,5 +393,5 @@ def assemble_venv(
 
     return struct(
         bin_python = bin_python,
-        all_files = declared,
+        declared_outputs = declared,
     )

--- a/py/tests/py-library-runfiles/BUILD.bazel
+++ b/py/tests/py-library-runfiles/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//py:defs.bzl", "py_library", "py_test", "py_venv")
-load(":runfiles_test.bzl", "py_library_runfiles_test", "py_venv_runfiles_test")
+load("//py:defs.bzl", "py_binary", "py_library", "py_test", "py_venv")
+load(":runfiles_test.bzl", "private_venv_provider_test", "py_library_runfiles_test", "py_venv_runfiles_test")
 
 package(default_testonly = True)
 
@@ -29,6 +29,27 @@ py_venv_runfiles_test(
         "library.py",
     ],
     target_under_test = ":public_venv",
+)
+
+py_binary(
+    name = "private_venv_bin",
+    srcs = ["main.py"],
+    imports = ["."],
+    main = "main.py",
+    deps = [":library"],
+)
+
+# The default py_binary path uses an internal _py_venv_lib. Verify its
+# VirtualenvInfo is the source of truth for the consumer's PyInfo and source
+# runfiles closure.
+private_venv_provider_test(
+    name = "private_venv_provider_test",
+    consumer = ":private_venv_bin",
+    expected_sources = [
+        "main.py",
+        "library.py",
+    ],
+    target_under_test = ":_private_venv_bin.venv",
 )
 
 py_test(

--- a/py/tests/py-library-runfiles/runfiles_test.bzl
+++ b/py/tests/py-library-runfiles/runfiles_test.bzl
@@ -1,6 +1,8 @@
 """Analysis coverage for py_library's source-free default runfiles."""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//py/private:py_info.bzl", "PyInfo")
+load("//py/private/py_venv:defs.bzl", "VirtualenvInfo")
 
 def _has(paths, suffix):
     return any([path.endswith(suffix) for path in paths])
@@ -26,4 +28,29 @@ def _py_venv_runfiles_test_impl(ctx):
 py_venv_runfiles_test = analysistest.make(
     _py_venv_runfiles_test_impl,
     attrs = {"expected_sources": attr.string_list(mandatory = True)},
+)
+
+def _private_venv_provider_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    venv = analysistest.target_under_test(env)
+    consumer = ctx.attr.consumer
+    venv_info = venv[VirtualenvInfo]
+    venv_paths = [f.short_path for f in venv[DefaultInfo].default_runfiles.files.to_list()]
+    consumer_paths = [f.short_path for f in consumer[DefaultInfo].default_runfiles.files.to_list()]
+    source_paths = [f.short_path for f in venv_info.transitive_sources.to_list()]
+
+    asserts.true(env, venv_info.bin_python.short_path in venv_paths, "lib venv retains bin/python")
+    asserts.equals(env, venv_info.imports.to_list(), consumer[PyInfo].imports.to_list())
+    asserts.equals(env, source_paths, [f.short_path for f in consumer[PyInfo].transitive_sources.to_list()])
+    for source in ctx.attr.expected_sources:
+        asserts.true(env, _has(source_paths, "/" + source), "VirtualenvInfo retains source " + source)
+        asserts.true(env, _has(consumer_paths, "/" + source), "consumer restores source " + source)
+    return analysistest.end(env)
+
+private_venv_provider_test = analysistest.make(
+    _private_venv_provider_test_impl,
+    attrs = {
+        "consumer": attr.label(mandatory = True),
+        "expected_sources": attr.string_list(mandatory = True),
+    },
 )


### PR DESCRIPTION
Just move/rename some things, with the goal of better clarity including better organization of which file owns what:
* `py_venv.bzl`: rule and macro policy: attrs, toolchains, executable versus lib behavior, launcher environment etc
* `venv.bzl`: physical venv layout only: declares bin/, pyvenv.cfg, .pth, site-package links, console scripts, and merge actions

So things like rule attribute, provider, `depset` etc logic are being moved into `py_venv.bzl`

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
