### PR TITLE
fix: report no-match from _apply_strip_prefix instead of the natural path

### DIFF
--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -678,6 +678,21 @@ py_test(
     main = "assert_tar_paths.py",
 )
 
+# A strip_prefix remap that lands on the natural runfiles paths keeps the
+# launcher at its stripped destination instead of the tier root.
+platform_transition_filegroup(
+    name = "platform_scalar_strip_identity_layers",
+    srcs = [":_scalar_strip_identity_layers"],
+    target_platform = ":x86_64_linux",
+)
+
+assert_tar_listing(
+    name = "scalar_strip_identity_layers_snapshot",
+    actual = [":platform_scalar_strip_identity_layers"],
+    exclude = ["python_interpreters"],
+    expected = "scalar_strip_identity_listing.yaml",
+)
+
 # Snapshot the same binary's ordinary image layer to prove explicitly declared
 # runtime data remains packaged even when the collision fixture uses a custom
 # layer root.

--- a/e2e/cases/oci/py_image_layer/image_layer_analysis_tests.bzl
+++ b/e2e/cases/oci/py_image_layer/image_layer_analysis_tests.bzl
@@ -502,6 +502,24 @@ touch $@
         binary = ":_scalar_strip_collision",
         layer_tier = ":_scalar_strip_collision_tier",
     )
+
+    # strip_prefix remapping onto the natural runfiles paths is an identity:
+    # the launcher keeps its stripped destination, not the tier root.
+    py_binary(
+        name = "_scalar_strip_identity",
+        srcs = ["server.py"],
+        data = ["my_app_peer_bin/config.json"],
+    )
+    py_layer_tier(
+        name = "_scalar_strip_identity_tier",
+        root = "/app.runfiles/_main/oci/py_image_layer",
+        strip_prefix = "oci/py_image_layer",
+    )
+    py_image_layer(
+        name = "_scalar_strip_identity_layers",
+        binary = ":_scalar_strip_identity",
+        layer_tier = ":_scalar_strip_identity_tier",
+    )
     py_image_layer(
         name = "_scalar_data_layers",
         binary = ":_scalar_strip_collision",

--- a/e2e/cases/oci/py_image_layer/snapshots/scalar_strip_identity_listing.yaml
+++ b/e2e/cases/oci/py_image_layer/snapshots/scalar_strip_identity_listing.yaml
@@ -1,0 +1,12 @@
+---
+layer: 0
+files:
+  - -rwxr-xr-x  0 0      0        2126 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_identity.venv/bin/activate
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_identity.venv/bin/python3 -> python
+  - lrwxr-xr-x  0 0      0           0 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_identity.venv/bin/python3.11 -> python
+  - -rwxr-xr-x  0 0      0         270 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_identity.venv/lib/python3.11/site-packages/__scalar_strip_identity.venv.pth
+  - -rwxr-xr-x  0 0      0         111 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/.__scalar_strip_identity.venv/pyvenv.cfg
+  - -rwxr-xr-x  0 0      0       18856 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/_scalar_strip_identity
+  - -rwxr-xr-x  0 0      0          28 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/my_app_peer_bin/config.json
+  - -rwxr-xr-x  0 0      0          50 Jan  1  2023 ./app.runfiles/_main/oci/py_image_layer/server.py
+  - -rwxr-xr-x  0 0      0 * Jan  1  2023 ./app.runfiles/_repo_mapping

--- a/e2e/cases/oci/test.sh
+++ b/e2e/cases/oci/test.sh
@@ -45,14 +45,24 @@ if ! "$BAZEL" build --output_groups=_validation -- \
 fi
 
 echo "== remapped destinations must fail validation =="
-for target in _scalar_strip_collision_layers _scalar_root_collision_layers; do
+expect_collision() {
+    local target="$1"
+    local destination="$2"
     if "$BAZEL" build --output_groups=_validation -- \
         "${PKG}:$target" >"$output_log" 2>&1; then
         cat "$output_log" >&2
         fail "expected ${target} to fail validation"
     fi
-    expect_diagnostic "py_image_layer runfile collision at ./app.runfiles/_main/oci/py_image_layer/server.py:"
-done
+    expect_diagnostic "py_image_layer runfile collision at ${destination}:"
+}
+
+# The launcher's stripped destination shadows its same-named data directory.
+expect_collision _scalar_strip_collision_layers \
+    "./app.runfiles/_main/oci/py_image_layer/_scalar_strip_collision/data.txt"
+
+# The tier root points at a file destination the relocated launcher collides with.
+expect_collision _scalar_root_collision_layers \
+    "./app.runfiles/_main/oci/py_image_layer/server.py"
 
 echo "PASS: expanded and remapped destinations validate correctly"
 

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -586,13 +586,14 @@ _merge_aspect = aspect(
 )
 
 def _apply_strip_prefix(sp, strip_prefix, root):
+    """Destination for sp under the strip remap, or None when the prefix does not apply."""
     prefix = strip_prefix.replace("\\/", "/")
     if sp == prefix:
         return "." + root
 
     if sp.startswith(prefix + ".runfiles/") or sp.startswith(prefix + "/"):
         return "." + root + sp[len(prefix):]
-    return "./app.runfiles/_main/" + sp
+    return None
 
 def _source_destination(sp, strip_prefix, root, executable_dsts):
     executable_dst = executable_dsts.get(sp, None)
@@ -611,21 +612,21 @@ def _source_destination(sp, strip_prefix, root, executable_dsts):
     if runfiles_prefix != None:
         if strip_prefix and not runfiles_prefix.startswith("../") and not executable_dsts[runfiles_prefix]:
             destination = _apply_strip_prefix(sp, strip_prefix, root)
-            if destination != "./app.runfiles/_main/" + sp:
+            if destination != None:
                 return destination
         runfiles_root = "/app" if executable_dsts[runfiles_prefix] else root
         return _apply_strip_prefix(sp, runfiles_prefix, runfiles_root)
     if sp.startswith("../"):
         if strip_prefix and (sp in executable_dsts or sp == strip_prefix):
             destination = _apply_strip_prefix(sp, strip_prefix, root)
-            if destination != "./app.runfiles/_main/" + sp:
+            if destination != None:
                 return destination
         if sp in executable_dsts:
             return _apply_strip_prefix(sp, sp, root)
         return "./app.runfiles/" + sp[3:]
     if strip_prefix and not any(executable_dsts.values()):
         destination = _apply_strip_prefix(sp, strip_prefix, root)
-        if destination != "./app.runfiles/_main/" + sp:
+        if destination != None:
             return destination
     if sp in executable_dsts:
         return _apply_strip_prefix(sp, sp, root)


### PR DESCRIPTION
The `_scalar_strip_collision` fixture now fails validation on its actual conflict (the binary name shadowing its data directory); test.sh expectations are split per target.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
