### PR TITLE
refactor: make build_helper.py import-safe, add unit test harness

### DIFF
--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -28,6 +28,13 @@ py_test(
 )
 
 py_test(
+    name = "build_helper_test",
+    srcs = ["build_helper_test.py"],
+    main = "build_helper_test.py",
+    deps = ["//uv/private/pep517_whl/tools"],
+)
+
+py_test(
     name = "local_cxx_companion_test",
     srcs = ["local_cxx_companion_test.py"],
     data = ["//uv/private/pep517_whl/tools:build_helper.py"],

--- a/uv/private/pep517_whl/tests/build_helper_test.py
+++ b/uv/private/pep517_whl/tests/build_helper_test.py
@@ -1,0 +1,216 @@
+"""Unit tests for build_helper's pure helpers.
+
+These exist because build_helper.py is import-safe: the CLI body lives
+under main(), so the module's functions can be exercised directly. The
+import at the top of this file is itself the regression test for that
+guard — before it, importing the module ran the build.
+"""
+
+import os
+import tempfile
+import unittest
+from os import path
+
+from uv.private.pep517_whl.tools import build_helper
+
+
+def _make_executable(directory: str, name: str) -> str:
+    exe = path.join(directory, name)
+    with open(exe, "w") as f:
+        f.write("#!/bin/sh\n")
+    os.chmod(exe, 0o755)
+    return exe
+
+
+class ImportSafetyTest(unittest.TestCase):
+    def test_main_is_exposed_not_executed(self) -> None:
+        self.assertTrue(callable(build_helper.main))
+
+
+class AbsolutizePathTest(unittest.TestCase):
+    def test_empty_stays_empty(self) -> None:
+        self.assertEqual(build_helper._absolutize_path(""), "")
+
+    def test_absolute_untouched(self) -> None:
+        self.assertEqual(build_helper._absolutize_path("/usr/bin/cc"), "/usr/bin/cc")
+
+    def test_relative_resolves_against_cwd(self) -> None:
+        self.assertEqual(
+            build_helper._absolutize_path("bin/cc"),
+            path.join(os.getcwd(), "bin/cc"),
+        )
+
+
+class ResolveCompilerPathTest(unittest.TestCase):
+    def test_missing_key_returns_default(self) -> None:
+        self.assertEqual(build_helper._resolve_compiler_path({}, "CC", "cc"), "cc")
+
+    def test_empty_value_returns_default(self) -> None:
+        self.assertEqual(build_helper._resolve_compiler_path({"CC": ""}, "CC", "cc"), "cc")
+
+    def test_pathful_value_is_absolutized(self) -> None:
+        env = {"CC": "external/toolchain/bin/gcc"}
+        self.assertEqual(
+            build_helper._resolve_compiler_path(env, "CC", "cc"),
+            path.join(os.getcwd(), "external/toolchain/bin/gcc"),
+        )
+
+    def test_flags_after_the_driver_are_ignored(self) -> None:
+        env = {"CC": "/opt/bin/gcc -pthread"}
+        self.assertEqual(build_helper._resolve_compiler_path(env, "CC", "cc"), "/opt/bin/gcc")
+
+    def test_bare_name_resolves_on_env_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = _make_executable(tmp, "mycc")
+            env = {"CC": "mycc", "PATH": tmp}
+            self.assertEqual(build_helper._resolve_compiler_path(env, "CC", "cc"), exe)
+
+    def test_bare_name_not_on_path_passes_through(self) -> None:
+        env = {"CC": "no-such-compiler", "PATH": "/nonexistent"}
+        self.assertEqual(
+            build_helper._resolve_compiler_path(env, "CC", "cc"),
+            "no-such-compiler",
+        )
+
+
+class LocalCxxCompanionTest(unittest.TestCase):
+    def test_no_current_returns_compiler(self) -> None:
+        self.assertEqual(build_helper._local_cxx_companion(None, "/opt/gcc"), "/opt/gcc")
+
+    def test_relative_current_returns_compiler(self) -> None:
+        self.assertEqual(build_helper._local_cxx_companion("gcc", "/opt/gcc"), "/opt/gcc")
+
+    def test_gcc_finds_sibling_gxx(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            gcc = _make_executable(tmp, "gcc")
+            gxx = _make_executable(tmp, "g++")
+            self.assertEqual(build_helper._local_cxx_companion(gcc, gcc), gxx)
+
+    def test_versioned_clang_finds_versioned_companion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            clang = _make_executable(tmp, "clang-15")
+            clangxx = _make_executable(tmp, "clang++-15")
+            self.assertEqual(build_helper._local_cxx_companion(clang, clang), clangxx)
+
+    def test_prefixed_cc_finds_prefixed_cxx(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cc = _make_executable(tmp, "aarch64-linux-gnu-gcc")
+            cxx = _make_executable(tmp, "aarch64-linux-gnu-g++")
+            self.assertEqual(build_helper._local_cxx_companion(cc, cc), cxx)
+
+    def test_missing_companion_returns_compiler(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            gcc = _make_executable(tmp, "gcc")
+            self.assertEqual(build_helper._local_cxx_companion(gcc, gcc), gcc)
+
+    def test_non_compiler_stem_returns_compiler(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tool = _make_executable(tmp, "rustc")
+            _make_executable(tmp, "rustc++")
+            self.assertEqual(build_helper._local_cxx_companion(tool, tool), tool)
+
+
+class OverrideToolTest(unittest.TestCase):
+    def test_absent_key_is_untouched(self) -> None:
+        env = {}
+        build_helper._override_tool(env, "CC", "/wrap/cc")
+        self.assertNotIn("CC", env)
+
+    def test_driver_swapped_flags_preserved(self) -> None:
+        env = {"LDSHARED": "gcc -shared -pthread"}
+        build_helper._override_tool(env, "LDSHARED", "/wrap/cc")
+        self.assertEqual(env["LDSHARED"], "/wrap/cc -shared -pthread")
+
+
+class MakeCompilerWrapperTest(unittest.TestCase):
+    def test_wrapper_is_executable_and_bakes_the_driver(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = build_helper._make_compiler_wrapper(tmp, "cc", "/opt/real-cc")
+            self.assertTrue(os.access(wrapper, os.X_OK))
+            with open(wrapper) as f:
+                content = f.read()
+            self.assertIn("/opt/real-cc", content)
+            self.assertIn(build_helper._DEBUG_FLAG, content)
+
+
+class LegacyMetadataConflictTest(unittest.TestCase):
+    def _worktree(
+        self,
+        tmp: str,
+        pyproject: str | None = None,
+        setup_py: str | None = None,
+        setup_cfg: str | None = None,
+    ) -> str:
+        if pyproject is not None:
+            with open(path.join(tmp, "pyproject.toml"), "w") as f:
+                f.write(pyproject)
+        if setup_py is not None:
+            with open(path.join(tmp, "setup.py"), "w") as f:
+                f.write(setup_py)
+        if setup_cfg is not None:
+            with open(path.join(tmp, "setup.cfg"), "w") as f:
+                f.write(setup_cfg)
+        return tmp
+
+    _SETUPTOOLS_PYPROJECT = (
+        '[build-system]\nbuild-backend = "setuptools.build_meta"\n'
+        '[project]\nname = "pkg"\nversion = "1.0"\n'
+    )
+
+    def test_no_pyproject_is_no_conflict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._worktree(tmp, setup_py="install_requires=['x']")
+            self.assertFalse(build_helper._legacy_metadata_conflicts_with_pyproject(tmp))
+
+    def test_setup_py_install_requires_undeclared_in_pyproject_conflicts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._worktree(
+                tmp,
+                pyproject=self._SETUPTOOLS_PYPROJECT,
+                setup_py="setup(install_requires=['x'])",
+            )
+            self.assertTrue(build_helper._legacy_metadata_conflicts_with_pyproject(tmp))
+
+    def test_static_dependencies_win_over_setup_py(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._worktree(
+                tmp,
+                pyproject=self._SETUPTOOLS_PYPROJECT + 'dependencies = ["y"]\n',
+                setup_py="setup(install_requires=['x'])",
+            )
+            self.assertFalse(build_helper._legacy_metadata_conflicts_with_pyproject(tmp))
+
+    def test_dynamic_dependencies_declaration_is_no_conflict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._worktree(
+                tmp,
+                pyproject=self._SETUPTOOLS_PYPROJECT + 'dynamic = ["dependencies"]\n',
+                setup_py="setup(install_requires=['x'])",
+            )
+            self.assertFalse(build_helper._legacy_metadata_conflicts_with_pyproject(tmp))
+
+    def test_non_setuptools_backend_is_no_conflict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._worktree(
+                tmp,
+                pyproject=(
+                    '[build-system]\nbuild-backend = "mesonpy"\n'
+                    '[project]\nname = "pkg"\nversion = "1.0"\n'
+                ),
+                setup_py="setup(install_requires=['x'])",
+            )
+            self.assertFalse(build_helper._legacy_metadata_conflicts_with_pyproject(tmp))
+
+    def test_extras_require_in_setup_cfg_conflicts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._worktree(
+                tmp,
+                pyproject=self._SETUPTOOLS_PYPROJECT + 'dependencies = ["y"]\n',
+                setup_py="setup()",
+                setup_cfg="[options.extras_require]\ndev = pytest",
+            )
+            self.assertTrue(build_helper._legacy_metadata_conflicts_with_pyproject(tmp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -277,128 +277,134 @@ PARSER.add_argument("--validate-anyarch", action="store_true")
 PARSER.add_argument("--patch-strip", type=int, default=0, help="Strip count for patch (-p)")
 PARSER.add_argument("--patch", action="append", default=[], dest="patches", help="Patch file to apply (repeatable)")
 PARSER.add_argument("--execroot-marker", help="Token in env values to replace with the absolute execroot")
-opts, _ = PARSER.parse_known_args()
 
-tmp_root = path.abspath(opts.output) + ".tmp"
-# Sandboxed/remote actions get a fresh root each run, so we don't expect a stale tmp_root to exist.
-makedirs(tmp_root, exist_ok=False)
+def main() -> None:
+    opts, _ = PARSER.parse_known_args()
 
-t = path.join(tmp_root, "worktree")
+    tmp_root = path.abspath(opts.output) + ".tmp"
+    # Sandboxed/remote actions get a fresh root each run, so we don't expect a stale tmp_root to exist.
+    makedirs(tmp_root, exist_ok=False)
 
-shutil.unpack_archive(opts.srcarchive, t)
+    t = path.join(tmp_root, "worktree")
 
-# Annoyingly, unpack_archive creates a subdir in the target. Update t
-# accordingly. Not worth the eng effort to prevent creating this dir.
-t = path.join(t, listdir(t)[0])
+    shutil.unpack_archive(opts.srcarchive, t)
 
-if opts.patches:
-    for patch_file in opts.patches:
-        abs_patch = path.abspath(patch_file)
-        # --no-backup-if-mismatch: a fuzz/offset apply otherwise drops a
-        # `<file>.orig` into the worktree that gets swept into the built wheel.
-        patch_cmd = [
-            "patch",
-            "--no-backup-if-mismatch",
-            "-p{}".format(opts.patch_strip),
-            "-i",
-            abs_patch,
+    # Annoyingly, unpack_archive creates a subdir in the target. Update t
+    # accordingly. Not worth the eng effort to prevent creating this dir.
+    t = path.join(t, listdir(t)[0])
+
+    if opts.patches:
+        for patch_file in opts.patches:
+            abs_patch = path.abspath(patch_file)
+            # --no-backup-if-mismatch: a fuzz/offset apply otherwise drops a
+            # `<file>.orig` into the worktree that gets swept into the built wheel.
+            patch_cmd = [
+                "patch",
+                "--no-backup-if-mismatch",
+                "-p{}".format(opts.patch_strip),
+                "-i",
+                abs_patch,
+            ]
+            try:
+                check_call(patch_cmd, cwd=t)
+            except CalledProcessError as exc:
+                # Fail with a concise reason on stderr instead of a Python traceback.
+                print(
+                    "Error: failed to apply patch {} (patch exited {}).".format(abs_patch, exc.returncode),
+                    file=sys.stderr,
+                )
+                exit(1)
+
+
+    # Backends take an output directory, not a file: build into a scratch dir.
+    outdir = path.join(tmp_root, "dist")
+    makedirs(outdir)
+
+    # Preserve PATH so native sdist builds can find compilers (clang, gcc),
+    # and re-point CC/CXX/etc. through wrapper scripts in tmp_root so the
+    # Bazel-supplied workspace-relative compiler paths survive the cwd
+    # change into the worktree.
+    build_env = _compiler_env(tmp_root, opts.execroot_marker)
+
+    if _legacy_metadata_conflicts_with_pyproject(t):
+        print(
+            "Warning: falling back to setup.py because pyproject.toml omits dynamic dependency metadata "
+            "that setuptools still reads from setup.py/setup.cfg.",
+            file=sys.stderr,
+        )
+        cmd = [
+            sys.executable,
+            path.realpath(path.join(t, "setup.py")),
+            "bdist_wheel",
+            "--dist-dir",
+            outdir,
         ]
+    elif path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "setup.py")):
+        # Always use `python -m build` (PEP 517 frontend). For setup.py-only
+        # packages without a pyproject.toml, build creates a minimal PEP 517
+        # shim automatically. --no-isolation ensures it uses the deps we've
+        # already provided in the build venv rather than trying to pip-install.
+        # Routing legacy setup_requires=… packages (e.g. googlemaps 4.10.0)
+        # through setup.py directly triggers setuptools' deprecated
+        # fetch_build_eggs path, which crashes on modern packaging.
+        #
+        # --skip-dependency-check disables `build`'s validation of
+        # `[build-system].requires` against the active venv. The
+        # validation is redundant under --no-isolation (we already
+        # commit to managing the venv) and rejects packages that pile
+        # unrelated dev tooling into `requires` — cdifflib 1.2.9 lists
+        # pytest/ruff/twine there, none of which are actually needed
+        # to compile its C extension.
+        cmd = [
+            sys.executable,
+            "-m", "build",
+            "--wheel",
+            "--no-isolation",
+            "--skip-dependency-check",
+            "--outdir", outdir,
+        ]
+    else:
+        print("Error: Unable to detect build command! Neither pyproject.toml nor setup.py found!", file=sys.stderr)
+        raise SystemExit(1)
+
+    with TemporaryFile(mode="w+") as build_log:
         try:
-            check_call(patch_cmd, cwd=t)
-        except CalledProcessError as exc:
-            # Fail with a concise reason on stderr instead of a Python traceback.
-            print(
-                "Error: failed to apply patch {} (patch exited {}).".format(abs_patch, exc.returncode),
-                file=sys.stderr,
-            )
+            if opts.monitor_memory:
+                # Generated build tools include this dependency only when the
+                # corresponding wheel opts into monitoring.
+                from uv.private.pep517_whl.tools.memory_monitor import run_with_memory_monitor
+
+                run_with_memory_monitor(
+                    cmd,
+                    cwd=t,
+                    env=build_env,
+                    stdout=build_log,
+                    wheel=path.basename(opts.srcarchive),
+                )
+            else:
+                run(cmd, cwd=t, env=build_env, stdout=build_log, stderr=STDOUT, check=True)
+        except CalledProcessError:
+            build_log.seek(0)
+            output = build_log.read()
+            if output:
+                sys.stderr.write(output)
+                if not output.endswith("\n"):
+                    sys.stderr.write("\n")
+            print("Error: Build failed!\nSee {} for the sandbox".format(t), file=sys.stderr)
             exit(1)
 
+    inventory = listdir(outdir)
 
-# Backends take an output directory, not a file: build into a scratch dir.
-outdir = path.join(tmp_root, "dist")
-makedirs(outdir)
-
-# Preserve PATH so native sdist builds can find compilers (clang, gcc),
-# and re-point CC/CXX/etc. through wrapper scripts in tmp_root so the
-# Bazel-supplied workspace-relative compiler paths survive the cwd
-# change into the worktree.
-build_env = _compiler_env(tmp_root, opts.execroot_marker)
-
-if _legacy_metadata_conflicts_with_pyproject(t):
-    print(
-        "Warning: falling back to setup.py because pyproject.toml omits dynamic dependency metadata "
-        "that setuptools still reads from setup.py/setup.cfg.",
-        file=sys.stderr,
-    )
-    cmd = [
-        sys.executable,
-        path.realpath(path.join(t, "setup.py")),
-        "bdist_wheel",
-        "--dist-dir",
-        outdir,
-    ]
-elif path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "setup.py")):
-    # Always use `python -m build` (PEP 517 frontend). For setup.py-only
-    # packages without a pyproject.toml, build creates a minimal PEP 517
-    # shim automatically. --no-isolation ensures it uses the deps we've
-    # already provided in the build venv rather than trying to pip-install.
-    # Routing legacy setup_requires=… packages (e.g. googlemaps 4.10.0)
-    # through setup.py directly triggers setuptools' deprecated
-    # fetch_build_eggs path, which crashes on modern packaging.
-    #
-    # --skip-dependency-check disables `build`'s validation of
-    # `[build-system].requires` against the active venv. The
-    # validation is redundant under --no-isolation (we already
-    # commit to managing the venv) and rejects packages that pile
-    # unrelated dev tooling into `requires` — cdifflib 1.2.9 lists
-    # pytest/ruff/twine there, none of which are actually needed
-    # to compile its C extension.
-    cmd = [
-        sys.executable,
-        "-m", "build",
-        "--wheel",
-        "--no-isolation",
-        "--skip-dependency-check",
-        "--outdir", outdir,
-    ]
-else:
-    print("Error: Unable to detect build command! Neither pyproject.toml nor setup.py found!", file=sys.stderr)
-    raise SystemExit(1)
-
-with TemporaryFile(mode="w+") as build_log:
-    try:
-        if opts.monitor_memory:
-            # Generated build tools include this dependency only when the
-            # corresponding wheel opts into monitoring.
-            from uv.private.pep517_whl.tools.memory_monitor import run_with_memory_monitor
-
-            run_with_memory_monitor(
-                cmd,
-                cwd=t,
-                env=build_env,
-                stdout=build_log,
-                wheel=path.basename(opts.srcarchive),
-            )
-        else:
-            run(cmd, cwd=t, env=build_env, stdout=build_log, stderr=STDOUT, check=True)
-    except CalledProcessError:
-        build_log.seek(0)
-        output = build_log.read()
-        if output:
-            sys.stderr.write(output)
-            if not output.endswith("\n"):
-                sys.stderr.write("\n")
-        print("Error: Build failed!\nSee {} for the sandbox".format(t), file=sys.stderr)
+    if len(inventory) != 1:
+        print("Error: Expected exactly one built wheel, found {}!\nSee {} for the sandbox".format(len(inventory), t), file=sys.stderr)
         exit(1)
 
-inventory = listdir(outdir)
+    if opts.validate_anyarch and not inventory[0].endswith("-none-any.whl"):
+        print("Error: Target was anyarch but built a none-any wheel!\nSee {} for the sandbox".format(t), file=sys.stderr)
+        exit(1)
 
-if len(inventory) != 1:
-    print("Error: Expected exactly one built wheel, found {}!\nSee {} for the sandbox".format(len(inventory), t), file=sys.stderr)
-    exit(1)
+    os.replace(path.join(outdir, inventory[0]), path.abspath(opts.output))
 
-if opts.validate_anyarch and not inventory[0].endswith("-none-any.whl"):
-    print("Error: Target was anyarch but built a none-any wheel!\nSee {} for the sandbox".format(t), file=sys.stderr)
-    exit(1)
 
-os.replace(path.join(outdir, inventory[0]), path.abspath(opts.output))
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`build_helper.py` runs its CLI body at module level, so importing the module executes a build — which is why none of its helpers had unit tests (`memory_monitor_test` deliberately imports only `memory_monitor`). This moves the body under `main()` with a `__main__` guard and adds the missing coverage.

- **Pure reindentation**: `git diff -w` on the helper shows only the `def main() -> None:` line and the guard; no logic changes.
- **New `build_helper_test`**: table-driven unit tests for the pure helpers — `_absolutize_path`, `_resolve_compiler_path` (defaults, PATH lookup, flag-carrying values), `_local_cxx_companion` (gcc/g++, versioned clang, cross-prefixed drivers, missing companion), `_override_tool`, `_make_compiler_wrapper`, and `_legacy_metadata_conflicts_with_pyproject` (static vs dynamic vs legacy metadata shapes). The import at the top of the test file is itself the regression test for the guard.

### Changes are visible to end-users: no

The generated build tools invoke the helper as a script; the `__main__` guard keeps that entry point identical.

### Test plan

- New `//uv/private/pep517_whl/tests:build_helper_test` (27 cases)
- `bazel test //uv/private/pep517_whl/...`: the existing wheel-building integration tests re-ran against the refactored helper and pass
- `ruff check`, `pyright --pythonversion 3.10`, and `ty check` (the typecheck CI chain) pass locally on the touched files