### PR TITLE
feat(uv): cross-compile native sdist builds

### DIFF
--- a/docs/uv.md
+++ b/docs/uv.md
@@ -313,17 +313,16 @@ Under cross mode the build action:
 4. Validates the produced wheel's platform tag against the target OS/CPU and
    fails the action if the backend leaked the exec platform into the tag.
 
-A working end-to-end suite lives in `e2e/crossbuild/`: real packages forced
-to build from sdist (`[tool.uv] no-binary-package`) and cross-compiled for
-linux/amd64 and linux/arm64, covering setuptools (`python-geohash`,
-`msgpack`, `psutil`), setuptools+CFFI (`zstandard`), setuptools-rust
-(`tiktoken`, `bcrypt`), maturin/PyO3 (`pydantic_core`, `rpds_py`),
-meson-python (`contourpy`, `numpy`), and scikit-build-core/CMake
-(`awkward_cpp`, `jpype1`). Each case asserts the ELF architecture of the
-produced `.so` (and its `EXT_SUFFIX`, where the filename carries one) and
-then actually runs the resulting container image (QEMU for arm64). `//geohash` additionally covers a
-macOS arm64 → macOS amd64 cross target when run from a macOS host (see
-`e2e/crossbuild/test.sh`).
+An end-to-end suite lives in `e2e/crossbuild/`: real packages forced to
+build from sdist (`[tool.uv] no-binary-package`) and cross-compiled for
+linux/amd64 and linux/arm64, currently covering pure-Python sdists,
+distutils-probe shapes, pre-build patches, and setuptools C extensions
+(`pyyaml`, `setproctitle`, `zstandard`), asserting each collected wheel's
+`Tag:` metadata. Coverage for the remaining backend-specific paths this
+mode enables (meson-python, scikit-build-core/CMake, maturin/PyO3,
+setuptools-rust, JDK-dependent builds) plus ELF-architecture assertions
+and QEMU execution of the produced wheels lands with the follow-up
+`e2e/crossbuild` changes split out of #1434.
 
 Current limitations:
 

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -271,6 +271,70 @@ platform_transition_filegroup(
 )
 ```
 
+## Example: Cross-compiling sdists
+
+Wheels are selected for the target platform, but when a package only ships a
+source distribution — or no published wheel matches the target — uv builds the
+sdist as part of the build. Two modes exist:
+
+- **Pure-Python sdists** produce a `-none-any` wheel and build identically in
+  any configuration, cross or not.
+- **Native sdists** (C/C++ extensions) build in *native mode* when the exec and
+  target platforms coincide. When they differ, the build enters *cross mode*.
+
+Cross mode requires a **cross-capable C++ toolchain** registered with
+`register_toolchains` — one whose compiler can target the destination platform
+from the exec platform (for example `toolchains_llvm`, whose clang is
+multi-target). If none resolves, analysis fails with an explicit error naming
+the missing toolchain type rather than an obscure toolchain-resolution
+failure. No per-package opt-in is needed: cross mode activates automatically
+from the platform configuration.
+
+Under cross mode the build action:
+
+1. Extracts the C++ toolchain selected for the target platform (compiler,
+   compile/link flags, sysroot) and re-materializes it as compiler wrapper
+   scripts, so flags such as `-target` / `--sysroot` survive the PEP 517
+   backend's own command construction. Per backend it also generates the
+   cross artifact the backend requires: a meson cross file plus exe_wrapper
+   (meson-python only auto-synthesizes cross files on macOS), a CMake
+   toolchain file (scikit-build-core's cross detection likewise only covers
+   macOS), and a `rustc --sysroot` wrapper plus sandboxed `CARGO_HOME` for
+   cargo-based backends (maturin, setuptools-rust).
+2. Overrides the target interpreter's sysconfig for the build
+   (`_PYTHON_SYSCONFIGDATA_NAME` pointing at the target runtime's
+   `_sysconfigdata_*.py`, `_PYTHON_HOST_PLATFORM`, and the target's
+   `EXT_SUFFIX`/`SOABI`), so the produced `.so` and wheel are tagged for the
+   destination platform.
+3. Resolves the sdist's *build* dependencies (`uv.project`'s
+   `default_build_dependencies`, e.g. `build`, `setuptools`, `cffi`) for the
+   **exec platform** but the **target Python version** — the interpreter that
+   runs the build is the host one; the wheels it imports match the host.
+4. Validates the produced wheel's platform tag against the target OS/CPU and
+   fails the action if the backend leaked the exec platform into the tag.
+
+A working end-to-end suite lives in `e2e/crossbuild/`: real packages forced
+to build from sdist (`[tool.uv] no-binary-package`) and cross-compiled for
+linux/amd64 and linux/arm64, covering setuptools (`python-geohash`,
+`msgpack`, `psutil`), setuptools+CFFI (`zstandard`), setuptools-rust
+(`tiktoken`, `bcrypt`), maturin/PyO3 (`pydantic_core`, `rpds_py`),
+meson-python (`contourpy`, `numpy`), and scikit-build-core/CMake
+(`awkward_cpp`, `jpype1`). Each case asserts the ELF architecture of the
+produced `.so` (and its `EXT_SUFFIX`, where the filename carries one) and
+then actually runs the resulting container image (QEMU for arm64). `//geohash` additionally covers a
+macOS arm64 → macOS amd64 cross target when run from a macOS host (see
+`e2e/crossbuild/test.sh`).
+
+Current limitations:
+
+- CPU-feature detection that runs compiled binaries cannot work in cross
+  mode and needs per-package baselines.
+- No shared-library "repair" (auditwheel/delocate style bundling) is performed
+  yet; wheels linking against Bazel-provided native libraries need care.
+- Windows targets and MSVC are not supported.
+- Remote execution with an exec platform different from the host is untested;
+  the build-dependency resolution assumes exec == host.
+
 ## Example: Constraining library compatibility
 
 By default uv hubs let you write `py_library` and other targets which are

--- a/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
+++ b/e2e/cases/pep517-frontend-exec-group/BUILD.bazel
@@ -479,16 +479,7 @@ write_file(
     content = [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
-    ] + select({
-        ":linux_aarch64_config": ["actual=aarch64"],
-        ":linux_x86_64_config": ["actual=x86_64"],
-        "//conditions:default": ["actual=default"],
-    }) + [
         "expected=\"$1\"",
-        "if [[ \"${actual}\" != \"${expected}\" ]]; then",
-        "  echo \"frontend used ${actual}; expected ${expected}\" >&2",
-        "  exit 1",
-        "fi",
         "compiler_actual=\"$(\"${CC}\")\"",
         "if [[ \"${compiler_actual}\" != \"${expected}\" ]]; then",
         "  echo \"compiler ${CC} reported ${compiler_actual}; expected ${expected}\" >&2",
@@ -733,6 +724,11 @@ build_test(
         ":wheel_linux_x86_64",
     ],
 )
+
+# NOTE: the frontend tool itself is configured for the host platform (see
+# exec_transition.bzl); this test verifies the CC toolchain of the "target"
+# exec group is exposed to the build, not that the tool runs in the exec
+# group's platform configuration.
 
 build_test(
     name = "configured_compiler_tools_test",

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -24,6 +24,7 @@ bzl_library(
         "//py/private/interpreter:versions",
         "//py/private/toolchain:types",
         "@bazel_lib//lib:resource_sets",
+        "@bazel_skylib//rules:common_settings",
         "@rules_cc//cc:action_names_bzl",
         "@rules_cc//cc/common",
     ],

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -18,7 +18,10 @@ bzl_library(
     name = "pep517_native_whl",
     srcs = ["pep517_native_whl.bzl"],
     deps = [
+        ":cc_layer",
         ":common",
+        ":exec_transition",
+        "//py/private/interpreter:versions",
         "//py/private/toolchain:types",
         "@bazel_lib//lib:resource_sets",
         "@rules_cc//cc:action_names_bzl",
@@ -30,7 +33,24 @@ bzl_library(
     name = "common",
     srcs = ["common.bzl"],
     deps = [
+        ":exec_transition",
         "//uv/private:source_built_wheel",
         "@bazel_lib//lib:resource_sets",
     ],
+)
+
+bzl_library(
+    name = "cc_layer",
+    srcs = ["cc_layer.bzl"],
+    visibility = ["//uv/private:__subpackages__"],
+    deps = [
+        "@rules_cc//cc:action_names_bzl",
+        "@rules_cc//cc/common",
+    ],
+)
+
+bzl_library(
+    name = "exec_transition",
+    srcs = ["exec_transition.bzl"],
+    deps = ["@aspect_rules_py_uv_host//:defs"],
 )

--- a/uv/private/pep517_whl/cc_layer.bzl
+++ b/uv/private/pep517_whl/cc_layer.bzl
@@ -1,0 +1,216 @@
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+
+_EXECROOT_MARKER = "__ASPECT_RULES_PY_EXECROOT__"
+
+_CC_DISABLED_FEATURES = [
+    "thin_lto",
+    "module_maps",
+    "fdo_instrument",
+    "fdo_optimize",
+    "layering_check",
+]
+
+_PATH_FLAG_PREFIXES = ("-I", "-L", "-isysroot", "-iwithsysroot", "-isystem", "-B")
+
+CC_LAYER_ATTRS = {
+    "_os_linux": attr.label(default = "@platforms//os:linux"),
+    "_os_macos": attr.label(default = "@platforms//os:macos"),
+    "_os_windows": attr.label(default = "@platforms//os:windows"),
+    "_cpu_x86_64": attr.label(default = "@platforms//cpu:x86_64"),
+    "_cpu_aarch64": attr.label(default = "@platforms//cpu:aarch64"),
+    "_cpu_arm": attr.label(default = "@platforms//cpu:arm"),
+    "_cpu_x86_32": attr.label(default = "@platforms//cpu:x86_32"),
+}
+
+def _absolutize_flag(flag):
+    """Prefix execroot-relative paths with the EXECROOT marker.
+
+    The marker is replaced with os.getcwd() at execution time by
+    build_helper.py's _compiler_env, so paths survive the backend's
+    chdir into the unpacked sdist worktree.
+    """
+    if not flag:
+        return flag
+    if not flag.startswith("-"):
+        if "/" in flag:
+            return _EXECROOT_MARKER + "/" + flag
+        return flag
+    for pfx in _PATH_FLAG_PREFIXES:
+        if flag.startswith(pfx) and len(flag) > len(pfx):
+            rest = flag[len(pfx):]
+            if rest and not rest.startswith("/") and "/" in rest:
+                return pfx + _EXECROOT_MARKER + "/" + rest
+    return flag
+
+def get_target_platform(ctx):
+    """Determine target OS and CPU from platform constraints.
+
+    Returns Python-sysconfig-style names: (target_os, target_cpu).
+    Each may be None if the target platform lacks a recognized constraint.
+    """
+    target_os = None
+    target_cpu = None
+
+    if ctx.target_platform_has_constraint(ctx.attr._os_linux[platform_common.ConstraintValueInfo]):
+        target_os = "linux"
+    elif ctx.target_platform_has_constraint(ctx.attr._os_macos[platform_common.ConstraintValueInfo]):
+        target_os = "darwin"
+    elif ctx.target_platform_has_constraint(ctx.attr._os_windows[platform_common.ConstraintValueInfo]):
+        target_os = "windows"
+
+    if ctx.target_platform_has_constraint(ctx.attr._cpu_x86_64[platform_common.ConstraintValueInfo]):
+        target_cpu = "x86_64"
+    elif ctx.target_platform_has_constraint(ctx.attr._cpu_aarch64[platform_common.ConstraintValueInfo]):
+        target_cpu = "aarch64"
+    elif ctx.target_platform_has_constraint(ctx.attr._cpu_arm[platform_common.ConstraintValueInfo]):
+        target_cpu = "arm"
+    elif ctx.target_platform_has_constraint(ctx.attr._cpu_x86_32[platform_common.ConstraintValueInfo]):
+        target_cpu = "x86"
+
+    return target_os, target_cpu
+
+def extract_cc_layer(ctx, cc_toolchain):
+    """Extract CC toolchain tools, flags, and target platform info.
+
+    Called only in cross-compilation mode. The native path relies on the
+    existing _cc_toolchain_inputs_and_tools + backend self-discovery.
+
+    Args:
+        ctx: The rule context. Must include CC_LAYER_ATTRS and
+            fragments = ["cpp"].
+        cc_toolchain: The resolved CcToolchainInfo-like object from
+            ctx.exec_groups[_TARGET_EXEC_GROUP].toolchains[_CC_TOOLCHAIN_TYPE].
+
+    Returns:
+        struct(
+            cc, cxx, ar       — tool execpaths,
+            cflags, cxxflags  — joined compile flags (absolutized),
+            ldflags           — joined executable linker flags (absolutized),
+            ldshared_flags    — joined shared-lib linker flags (absolutized),
+            ccshared          — "-fPIC" or "",
+            target_os         — "linux" | "darwin" | "windows" | None,
+            target_cpu        — "x86_64" | "aarch64" | "arm" | "x86" | None,
+        )
+    """
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features + _CC_DISABLED_FEATURES,
+    )
+
+    action_map = {
+        "cc": ACTION_NAMES.c_compile,
+        "cxx": ACTION_NAMES.cpp_compile,
+        "ldshared": ACTION_NAMES.cpp_link_dynamic_library,
+        "ld": ACTION_NAMES.cpp_link_executable,
+        "ar": ACTION_NAMES.cpp_link_static_library,
+    }
+
+    tools = {}
+    for key, action_name in action_map.items():
+        if cc_common.action_is_enabled(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+        ):
+            tools[key] = cc_common.get_tool_for_action(
+                feature_configuration = feature_configuration,
+                action_name = action_name,
+            )
+
+    compile_vars = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+    )
+    cxx_vars = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        add_legacy_cxx_options = True,
+    )
+    link_shared_vars = cc_common.create_link_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        is_using_linker = True,
+        is_linking_dynamic_library = True,
+        must_keep_debug = False,
+    )
+    link_exe_vars = cc_common.create_link_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        is_using_linker = True,
+        is_linking_dynamic_library = False,
+        must_keep_debug = False,
+    )
+    link_static_vars = cc_common.create_link_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        is_using_linker = False,
+        is_linking_dynamic_library = False,
+        must_keep_debug = False,
+    )
+
+    vars_map = {
+        "cc": compile_vars,
+        "cxx": cxx_vars,
+        "ldshared": link_shared_vars,
+        "ld": link_exe_vars,
+        "ar": link_static_vars,
+    }
+
+    flags = {}
+    for key, action_name in action_map.items():
+        if not cc_common.action_is_enabled(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+        ):
+            continue
+        raw = cc_common.get_memory_inefficient_command_line(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+            variables = vars_map[key],
+        )
+        flags[key] = " ".join([_absolutize_flag(f) for f in raw])
+
+    needs_pic = cc_common.action_is_enabled(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.cpp_link_dynamic_library,
+    )
+
+    target_os, target_cpu = get_target_platform(ctx)
+
+    # A "-nostdlib++" toolchain (the BCR llvm module) supplies its C++/unwind
+    # runtime as toolchain *inputs* (static_runtime_lib), not as link-action
+    # flags — get_memory_inefficient_command_line never sees them, so a PEP
+    # 517 backend linking through our wrappers produces .so's with undefined
+    # std::__1/_Unwind_* symbols that only explode at dlopen time on the
+    # target. Extract the archives so the wrapper can link them explicitly.
+    # Only probed behind the -nostdlib++ marker: self-contained drivers
+    # (gcc_toolchain) resolve their own runtime and may not define
+    # static_runtime_lib at all, which would fail the API call.
+    static_runtime_files = None
+    static_runtime_paths = []
+    if "-nostdlib++" in flags.get("ldshared", ""):
+        static_runtime_files = cc_toolchain.static_runtime_lib(
+            feature_configuration = feature_configuration,
+        )
+        static_runtime_paths = [
+            _EXECROOT_MARKER + "/" + f.path
+            for f in static_runtime_files.to_list()
+            if f.path.endswith(".a")
+        ]
+
+    return struct(
+        cc = tools.get("cc"),
+        cxx = tools.get("cxx"),
+        ar = tools.get("ar"),
+        cflags = flags.get("cc", ""),
+        cxxflags = flags.get("cxx", ""),
+        ldflags = flags.get("ld", ""),
+        ldshared_flags = flags.get("ldshared", ""),
+        ccshared = "-fPIC" if needs_pic else "",
+        target_os = target_os,
+        target_cpu = target_cpu,
+        static_runtime_files = static_runtime_files,
+        static_runtime_paths = static_runtime_paths,
+    )

--- a/uv/private/pep517_whl/common.bzl
+++ b/uv/private/pep517_whl/common.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set_attr")
 load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
+load(":exec_transition.bzl", "exec_transition")
 
 TARGET_EXEC_GROUP = "target"
 
@@ -16,6 +17,12 @@ def wheel_providers(wheel_file, console_scripts):
         DefaultInfo(files = depset([wheel_file])),
         SourceBuiltWheelInfo(console_scripts = tuple(console_scripts)),
     ]
+
+def tool_files_to_run(ctx):
+    tool = ctx.attr.tool
+    if type(tool) == "list":
+        tool = tool[0]
+    return tool[DefaultInfo].files_to_run
 
 def common_env(ctx):
     # pyproject_hooks copies the build process environment and launches its
@@ -65,10 +72,16 @@ _PATCH_ATTRS = {
 
 PEP517_WHL_ATTRS = {
     "src": attr.label(allow_single_file = True),
-    # The wheel action uses the named group below, so its frontend must use the
-    # same execution platform:
-    # https://bazel.build/extending/exec-groups#defining-exec-groups
-    "tool": attr.label(executable = True, cfg = config.exec(TARGET_EXEC_GROUP)),
+    # The wheel action runs in the "target" exec group; its frontend must run
+    # on the exec (host) platform but resolve its Python build dependencies
+    # for the *target* Python version. exec_transition pins --platforms to the
+    # host and resets the platform_libc/platform_version flags to host values
+    # (Starlark flags otherwise leak from the target configuration and break
+    # wheel selection for build deps). See exec_transition.bzl.
+    "tool": attr.label(executable = True, cfg = exec_transition),
+    "_allowlist_function_transition": attr.label(
+        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
     "version": attr.string(),
     "console_scripts": attr.string_list(
         doc = "Console scripts discovered from the source distribution's entry-point metadata.",

--- a/uv/private/pep517_whl/exec_transition.bzl
+++ b/uv/private/pep517_whl/exec_transition.bzl
@@ -1,0 +1,34 @@
+load("@aspect_rules_py_uv_host//:defs.bzl", "CURRENT_PLATFORM_LIBC", "CURRENT_PLATFORM_VERSION")
+
+_PLATFORM_LIBC_FLAG = str(Label("@aspect_rules_py//uv/private/constraints/platform:platform_libc"))
+_PLATFORM_VERSION_FLAG = str(Label("@aspect_rules_py//uv/private/constraints/platform:platform_version"))
+
+_INPUTS = [
+    "//command_line_option:platforms",
+    "//command_line_option:host_platform",
+    _PLATFORM_LIBC_FLAG,
+    _PLATFORM_VERSION_FLAG,
+]
+
+_OUTPUTS = [
+    "//command_line_option:platforms",
+    _PLATFORM_LIBC_FLAG,
+    _PLATFORM_VERSION_FLAG,
+]
+
+def _exec_transition_impl(settings, _attr):
+    if settings["//command_line_option:platforms"] == [settings["//command_line_option:host_platform"]] and \
+       settings[_PLATFORM_LIBC_FLAG] == CURRENT_PLATFORM_LIBC and \
+       settings[_PLATFORM_VERSION_FLAG] == CURRENT_PLATFORM_VERSION:
+        return {}
+    return {
+        "//command_line_option:platforms": [settings["//command_line_option:host_platform"]],
+        _PLATFORM_LIBC_FLAG: CURRENT_PLATFORM_LIBC,
+        _PLATFORM_VERSION_FLAG: CURRENT_PLATFORM_VERSION,
+    }
+
+exec_transition = transition(
+    implementation = _exec_transition_impl,
+    inputs = _INPUTS,
+    outputs = _OUTPUTS,
+)

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -137,21 +137,24 @@ def _find_sysconfigdata(runtime):
             return f
     return None
 
+# Deployment-target floor for the macOS platform string when the real value
+# is unknown: 11.0 is the first macOS release with arm64 support, so it is
+# the most conservative version every hermetic arm64 interpreter satisfies.
+_MACOS_DEPLOYMENT_FALLBACK = "11.0"
+
 def _derive_python_host_platform(target_os, target_cpu):
     """Derive _PYTHON_HOST_PLATFORM from target platform constraints.
 
     Linux: libc does not affect the platform string — always linux-{cpu}.
-    macOS: uses arm64 (not aarch64) and requires a version component. The
-    version here is only an analysis-time fallback: the deployment target is
-    a property of the target interpreter, which analysis can't read, so
-    build_helper re-derives it at build time from the target sysconfigdata's
-    MACOSX_DEPLOYMENT_TARGET whenever that file is available.
+    macOS: uses arm64 (not aarch64) and requires a version component,
+    defaulting to _MACOS_DEPLOYMENT_FALLBACK when the interpreter's real
+    deployment target is not known.
     """
     if target_os == "linux":
         return "linux-" + _PYTHON_CPU_MAP.get(target_cpu, target_cpu)
     if target_os == "darwin":
         cpu = "arm64" if target_cpu == "aarch64" else target_cpu
-        return "macosx-11.0-" + cpu
+        return "macosx-{}-{}".format(_MACOS_DEPLOYMENT_FALLBACK, cpu)
     return None
 
 def _interpreter_platform_triple(runtime):

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -258,14 +258,21 @@ def _pep517_native_whl(ctx):
             extra_inputs.append(cc_layer.static_runtime_files)
         if cc_layer.static_runtime_paths:
             env["RULES_PY_CXX_STATIC_RUNTIME"] = ":".join(cc_layer.static_runtime_paths)
-        if cc_layer.cflags:
-            env["CFLAGS"] = cc_layer.cflags
-        if cc_layer.cxxflags:
-            env["CXXFLAGS"] = cc_layer.cxxflags
-        if cc_layer.ldflags:
-            env["LDFLAGS"] = cc_layer.ldflags
-        if cc_layer.ldshared_flags:
-            env["LDSHAREDFLAGS"] = cc_layer.ldshared_flags
+        # Toolchain flags first, then any flags the package set via `env`
+        # (uv.override_package): the package's -D/-std/feature-baseline
+        # additions must survive, and trailing position lets them override.
+        # Values inherited from the ambient shell env stay excluded — only
+        # an explicit `env` entry merges.
+        for key, toolchain_flags in (
+            ("CFLAGS", cc_layer.cflags),
+            ("CXXFLAGS", cc_layer.cxxflags),
+            ("LDFLAGS", cc_layer.ldflags),
+            ("LDSHAREDFLAGS", cc_layer.ldshared_flags),
+        ):
+            if not toolchain_flags:
+                continue
+            package_flags = env.get(key) if key in ctx.attr.env else None
+            env[key] = toolchain_flags + " " + package_flags if package_flags else toolchain_flags
         if cc_layer.ccshared:
             env["CFLAGS"] = (env.get("CFLAGS", "") + " " + cc_layer.ccshared).strip()
             env["CXXFLAGS"] = (env.get("CXXFLAGS", "") + " " + cc_layer.ccshared).strip()

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -1,13 +1,11 @@
-"""PEP 517 sdist to platform-specific whl build rule.
-
-Uses `python -m build` (the pypa/build frontend) which delegates to whatever
-build backend the sdist declares in its `[build-system]` table.
-"""
+"""PEP 517 sdist to platform-specific whl build rule."""
 
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set")
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
-load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
+load("//py/private/interpreter:versions.bzl", "PLATFORMS")
+load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
+load(":cc_layer.bzl", "CC_LAYER_ATTRS", "extract_cc_layer")
 load(
     ":common.bzl",
     "PEP517_WHL_ATTRS",
@@ -15,8 +13,10 @@ load(
     "common_env",
     "memory_args",
     "patch_args_and_inputs",
+    "tool_files_to_run",
     "wheel_providers",
 )
+load(":exec_transition.bzl", "exec_transition")
 
 _CC_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:toolchain_type")
 _EXECROOT_MARKER = "__ASPECT_RULES_PY_EXECROOT__"
@@ -116,10 +116,112 @@ def _cc_toolchain_inputs_and_tools(ctx):
     infer_cxx = infer_cxx or tools.get("CXX") == tools.get("CC")
     return files, {key: value for key, value in tools.items() if value}, infer_cxx
 
+_PYTHON_CPU_MAP = {
+    "x86_64": "x86_64",
+    "aarch64": "aarch64",
+    "x86": "i686",
+    "arm": "arm",
+}
+
+def _find_sysconfigdata(runtime):
+    """Locate _sysconfigdata*.py inside the target interpreter's file tree."""
+    if not runtime or not hasattr(runtime, "interpreter_version_info"):
+        return None
+    info = runtime.interpreter_version_info
+    prefix = "lib/python{}.{}".format(info.major, info.minor)
+    for f in runtime.files.to_list():
+        if f.basename.startswith("_sysconfigdata") and f.basename.endswith(".py") and prefix in f.path:
+            return f
+    return None
+
+def _derive_python_host_platform(target_os, target_cpu):
+    """Derive _PYTHON_HOST_PLATFORM from target platform constraints.
+
+    Linux: libc does not affect the platform string — always linux-{cpu}.
+    macOS: uses arm64 (not aarch64) and requires a version component. The
+    version here is only an analysis-time fallback: the deployment target is
+    a property of the target interpreter, which analysis can't read, so
+    build_helper re-derives it at build time from the target sysconfigdata's
+    MACOSX_DEPLOYMENT_TARGET whenever that file is available.
+    """
+    if target_os == "linux":
+        return "linux-" + _PYTHON_CPU_MAP.get(target_cpu, target_cpu)
+    if target_os == "darwin":
+        cpu = "arm64" if target_cpu == "aarch64" else target_cpu
+        return "macosx-11.0-" + cpu
+    return None
+
+def _interpreter_platform_triple(runtime):
+    """Best-effort platform triple of the repo a PyRuntimeInfo comes from.
+
+    Interpreter repositories encode the PBS platform triple in their name
+    (`python_3_12_aarch64-apple-darwin`, sanitized variants with underscores,
+    and rules_python's hyphenated `python_3_11_aarch64-apple-darwin`).
+    Returns the matching PLATFORMS key, or None when the interpreter's origin
+    is not recognizable (custom or non-hermetic toolchains).
+    """
+    if runtime == None or runtime.interpreter == None:
+        return None
+    short_path = runtime.interpreter.short_path
+    repo = short_path.split("/")[1] if short_path.startswith("../") else short_path.split("/")[0]
+    for triple in PLATFORMS:
+        if triple in repo or triple.replace("-", "_") in repo:
+            return triple
+    return None
+
+def _cross_compile(ctx, eg_toolchains):
+    """Decide cross mode from exec/target interpreter platform identities.
+
+    The exec interpreter (EXEC_TOOLS_TOOLCHAIN, selected by exec platform)
+    and the target interpreter (PY_TOOLCHAIN, selected by target platform)
+    carry their origin repo's platform triple. Identical triples prove
+    exec == target, so a native build stays native even when the optional
+    NATIVE_BUILD_TOOLCHAIN sentinel is not registered for the platform.
+
+    When either identity is unrecognizable (custom interpreters), fall back
+    to the sentinel's absence as the cross signal — the previous behavior.
+    """
+    exec_tc = eg_toolchains[EXEC_TOOLS_TOOLCHAIN]
+    py_tc = ctx.toolchains[PY_TOOLCHAIN]
+    exec_triple = _interpreter_platform_triple(getattr(exec_tc, "exec_runtime", None) if exec_tc != None else None)
+    target_triple = _interpreter_platform_triple(getattr(py_tc, "py3_runtime", None) if py_tc != None else None)
+    if exec_triple and target_triple:
+        return exec_triple != target_triple
+    return eg_toolchains[NATIVE_BUILD_TOOLCHAIN] == None
+
 def _pep517_native_whl(ctx):
     archive = ctx.file.src
+
+    # Fixed name; the backend picks the real filename at build time and the
+    # helper renames onto this. Consumers read identity from dist-info only.
     wheel_file = ctx.actions.declare_file(ctx.label.name + ".whl")
     patch_args, patch_inputs = patch_args_and_inputs(ctx)
+
+    eg_toolchains = ctx.exec_groups[TARGET_EXEC_GROUP].toolchains
+    cross = _cross_compile(ctx, eg_toolchains)
+    cc_toolchain_raw = eg_toolchains[_CC_TOOLCHAIN_TYPE]
+
+    if cc_toolchain_raw == None:
+        if cross:
+            fail(
+                ("Cross-compilation of sdist '{}' requires a CC toolchain " +
+                 "registered for the target platform. No toolchain of type {} " +
+                 "resolved against the current exec/target platform combination.\n" +
+                 "Register a cross CC toolchain (e.g., toolchains_llvm with " +
+                 "matching target_compatible_with) via register_toolchains.").format(
+                    ctx.attr.src.label,
+                    _CC_TOOLCHAIN_TYPE,
+                ),
+            )
+        fail(
+            ("sdist '{}' requires a CC toolchain but none resolved. " +
+             "Register a CC toolchain (e.g., rules_cc, toolchains_llvm) " +
+             "via register_toolchains.").format(ctx.attr.src.label),
+        )
+
+    cc_toolchain = cc_toolchain_raw
+    if hasattr(cc_toolchain, "cc_provider_in_toolchain") and hasattr(cc_toolchain, "cc"):
+        cc_toolchain = cc_toolchain.cc
 
     env = common_env(ctx)
     extra_inputs, known_variables = _collect_toolchain_inputs_and_vars(ctx)
@@ -144,12 +246,60 @@ def _pep517_native_whl(ctx):
     if "CXX" not in ctx.attr.env and cc_tools.get("CXX") and infer_cxx:
         env[_INFER_CXX_COMPANION] = "1"
 
+    if cross:
+        cc_layer = extract_cc_layer(ctx, cc_toolchain)
+        env["RULES_PY_CROSS_COMPILE"] = "1"
+        env["RULES_PY_TARGET_OS"] = cc_layer.target_os or ""
+        env["RULES_PY_TARGET_CPU"] = cc_layer.target_cpu or ""
+        if cc_layer.static_runtime_files:
+            extra_inputs.append(cc_layer.static_runtime_files)
+        if cc_layer.static_runtime_paths:
+            env["RULES_PY_CXX_STATIC_RUNTIME"] = ":".join(cc_layer.static_runtime_paths)
+        if cc_layer.cflags:
+            env["CFLAGS"] = cc_layer.cflags
+        if cc_layer.cxxflags:
+            env["CXXFLAGS"] = cc_layer.cxxflags
+        if cc_layer.ldflags:
+            env["LDFLAGS"] = cc_layer.ldflags
+        if cc_layer.ldshared_flags:
+            env["LDSHAREDFLAGS"] = cc_layer.ldshared_flags
+        if cc_layer.ccshared:
+            env["CFLAGS"] = (env.get("CFLAGS", "") + " " + cc_layer.ccshared).strip()
+            env["CXXFLAGS"] = (env.get("CXXFLAGS", "") + " " + cc_layer.ccshared).strip()
+        cross_args = [
+            "--cross",
+            "--target-os",
+            cc_layer.target_os or "",
+            "--target-cpu",
+            cc_layer.target_cpu or "",
+        ]
+
+        py_toolchain = ctx.toolchains[PY_TOOLCHAIN]
+        if py_toolchain != None:
+            runtime = getattr(py_toolchain, "py3_runtime", None)
+            if runtime:
+                sysconfig_file = _find_sysconfigdata(runtime)
+                if sysconfig_file:
+                    extra_inputs.append(depset([sysconfig_file]))
+                    env["RULES_PY_TARGET_SYSCONFIGDATA"] = sysconfig_file.path
+
+        host_platform = _derive_python_host_platform(cc_layer.target_os, cc_layer.target_cpu)
+        if host_platform:
+            env["_PYTHON_HOST_PLATFORM"] = host_platform
+    else:
+        cross_args = []
+
+    tool = tool_files_to_run(ctx)
+
     ctx.actions.run(
-        mnemonic = "PySdistNativeBuild",
-        progress_message = "Native source compiling {} to a whl".format(archive.basename),
-        executable = ctx.executable.tool,
+        mnemonic = "PySdistCrossBuild" if cross else "PySdistNativeBuild",
+        progress_message = "{} source compiling {} to a whl".format(
+            "Cross" if cross else "Native",
+            archive.basename,
+        ),
+        executable = tool,
         toolchain = None,
-        arguments = ctx.attr.args + patch_args + memory_args(ctx) + [
+        arguments = ctx.attr.args + patch_args + memory_args(ctx) + cross_args + [
             "--execroot-marker",
             _EXECROOT_MARKER,
             archive.path,
@@ -159,7 +309,7 @@ def _pep517_native_whl(ctx):
             [archive] + patch_inputs,
             transitive = extra_inputs,
         ),
-        tools = [ctx.attr.tool[DefaultInfo].files_to_run],
+        tools = [tool],
         outputs = [wheel_file],
         env = env,
         exec_group = TARGET_EXEC_GROUP,
@@ -183,8 +333,15 @@ attribute maps environment variable names to strings that may reference
 `$(VAR)` make-variables sourced from those toolchains. This mirrors the
 pattern used by `rules_rust`'s `cargo_build_script`.
 
-The build is guaranteed to occur on an execution platform matching the
-constraints of the target platform.
+In native mode (exec platform == target platform) the build uses the host
+CC toolchain. Cross mode is decided by comparing the platform triples of the
+exec interpreter (exec-tools toolchain) and the target interpreter (Python
+toolchain): differing triples enter cross mode, where the CC toolchain of
+the "target" exec group resolves against a user-registered cross CC toolchain
+(e.g., toolchains_llvm). If no cross CC toolchain is found, analysis fails
+with a diagnostic naming the required toolchain type. When the interpreter
+origins are unrecognizable, the optional NATIVE_BUILD_TOOLCHAIN sentinel's
+absence is used as the cross signal.
 
 """,
     attrs = PEP517_WHL_ATTRS | {
@@ -199,27 +356,19 @@ constraints of the target platform.
                   "the unpacked source tree. Omit CC/CXX/AR/LD/STRIP to use the " +
                   "configured C++ action tools.",
         ),
-    },
+        "tool": attr.label(executable = True, cfg = exec_transition),
+    } | CC_LAYER_ATTRS,
     fragments = ["cpp"],
+    toolchains = [
+        config_common.toolchain_type(PY_TOOLCHAIN, mandatory = False),
+    ],
     exec_groups = {
-        # Create an exec group which depends on a toolchain which can only be
-        # resolved to exec_compatible_with constraints equal to the target. This
-        # allows us to discover what those constraints need to be.
-        #
-        # NATIVE_BUILD_TOOLCHAIN has matching exec_compatible_with and
-        # target_compatible_with, so this exec group only resolves when the exec
-        # and target platforms match. Cross-compilation of sdists is intentionally
-        # unsupported: PEP 517 build backends (setuptools, meson-python, etc.)
-        # have no standard mechanism for cross-compilation, Python headers for
-        # the target platform are not readily available, and output wheel tags
-        # would need to encode the target platform with no upstream tooling
-        # support. Packages that need cross-compiled native extensions should
-        # publish pre-built wheels for their target platforms instead.
         TARGET_EXEC_GROUP: exec_group(
             toolchains = [
                 PY_TOOLCHAIN,
-                NATIVE_BUILD_TOOLCHAIN,
-                _CC_TOOLCHAIN_TYPE,
+                config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
+                config_common.toolchain_type(NATIVE_BUILD_TOOLCHAIN, mandatory = False),
+                config_common.toolchain_type(_CC_TOOLCHAIN_TYPE, mandatory = False),
             ],
         ),
     },

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -120,7 +120,9 @@ _PYTHON_CPU_MAP = {
     "x86_64": "x86_64",
     "aarch64": "aarch64",
     "x86": "i686",
-    "arm": "arm",
+    # armv7 CPython reports "linux-armv7l"; build_helper's tag validation
+    # expects the same spelling.
+    "arm": "armv7l",
 }
 
 def _find_sysconfigdata(runtime):

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -261,6 +261,7 @@ def _pep517_native_whl(ctx):
             extra_inputs.append(cc_layer.static_runtime_files)
         if cc_layer.static_runtime_paths:
             env["RULES_PY_CXX_STATIC_RUNTIME"] = ":".join(cc_layer.static_runtime_paths)
+
         # Toolchain flags first, then any flags the package set via `env`
         # (uv.override_package): the package's -D/-std/feature-baseline
         # additions must survive, and trailing position lets them override.

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -1,6 +1,7 @@
 """PEP 517 sdist to platform-specific whl build rule."""
 
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//py/private/interpreter:versions.bzl", "PLATFORMS")
@@ -274,6 +275,11 @@ def _pep517_native_whl(ctx):
             cc_layer.target_os or "",
             "--target-cpu",
             cc_layer.target_cpu or "",
+            # Libc reaches the helper for Rust target-triple derivation:
+            # <cpu>-unknown-linux-{gnu,musl} — the CC toolchain triple alone
+            # can't distinguish them for cargo.
+            "--target-libc",
+            ctx.attr._platform_libc[BuildSettingInfo].value or "",
         ]
 
         py_toolchain = ctx.toolchains[PY_TOOLCHAIN]
@@ -359,6 +365,9 @@ absence is used as the cross signal.
                   "configured C++ action tools.",
         ),
         "tool": attr.label(executable = True, cfg = exec_transition),
+        "_platform_libc": attr.label(
+            default = Label("//uv/private/constraints/platform:platform_libc"),
+        ),
     } | CC_LAYER_ATTRS,
     fragments = ["cpp"],
     toolchains = [

--- a/uv/private/pep517_whl/pep517_whl.bzl
+++ b/uv/private/pep517_whl/pep517_whl.bzl
@@ -13,6 +13,7 @@ load(
     "common_env",
     "memory_args",
     "patch_args_and_inputs",
+    "tool_files_to_run",
     "wheel_providers",
 )
 
@@ -29,17 +30,18 @@ def _pep517_whl(ctx):
     # the action sandbox, which means the venv shim can find the interpreter
     # via the standard runfiles mechanism regardless of whether the interpreter
     # comes from an external repo or the main workspace.
+    tool = tool_files_to_run(ctx)
     ctx.actions.run(
         mnemonic = "PySdistBuild",
         progress_message = "Source compiling {} to a whl".format(archive.basename),
-        executable = ctx.executable.tool,
+        executable = tool,
         toolchain = None,
         arguments = ctx.attr.args + patch_args + memory_args(ctx) + [
             archive.path,
             wheel_file.path,
         ],
         inputs = [archive] + patch_inputs,
-        tools = [ctx.attr.tool[DefaultInfo].files_to_run],
+        tools = [tool],
         outputs = [wheel_file],
         env = common_env(ctx),
         exec_group = TARGET_EXEC_GROUP,

--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -28,6 +28,18 @@ py_test(
 )
 
 py_test(
+    name = "build_helper_cross_test",
+    srcs = ["build_helper_cross_test.py"],
+    data = ["//uv/private/pep517_whl/tools:build_helper.py"],
+    main = "build_helper_cross_test.py",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        "@pypi//build",
+        "@pypi//setuptools",
+    ],
+)
+
+py_test(
     name = "local_cxx_companion_test",
     srcs = ["local_cxx_companion_test.py"],
     data = ["//uv/private/pep517_whl/tools:build_helper.py"],

--- a/uv/private/pep517_whl/tests/build_helper_cross_test.py
+++ b/uv/private/pep517_whl/tests/build_helper_cross_test.py
@@ -1,0 +1,130 @@
+"""Verify build_helper.py's cross-build runtime-identity faking end to end.
+
+A package's setup.py can branch on platform.machine()/os.uname() directly
+(e.g. to pick a vectorized code path) — sysconfig.get_platform() env vars
+don't reach that. This drives build_helper.py exactly as sdist_build's
+generated build_tool does (a plain subprocess against a real sdist), so it
+also exercises exactly what pycross-distutils-probe/uv-sdist-mpicc rely on:
+build_helper.py must stay importable as a bare script with no sibling-module
+dependencies, since those tests find it by path and run it standalone.
+"""
+
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+_SETUP_PY = """\
+import os
+import platform
+import sys
+
+from setuptools import setup
+
+expected = os.environ.get("EXPECTED_MACHINE")
+if expected is not None:
+    if platform.machine() != expected:
+        sys.exit("WRONG_PLATFORM_MACHINE: saw {!r}, expected {!r}".format(platform.machine(), expected))
+    if os.uname().machine != expected:
+        sys.exit("WRONG_UNAME_MACHINE: saw {!r}, expected {!r}".format(os.uname().machine, expected))
+    if os.environ.get("EXPECT_MANYLINUX_DISABLED") == "1":
+        import _manylinux
+        if _manylinux.manylinux_compatible(2, 17, expected):
+            sys.exit("MANYLINUX_NOT_DISABLED")
+
+expected_ar = os.environ.get("EXPECTED_AR_BASENAME")
+if expected_ar is not None:
+    seen_ar = os.path.basename(os.environ.get("AR", ""))
+    if seen_ar != expected_ar:
+        sys.exit("WRONG_AR: saw {!r}, expected {!r}".format(seen_ar, expected_ar))
+
+setup(name="cross_site_probe", version="1.0", py_modules=[])
+"""
+
+
+def _make_fake_llvm_bindir(workdir: str) -> str:
+    bindir = os.path.join(workdir, "llvm-bin")
+    os.makedirs(bindir)
+    for tool in ("llvm-libtool-darwin", "llvm-ar"):
+        with open(os.path.join(bindir, tool), "w") as f:
+            f.write("#!/bin/sh\nexit 0\n")
+        os.chmod(os.path.join(bindir, tool), 0o755)
+    return bindir
+
+
+def _make_sdist(workdir: str) -> str:
+    pkgdir = os.path.join(workdir, "cross_site_probe-1.0")
+    os.makedirs(pkgdir)
+    with open(os.path.join(pkgdir, "setup.py"), "w") as f:
+        f.write(_SETUP_PY)
+    sdist = os.path.join(workdir, "cross_site_probe-1.0.tar.gz")
+    with tarfile.open(sdist, "w:gz") as archive:
+        archive.add(pkgdir, arcname="cross_site_probe-1.0")
+    return sdist
+
+
+def _run(helper: str, sdist: str, workdir: str, label: str, env: dict, args: list) -> None:
+    outdir = os.path.join(workdir, "out-" + label)
+    full_env = {"HOME": workdir, "PATH": "/usr/bin:/bin"}
+    full_env.update(env)
+    result = subprocess.run(
+        [sys.executable, helper, *args, sdist, outdir],
+        capture_output=True,
+        cwd=workdir,
+        env=full_env,
+        text=True,
+    )
+    if result.returncode:
+        raise AssertionError("build_helper failed for {}:\n{}\n{}".format(label, result.stdout, result.stderr))
+
+
+def main() -> None:
+    workdir = tempfile.mkdtemp(dir=os.environ["TEST_TMPDIR"])
+    sdist = _make_sdist(workdir)
+    helper = os.path.join(os.path.dirname(os.path.dirname(__file__)), "tools", "build_helper.py")
+
+    real_machine = os.uname().machine
+    fake_machine = "aarch64" if real_machine != "aarch64" else "x86_64"
+
+    # Cross build: setup.py must see the FAKED target arch, not the host's,
+    # and manylinux compatibility must be refused for it.
+    _run(
+        helper,
+        sdist,
+        workdir,
+        "cross",
+        {"EXPECTED_MACHINE": fake_machine, "EXPECT_MANYLINUX_DISABLED": "1"},
+        ["--cross", "--target-os", "linux", "--target-cpu", fake_machine],
+    )
+
+    # Native build: no faking involved — setup.py must see the real host arch.
+    _run(helper, sdist, workdir, "native", {"EXPECTED_MACHINE": real_machine}, [])
+
+    # llvm-libtool-darwin (the llvm toolchain's static-library tool on darwin
+    # exec hosts) only takes libtool-style args, but every $AR consumer
+    # invokes ar-style — the helper must swap in the sibling llvm-ar for
+    # native and cross builds alike.
+    fake_ar = os.path.join(_make_fake_llvm_bindir(workdir), "llvm-libtool-darwin")
+    _run(
+        helper,
+        sdist,
+        workdir,
+        "ar-swap-native",
+        {"AR": fake_ar, "EXPECTED_AR_BASENAME": "llvm-ar"},
+        [],
+    )
+    _run(
+        helper,
+        sdist,
+        workdir,
+        "ar-swap-cross",
+        {"AR": fake_ar, "EXPECTED_AR_BASENAME": "llvm-ar"},
+        ["--cross", "--target-os", "linux", "--target-cpu", fake_machine],
+    )
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -937,7 +937,13 @@ def _merge_rust_sysroot(tmpdir: str, target_rustc: str, host_sysroot: str) -> st
     return merged
 
 
-def _configure_cargo_cross_env(build_env: dict[str, str], tmpdir: str, target_os: str, target_cpu: str) -> None:
+def _configure_cargo_cross_env(
+    build_env: dict[str, str],
+    tmpdir: str,
+    target_os: str,
+    target_cpu: str,
+    target_libc: str = "",
+) -> None:
     """Cross env vars for maturin/setuptools-rust (Cargo-driven PyO3 builds).
 
     Cargo has no cross auto-detection: it needs an explicit target triple,
@@ -945,6 +951,10 @@ def _configure_cargo_cross_env(build_env: dict[str, str], tmpdir: str, target_os
     and fails.
     """
     os_suffix = _RUST_TARGET_OS.get(target_os, target_os)
+    # The rustup triple encodes libc; the OS/CPU pair alone would pick the
+    # glibc std for a musl destination (or fail on a musl-only sysroot).
+    if target_os == "linux" and target_libc == "musl":
+        os_suffix = "unknown-linux-musl"
     triple = "{}-{}".format(target_cpu, os_suffix)
     build_env["CARGO_BUILD_TARGET"] = triple
     linker_var = "CARGO_TARGET_{}_LINKER".format(triple.upper().replace("-", "_"))
@@ -1168,6 +1178,7 @@ PARSER.add_argument("--execroot-marker", help="Token in env values to replace wi
 PARSER.add_argument("--cross", action="store_true", help="Cross-compilation mode: target platform != exec platform")
 PARSER.add_argument("--target-os", default="", help="Target platform OS (linux, darwin, windows)")
 PARSER.add_argument("--target-cpu", default="", help="Target platform CPU (x86_64, aarch64, ...)")
+PARSER.add_argument("--target-libc", default="", help="Target platform libc (glibc, musl, ...)")
 opts, _ = PARSER.parse_known_args()
 
 tmp_root = path.abspath(opts.output) + ".tmp"
@@ -1267,7 +1278,7 @@ elif path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "se
             toolchain = _generate_cmake_toolchain_file(tmp_root, build_env, opts.target_os, opts.target_cpu)
             cmd += ["-C", "cmake.toolchain-file=" + toolchain]
         elif (build_backend == "maturin" or uses_setuptools_rust) and build_env.get("CARGO"):
-            _configure_cargo_cross_env(build_env, tmp_root, opts.target_os, opts.target_cpu)
+            _configure_cargo_cross_env(build_env, tmp_root, opts.target_os, opts.target_cpu, opts.target_libc)
 else:
     # raise, not _die(): ty doesn't narrow NoReturn in module-level flow and
     # would flag `cmd` below as possibly unbound.

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -1062,10 +1062,15 @@ def _generate_cross_site(
     # derived from the target's deployment target so both stay consistent.
     # Linux keeps "": nothing on that path parses it.
     release = _darwin_kernel_release(macos_deployment_target) if target_os == "darwin" else ""
+
+    # macOS reports "arm64", never the Bazel constraint's "aarch64" —
+    # setup.py scripts branch on platform.machine() == "arm64", and the
+    # faked identity must agree with the wheel tag derived elsewhere.
+    machine = "arm64" if target_os == "darwin" and target_cpu == "aarch64" else target_cpu
     _write_generated_file(
         path.join(site_dir, "sitecustomize.py"),
         _SITECUSTOMIZE_TEMPLATE.format(
-            machine=target_cpu,
+            machine=machine,
             sysname=_TITLECASE_OS.get(target_os, target_os),
             release=release,
             sys_platform=_SYS_PLATFORM.get(target_os, target_os),

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -1094,9 +1094,16 @@ _REQUIREMENT_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
 
 
 def _requirement_name(requirement: str) -> str:
-    """PEP 508 requirement string -> bare package name, extras/specifiers/markers stripped."""
+    """PEP 508 requirement string -> canonical package name.
+
+    Extras/specifiers/markers stripped, then normalized per PEP 503
+    (case-insensitive; runs of -, _, . are equivalent) so comparisons like
+    == "setuptools-rust" also match "Setuptools_Rust".
+    """
     match = _REQUIREMENT_NAME_RE.match(requirement)
-    return match.group(1) if match else ""
+    if not match:
+        return ""
+    return re.sub(r"[-_.]+", "-", match.group(1)).lower()
 
 
 def _legacy_metadata_conflicts_with_pyproject(worktree: str, pyproject_data: dict[str, object] | None) -> bool:

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -163,17 +163,28 @@ while i < len(args):
     filtered.append(a)
     i += 1
 
-# Standalone (non-"-shared") executables built here are never the wheel
+# Standalone (non-shared) executables built here are never the wheel
 # deliverable — only throwaway feature probes (meson sanity checks,
 # cc.run()) executed under QEMU, where dynamically-linked target-arch PIE
 # binaries hit a real qemu-user/glibc startup bug ("Inconsistency detected
 # by ld.so: ... DT_VERSYM"), reproducible with a single-toolchain
 # hello-world. "-static" sidesteps ld.so entirely; the .so deliverables
-# always pass "-shared" and load via dlopen's unrelated path. Mutually
+# always link shared and load via dlopen's unrelated path. Mutually
 # exclusive with the static-libstdc++ trick: its trailing "-Wl,-Bdynamic"
 # would undo a bare "-static" for driver-appended libs (libc included).
-is_shared = "-shared" in filtered
-if is_link and exe_link_flags:
+# Shared-link spellings: "-shared" (ELF), "-bundle"/"-dynamiclib" (ld64).
+# Scan pre-filter args: the darwin spellings are host-leak-dropped from
+# `filtered` when the target is not darwin.
+is_shared = any(a in ("-shared", "-bundle", "-dynamiclib") for a in args)
+if is_darwin and is_link and is_shared:
+    # Extension modules leave _Py* unresolved until dlopen; ld64 errors on
+    # them by default (ELF linkers don't), so mirror CPython's own LDSHARED
+    # unless the backend already passed it (kept as "-undefined
+    # dynamic_lookup" or the combined -Wl spelling). Takes precedence over
+    # the exe_link_flags branch: target identity beats toolchain plumbing.
+    if "dynamic_lookup" not in filtered and "-Wl,-undefined,dynamic_lookup" not in filtered:
+        filtered.append("-Wl,-undefined,dynamic_lookup")
+elif is_link and exe_link_flags:
     # LLVM-style toolchain (see the "-nostdlib++" detection in
     # build_helper): clang only reaches its crt objects and glibc/libc++
     # archives through the link action's -B/-L/--sysroot flags, and not
@@ -205,10 +216,6 @@ elif is_link and not is_shared and not is_darwin:
     filtered.append("-static")
 elif is_cxx and is_link and not is_darwin:
     filtered.extend(static_libstdcxx_flags)
-elif is_darwin and is_link and is_shared:
-    # Extension modules leave _Py* unresolved until dlopen; ld64 errors on
-    # them by default (ELF linkers don't), so mirror CPython's own LDSHARED.
-    filtered.append("-Wl,-undefined,dynamic_lookup")
 
 if is_link and lld_path:
     os.environ.setdefault("PATH", "")

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -83,10 +83,9 @@ sysroot = {sysroot!r}
 if sysroot and "-isysroot" not in filtered_args:
     filtered_args = ["-isysroot", sysroot] + filtered_args
 
-# argv[0] must be the compiler's full path, not just its basename: GCC's
-# driver resolves prefix-relative resources (libstdc++.a, LTO plugins) off
-# argv[0], not /proc/self/exe. A basename-only argv[0] makes it silently
-# search relative to our wrapper's own directory instead and miss them.
+# argv[0] repeats the compiler's full path: GCC-family drivers locate
+# prefix-relative resources (libstdc++.a, LTO plugins) off argv[0], not
+# /proc/self/exe.
 os.execv("{compiler_path}", ["{compiler_path}"] + filtered_args)
 """
 

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -46,14 +46,22 @@ def _die(message: str) -> NoReturn:
 # wrappers because non-clang drivers reject it.
 _DEBUG_FLAG = "-fdebug-default-version=4"
 
-# Forces the static libstdc++ archive regardless of driver name. Plain
-# `-static-libstdc++` is a no-op under gcc_toolchain, whose tool_path is
-# "gcc" (not "g++"): that flag only modifies the implicit libstdc++ link the
-# "g++" argv[0] spec adds. Without this, C++ extensions can build and even
-# import (borrowing symbols another loaded .so pulled in) yet fail at
-# runtime. GNU-ld-only syntax: skipped on Darwin, where clang++ links libc++
-# implicitly.
+# Forces the static libstdc++ archive when the configured C++ tool is a
+# plain C driver ("gcc", "clang"): only the "g++"/"clang++" argv[0] spec
+# adds the implicit libstdc++ link, so under such toolchains (e.g.
+# gcc_toolchain, whose cpp tool_path is "gcc") C++ extensions can build and
+# even import (borrowing symbols another loaded .so pulled in) yet fail at
+# runtime. Static, because a hermetic toolchain's libstdc++.so won't exist
+# on the deployment target. Real C++ drivers keep their own (dynamic)
+# stdlib link untouched. GNU-ld-only syntax: skipped on Darwin, where
+# clang++ links libc++ implicitly.
 _STATIC_LIBSTDCXX_FLAGS = ("-Wl,-Bstatic", "-lstdc++", "-Wl,-Bdynamic")
+
+
+def _static_libstdcxx_flags(compiler_path: str, is_cxx: bool, is_darwin: bool) -> list[str]:
+    if is_cxx and not is_darwin and not path.basename(compiler_path).endswith("++"):
+        return list(_STATIC_LIBSTDCXX_FLAGS)
+    return []
 
 _COMPILER_WRAPPER = """#!/usr/bin/env python3
 import os
@@ -343,7 +351,7 @@ def _make_compiler_wrapper(
             sysroot=sysroot,
             is_cxx=is_cxx,
             is_darwin=is_darwin,
-            static_libstdcxx_flags=list(_STATIC_LIBSTDCXX_FLAGS),
+            static_libstdcxx_flags=_static_libstdcxx_flags(compiler_path, is_cxx, is_darwin),
         ),
         executable=True,
     )

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
-"""
-A minimal python3 -m build wrapper
+"""Drive a PEP 517 sdist-to-wheel build inside a Bazel action.
 
-Mostly exists to allow debugging.
+Unpacks the sdist, assembles a build environment that survives the backend's
+chdir (compiler wrappers, absolutized toolchain paths) and — in cross mode —
+fakes the target platform's identity for the backend, then runs the
+pypa/build frontend. Deliberately a single self-contained script: it is the
+`main` of the py_binary each sdist_build repo generates.
 """
 
 from __future__ import annotations
@@ -12,12 +15,15 @@ from argparse import ArgumentParser
 import importlib
 import os
 import platform as _platform
+import re
 import shlex
 import shutil
 import sys
+import textwrap
 from os import chmod, defpath, listdir, makedirs, path, pathsep
 from subprocess import CalledProcessError, check_call, check_output, STDOUT, run
 from tempfile import TemporaryFile
+from typing import NoReturn
 
 try:
     tomllib = importlib.import_module("tomllib")
@@ -31,20 +37,179 @@ _SETUPTOOLS_BACKENDS = (
 )
 
 
-# Compiler commands must remain valid across working-directory changes.
-# argv[0] must name the resolved driver because compilers may use its directory
-# to locate sibling tools and resources. Clang does so under -no-canonical-prefixes:
-# https://github.com/llvm/llvm-project/blob/llvmorg-22.1.4/clang/tools/driver/driver.cpp#L63-L78
+def _die(message: str) -> NoReturn:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+# Clang-only DWARF flag some Bazel toolchains inject; stripped by the
+# wrappers because non-clang drivers reject it.
 _DEBUG_FLAG = "-fdebug-default-version=4"
+
+# Forces the static libstdc++ archive regardless of driver name. Plain
+# `-static-libstdc++` is a no-op under gcc_toolchain, whose tool_path is
+# "gcc" (not "g++"): that flag only modifies the implicit libstdc++ link the
+# "g++" argv[0] spec adds. Without this, C++ extensions can build and even
+# import (borrowing symbols another loaded .so pulled in) yet fail at
+# runtime. GNU-ld-only syntax: skipped on Darwin, where clang++ links libc++
+# implicitly.
+_STATIC_LIBSTDCXX_FLAGS = ("-Wl,-Bstatic", "-lstdc++", "-Wl,-Bdynamic")
+
 _COMPILER_WRAPPER = """#!/usr/bin/env python3
 import os
 import sys
 
 filtered_args = [arg for arg in sys.argv[1:] if arg != "{debug_flag}"]
+is_cxx = {is_cxx!r}
+is_darwin = {is_darwin!r}
+# Same non-link detection as the cross wrapper: compiles, preprocessing,
+# and compiler-introspection probes must not receive link-only flags.
+is_link = True
+for _arg in filtered_args:
+    if _arg in ("-c", "-E", "-S", "-fsyntax-only", "--version", "-dumpmachine", "-dumpversion", "-###") or _arg.startswith("-print-"):
+        is_link = False
+        break
+if is_cxx and is_link and not is_darwin:
+    filtered_args = filtered_args + {static_libstdcxx_flags!r}
 sysroot = {sysroot!r}
 if sysroot and "-isysroot" not in filtered_args:
     filtered_args = ["-isysroot", sysroot] + filtered_args
+
+# argv[0] must be the compiler's full path, not just its basename: GCC's
+# driver resolves prefix-relative resources (libstdc++.a, LTO plugins) off
+# argv[0], not /proc/self/exe. A basename-only argv[0] makes it silently
+# search relative to our wrapper's own directory instead and miss them.
 os.execv("{compiler_path}", ["{compiler_path}"] + filtered_args)
+"""
+
+_IDENTITY_FLAG_PREFIXES = (
+    "-target",
+    "--target",
+    "--sysroot",
+    "-isysroot",
+    "-mmacosx-version-min",
+)
+
+_DROP_LINKER_FLAGS = frozenset({
+    "-Wl,--start-group",
+    "-Wl,--end-group",
+    "-Wl,--as-needed",
+    "-Wl,--allow-shlib-undefined",
+    "-Wl,-O1",
+    "-Wl,-start_group",
+    "-Wl,-end_group",
+    "-bundle",
+    "STRIP_DEBUG_SYMBOLS",
+})
+
+_DROP_LINKER_PAIRS = frozenset({
+    "-arch",
+    "-undefined",
+    "-current_version",
+    "-compatibility_version",
+    "-install_name",
+})
+
+_DROP_LINKER_PREFIXES = (
+    "-mmacosx-version-min",
+)
+
+_CROSS_COMPILER_WRAPPER = """#!/usr/bin/env python3
+import os
+import sys
+
+args = sys.argv[1:]
+wrapper_flags = {wrapper_flags!r}
+drop_exact = {drop_exact!r}
+drop_pairs = {drop_pairs!r}
+drop_prefixes = {drop_prefixes!r}
+lld_path = {lld_path!r}
+debug_flag = {debug_flag!r}
+is_cxx = {is_cxx!r}
+is_darwin = {is_darwin!r}
+static_libstdcxx_flags = {static_libstdcxx_flags!r}
+exe_link_flags = {exe_link_flags!r}
+static_runtime_archives = {static_runtime_archives!r}
+
+# Not a link if compiling/preprocessing (-c/-E/-S/-fsyntax-only) or if this
+# is a compiler-introspection probe (meson runs "-E -v -", "-print-*",
+# "--version" through us): appending link inputs there is at best noise and
+# at worst catastrophic — "-E" *preprocesses* positional inputs, so an
+# appended static archive becomes megabytes of binary on stdout that
+# meson then strictly utf-8 decodes.
+is_link = True
+for a in args:
+    if a in ("-c", "-E", "-S", "-fsyntax-only", "--version", "-dumpmachine", "-dumpversion", "-###") or a.startswith("-print-"):
+        is_link = False
+        break
+filtered = []
+i = 0
+while i < len(args):
+    a = args[i]
+    if a == debug_flag or a in drop_exact or any(a.startswith(p) for p in drop_prefixes):
+        i += 1
+        continue
+    if a in drop_pairs and i + 1 < len(args):
+        i += 2
+        continue
+    filtered.append(a)
+    i += 1
+
+# Standalone (non-"-shared") executables built here are never the wheel
+# deliverable — only throwaway feature probes (meson sanity checks,
+# cc.run()) executed under QEMU, where dynamically-linked target-arch PIE
+# binaries hit a real qemu-user/glibc startup bug ("Inconsistency detected
+# by ld.so: ... DT_VERSYM"), reproducible with a single-toolchain
+# hello-world. "-static" sidesteps ld.so entirely; the .so deliverables
+# always pass "-shared" and load via dlopen's unrelated path. Mutually
+# exclusive with the static-libstdc++ trick: its trailing "-Wl,-Bdynamic"
+# would undo a bare "-static" for driver-appended libs (libc included).
+is_shared = "-shared" in filtered
+if is_link and exe_link_flags:
+    # LLVM-style toolchain (see the "-nostdlib++" detection in
+    # build_helper): clang only reaches its crt objects and glibc/libc++
+    # archives through the link action's -B/-L/--sysroot flags, and not
+    # every caller threads $LDSHARED through (rustc invokes this wrapper as
+    # "-C linker", meson links probes bare) — bake the flags into every
+    # link; duplicates are harmless to clang.
+    # rustc hardcodes "-lgcc_s" on *-linux-gnu but this toolchain ships no
+    # libgcc; its unwinder comes from the static runtime archives below
+    # (or, without them, from folding in "-lunwind" — cargo-zigbuild's
+    # trick, same ABI surface).
+    if static_runtime_archives and not is_darwin:
+        filtered = [a for a in filtered if a != "-lgcc_s"]
+    else:
+        filtered = ["-lunwind" if a == "-lgcc_s" else a for a in filtered]
+    filtered.extend(exe_link_flags)
+    if static_runtime_archives and not is_darwin:
+        # The toolchain's C++/unwind runtime (libc++.a, libc++abi.a,
+        # libunwind.a) travels as toolchain inputs, never as link flags —
+        # link the archives explicitly, in dependency order, after every
+        # object. Archive semantics make this safe on pure-C links: unused
+        # members are simply not pulled.
+        filtered.extend(static_runtime_archives)
+    elif is_cxx:
+        # No implicit C++ stdlib under -nostdlib++; statically embed
+        # libc++ so the produced .so has no host-libstdc++ dependency
+        # (only static archives exist on the toolchain's search path).
+        filtered.extend(["-lc++", "-lc++abi"])
+elif is_link and not is_shared and not is_darwin:
+    filtered.append("-static")
+elif is_cxx and is_link and not is_darwin:
+    filtered.extend(static_libstdcxx_flags)
+elif is_darwin and is_link and is_shared:
+    # Extension modules leave _Py* unresolved until dlopen; ld64 errors on
+    # them by default (ELF linkers don't), so mirror CPython's own LDSHARED.
+    filtered.append("-Wl,-undefined,dynamic_lookup")
+
+if is_link and lld_path:
+    os.environ.setdefault("PATH", "")
+    os.environ["PATH"] = os.path.dirname(lld_path) + os.pathsep + os.environ["PATH"]
+    if "-fuse-ld=lld" not in filtered:
+        filtered.insert(0, "-fuse-ld=lld")
+
+real = {compiler_path!r}
+os.execv(real, [real] + wrapper_flags + filtered)
 """
 
 
@@ -58,14 +223,57 @@ def _darwin_sysroot() -> str | None:
         return None
 
 
-def _absolutize_path(value: str) -> str:
-    """Resolve a relative path to absolute, leaving absolute/empty values untouched.
+def _xcode_developer_dir() -> str | None:
+    """Return the active Xcode Developer directory, or None if unavailable."""
+    try:
+        return check_output(["xcode-select", "-p"], text=True).strip()
+    except Exception:
+        return None
 
-    Shared by _resolve_compiler_path (CC/CXX) and _absolutize_tool_paths.
-    Toolchain execroot-relative paths break once the PEP 517 backend chdirs into the
-    unpacked sdist. Centralizing the policy keeps the two paths in lockstep
-    and gives future toolchains (FC, RUSTC, ...) a single primitive to call.
+
+_MACOSX_DEPLOYMENT_TARGET_RE = re.compile(
+    r"[\"']MACOSX_DEPLOYMENT_TARGET[\"']\s*:\s*[\"']?([0-9][0-9.]*)"
+)
+
+
+def _macosx_deployment_target(sysconfigdata_path: str) -> str | None:
+    """The target interpreter's deployment target, from its sysconfigdata.
+
+    The deployment version in wheel/platform tags is a property of the target
+    interpreter's build, not a constant — regex the build_time_vars literal
+    rather than importing it, since the file belongs to a foreign-platform
+    interpreter this process must not execute code from.
     """
+    try:
+        with open(sysconfigdata_path, encoding="utf-8") as f:
+            match = _MACOSX_DEPLOYMENT_TARGET_RE.search(f.read())
+    except OSError:
+        return None
+    return match.group(1) if match else None
+
+
+def _darwin_kernel_release(macos_deployment_target: str | None) -> str:
+    """Fake os.uname() release consistent with the macOS deployment target.
+
+    Darwin kernel majors track macOS marketing versions as 11→20 … 15→24;
+    from the year-based scheme (26 = Darwin 25) it's major−1. Only consumers
+    parsing a plausible kernel version matter here (ctypes' import does),
+    so unknown/missing values fall back to the macOS 11 baseline.
+    """
+    try:
+        major = int((macos_deployment_target or "").split(".")[0])
+    except ValueError:
+        major = 0
+    if 11 <= major <= 15:
+        return "{}.0.0".format(major + 9)
+    if major >= 26:
+        return "{}.0.0".format(major - 1)
+    return "20.0.0"
+
+
+def _absolutize_path(value: str) -> str:
+    """Make a relative path absolute: execroot-relative toolchain paths stop
+    resolving once the PEP 517 backend chdirs into the unpacked sdist."""
     return path.abspath(value) if value and not path.isabs(value) else value
 
 
@@ -108,22 +316,175 @@ def _local_cxx_companion(current: str | None, compiler_path: str) -> str:
     return compiler_path
 
 
+def _write_generated_file(file_path: str, content: str, executable: bool = False) -> str:
+    """Write content to file_path, creating parent dirs. Returns file_path for chaining."""
+    makedirs(path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w") as f:
+        f.write(content)
+    if executable:
+        chmod(file_path, 0o755)
+    return file_path
+
+
 def _make_compiler_wrapper(
     tmpdir: str,
     name: str,
     compiler_path: str,
     sysroot: str | None = None,
+    is_cxx: bool = False,
+    is_darwin: bool = False,
 ) -> str:
     wrapper = path.join(tmpdir, ".aspect_rules_py_compilers", name)
-    makedirs(path.dirname(wrapper), exist_ok=True)
-    with open(wrapper, "w") as f:
-        f.write(_COMPILER_WRAPPER.format(
+    return _write_generated_file(
+        wrapper,
+        _COMPILER_WRAPPER.format(
             debug_flag=_DEBUG_FLAG,
             compiler_path=compiler_path,
             sysroot=sysroot,
-        ))
-    chmod(wrapper, 0o755)
-    return wrapper
+            is_cxx=is_cxx,
+            is_darwin=is_darwin,
+            static_libstdcxx_flags=list(_STATIC_LIBSTDCXX_FLAGS),
+        ),
+        executable=True,
+    )
+
+
+_SYSROOT_FLAG_PREFIXES = ("--sysroot", "-isysroot")
+
+
+def _absolutize_sysroot_flags(flags: str) -> str:
+    """Absolutize sysroot values inside a flag string (CFLAGS, LDSHAREDFLAGS).
+
+    Must run while the process is still in the execroot; the backend splices
+    these env strings into commands it runs from inside the unpacked sdist,
+    where an execroot-relative sysroot no longer resolves. A later relative
+    "--sysroot" would also silently override the wrapper's absolute one —
+    the clang driver honors the last occurrence.
+    """
+    parts = shlex.split(flags)
+    result = []
+    i = 0
+    while i < len(parts):
+        p = parts[i]
+        flag, sep, value = p.partition("=")
+        if sep and flag in _SYSROOT_FLAG_PREFIXES:
+            p = "{}={}".format(flag, _absolutize_path(value))
+        elif p in _SYSROOT_FLAG_PREFIXES and i + 1 < len(parts):
+            result.append(p)
+            result.append(_absolutize_path(parts[i + 1]))
+            i += 2
+            continue
+        result.append(p)
+        i += 1
+    return shlex.join(result)
+
+
+def _get_wrapper_flags(cflags: str) -> list[str]:
+    """Extract identity flags (-target, --sysroot, -isysroot, ...) from CFLAGS.
+
+    The PEP 517 backend (setuptools, meson-python) may strip these when
+    constructing its own compile commands; the cross wrapper re-injects them
+    on every invocation so the real compiler always targets the right
+    platform. Sysroot values are absolutized first (see
+    _absolutize_sysroot_flags for why that must happen in the execroot).
+    """
+    parts = shlex.split(_absolutize_sysroot_flags(cflags))
+    result = []
+    i = 0
+    while i < len(parts):
+        p = parts[i]
+        if any(p == prefix or p.startswith(prefix + "=") for prefix in _IDENTITY_FLAG_PREFIXES):
+            result.append(p)
+            if "=" not in p and i + 1 < len(parts) and not parts[i + 1].startswith("-"):
+                result.append(parts[i + 1])
+                i += 1
+        i += 1
+    return result
+
+
+def _find_lld(compiler_path: str) -> str | None:
+    """Locate ld.lld or ld64.lld next to the compiler, if present."""
+    d = path.dirname(compiler_path)
+    if not d:
+        return None
+    for name in ("ld.lld", "ld64.lld", "lld"):
+        candidate = path.join(d, name)
+        if path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _make_cross_compiler_wrapper(
+    tmpdir: str,
+    name: str,
+    compiler_path: str,
+    wrapper_flags: list[str],
+    lld_path: str | None = None,
+    is_cxx: bool = False,
+    is_darwin: bool = False,
+    exe_link_flags: list[str] | None = None,
+    static_runtime_archives: list[str] | None = None,
+) -> str:
+    wrapper = path.join(tmpdir, ".aspect_rules_py_compilers", name)
+
+    # "-bundle" and "-undefined dynamic_lookup" leak from a macOS *host*
+    # sysconfig and break ELF linkers, but when the *target* is darwin they
+    # are exactly how extension modules must link (unresolved _Py* symbols
+    # bind at dlopen time) — keep them there.
+    drop_exact = set(_DROP_LINKER_FLAGS)
+    drop_pairs = set(_DROP_LINKER_PAIRS)
+    if is_darwin:
+        drop_exact.discard("-bundle")
+        drop_pairs.discard("-undefined")
+
+    return _write_generated_file(
+        wrapper,
+        _CROSS_COMPILER_WRAPPER.format(
+            compiler_path=compiler_path,
+            wrapper_flags=wrapper_flags,
+            drop_exact=sorted(drop_exact),
+            drop_pairs=sorted(drop_pairs),
+            drop_prefixes=list(_DROP_LINKER_PREFIXES),
+            lld_path=lld_path,
+            debug_flag=_DEBUG_FLAG,
+            is_cxx=is_cxx,
+            is_darwin=is_darwin,
+            static_libstdcxx_flags=list(_STATIC_LIBSTDCXX_FLAGS),
+            exe_link_flags=list(exe_link_flags or []),
+            static_runtime_archives=list(static_runtime_archives or []),
+        ),
+        executable=True,
+    )
+
+
+_AR_LIBTOOL_WRAPPER = """#!/usr/bin/env python3
+import os
+import sys
+
+libtool = {libtool!r}
+args = sys.argv[1:]
+
+# Already libtool-style ("-static ...") or a tool probe ("--version", "-V"):
+# hand through untouched.
+if not args or args[0].startswith("-"):
+    os.execv(libtool, [libtool] + args)
+
+# ar-style "<ops> <archive> <members...>" (meson "csr", CMake "qc",
+# distutils "rcs"). libtool -static always rewrites the whole symbol-tabled
+# archive, so create/replace/append modifiers all collapse to the same call.
+archive = args[1]
+members = args[2:]
+os.execv(libtool, [libtool, "-static", "-o", archive] + members)
+"""
+
+
+def _make_ar_libtool_wrapper(tmpdir: str, libtool_path: str) -> str:
+    wrapper = path.join(tmpdir, ".aspect_rules_py_compilers", "ar")
+    return _write_generated_file(
+        wrapper,
+        _AR_LIBTOOL_WRAPPER.format(libtool=libtool_path),
+        executable=True,
+    )
 
 
 def _override_tool(env: dict[str, str], key: str, wrapper: str) -> None:
@@ -138,7 +499,7 @@ def _override_tool(env: dict[str, str], key: str, wrapper: str) -> None:
 
 def _absolutize_tool_paths(env: dict[str, str]) -> None:
     """Resolve toolchain paths before the backend changes cwd."""
-    for key in ("JAVA_HOME", "JAVA"):
+    for key in ("JAVA_HOME", "JAVA", "CARGO", "RUSTC", "RULES_PY_RUST_HOST_SYSROOT", "ANT_HOME", "RULES_PY_ANT_BIN_DIR"):
         value = env.get(key)
         if value:
             env[key] = _absolutize_path(value)
@@ -153,18 +514,20 @@ def _absolutize_tool_paths(env: dict[str, str]) -> None:
             env[key] = shlex.join(parts)
 
 
-def _compiler_env(tmpdir: str, execroot_marker: str | None = None) -> dict[str, str]:
+def _compiler_env(
+    tmpdir: str,
+    execroot_marker: str | None = None,
+    cross: bool = False,
+    target_os: str = "",
+    target_cpu: str = "",
+) -> dict[str, str]:
     env = dict(os.environ)
     if execroot_marker:
         execroot = os.getcwd()
         env = {key: value.replace(execroot_marker, execroot) for key, value in env.items()}
-    # The helper's launcher exports RUNFILES_DIR, RUNFILES_MANIFEST_FILE, and
-    # JAVA_RUNFILES:
-    # https://github.com/hermeticbuild/hermetic-launcher/blob/381814d0818af0573263323dc0dd0e4e208fc3fa/README.md#runfiles-discovery
-    # Bazel adds RUNFILES_MANIFEST_ONLY when runfiles trees are disabled:
-    # https://github.com/bazelbuild/bazel/blob/9.1.1/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java#L192-L201
-    # Nested Bazel executables check that inherited state before adjacent
-    # runfiles, so remove the parent's identity before package code runs.
+    # The helper's own launcher exported this runfiles identity; nested Bazel
+    # executables launched by package code would trust it over their adjacent
+    # runfiles, so strip it before any package code runs.
     for key in (
         "JAVA_RUNFILES",
         "RUNFILES_DIR",
@@ -172,13 +535,38 @@ def _compiler_env(tmpdir: str, execroot_marker: str | None = None) -> dict[str, 
         "RUNFILES_MANIFEST_ONLY",
     ):
         env.pop(key, None)
+    # Some build deps (maturin) ship plain wheel-data scripts under
+    # <whl_install output>/bin, which venv assembly never merges (it only
+    # merges lib/site-packages) — so they land on neither sys.path nor PATH.
+    # They are still real runfiles; walk the runfiles roots for whl_install
+    # bin/ dirs and put those on PATH.
+    bin_dirs = []
+    for runfiles_root in sys.path:
+        if not path.isdir(runfiles_root) or "runfiles" not in runfiles_root:
+            continue
+        for entry in os.listdir(runfiles_root):
+            bin_dir = path.join(runfiles_root, entry, "actual_install.install", "bin")
+            if path.isdir(bin_dir):
+                bin_dirs.append(bin_dir)
+
     env["PATH"] = pathsep.join([
         path.dirname(sys.executable),
+        *bin_dirs,
         env.get("PATH", defpath),
     ])
     env["TMP"] = tmpdir
     env["TEMP"] = tmpdir
     env["TEMPDIR"] = tmpdir
+
+    # PBS interpreters bake their original build-time prefix into sysconfig's
+    # LIBDIR ("/install/lib", nonexistent after relocation), so anything that
+    # links libpythonX.Y (meson's Cython sanity check) fails. The
+    # interpreter's own pkg-config file resolves relative to itself
+    # (${pcfiledir}/../..) — point PKG_CONFIG_PATH at it instead.
+    interpreter_root = path.dirname(path.dirname(path.realpath(sys.executable)))
+    pkgconfig_dir = path.join(interpreter_root, "lib", "pkgconfig")
+    if path.isdir(pkgconfig_dir):
+        env["PKG_CONFIG_PATH"] = pathsep.join([pkgconfig_dir, env.get("PKG_CONFIG_PATH", "")]).rstrip(pathsep)
 
     # Bazel expands tool paths relative to the execroot. Resolve them while the
     # helper still runs there; bare tool names deliberately remain on PATH.
@@ -190,19 +578,115 @@ def _compiler_env(tmpdir: str, execroot_marker: str | None = None) -> dict[str, 
         cxx_path = _local_cxx_companion(env.get("CXX"), cxx_path)
 
     sysroot = _darwin_sysroot()
+    is_darwin = target_os == "darwin" if cross else _platform.system() == "Darwin"
 
-    cc = _make_compiler_wrapper(tmpdir, "cc", cc_path, sysroot)
-    cxx = _make_compiler_wrapper(tmpdir, "c++", cxx_path, sysroot)
+    if cross:
+        for key in ("CFLAGS", "CXXFLAGS", "CPPFLAGS", "LDSHAREDFLAGS"):
+            if env.get(key):
+                env[key] = _absolutize_sysroot_flags(env[key])
+
+        wrapper_flags = _get_wrapper_flags(env.get("CFLAGS", ""))
+        lld_path = _find_lld(cc_path)
+
+        # The -nostdlib++ toolchain's C++/unwind runtime archives, extracted
+        # by cc_layer.bzl from static_runtime_lib (they never appear in the
+        # link-action flags). Ordered for single-pass archive resolution:
+        # libc++ pulls from libc++abi, which pulls from libunwind.
+        static_runtime = [
+            _absolutize_path(p)
+            for p in env.pop("RULES_PY_CXX_STATIC_RUNTIME", "").split(":")
+            if p
+        ]
+        runtime_rank = {"libc++.a": 0, "libc++abi.a": 1, "libunwind.a": 2}
+        static_runtime.sort(key=lambda p: runtime_rank.get(path.basename(p), 3))
+
+        # An LLVM-style toolchain (BCR `llvm` module) reaches its crt objects
+        # and runtime archives only through the link action's flags; detect it
+        # by its "-nostdlib++" marker and bake those flags (sans "-shared")
+        # into the wrappers for probe-executable links. gcc_toolchain's driver
+        # is self-contained — it gets an empty list and keeps its "-static".
+        ldshared_flag_list = env.get("LDSHAREDFLAGS", "").split()
+        exe_link_flags = (
+            [f for f in ldshared_flag_list if f != "-shared"] if "-nostdlib++" in ldshared_flag_list else []
+        )
+
+        cc = _make_cross_compiler_wrapper(tmpdir, "cc", cc_path, wrapper_flags, lld_path, is_darwin=is_darwin, exe_link_flags=exe_link_flags, static_runtime_archives=static_runtime)
+        cxx = _make_cross_compiler_wrapper(tmpdir, "c++", cxx_path, wrapper_flags, lld_path, is_cxx=True, is_darwin=is_darwin, exe_link_flags=exe_link_flags, static_runtime_archives=static_runtime)
+
+        # gcc_toolchain layout (<root>/xbin/gcc, <root>/sysroot/...): a
+        # target-arch binary needs THIS toolchain's glibc/loader to run.
+        # Consumed only by meson's exe_wrapper (_generate_meson_cross_file).
+        target_gcc_sysroot = path.join(path.dirname(path.dirname(cc_path)), "sysroot")
+        if not is_darwin and path.isdir(target_gcc_sysroot):
+            env["RULES_PY_TARGET_GCC_SYSROOT"] = target_gcc_sysroot
+
+        # apple_support's wrapped_clang hard-fails without DEVELOPER_DIR /
+        # SDKROOT; Bazel injects them only into actions with Xcode execution
+        # requirements, which this PEP 517 action is not.
+        if is_darwin and _platform.system() == "Darwin":
+            if "DEVELOPER_DIR" not in env:
+                developer_dir = _xcode_developer_dir()
+                if developer_dir:
+                    env["DEVELOPER_DIR"] = developer_dir
+            if sysroot and "SDKROOT" not in env:
+                env["SDKROOT"] = sysroot
+    else:
+        cc = _make_compiler_wrapper(tmpdir, "cc", cc_path, sysroot, is_darwin=is_darwin)
+        cxx = _make_compiler_wrapper(tmpdir, "c++", cxx_path, sysroot, is_cxx=True, is_darwin=is_darwin)
 
     env.setdefault("CC", cc)
     env.setdefault("CXX", cxx)
 
-    # MPI builds (e.g. mpi4py) consult $MPICC before searching PATH, so a
-    # plain C compiler here would shadow the real mpicc. Only set it when
-    # a system mpicc exists, wrapped to keep the debug-flag stripping.
+    if cross:
+        ldshared_flags = env.get("LDSHAREDFLAGS", "")
+        env["LDSHARED"] = cc + (" " + ldshared_flags if ldshared_flags else "")
+        env["LDCXXSHARED"] = cxx + (" " + ldshared_flags if ldshared_flags else "")
+
+        deployment_target = None
+        target_sysconfig = env.get("RULES_PY_TARGET_SYSCONFIGDATA")
+        if target_sysconfig and path.exists(target_sysconfig):
+            sysconfig_dir = path.join(tmpdir, ".target_sysconfig")
+            makedirs(sysconfig_dir, exist_ok=True)
+            shutil.copy(target_sysconfig, sysconfig_dir)
+            module_name = path.basename(target_sysconfig)[:-3]
+            env["_PYTHON_SYSCONFIGDATA_NAME"] = module_name
+            env["PYTHONPATH"] = sysconfig_dir + pathsep + env.get("PYTHONPATH", "")
+
+            # The analysis-time _PYTHON_HOST_PLATFORM (rule.bzl) can only
+            # guess macosx-11.0; the target interpreter's sysconfig knows the
+            # real deployment version its wheel tags must carry. distutils'
+            # get_platform() also honors $MACOSX_DEPLOYMENT_TARGET directly.
+            if target_os == "darwin":
+                deployment_target = _macosx_deployment_target(target_sysconfig)
+                if deployment_target:
+                    env.setdefault("MACOSX_DEPLOYMENT_TARGET", deployment_target)
+                    cpu = "arm64" if target_cpu == "aarch64" else target_cpu
+                    env["_PYTHON_HOST_PLATFORM"] = "macosx-{}-{}".format(deployment_target, cpu)
+
+        if target_os and target_cpu:
+            site_dir = _generate_cross_site(tmpdir, target_os, target_cpu, deployment_target)
+            env["PYTHONPATH"] = site_dir + pathsep + env.get("PYTHONPATH", "")
+
+    # MPI builds (mpi4py) consult $MPICC before PATH; only set it when a real
+    # mpicc exists, wrapped to keep the debug-flag stripping.
     mpicc_path = shutil.which("mpicc", path=env["PATH"])
     if mpicc_path:
         env.setdefault("MPICC", _make_compiler_wrapper(tmpdir, "mpicc", mpicc_path, sysroot))
+
+    # $AR consumers (meson, distutils, CMake) all invoke it with ar-style
+    # args, but the llvm toolchain's cpp_link_static_library tool on a darwin
+    # exec host is llvm-libtool-darwin, which only accepts libtool-style
+    # `-static -o`. Prefer the sibling llvm-ar (symbol-table'd archives
+    # satisfy ld64 and ELF linkers alike), but the sandbox only mounts the
+    # toolchain's declared tool files — llvm-ar is usually not among them —
+    # so fall back to a wrapper that translates ar-style argv to libtool's.
+    ar_path = env.get("AR", "")
+    if path.basename(ar_path) == "llvm-libtool-darwin":
+        llvm_ar = path.join(path.dirname(ar_path), "llvm-ar")
+        if path.exists(llvm_ar):
+            env["AR"] = llvm_ar
+        else:
+            env["AR"] = _make_ar_libtool_wrapper(tmpdir, ar_path)
     env.setdefault("AR", "ar")
 
     for key, wrapper in [
@@ -213,6 +697,22 @@ def _compiler_env(tmpdir: str, execroot_marker: str | None = None) -> dict[str, 
         ("LDCXXSHARED", cxx),
     ]:
         _override_tool(env, key, wrapper)
+
+    # maturin and setuptools-rust locate cargo via shutil.which, not $CARGO —
+    # without it on PATH they auto-install a Rust toolchain (puccinialin).
+    cargo_path = env.get("CARGO")
+    if cargo_path:
+        env["PATH"] = pathsep.join([path.dirname(cargo_path), env.get("PATH", defpath)])
+
+        # Cargo's default $CARGO_HOME (~/.cargo) is unwritable in the sandbox.
+        cargo_home = path.join(tmpdir, ".cargo_home")
+        makedirs(cargo_home, exist_ok=True)
+        env.setdefault("CARGO_HOME", cargo_home)
+
+    # CMake's find_program(ANT_EXECUTABLE) (jpype1 et al.) needs ant on PATH.
+    ant_bin_dir = env.pop("RULES_PY_ANT_BIN_DIR", None)
+    if ant_bin_dir:
+        env["PATH"] = pathsep.join([ant_bin_dir, env.get("PATH", defpath)])
 
     return env
 
@@ -237,7 +737,339 @@ def _load_pyproject_data(worktree: str) -> dict[str, object] | None:
         return None
 
 
-def _legacy_metadata_conflicts_with_pyproject(worktree: str) -> bool:
+# Our lowercase target_os values, Title-Cased for whatever tool wants that
+# spelling: CMAKE_SYSTEM_NAME and the faked platform.system()/os.uname()
+# sysname both use it.
+_TITLECASE_OS = {"linux": "Linux", "darwin": "Darwin", "windows": "Windows"}
+_SYS_PLATFORM = {"linux": "linux", "darwin": "darwin", "windows": "win32"}
+
+
+def _generate_cmake_toolchain_file(
+    tmpdir: str,
+    build_env: dict[str, str],
+    target_os: str,
+    target_cpu: str,
+) -> str:
+    """Cross toolchain file for scikit-build-core/CMake.
+
+    scikit-build-core only auto-detects macOS ARCHFLAGS cross builds; a
+    Linux-arch cross build configures as native — it compiles fine off
+    $CC/$CXX but find_program picks the host `strip`, which rejects the
+    foreign-arch .so. CMAKE_SYSTEM_NAME also enables real
+    CMAKE_CROSSCOMPILING mode.
+    """
+    return _write_generated_file(
+        path.join(tmpdir, "cross_toolchain.cmake"),
+        textwrap.dedent("""\
+            set(CMAKE_SYSTEM_NAME {system})
+            set(CMAKE_SYSTEM_PROCESSOR {processor})
+            set(CMAKE_C_COMPILER {cc})
+            set(CMAKE_CXX_COMPILER {cxx})
+            set(CMAKE_AR {ar})
+            set(CMAKE_STRIP {strip})
+            """).format(
+            system=_TITLECASE_OS.get(target_os, target_os),
+            processor=target_cpu,
+            cc=build_env["CC"],
+            cxx=build_env["CXX"],
+            ar=build_env.get("AR", "ar"),
+            strip=build_env.get("STRIP", "strip"),
+        ),
+    )
+
+
+_MESON_EXE_WRAPPER = """#!/usr/bin/env python3
+import os
+import sys
+
+qemu_ld_prefix = {qemu_ld_prefix!r}
+if qemu_ld_prefix:
+    os.environ["QEMU_LD_PREFIX"] = qemu_ld_prefix
+os.execv(sys.argv[1], sys.argv[1:])
+"""
+
+
+# numpy's longdouble probe outputs (numpy/_core/meson.build), keyed by the
+# target ABI: x86 keeps the 80-bit x87 format padded to 16 bytes, aarch64
+# glibc uses IEEE binary128, and Apple aarch64 aliases long double to double.
+_MESON_LONGDOUBLE_FORMAT = {
+    ("darwin", "aarch64"): "IEEE_DOUBLE_LE",
+    ("darwin", "x86_64"): "INTEL_EXTENDED_16_BYTES_LE",
+    ("linux", "aarch64"): "IEEE_QUAD_LE",
+    ("linux", "x86_64"): "INTEL_EXTENDED_16_BYTES_LE",
+}
+
+
+def _generate_meson_cross_file(
+    tmpdir: str,
+    build_env: dict[str, str],
+    target_os: str,
+    target_cpu: str,
+) -> str:
+    """Cross file for meson-python.
+
+    meson-python only auto-synthesizes a cross file for macOS
+    ARCHFLAGS/cibuildwheel/iOS; a Linux-arch cross build configures as
+    native and meson fails running its compiler sanity-check binary.
+    `needs_exe_wrapper` alone only covers meson's own checks — projects
+    calling `cc.run()` directly (numpy) hard-error unless a real
+    `exe_wrapper` program exists. binfmt_misc+qemu-user already runs
+    target-arch ELFs transparently, so the wrapper just execs through; what
+    it adds is QEMU_LD_PREFIX pointed at the cross toolchain's sysroot,
+    without which qemu-user searches the exec host for the target's
+    ld-linux/glibc and finds none.
+    """
+    # The wrapper is only offered when the emulated binary can actually
+    # resolve its dynamic interpreter: binfmt+qemu need QEMU_LD_PREFIX to
+    # locate the target's ld.so/glibc, and only the gcc_toolchain layout
+    # hands us that sysroot. Everywhere else (darwin hosts can't execute
+    # ELF at all; the llvm toolchain's empty-sysroot layout gives qemu no
+    # loader prefix) meson gets needs_exe_wrapper=true with NO exe_wrapper:
+    # it skips its own sanity runs and cc.run() callers get meson's
+    # explicit cross-environment error — an honest limitation.
+    exe_wrapper_line = ""
+    if _platform.system() == "Linux" and build_env.get("RULES_PY_TARGET_GCC_SYSROOT"):
+        exe_wrapper = _write_generated_file(
+            path.join(tmpdir, "meson_exe_wrapper.py"),
+            _MESON_EXE_WRAPPER.format(qemu_ld_prefix=build_env.get("RULES_PY_TARGET_GCC_SYSROOT", "")),
+            executable=True,
+        )
+        exe_wrapper_line = "exe_wrapper = ['{}']\n".format(exe_wrapper)
+
+    # numpy's documented cross recipe: its meson.build reads this external
+    # property and only falls back to a cc.run() probe when it is absent —
+    # which hard-errors wherever no exe_wrapper exists (any darwin→linux
+    # cross). The value is an ABI constant of (os, cpu, libc), so bake it in
+    # rather than making every consumer rediscover numpy gh-23972.
+    longdouble_line = ""
+    longdouble_format = _MESON_LONGDOUBLE_FORMAT.get((target_os, target_cpu))
+    if longdouble_format:
+        longdouble_line = "longdouble_format = '{}'\n".format(longdouble_format)
+    return _write_generated_file(
+        path.join(tmpdir, "cross_file.ini"),
+        textwrap.dedent("""\
+            [binaries]
+            c = '{cc}'
+            cpp = '{cxx}'
+            ar = '{ar}'
+            strip = '{strip}'
+            {exe_wrapper_line}
+            [host_machine]
+            system = '{system}'
+            cpu_family = '{cpu_family}'
+            cpu = '{cpu}'
+            endian = 'little'
+
+            [properties]
+            needs_exe_wrapper = true
+            {longdouble_line}""").format(
+            cc=build_env["CC"],
+            cxx=build_env["CXX"],
+            exe_wrapper_line=exe_wrapper_line,
+            longdouble_line=longdouble_line,
+            ar=build_env.get("AR", "ar"),
+            strip=build_env.get("STRIP", "strip"),
+            system=target_os,
+            cpu_family=target_cpu,
+            cpu=target_cpu,
+        ),
+    )
+
+
+_RUST_TARGET_OS = {"linux": "unknown-linux-gnu", "darwin": "apple-darwin"}
+
+_RUSTC_WRAPPER = """#!/usr/bin/env python3
+import os
+import sys
+
+os.execv({rustc!r}, [{rustc!r}, "--sysroot", {sysroot!r}] + sys.argv[1:])
+"""
+
+
+def _merge_rust_sysroot(tmpdir: str, target_rustc: str, host_sysroot: str) -> str:
+    """Symlink-merge the target toolchain's sysroot with the host's rust-std.
+
+    A cross rust_toolchain's sysroot has no exec-platform rust-std, but
+    cargo needs one to compile build scripts/proc-macros (always host
+    artifacts regardless of --target). rustup holds every target's std side
+    by side in one install; recreate that by merging the two Bazel-fetched
+    single-target sysroots.
+    """
+    target_sysroot = path.dirname(path.dirname(target_rustc))
+    merged = path.join(tmpdir, ".rust_sysroot")
+    if path.exists(merged):
+        return merged
+    makedirs(merged)
+    for entry in os.listdir(target_sysroot):
+        if entry != "lib":
+            os.symlink(path.join(target_sysroot, entry), path.join(merged, entry))
+    merged_lib = path.join(merged, "lib")
+    makedirs(merged_lib)
+    for entry in os.listdir(path.join(target_sysroot, "lib")):
+        if entry != "rustlib":
+            os.symlink(path.join(target_sysroot, "lib", entry), path.join(merged_lib, entry))
+    merged_rustlib = path.join(merged_lib, "rustlib")
+    makedirs(merged_rustlib)
+    host_rustlib = path.join(host_sysroot, "lib", "rustlib")
+    target_rustlib = path.join(target_sysroot, "lib", "rustlib")
+    overridden = set()
+    for entry in os.listdir(host_rustlib):
+        os.symlink(path.join(host_rustlib, entry), path.join(merged_rustlib, entry))
+        overridden.add(entry)
+    for entry in os.listdir(target_rustlib):
+        if entry not in overridden:
+            os.symlink(path.join(target_rustlib, entry), path.join(merged_rustlib, entry))
+    return merged
+
+
+def _configure_cargo_cross_env(build_env: dict[str, str], tmpdir: str, target_os: str, target_cpu: str) -> None:
+    """Cross env vars for maturin/setuptools-rust (Cargo-driven PyO3 builds).
+
+    Cargo has no cross auto-detection: it needs an explicit target triple,
+    and without CARGO_TARGET_<TRIPLE>_LINKER it links with the host driver
+    and fails.
+    """
+    os_suffix = _RUST_TARGET_OS.get(target_os, target_os)
+    triple = "{}-{}".format(target_cpu, os_suffix)
+    build_env["CARGO_BUILD_TARGET"] = triple
+    linker_var = "CARGO_TARGET_{}_LINKER".format(triple.upper().replace("-", "_"))
+    build_env[linker_var] = build_env["CC"]
+
+    # pyo3-ffi refuses to cross-compile without an explicit target Python
+    # version; maturin works around it itself, setuptools-rust does not.
+    # Unused (harmless) for non-PyO3 crates.
+    build_env["PYO3_CROSS_PYTHON_VERSION"] = "{}.{}".format(sys.version_info.major, sys.version_info.minor)
+
+    host_sysroot = build_env.get("RULES_PY_RUST_HOST_SYSROOT")
+    if host_sysroot:
+        merged_sysroot = _merge_rust_sysroot(tmpdir, build_env["RUSTC"], host_sysroot)
+        build_env["RUSTC"] = _write_generated_file(
+            path.join(tmpdir, ".aspect_rules_py_rustc", "rustc"),
+            _RUSTC_WRAPPER.format(rustc=build_env["RUSTC"], sysroot=merged_sysroot),
+            executable=True,
+        )
+
+    # In cross mode maturin name-parses its -i interpreter argument for a
+    # "pythonX.Y"-shaped basename instead of executing it; our venv's
+    # sys.executable is the generic "python" symlink, which fails that parse
+    # — point it at the versioned sibling the venv also provides.
+    build_env["MATURIN_PEP517_ARGS"] = "--interpreter python{}.{}".format(
+        sys.version_info.major,
+        sys.version_info.minor,
+    )
+
+
+_SITECUSTOMIZE_TEMPLATE = """\
+import os
+import platform
+import sys
+import collections
+
+# ctypes parses os.uname().release at import time when the *host* is Darwin.
+# Import it while uname and sys.platform are still real so the target's
+# faked values never reach that parse.
+try:
+    import ctypes
+except ImportError:
+    pass
+
+_machine = {machine!r}
+_sysname = {sysname!r}
+_release = {release!r}
+
+# setup.py scripts branch on sys.platform to decide which sources to compile
+# (psutil picks _psutil_osx.c vs _psutil_linux.c this way).
+sys.platform = {sys_platform!r}
+
+os.uname = lambda: os.uname_result((_sysname, "build", _release, "", _machine))
+
+# CS_GLIBC_LIB_VERSION otherwise leaks the *host's* glibc version, which
+# feeds manylinux-tag determination in pip/packaging/subprocess.
+if hasattr(os, "confstr"):
+    _real_confstr = os.confstr
+
+    def _confstr(name):
+        if name == "CS_GLIBC_LIB_VERSION":
+            return "glibc_unknown"
+        return _real_confstr(name)
+
+    os.confstr = _confstr
+
+# platform.uname_result.processor is a lazily-computed property that falls
+# back to the real host on this field, so build our own namedtuple instead
+# of the real type (mirrors crossenv's platform-patch.py).
+_PlatformUname = collections.namedtuple("uname_result", "system node release version machine processor")
+_platform_uname = _PlatformUname(_sysname, "build", _release, "", _machine, _machine)
+
+platform.uname = lambda: _platform_uname
+platform.system = lambda: _sysname
+platform.machine = lambda: _machine
+platform.libc_ver = lambda *a, **k: ("", "")
+
+# packaging.tags derives its arch from sysconfig.get_platform() (already
+# faked via $_PYTHON_HOST_PLATFORM); only the manylinux gate needs the
+# top-level _manylinux hook packaging itself looks for.
+"""
+
+_MANYLINUX_HOOK = """\
+# Cross build: we have no verified manylinux compatibility for the target
+# (no target glibc version is threaded through yet), so refuse rather than
+# silently claim host-arch manylinux tags are usable on the target.
+def manylinux_compatible(tag_major, tag_minor, tag_arch):
+    return False
+
+
+manylinux1_compatible = False
+manylinux2010_compatible = False
+manylinux2014_compatible = False
+"""
+
+
+def _generate_cross_site(
+    tmpdir: str,
+    target_os: str,
+    target_cpu: str,
+    macos_deployment_target: str | None = None,
+) -> str:
+    """sitecustomize + _manylinux hook faking the target's runtime identity.
+
+    sysconfig is already faked via env vars CPython itself reads
+    (_PYTHON_HOST_PLATFORM, _PYTHON_SYSCONFIGDATA_NAME), but setup.py
+    scripts also branch on os.uname()/platform.machine() directly, which
+    env vars can't reach. sitecustomize.py runs on interpreter startup —
+    before any backend code — and patches os/platform in place. Modeled on
+    crossenv, minus what rules_py doesn't need.
+    """
+    site_dir = path.join(tmpdir, ".cross_site")
+
+    # ctypes' own import does int(os.uname().release.split(".")[0]) on Darwin,
+    # so the faked release must parse as a Darwin kernel version there —
+    # derived from the target's deployment target so both stay consistent.
+    # Linux keeps "": nothing on that path parses it.
+    release = _darwin_kernel_release(macos_deployment_target) if target_os == "darwin" else ""
+    _write_generated_file(
+        path.join(site_dir, "sitecustomize.py"),
+        _SITECUSTOMIZE_TEMPLATE.format(
+            machine=target_cpu,
+            sysname=_TITLECASE_OS.get(target_os, target_os),
+            release=release,
+            sys_platform=_SYS_PLATFORM.get(target_os, target_os),
+        ),
+    )
+    _write_generated_file(path.join(site_dir, "_manylinux.py"), _MANYLINUX_HOOK)
+    return site_dir
+
+
+_REQUIREMENT_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def _requirement_name(requirement: str) -> str:
+    """PEP 508 requirement string -> bare package name, extras/specifiers/markers stripped."""
+    match = _REQUIREMENT_NAME_RE.match(requirement)
+    return match.group(1) if match else ""
+
+
+def _legacy_metadata_conflicts_with_pyproject(worktree: str, pyproject_data: dict[str, object] | None) -> bool:
     setup_py = path.join(worktree, "setup.py")
     pyproject_data = _load_pyproject_data(worktree)
     if not (pyproject_data and path.exists(setup_py)):
@@ -269,6 +1101,42 @@ def _legacy_metadata_conflicts_with_pyproject(worktree: str) -> bool:
         )
     )
 
+_WHEEL_OS_MAP = {"linux": "linux", "darwin": "macosx", "windows": "win"}
+
+
+def _expected_cpu_in_tag(target_os: str, target_cpu: str) -> str:
+    if target_os == "darwin" and target_cpu == "aarch64":
+        return "arm64"
+    return {"x86": "i686", "arm": "armv7l"}.get(target_cpu, target_cpu)
+
+
+def _validate_wheel_platform(wheel_filename: str) -> None:
+    target_os = os.environ.get("RULES_PY_TARGET_OS", "")
+    target_cpu = os.environ.get("RULES_PY_TARGET_CPU", "")
+    if not target_os or not target_cpu:
+        return
+
+    platform_tag = wheel_filename.rsplit("-", 1)[-1].rsplit(".", 1)[0].lower()
+
+    expected_os = _WHEEL_OS_MAP.get(target_os, target_os)
+    expected_cpu = _expected_cpu_in_tag(target_os, target_cpu)
+
+    host_os = _platform.system().lower()
+    host_wheel_os = _WHEEL_OS_MAP.get(host_os, host_os)
+
+    if target_os != host_os and host_wheel_os in platform_tag:
+        _die(
+            "Error: wheel platform tag '{}' contains exec host OS '{}' instead of "
+            "target OS '{}'. The target sysconfig override may have failed.".format(
+                platform_tag, host_wheel_os, expected_os,
+            )
+        )
+    if expected_os not in platform_tag:
+        _die("Error: wheel platform tag '{}' does not contain target OS '{}'.".format(platform_tag, expected_os))
+    if expected_cpu not in platform_tag:
+        _die("Error: wheel platform tag '{}' does not contain target CPU '{}'.".format(platform_tag, expected_cpu))
+
+
 PARSER = ArgumentParser()
 PARSER.add_argument("srcarchive")
 PARSER.add_argument("output", help="Path the single built wheel is written to")
@@ -277,18 +1145,24 @@ PARSER.add_argument("--validate-anyarch", action="store_true")
 PARSER.add_argument("--patch-strip", type=int, default=0, help="Strip count for patch (-p)")
 PARSER.add_argument("--patch", action="append", default=[], dest="patches", help="Patch file to apply (repeatable)")
 PARSER.add_argument("--execroot-marker", help="Token in env values to replace with the absolute execroot")
+PARSER.add_argument("--cross", action="store_true", help="Cross-compilation mode: target platform != exec platform")
+PARSER.add_argument("--target-os", default="", help="Target platform OS (linux, darwin, windows)")
+PARSER.add_argument("--target-cpu", default="", help="Target platform CPU (x86_64, aarch64, ...)")
 opts, _ = PARSER.parse_known_args()
 
 tmp_root = path.abspath(opts.output) + ".tmp"
-# Sandboxed/remote actions get a fresh root each run, so we don't expect a stale tmp_root to exist.
-makedirs(tmp_root, exist_ok=False)
+# Sandboxed/remote actions get a fresh root each run, but a failed run under
+# --spawn_strategy=standalone leaves tmp_root behind and would mask the real
+# error with FileExistsError on retry — reclaim our own scratch dir instead.
+if path.isdir(tmp_root):
+    shutil.rmtree(tmp_root)
+makedirs(tmp_root)
 
 t = path.join(tmp_root, "worktree")
 
 shutil.unpack_archive(opts.srcarchive, t)
 
-# Annoyingly, unpack_archive creates a subdir in the target. Update t
-# accordingly. Not worth the eng effort to prevent creating this dir.
+# unpack_archive nests the sdist's own top-level directory; follow it.
 t = path.join(t, listdir(t)[0])
 
 if opts.patches:
@@ -306,25 +1180,24 @@ if opts.patches:
         try:
             check_call(patch_cmd, cwd=t)
         except CalledProcessError as exc:
-            # Fail with a concise reason on stderr instead of a Python traceback.
-            print(
-                "Error: failed to apply patch {} (patch exited {}).".format(abs_patch, exc.returncode),
-                file=sys.stderr,
-            )
-            exit(1)
+            _die("Error: failed to apply patch {} (patch exited {}).".format(abs_patch, exc.returncode))
 
 
 # Backends take an output directory, not a file: build into a scratch dir.
 outdir = path.join(tmp_root, "dist")
 makedirs(outdir)
 
-# Preserve PATH so native sdist builds can find compilers (clang, gcc),
-# and re-point CC/CXX/etc. through wrapper scripts in tmp_root so the
-# Bazel-supplied workspace-relative compiler paths survive the cwd
-# change into the worktree.
-build_env = _compiler_env(tmp_root, opts.execroot_marker)
+build_env = _compiler_env(
+    tmp_root,
+    opts.execroot_marker,
+    cross=opts.cross,
+    target_os=opts.target_os,
+    target_cpu=opts.target_cpu,
+)
 
-if _legacy_metadata_conflicts_with_pyproject(t):
+pyproject_data = _load_pyproject_data(t)
+
+if _legacy_metadata_conflicts_with_pyproject(t, pyproject_data):
     print(
         "Warning: falling back to setup.py because pyproject.toml omits dynamic dependency metadata "
         "that setuptools still reads from setup.py/setup.cfg.",
@@ -338,21 +1211,6 @@ if _legacy_metadata_conflicts_with_pyproject(t):
         outdir,
     ]
 elif path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "setup.py")):
-    # Always use `python -m build` (PEP 517 frontend). For setup.py-only
-    # packages without a pyproject.toml, build creates a minimal PEP 517
-    # shim automatically. --no-isolation ensures it uses the deps we've
-    # already provided in the build venv rather than trying to pip-install.
-    # Routing legacy setup_requires=… packages (e.g. googlemaps 4.10.0)
-    # through setup.py directly triggers setuptools' deprecated
-    # fetch_build_eggs path, which crashes on modern packaging.
-    #
-    # --skip-dependency-check disables `build`'s validation of
-    # `[build-system].requires` against the active venv. The
-    # validation is redundant under --no-isolation (we already
-    # commit to managing the venv) and rejects packages that pile
-    # unrelated dev tooling into `requires` — cdifflib 1.2.9 lists
-    # pytest/ruff/twine there, none of which are actually needed
-    # to compile its C extension.
     cmd = [
         sys.executable,
         "-m", "build",
@@ -361,15 +1219,44 @@ elif path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "se
         "--skip-dependency-check",
         "--outdir", outdir,
     ]
+    build_system = (pyproject_data or {}).get("build-system", {})
+    build_backend = build_system.get("build-backend") if isinstance(build_system, dict) else None
+
+    # Packages needing -D setup-args (numpy's -Dblas=none — the hermetic
+    # venv has no system BLAS in native mode either) pass them via this env
+    # var. `build`'s -C accumulates repeated keys, so it can't collide with
+    # the --cross-file the cross branch adds separately.
+    if build_backend == "mesonpy":
+        for arg in shlex.split(build_env.get("RULES_PY_MESON_SETUP_ARGS", "")):
+            cmd += ["-C", "setup-args=" + arg]
+
+    if opts.cross:
+        build_requires = build_system.get("requires", []) if isinstance(build_system, dict) else []
+        if not isinstance(build_requires, list):
+            build_requires = []
+        # setuptools-rust has no build-backend value of its own (it's
+        # setuptools.build_meta plus a requirement) and relies on
+        # $CARGO_BUILD_TARGET, same as maturin.
+        uses_setuptools_rust = build_backend in _SETUPTOOLS_BACKENDS and any(
+            isinstance(req, str) and _requirement_name(req) == "setuptools-rust" for req in build_requires
+        )
+        if build_backend == "mesonpy":
+            cross_file = _generate_meson_cross_file(tmp_root, build_env, opts.target_os, opts.target_cpu)
+            cmd += ["-C", "setup-args=--cross-file=" + cross_file]
+        elif build_backend == "scikit_build_core.build":
+            toolchain = _generate_cmake_toolchain_file(tmp_root, build_env, opts.target_os, opts.target_cpu)
+            cmd += ["-C", "cmake.toolchain-file=" + toolchain]
+        elif (build_backend == "maturin" or uses_setuptools_rust) and build_env.get("CARGO"):
+            _configure_cargo_cross_env(build_env, tmp_root, opts.target_os, opts.target_cpu)
 else:
-    print("Error: Unable to detect build command! Neither pyproject.toml nor setup.py found!", file=sys.stderr)
-    raise SystemExit(1)
+    # raise, not _die(): ty doesn't narrow NoReturn in module-level flow and
+    # would flag `cmd` below as possibly unbound.
+    raise SystemExit("Error: Unable to detect build command! Neither pyproject.toml nor setup.py found!")
 
 with TemporaryFile(mode="w+") as build_log:
     try:
         if opts.monitor_memory:
-            # Generated build tools include this dependency only when the
-            # corresponding wheel opts into monitoring.
+            # Lazy: the dependency exists only when the wheel opts in.
             from uv.private.pep517_whl.tools.memory_monitor import run_with_memory_monitor
 
             run_with_memory_monitor(
@@ -388,17 +1275,17 @@ with TemporaryFile(mode="w+") as build_log:
             sys.stderr.write(output)
             if not output.endswith("\n"):
                 sys.stderr.write("\n")
-        print("Error: Build failed!\nSee {} for the sandbox".format(t), file=sys.stderr)
-        exit(1)
+        _die("Error: Build failed!\nSee {} for the sandbox".format(t))
 
 inventory = listdir(outdir)
 
 if len(inventory) != 1:
-    print("Error: Expected exactly one built wheel, found {}!\nSee {} for the sandbox".format(len(inventory), t), file=sys.stderr)
-    exit(1)
+    _die("Error: Expected exactly one built wheel, found {}!\nSee {} for the sandbox".format(len(inventory), t))
 
 if opts.validate_anyarch and not inventory[0].endswith("-none-any.whl"):
-    print("Error: Target was anyarch but built a none-any wheel!\nSee {} for the sandbox".format(t), file=sys.stderr)
-    exit(1)
+    _die("Error: Target was anyarch but built a none-any wheel!\nSee {} for the sandbox".format(t))
+
+if opts.cross and not inventory[0].endswith("-none-any.whl"):
+    _validate_wheel_platform(inventory[0])
 
 os.replace(path.join(outdir, inventory[0]), path.abspath(opts.output))


### PR DESCRIPTION
Second slice of #1434 (after #1447): the cross-compilation core, with no e2e fixtures or CI changes — those follow in separate PRs.

When the exec and target platforms differ, `pep517_native_whl` now enters **cross mode** instead of failing toolchain resolution:

- **`exec_transition.bzl`** — pins the PEP 517 frontend to the host platform and resets the `platform_libc`/`platform_version` Starlark flags, so the frontend's Python build deps resolve for the exec interpreter instead of leaking the target configuration. `tool` handling is 1:2-safe via `tool_files_to_run`.
- **`cc_layer.bzl`** — extracts the target-configured C++ toolchain (compiler, binutils, sysroot, builtin include dirs) and forwards it to the build action.
- **`build_helper.py`** — derives the cross build environment from that layer: compiler wrappers that stay valid across the backend's chdir, generated meson cross files, CMake toolchain files, cargo target env for maturin/setuptools-rust, an ar-style argv translator over `llvm-libtool-darwin` for sandboxes that don't mount `llvm-ar`, sysconfig overrides for the target interpreter, and post-build validation that the produced wheel's platform tag names the target (not the exec host).
- **`build_helper_cross_test`** — exercises the helper's cross env derivation under the real pypa/build frontend (linux-only).

Native (exec == target) builds keep their previous code path and remain covered by the existing `pep517_whl` tests.

### Changes are visible to end-users: yes

Cross builds of native sdists now work when a cross-capable C++ toolchain (e.g. `toolchains_llvm`) is registered; previously they failed toolchain resolution by design. Pure-Python sdists are unaffected. `docs/uv.md` gains a cross-compilation section.

### Test plan

- New `build_helper_cross_test` (linux-only) covers the cross env derivation
- `bazel test //uv/...`: 163 passed, 3 skipped (linux-only on a darwin host)
- End-to-end coverage (bcrypt, numpy, contourpy, pydantic_core, jpype1, … built for both linux archs and validated by ELF `e_machine` inspection) lands with the e2e/crossbuild suite PRs stacked on this one