### PR TITLE
feat(uv): fail cross sdist builds with an explicit analysis error

### DIFF
--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -19,6 +19,7 @@ bzl_library(
     srcs = ["pep517_native_whl.bzl"],
     deps = [
         ":common",
+        "//py/private/interpreter:versions",
         "//py/private/toolchain:types",
         "@bazel_lib//lib:resource_sets",
         "@rules_cc//cc:action_names_bzl",

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -7,7 +7,8 @@ build backend the sdist declares in its `[build-system]` table.
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set")
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
-load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
+load("//py/private/interpreter:versions.bzl", "PLATFORMS")
+load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
 load(
     ":common.bzl",
     "PEP517_WHL_ATTRS",
@@ -116,8 +117,79 @@ def _cc_toolchain_inputs_and_tools(ctx):
     infer_cxx = infer_cxx or tools.get("CXX") == tools.get("CC")
     return files, {key: value for key, value in tools.items() if value}, infer_cxx
 
+def _interpreter_platform_triple(runtime):
+    """Best-effort platform triple of the repo a PyRuntimeInfo comes from.
+
+    Interpreter repositories encode the PBS platform triple in their name
+    (`python_3_12_aarch64-apple-darwin`, sanitized variants with underscores,
+    and rules_python's hyphenated `python_3_11_aarch64-apple-darwin`).
+    Returns the matching PLATFORMS key, or None when the interpreter's origin
+    is not recognizable (custom or non-hermetic toolchains).
+    """
+    if runtime == None or getattr(runtime, "interpreter", None) == None:
+        return None
+    short_path = runtime.interpreter.short_path
+    repo = short_path.split("/")[1] if short_path.startswith("../") else short_path.split("/")[0]
+    for triple in PLATFORMS:
+        if triple in repo or triple.replace("-", "_") in repo:
+            return triple
+    return None
+
+def _cross_decision(exec_triple, target_triple, has_native_build_toolchain):
+    """Whether building on this execution platform would cross-compile.
+
+    Identical exec and target interpreter triples prove exec == target, so a
+    native build stays native even when the NATIVE_BUILD_TOOLCHAIN sentinel is
+    not registered for the platform. When either identity is unrecognizable
+    (custom interpreters), fall back to the sentinel's absence as the cross
+    signal — the sentinel only resolves when exec and target platforms match.
+    """
+    if exec_triple and target_triple:
+        return exec_triple != target_triple
+    return not has_native_build_toolchain
+
+def _cross_compile(ctx, eg_toolchains):
+    """Cross decision plus the interpreter triples it was based on."""
+    exec_tc = eg_toolchains[EXEC_TOOLS_TOOLCHAIN]
+    py_tc = ctx.toolchains[PY_TOOLCHAIN]
+    exec_triple = _interpreter_platform_triple(getattr(exec_tc, "exec_runtime", None) if exec_tc != None else None)
+    target_triple = _interpreter_platform_triple(getattr(py_tc, "py3_runtime", None) if py_tc != None else None)
+    cross = _cross_decision(exec_triple, target_triple, eg_toolchains[NATIVE_BUILD_TOOLCHAIN] != None)
+    return cross, exec_triple, target_triple
+
+# Exposed for the unit tests in tests/pep517_whl_test.bzl only.
+cross_detection_test_util = struct(
+    interpreter_platform_triple = _interpreter_platform_triple,
+    cross_decision = _cross_decision,
+)
+
 def _pep517_native_whl(ctx):
     archive = ctx.file.src
+
+    eg_toolchains = ctx.exec_groups[TARGET_EXEC_GROUP].toolchains
+    cross, exec_triple, target_triple = _cross_compile(ctx, eg_toolchains)
+    if cross:
+        detail = ""
+        if exec_triple and target_triple:
+            detail = " (execution platform interpreter: {}, target interpreter: {})".format(exec_triple, target_triple)
+        fail(
+            "{}: building this sdist would cross-compile its native extensions{}. ".format(ctx.label, detail) +
+            "Cross-compilation of sdists is not supported: build on an execution " +
+            "platform matching the target platform, or supply a prebuilt wheel " +
+            "for the target instead of building from source.",
+        )
+
+    # Native build classified: a missing C++ toolchain must stay an explicit
+    # analysis error (it used to be a resolution failure when the type was
+    # mandatory) — otherwise the backend compiles with whatever ambient
+    # compiler the sandbox exposes, or fails at execution time.
+    if eg_toolchains[_CC_TOOLCHAIN_TYPE] == None:
+        fail(
+            "{}: no C++ toolchain resolved for this native sdist build. ".format(ctx.label) +
+            "Building native extensions requires a registered C++ toolchain " +
+            "usable on the selected execution platform.",
+        )
+
     wheel_file = ctx.actions.declare_file(ctx.label.name + ".whl")
     patch_args, patch_inputs = patch_args_and_inputs(ctx)
 
@@ -201,25 +273,37 @@ constraints of the target platform.
         ),
     },
     fragments = ["cpp"],
+    toolchains = [
+        # Target-configured interpreter, read only for its platform triple in
+        # the cross detection; optional so unresolvable targets surface the
+        # rule's own error instead of a toolchain-resolution one.
+        config_common.toolchain_type(PY_TOOLCHAIN, mandatory = False),
+    ],
     exec_groups = {
-        # Create an exec group which depends on a toolchain which can only be
-        # resolved to exec_compatible_with constraints equal to the target. This
-        # allows us to discover what those constraints need to be.
-        #
-        # NATIVE_BUILD_TOOLCHAIN has matching exec_compatible_with and
-        # target_compatible_with, so this exec group only resolves when the exec
-        # and target platforms match. Cross-compilation of sdists is intentionally
-        # unsupported: PEP 517 build backends (setuptools, meson-python, etc.)
-        # have no standard mechanism for cross-compilation, Python headers for
-        # the target platform are not readily available, and output wheel tags
-        # would need to encode the target platform with no upstream tooling
+        # Cross-compilation of sdists is intentionally unsupported: PEP 517
+        # build backends (setuptools, meson-python, etc.) have no standard
+        # mechanism for cross-compilation, Python headers for the target
+        # platform are not readily available, and output wheel tags would
+        # need to encode the target platform with no upstream tooling
         # support. Packages that need cross-compiled native extensions should
         # publish pre-built wheels for their target platforms instead.
+        #
+        # Detection inputs: NATIVE_BUILD_TOOLCHAIN has matching
+        # exec_compatible_with and target_compatible_with, so it resolves
+        # exactly when the exec and target platforms match — optional, its
+        # absence is a cross signal, not a resolution error. The exec- and
+        # target-configured interpreters' platform triples refine that signal
+        # (see _cross_decision). The rule fails with an explicit message
+        # instead of the toolchain-resolution error it used to surface.
         TARGET_EXEC_GROUP: exec_group(
             toolchains = [
                 PY_TOOLCHAIN,
-                NATIVE_BUILD_TOOLCHAIN,
-                _CC_TOOLCHAIN_TYPE,
+                config_common.toolchain_type(EXEC_TOOLS_TOOLCHAIN, mandatory = False),
+                config_common.toolchain_type(NATIVE_BUILD_TOOLCHAIN, mandatory = False),
+                # Optional for the same reason: on a cross target no C++
+                # toolchain may resolve, and the rule's own error must win
+                # over a resolution failure.
+                config_common.toolchain_type(_CC_TOOLCHAIN_TYPE, mandatory = False),
             ],
         ),
     },

--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -7,9 +7,17 @@ load("//py:defs.bzl", "py_binary", "py_test")
 load("//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 load("//uv/private/pep517_whl:pep517_whl.bzl", "pep517_whl")
 load(
+    ":exec_platform_steering_test.bzl",
+    "exec_platform_prefers_native_match_test",
+    "exec_platform_steering_test",
+)
+load(
     ":pep517_whl_test.bzl",
+    "cross_decision_test",
     "execroot_collision_toolchain",
     "hostile_python_env_target",
+    "interpreter_platform_triple_test",
+    "pep517_native_whl_cross_unsupported_test",
     "pep517_native_whl_execroot_collision_test",
     "pep517_native_whl_toolchain_env_test",
     "pep517_whl_console_scripts_test",
@@ -18,6 +26,71 @@ load(
 package(
     default_testonly = True,
     default_visibility = ["//uv/private/pep517_whl/tests:__subpackages__"],
+)
+
+interpreter_platform_triple_test(name = "interpreter_platform_triple_test")
+
+cross_decision_test(name = "cross_decision_test")
+
+platform(
+    name = "cross_target_platform",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+config_setting(
+    name = "_linux_aarch64_host",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+# Minimal fixture: no extra toolchains, so under the cross transition the
+# only analysis-time failure can be the rule's own cross-unsupported error.
+pep517_native_whl(
+    name = "__cross_fixture",
+    src = ":__stub_sdist",
+    tags = ["manual"],
+    tool = ":__stub_tool",
+    version = "0.0.1",
+)
+
+platform(
+    name = "decoy_exec_platform",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+exec_platform_steering_test(
+    name = "exec_platform_steering_test",
+    # On a linux-aarch64 host the decoy IS a valid native platform and the
+    # steering property is vacuous.
+    target_compatible_with = select({
+        ":_linux_aarch64_host": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    target_under_test = ":__cross_fixture",
+)
+
+exec_platform_prefers_native_match_test(
+    name = "exec_platform_prefers_native_match_test",
+    target_under_test = ":__cross_fixture",
+)
+
+pep517_native_whl_cross_unsupported_test(
+    name = "cross_unsupported_test",
+    # On a linux-aarch64 host the fixed cross target platform IS the host —
+    # the build would be native and the expected failure never fires.
+    target_compatible_with = select({
+        ":_linux_aarch64_host": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    target_under_test = ":__cross_fixture",
 )
 
 py_test(
@@ -171,4 +244,12 @@ pep517_native_whl(
 pep517_native_whl_execroot_collision_test(
     name = "execroot_collision_test",
     target_under_test = ":__execroot_collision_fixture",
+)
+
+platform(
+    name = "foreign_exec_platform",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
 )

--- a/uv/private/pep517_whl/tests/exec_platform_steering_test.bzl
+++ b/uv/private/pep517_whl/tests/exec_platform_steering_test.bzl
@@ -1,0 +1,52 @@
+"""pep517_native_whl's exec-platform selection must keep steering builds
+onto platforms that can build the target natively.
+
+With the NATIVE_BUILD_TOOLCHAIN sentinel (and friends) optional, steering
+relies on Bazel preferring the highest-priority execution platform that
+satisfies *all* requested toolchain types — optional ones included — over
+platforms that satisfy only the mandatory set. These tests pin that
+property, because losing it would silently schedule native sdist builds
+onto platforms that cannot run them:
+
+- steering: a foreign platform registered ahead of every other candidate
+  must lose to a platform matching the target.
+- native match preference: with a target-matching platform registered
+  *behind* a foreign one, the matching platform must still win.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _native_action_present_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    actions = [a for a in target.actions if a.mnemonic == "PySdistNativeBuild"]
+    asserts.equals(
+        env,
+        1,
+        len(actions),
+        "expected the native build action: a foreign execution platform must " +
+        "lose selection to a platform matching the target",
+    )
+    return analysistest.end(env)
+
+exec_platform_steering_test = analysistest.make(
+    _native_action_present_test_impl,
+    config_settings = {
+        "//command_line_option:extra_execution_platforms": [
+            str(Label("//uv/private/pep517_whl/tests:decoy_exec_platform")),
+        ],
+    },
+)
+
+exec_platform_prefers_native_match_test = analysistest.make(
+    _native_action_present_test_impl,
+    config_settings = {
+        "//command_line_option:platforms": [
+            str(Label("//uv/private/pep517_whl/tests:cross_target_platform")),
+        ],
+        "//command_line_option:extra_execution_platforms": [
+            str(Label("//uv/private/pep517_whl/tests:foreign_exec_platform")),
+            str(Label("//uv/private/pep517_whl/tests:cross_target_platform")),
+        ],
+    },
+)

--- a/uv/private/pep517_whl/tests/pep517_whl_test.bzl
+++ b/uv/private/pep517_whl/tests/pep517_whl_test.bzl
@@ -5,8 +5,9 @@ Inspecting the action at analysis time avoids actually running a PEP 517
 build to verify the env wiring.
 """
 
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
+load("//uv/private/pep517_whl:pep517_native_whl.bzl", "cross_detection_test_util")
 
 _ACTION_ENV = "//command_line_option:action_env"
 _HOST_ENV = [
@@ -131,4 +132,67 @@ def _execroot_collision_test_impl(ctx):
 pep517_native_whl_execroot_collision_test = analysistest.make(
     _execroot_collision_test_impl,
     expect_failure = True,
+)
+
+def _fake_runtime(short_path):
+    return struct(interpreter = struct(short_path = short_path))
+
+def _interpreter_platform_triple_test_impl(ctx):
+    env = unittest.begin(ctx)
+    triple = cross_detection_test_util.interpreter_platform_triple
+    asserts.equals(
+        env,
+        "aarch64-apple-darwin",
+        triple(_fake_runtime("../python_3_12_aarch64-apple-darwin/python")),
+    )
+    asserts.equals(
+        env,
+        "x86_64-unknown-linux-gnu",
+        triple(_fake_runtime("../python_3_13_x86_64_unknown_linux_gnu/bin/python3")),
+    )
+    asserts.equals(
+        env,
+        "aarch64-apple-darwin",
+        triple(_fake_runtime("../rules_python++python+python_3_11_aarch64-apple-darwin/bin/python3")),
+    )
+    asserts.equals(env, None, triple(_fake_runtime("tools/python/bin/python3")))
+    asserts.equals(env, None, triple(_fake_runtime("../custom_interpreter/bin/python")))
+    asserts.equals(env, None, triple(None))
+    asserts.equals(env, None, triple(struct(interpreter = None)))
+    return unittest.end(env)
+
+interpreter_platform_triple_test = unittest.make(_interpreter_platform_triple_test_impl)
+
+def _cross_decision_test_impl(ctx):
+    env = unittest.begin(ctx)
+    decision = cross_detection_test_util.cross_decision
+    linux = "x86_64-unknown-linux-gnu"
+    darwin = "aarch64-apple-darwin"
+
+    # Matching triples prove native, even without the sentinel registered.
+    asserts.false(env, decision(linux, linux, False))
+
+    # Differing triples prove cross, even when a sentinel resolved.
+    asserts.true(env, decision(darwin, linux, True))
+
+    # Unrecognizable identities fall back to the sentinel.
+    asserts.false(env, decision(None, linux, True))
+    asserts.true(env, decision(None, linux, False))
+    asserts.true(env, decision(darwin, None, False))
+    asserts.false(env, decision(None, None, True))
+    return unittest.end(env)
+
+cross_decision_test = unittest.make(_cross_decision_test_impl)
+
+def _cross_unsupported_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(env, "would cross-compile its native extensions")
+    return analysistest.end(env)
+
+pep517_native_whl_cross_unsupported_test = analysistest.make(
+    _cross_unsupported_test_impl,
+    expect_failure = True,
+    config_settings = {
+        "//command_line_option:platforms": [Label("//uv/private/pep517_whl/tests:cross_target_platform")],
+    },
 )


### PR DESCRIPTION
Building a native sdist for a target platform that no execution platform matches used to die with Bazel's opaque toolchain-resolution error (`no matching toolchains found for @aspect_rules_py//py/private/toolchain:native_build_toolchain_type`), leaving users to reverse-engineer what it meant. `pep517_native_whl` now detects the situation itself and fails with an actionable message naming both interpreter platforms.

**Detection** (analysis time, in the rule impl):
- When both the exec-configured and target-configured interpreters come from recognizable hermetic repos, their platform triples decide: equal → native, different → cross. This also *keeps a build native* when the triples match but the `NATIVE_BUILD_TOOLCHAIN` sentinel isn't registered for the platform — previously that combination failed resolution.
- When either identity is unrecognizable (custom interpreters), the sentinel's absence remains the cross signal, preserving today's semantics.

**Toolchain changes**: the sentinel, `EXEC_TOOLS_TOOLCHAIN`, and the C++ toolchain become `mandatory = False` in the `target` exec group (and the rule gains an optional target-level `PY_TOOLCHAIN` to read the target triple) so the rule's own error wins over resolution failures in any of them. Native builds resolve exactly as before — the full existing analysis/integration suite is the non-regression check.

### Changes are visible to end-users: yes

Cross builds of native sdists still fail, but with an explicit error naming the execution and target interpreter platforms instead of a toolchain-resolution failure.

### Test plan

- `interpreter_platform_triple_test` (skylib unittest): PBS repo names, underscore-sanitized variants, rules_python-style repos, main-workspace paths, unrecognizable/custom interpreters
- `cross_decision_test`: full decision table (triples agree/disagree × sentinel present/absent)
- `cross_unsupported_test` (analysistest, `expect_failure`): transitions a minimal fixture to linux-aarch64 and asserts the new message; skipped on linux-aarch64 hosts where that target is native
- `bazel test //uv/...`: 167 passed, 2 skipped (platform-incompatible locally)