### PR TITLE
fix: traverse resolutions edges in the image layer aspect

### DIFF
--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -665,6 +665,20 @@ py_test(
     main = "assert_tar_paths.py",
 )
 
+# The resolved wheel ships once, in the pip layer.
+py_test(
+    name = "resolved_wheel_layer_test",
+    srcs = ["assert_tar_paths.py"],
+    args = [
+        "--tar-contains=_squashed.tar.gz=/colorama/ansi.py",
+        "--tar-absent=_default.tar.gz=/colorama/ansi.py",
+        "--count=/colorama/ansi.py=1",
+        "$(rootpaths :_resolved_wheel_layers)",
+    ],
+    data = [":_resolved_wheel_layers"],
+    main = "assert_tar_paths.py",
+)
+
 # The configured interpreter must be emitted by its dedicated layer, not also
 # by the default source layer assembled from VirtualenvInfo.runtime_files.
 py_test(

--- a/e2e/cases/oci/py_image_layer/image_layer_analysis_tests.bzl
+++ b/e2e/cases/oci/py_image_layer/image_layer_analysis_tests.bzl
@@ -160,6 +160,24 @@ def image_layer_analysis_test_suite():
         binary = ":_virtual_runtime_bin",
     )
 
+    # A wheel reached only through a resolution must get a pip layer, not
+    # ride the default source layer.
+    py_library(
+        name = "_resolved_wheel_consumer",
+        virtual_deps = ["colorama"],
+    )
+    py_binary(
+        name = "_resolved_wheel_bin",
+        srcs = ["server.py"],
+        dep_group = "images",
+        resolutions = {"colorama": "@pypi_oci_py_image_layer//colorama"},
+        deps = [":_resolved_wheel_consumer"],
+    )
+    py_image_layer(
+        name = "_resolved_wheel_layers",
+        binary = ":_resolved_wheel_bin",
+    )
+
     _image_layer_failure(
         name = "relative_launcher_dir",
         expected_error = "py_image_layer.launcher_dir must be an absolute image path",

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -235,6 +235,9 @@ def _collect_from_deps(ctx, provider):
         for dep in actual:
             if provider in dep:
                 results.append(dep[provider])
+    for dep in getattr(ctx.rule.attr, "resolutions", {}).values():
+        if provider in dep:
+            results.append(dep[provider])
     return results
 
 def _compression_for(plan, group_name):
@@ -494,7 +497,7 @@ def _layer_aspect_impl(target, ctx):
 
 _layer_aspect = aspect(
     implementation = _layer_aspect_impl,
-    attr_aspects = ["deps", "data", "actual", "venv"],
+    attr_aspects = ["deps", "data", "actual", "venv", "resolutions"],
     attrs = {
         "_layer_tier": attr.label(
             default = "//py:layer_tier",


### PR DESCRIPTION
Wheels reached only through a virtual resolution were invisible to the aspect, so they shipped via the binary's runfiles in the default source layer instead of their own pip layers. Traversing the resolutions dict routes them through the same per-package layering as direct deps; the binary's existing skip set keeps them out of the source layer.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
