### PR TITLE
feat(uv): validate the built wheel's platform tag against a requested target

### DIFF
--- a/uv/private/pep517_whl/tests/build_helper_test.py
+++ b/uv/private/pep517_whl/tests/build_helper_test.py
@@ -212,5 +212,122 @@ class LegacyMetadataConflictTest(unittest.TestCase):
             self.assertTrue(build_helper._legacy_metadata_conflicts_with_pyproject(tmp))
 
 
+class WheelPlatformIdentityTest(unittest.TestCase):
+    def test_table(self) -> None:
+        for target_os, target_cpu, expected in (
+            ("linux", "x86_64", ("linux", "x86_64")),
+            ("linux", "aarch64", ("linux", "aarch64")),
+            ("linux", "x86", ("linux", "i686")),
+            ("linux", "arm", ("linux", "armv7l")),
+            ("darwin", "aarch64", ("macosx", "arm64")),
+            ("darwin", "x86_64", ("macosx", "x86_64")),
+            ("windows", "x86_64", ("win", "amd64")),
+            ("windows", "aarch64", ("win", "arm64")),
+        ):
+            with self.subTest(target_os=target_os, target_cpu=target_cpu):
+                self.assertEqual(
+                    build_helper._wheel_platform_identity(target_os, target_cpu), expected
+                )
+
+
+class WheelPlatformErrorTest(unittest.TestCase):
+    def test_no_target_requested_is_exempt(self) -> None:
+        self.assertIsNone(
+            build_helper._wheel_platform_error(
+                "pkg-1.0-cp313-cp313-macosx_11_0_arm64.whl", "", "", host_os="linux"
+            )
+        )
+
+    def test_none_any_wheels_are_exempt(self) -> None:
+        self.assertIsNone(
+            build_helper._wheel_platform_error(
+                "pkg-1.0-py3-none-any.whl", "linux", "aarch64", host_os="linux"
+            )
+        )
+
+    def test_matching_tags_pass(self) -> None:
+        for filename, target_os, target_cpu, host_os in (
+            ("pkg-1.0-cp313-cp313-manylinux_2_17_x86_64.whl", "linux", "x86_64", "linux"),
+            ("pkg-1.0-cp313-cp313-musllinux_1_2_x86_64.whl", "linux", "x86_64", "linux"),
+            ("pkg-1.0-cp313-cp313-linux_aarch64.whl", "linux", "aarch64", "darwin"),
+            ("pkg-1.0-cp313-cp313-linux_armv7l.whl", "linux", "arm", "linux"),
+            ("pkg-1.0-cp313-cp313-macosx_11_0_arm64.whl", "darwin", "aarch64", "darwin"),
+            ("pkg-1.0-cp313-cp313-macosx_10_9_x86_64.whl", "darwin", "x86_64", "linux"),
+            ("PKG-1.0-cp313-cp313-MACOSX_11_0_ARM64.whl", "darwin", "aarch64", "darwin"),
+            ("pkg-1.0-cp313-cp313-win_amd64.whl", "windows", "x86_64", "linux"),
+            ("pkg-1.0-cp313-cp313-win_arm64.whl", "windows", "aarch64", "linux"),
+            ("pkg-1.0-cp313-cp313-macosx_11_0_universal2.whl", "darwin", "aarch64", "darwin"),
+            ("pkg-1.0-cp313-cp313-macosx_10_9_universal2.whl", "darwin", "x86_64", "darwin"),
+        ):
+            with self.subTest(filename=filename):
+                self.assertIsNone(
+                    build_helper._wheel_platform_error(
+                        filename, target_os, target_cpu, host_os=host_os
+                    )
+                )
+
+    def test_host_os_leak_is_reported_as_leak(self) -> None:
+        error = build_helper._wheel_platform_error(
+            "pkg-1.0-cp313-cp313-macosx_11_0_arm64.whl", "linux", "aarch64", host_os="darwin"
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("exec host OS 'macosx'", error)
+
+    def test_linux_tag_for_darwin_target_on_linux_host_is_a_leak(self) -> None:
+        error = build_helper._wheel_platform_error(
+            "pkg-1.0-cp313-cp313-manylinux_2_17_aarch64.whl", "darwin", "aarch64", host_os="linux"
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("exec host OS 'linux'", error)
+
+    def test_wrong_os_without_leak_reports_missing_target_os(self) -> None:
+        error = build_helper._wheel_platform_error(
+            "pkg-1.0-cp313-cp313-macosx_10_9_x86_64.whl", "windows", "x86_64", host_os="linux"
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("does not contain target OS 'win'", error)
+
+    def test_wrong_cpu_reports_missing_target_cpu(self) -> None:
+        error = build_helper._wheel_platform_error(
+            "pkg-1.0-cp313-cp313-manylinux_2_17_x86_64.whl", "linux", "aarch64", host_os="linux"
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("does not contain target CPU 'aarch64'", error)
+
+    def test_darwin_tag_spelled_aarch64_fails_cpu_check(self) -> None:
+        error = build_helper._wheel_platform_error(
+            "pkg-1.0-cp313-cp313-macosx_11_0_aarch64.whl", "darwin", "aarch64", host_os="darwin"
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("target CPU 'arm64'", error)
+
+    def test_universal2_does_not_bypass_non_darwin_targets(self) -> None:
+        error = build_helper._wheel_platform_error(
+            "pkg-1.0-cp313-cp313-macosx_11_0_universal2.whl", "linux", "aarch64", host_os="linux"
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("does not contain target OS 'linux'", error)
+
+    def test_bare_linux_arm_tag_fails_armv7l_check(self) -> None:
+        error = build_helper._wheel_platform_error(
+            "pkg-1.0-cp313-cp313-linux_arm.whl", "linux", "arm", host_os="linux"
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("target CPU 'armv7l'", error)
+
+
+class TargetFlagsTest(unittest.TestCase):
+    def test_parser_accepts_and_defaults_target_flags(self) -> None:
+        opts, _ = build_helper.PARSER.parse_known_args(["src.tar.gz", "out.whl"])
+        self.assertEqual(opts.target_os, "")
+        self.assertEqual(opts.target_cpu, "")
+        opts, _ = build_helper.PARSER.parse_known_args(
+            ["src.tar.gz", "out.whl", "--target-os", "linux", "--target-cpu", "aarch64"]
+        )
+        self.assertEqual(opts.target_os, "linux")
+        self.assertEqual(opts.target_cpu, "aarch64")
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -269,6 +269,77 @@ def _legacy_metadata_conflicts_with_pyproject(worktree: str) -> bool:
         )
     )
 
+
+def _wheel_platform_identity(target_os: str, target_cpu: str) -> tuple[str, str]:
+    """The wheel platform-tag OS and CPU spellings for a Bazel OS/CPU constraint pair."""
+    if target_os == "darwin":
+        wheel_os = "macosx"
+        wheel_cpu = "arm64" if target_cpu == "aarch64" else target_cpu
+    elif target_os == "windows":
+        wheel_os = "win"
+        if target_cpu == "x86_64":
+            wheel_cpu = "amd64"
+        elif target_cpu == "aarch64":
+            wheel_cpu = "arm64"
+        else:
+            wheel_cpu = target_cpu
+    else:
+        wheel_os = target_os
+        if target_cpu == "x86":
+            wheel_cpu = "i686"
+        elif target_cpu == "arm":
+            wheel_cpu = "armv7l"
+        else:
+            wheel_cpu = target_cpu
+    return wheel_os, wheel_cpu
+
+
+def _wheel_platform_error(
+    wheel_filename: str,
+    target_os: str,
+    target_cpu: str,
+    host_os: str | None = None,
+) -> str | None:
+    """Check a built wheel's platform tag against the requested target platform.
+
+    Returns an error message when the tag names the wrong platform, None when
+    it matches or no target was requested. The platform tag is the last
+    dash-separated component of the filename (PEP 427); -none-any wheels are
+    exempt — they carry no platform identity. host_os is injectable for tests
+    and defaults to the running host.
+    """
+    if not target_os or not target_cpu:
+        return None
+    if wheel_filename.endswith("-none-any.whl"):
+        return None
+
+    platform_tag = wheel_filename.rsplit("-", 1)[-1].rsplit(".", 1)[0].lower()
+    expected_os, expected_cpu = _wheel_platform_identity(target_os, target_cpu)
+
+    if host_os is None:
+        host_os = _platform.system().lower()
+    host_wheel_os, _ = _wheel_platform_identity(host_os, "")
+
+    # A tag naming the host's OS on a foreign-target build is the signature
+    # of the backend compiling for the machine it runs on: report it as the
+    # leak it is rather than a generic mismatch.
+    if target_os != host_os and host_wheel_os in platform_tag:
+        return (
+            "Error: wheel platform tag '{}' contains exec host OS '{}' instead of "
+            "target OS '{}'.".format(platform_tag, host_wheel_os, expected_os)
+        )
+    if expected_os not in platform_tag:
+        return "Error: wheel platform tag '{}' does not contain target OS '{}'.".format(platform_tag, expected_os)
+
+    # macOS universal2 wheels carry both architectures in one binary; either
+    # darwin CPU target is satisfied by them.
+    if target_os == "darwin" and "universal2" in platform_tag:
+        return None
+    if expected_cpu not in platform_tag:
+        return "Error: wheel platform tag '{}' does not contain target CPU '{}'.".format(platform_tag, expected_cpu)
+    return None
+
+
 PARSER = ArgumentParser()
 PARSER.add_argument("srcarchive")
 PARSER.add_argument("output", help="Path the single built wheel is written to")
@@ -277,6 +348,8 @@ PARSER.add_argument("--validate-anyarch", action="store_true")
 PARSER.add_argument("--patch-strip", type=int, default=0, help="Strip count for patch (-p)")
 PARSER.add_argument("--patch", action="append", default=[], dest="patches", help="Patch file to apply (repeatable)")
 PARSER.add_argument("--execroot-marker", help="Token in env values to replace with the absolute execroot")
+PARSER.add_argument("--target-os", default="", help="Target platform OS the wheel must be tagged for (linux, darwin, windows)")
+PARSER.add_argument("--target-cpu", default="", help="Target platform CPU the wheel must be tagged for (x86_64, aarch64, ...)")
 
 def main() -> None:
     opts, _ = PARSER.parse_known_args()
@@ -401,6 +474,11 @@ def main() -> None:
 
     if opts.validate_anyarch and not inventory[0].endswith("-none-any.whl"):
         print("Error: Target was anyarch but built a none-any wheel!\nSee {} for the sandbox".format(t), file=sys.stderr)
+        exit(1)
+
+    tag_error = _wheel_platform_error(inventory[0], opts.target_os, opts.target_cpu)
+    if tag_error:
+        print("{}\nSee {} for the sandbox".format(tag_error, t), file=sys.stderr)
         exit(1)
 
     os.replace(path.join(outdir, inventory[0]), path.abspath(opts.output))


### PR DESCRIPTION
`build_helper` gains `--target-os` / `--target-cpu` and, when both are set, validates the produced wheel's PEP 427 platform tag (the last dash-separated component of the backend's filename) before renaming onto the fixed output:

- the tag must name the requested OS (`linux`/`macosx`/`win`) and CPU
- `-none-any` wheels are exempt — they carry no platform identity
- a tag naming the **exec host's** OS on a foreign-target build gets a dedicated error: that signature means the backend compiled for the machine it ran on, which is worth distinguishing from a generic mismatch
- CPU spellings follow what interpreters actually report: darwin `aarch64` → `arm64`, `arm` → `armv7l`, `x86` → `i686`

The check lives in a pure function (`_wheel_platform_error`, returns an error string or `None`, `host_os` injectable) so the full decision table is unit-tested — matching manylinux/musllinux/macosx tags, case normalization, both leak directions, wrong-OS and wrong-CPU, and the arm64/aarch64 and armv7l spellings.

### Changes are visible to end-users: no

Nothing passes the new flags yet; without them the validation short-circuits and existing builds behave identically.

### Test plan

- 12 new unit-test cases in `//uv/private/pep517_whl/tests:build_helper_test` (decision table + flag parsing defaults)
- `bazel test //uv/private/pep517_whl/...`: 10 passed, 2 skipped (platform-incompatible locally)
- `ruff check`, `pyright --pythonversion 3.10`, `ty check` pass on the touched files