### PR TITLE
perf(uv): share sdist dependency maps

### DIFF
--- a/e2e/cases/snapshots/project_single.BUILD.bazel
+++ b/e2e/cases/snapshots/project_single.BUILD.bazel
@@ -109,6 +109,6 @@ filegroup(
 )
 
 exports_files(
-    ["BUILD.bazel"],
+    ["BUILD.bazel", "available_deps.json"],
     visibility = ["//visibility:public"],
 )

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -53,7 +53,6 @@ resolved dependencies available in the `@uv` repository.
 
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set_values")
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load("@bazel_skylib//lib:structs.bzl", "structs")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("//py/private/interpreter:resolve.bzl", "resolve_host_interpreter_label")
 load("//uv/private:normalize_name.bzl", "normalize_name")
@@ -122,15 +121,6 @@ def dedupe_shared_installs(install_cfgs):
     for dropped in id_remap:
         install_cfgs.pop(dropped)
     return id_remap
-
-def _rewrite_available_deps(sbuild_cfg, target_remap):
-    """Rebuild an sbuild spec with its available_deps routed through the remap."""
-    fields = structs.to_dict(sbuild_cfg)
-    fields["available_deps"] = {
-        pkg: target_remap.get(target, target)
-        for pkg, target in sbuild_cfg.available_deps.items()
-    }
-    return struct(**fields)
 
 def parse_declared_console_script(name, entry_point):
     """Canonicalize one override_package console-script declaration.
@@ -583,7 +573,7 @@ def _parse_projects(module_ctx, hub_specs):
                         version = package["version"],
                         pre_build_patches = pre_build_patches,
                         pre_build_patch_strip = pre_build_patch_strip,
-                        available_deps = project_available_deps,
+                        project_id = project_id,
                         extra_toolchains = extra_toolchains,
                         extra_env = extra_env,
                         monitor_memory = monitor_memory,
@@ -635,6 +625,7 @@ def _parse_projects(module_ctx, hub_specs):
             #
             # FIXME: extract a re-keying helper.
             project_cfgs[project_id] = struct(
+                available_deps = project_available_deps,
                 dep_to_scc = marked_package_cfg_sccs,
                 scc_deps = {
                     k: _merge_scc_dep_markers_by_surface_package(deps)
@@ -678,7 +669,7 @@ def _parse_projects(module_ctx, hub_specs):
 
     # Collapse installs that resolve identically across lock universes into one
     # repo, then rewrite the two carriers of `@id//:install` labels — SCC graph
-    # keys and each sbuild's available_deps — so dropped ids leave no dangling
+    # keys and project available_deps — so dropped ids leave no dangling
     # reference.
     id_remap = dedupe_shared_installs(install_cfgs)
     if id_remap:
@@ -688,6 +679,10 @@ def _parse_projects(module_ctx, hub_specs):
         }
         project_cfgs = {
             project_id: struct(
+                available_deps = {
+                    package: target_remap.get(target, target)
+                    for package, target in pc.available_deps.items()
+                },
                 dep_to_scc = pc.dep_to_scc,
                 scc_deps = pc.scc_deps,
                 scc_graph = {
@@ -699,10 +694,6 @@ def _parse_projects(module_ctx, hub_specs):
                 },
             )
             for project_id, pc in project_cfgs.items()
-        }
-        sbuild_specs = {
-            sbuild_id: _rewrite_available_deps(sc, target_remap)
-            for sbuild_id, sc in sbuild_specs.items()
         }
 
     return struct(
@@ -798,6 +789,7 @@ def _uv_impl(module_ctx):
     for sbuild_id, sbuild_cfg in cfg.sbuild_cfgs.items():
         sbuild_kwargs = {
             "name": sbuild_id,
+            "available_deps": "@{}//:available_deps.json".format(sbuild_cfg.project_id),
             "src": sbuild_cfg.src,
             "deps": sbuild_cfg.deps,
             "is_native": sbuild_cfg.is_native,
@@ -807,8 +799,6 @@ def _uv_impl(module_ctx):
         if default_configure_command:
             sbuild_kwargs["configure_command"] = default_configure_command
 
-        if sbuild_cfg.available_deps:
-            sbuild_kwargs["available_deps"] = sbuild_cfg.available_deps
         if sbuild_cfg.pre_build_patches:
             sbuild_kwargs["pre_build_patches"] = sbuild_cfg.pre_build_patches
             sbuild_kwargs["pre_build_patch_strip"] = sbuild_cfg.pre_build_patch_strip
@@ -845,6 +835,7 @@ def _uv_impl(module_ctx):
     for project_id, project_cfg in cfg.project_cfgs.items():
         uv_project(
             name = project_id,
+            available_deps = json.encode(project_cfg.available_deps),
             dep_to_scc = json.encode(project_cfg.dep_to_scc),
             scc_deps = json.encode(project_cfg.scc_deps),
             scc_graph = json.encode(project_cfg.scc_graph),

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -298,7 +298,8 @@ sdist_build = repository_rule(
         "deps": attr.label_list(),
         "available_deps": attr.label(
             mandatory = True,
-            doc = "JSON mapping normalized package names to install labels.",
+            allow_single_file = [".json"],
+            doc = "JSON file mapping normalized package names to install labels.",
         ),
         "is_native": attr.string(default = "auto", values = ["auto", "true", "false"]),
         "configure_command": attr.string_list(

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -11,7 +11,7 @@ load(":attrs.bzl", "validate_build_attrs")
 
 # --- Configure tool invocation ---
 
-def _write_context_file(repository_ctx):
+def _write_context_file(repository_ctx, available_deps):
     """Write the context JSON file that the configure tool reads.
 
     See //uv/private/sdist_configure:defs.bzl for the schema.
@@ -20,14 +20,14 @@ def _write_context_file(repository_ctx):
         "src": str(repository_ctx.attr.src),
         "version": repository_ctx.attr.version,
         "deps": [str(d) for d in repository_ctx.attr.deps],
-        "available_deps": repository_ctx.attr.available_deps,
+        "available_deps": available_deps,
     }
 
     context_path = repository_ctx.path("_configure_context.json")
     repository_ctx.file("_configure_context.json", content = json.encode(context))
     return context_path
 
-def _run_configure_tool(repository_ctx, archive_path):
+def _run_configure_tool(repository_ctx, archive_path, available_deps):
     """Run the sdist configure tool and return its parsed JSON output.
 
     See //uv/private/sdist_configure:defs.bzl for the tool contract.
@@ -39,7 +39,7 @@ def _run_configure_tool(repository_ctx, archive_path):
     if not configure_command:
         return None
 
-    context_path = _write_context_file(repository_ctx)
+    context_path = _write_context_file(repository_ctx, available_deps)
 
     cmd = []
     for arg in configure_command:
@@ -68,7 +68,7 @@ def _run_configure_tool(repository_ctx, archive_path):
 
 # --- Dep resolution ---
 
-def _resolve_extra_deps(repository_ctx, inspection):
+def _resolve_extra_deps(repository_ctx, inspection, available_deps):
     """Resolve extra_deps from the configure tool output into label strings.
 
     Returns a list of label strings. Calls fail() if a dep cannot be resolved.
@@ -78,8 +78,6 @@ def _resolve_extra_deps(repository_ctx, inspection):
     extra_dep_names = inspection.get("extra_deps", [])
     if not extra_dep_names:
         return []
-
-    available_deps = repository_ctx.attr.available_deps
 
     resolved = []
     unresolvable = []
@@ -153,9 +151,10 @@ def _sdist_build_impl(repository_ctx):
         repository_ctx: The repository context.
     """
 
+    available_deps = json.decode(repository_ctx.read(repository_ctx.attr.available_deps))
     is_native_override = repository_ctx.attr.is_native
     archive_path = _resolve_archive_path(repository_ctx)
-    inspection = _run_configure_tool(repository_ctx, archive_path) if archive_path else None
+    inspection = _run_configure_tool(repository_ctx, archive_path, available_deps) if archive_path else None
 
     if is_native_override == "auto":
         if inspection != None:
@@ -197,7 +196,7 @@ def _sdist_build_impl(repository_ctx):
         )
 
     # Resolve additional deps discovered by the configure tool
-    extra_dep_labels = _resolve_extra_deps(repository_ctx, inspection)
+    extra_dep_labels = _resolve_extra_deps(repository_ctx, inspection, available_deps)
 
     # TODO: When the configure tool didn't run or failed, we may want to
     # conservatively add setuptools + wheel as fallback build deps. For now
@@ -297,10 +296,9 @@ sdist_build = repository_rule(
     attrs = {
         "src": attr.label(),
         "deps": attr.label_list(),
-        "available_deps": attr.string_dict(
-            doc = "Dict mapping normalized package names to install labels. " +
-                  "Passed from the uv extension; used to resolve deps " +
-                  "discovered by the configure tool.",
+        "available_deps": attr.label(
+            mandatory = True,
+            doc = "JSON mapping normalized package names to install labels.",
         ),
         "is_native": attr.string(default = "auto", values = ["auto", "true", "false"]),
         "configure_command": attr.string_list(

--- a/uv/private/uv_hub/snapshots/project.BUILD.bazel
+++ b/uv/private/uv_hub/snapshots/project.BUILD.bazel
@@ -3503,6 +3503,6 @@ filegroup(
 )
 
 exports_files(
-    ["BUILD.bazel"],
+    ["BUILD.bazel", "available_deps.json"],
     visibility = ["//visibility:public"],
 )

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -187,7 +187,7 @@ filegroup(
 )
 
 exports_files(
-    ["BUILD.bazel"],
+    ["BUILD.bazel", "available_deps.json"],
     visibility = ["//visibility:public"],
 )
 """.format(
@@ -195,6 +195,7 @@ exports_files(
     ))
 
     repository_ctx.file("BUILD.bazel", "\n".join(content))
+    repository_ctx.file("available_deps.json", repository_ctx.attr.available_deps)
 
     ################################0################################################
     # Now the slightly harder bit -- lay down the SCCs
@@ -291,6 +292,7 @@ exports_files(
 uv_project = repository_rule(
     implementation = _project_impl,
     attrs = {
+        "available_deps": attr.string(),
         "dep_to_scc": attr.string(),
         "scc_deps": attr.string(),
         "scc_graph": attr.string(),


### PR DESCRIPTION
Each sdist repository currently receives a complete per-project map of available build dependencies. Bazel persists those repository attributes in its hidden output-base module lockfile, so projects with many source-distribution candidates repeatedly serialize the same large map.

Store the dependency map once as available_deps.json in each existing uv_project repository and pass source-build repositories a label to that shared file. Decode the map only when the source-build repository is evaluated, preserve the configure-tool JSON contract and dynamically discovered build dependencies, and rewrite deduplicated wheel-install labels once per project instead of once per sdist. No additional repositories are introduced.

In a large workspace, 4,450 source-build repository specifications shared only 11 distinct dependency maps. The output-base MODULE.bazel.lock shrank from 544,016,286 bytes to 190,503,315 bytes, saving 353,512,971 bytes (337.136 MiB; 64.982%).

Validated with all 35 //uv/private/extension/tests:all tests and the existing //uv-sdist-fallback:test, //dedup-installs:canonical, //dedup-installs:duplicate, and //dedup-installs:triplicate integration tests. The fallback test successfully builds cowsay from its source distribution, and its configure context retains the shared dependency map including build and setuptools. The canonical bazel run //:snapshots generator updates only the expected project snapshot and remains stable on a second run.

Close #1454

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
