### PR TITLE
fix(uv): stop forwarding py_binary kwargs to genrule

### DIFF
--- a/e2e/cases/uv-console-script-binary/BUILD.bazel
+++ b/e2e/cases/uv-console-script-binary/BUILD.bazel
@@ -14,6 +14,19 @@ py_console_script_binary(
     script = "whoowns",
 )
 
+# Regression: py_binary-specific kwargs (python_version) must reach the
+# generated py_binary targets without being forwarded to the internal
+# genrule, where they are a load-time error; universally-shared kwargs
+# (tags) must still reach every generated target.
+py_console_script_binary(
+    name = "whoowns_kwargs",
+    dep_group = "uv-console-script-binary",
+    pkg = "@pypi_uv_console_script_binary//whoowns",
+    python_version = "3.11",
+    script = "whoowns",
+    tags = ["kwargs-regression"],
+)
+
 py_console_script_binary(
     name = "mkdocs",
     dep_group = "uv-console-script-binary",
@@ -33,5 +46,6 @@ sh_test(
         ":mkdocs",
         ":whoowns",
         ":whoowns_explicit",
+        ":whoowns_kwargs",
     ],
 )

--- a/e2e/cases/uv-console-script-binary/test_console_scripts.sh
+++ b/e2e/cases/uv-console-script-binary/test_console_scripts.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 DIR="$(cd "$TEST_SRCDIR/_main/uv-console-script-binary" && pwd)"
 DEFAULT_BIN="${DIR}/whoowns"
 EXPLICIT_BIN="${DIR}/whoowns_explicit"
+KWARGS_BIN="${DIR}/whoowns_kwargs"
 MKDOCS_BIN="${DIR}/mkdocs"
 
-for bin in "${DEFAULT_BIN}" "${EXPLICIT_BIN}" "${MKDOCS_BIN}"; do
+for bin in "${DEFAULT_BIN}" "${EXPLICIT_BIN}" "${KWARGS_BIN}" "${MKDOCS_BIN}"; do
     if [[ ! -x "${bin}" ]]; then
         echo "FAIL: expected executable binary at ${bin}" >&2
         exit 1
@@ -23,6 +24,15 @@ fi
 
 if [[ -z "${explicit_out}" ]]; then
     echo "FAIL: explicit-script console script produced no help output" >&2
+    exit 1
+fi
+
+# The kwargs target passes python_version (py_binary-specific) and tags;
+# it existing and running at all is the regression assertion — forwarding
+# python_version to the internal genrule was a load-time error.
+kwargs_out="$("${KWARGS_BIN}" --help 2>&1)"
+if [[ -z "${kwargs_out}" ]]; then
+    echo "FAIL: kwargs console script produced no help output" >&2
     exit 1
 fi
 

--- a/uv/private/py_entrypoint_binary/defs.bzl
+++ b/uv/private/py_entrypoint_binary/defs.bzl
@@ -64,9 +64,11 @@ def py_console_script_binary(
             via entry points, such as mkdocs or pytest plugins.
         dep_group: The dependency group within which to resolve dependencies,
             forwarded to the underlying `py_binary` targets.
-        **kwargs: Common attributes forwarded to every generated target;
-            `visibility` is applied only to the binary, since the search
-            tool and genrule are private implementation details.
+        **kwargs: Attributes forwarded to the generated `py_binary` targets
+            (e.g. `python_version`); `visibility` is applied only to the
+            binary, since the search tool and genrule are private
+            implementation details. Only universally-shared attributes
+            (`tags`, `testonly`) are forwarded to the internal genrule.
     """
     main = "_{}_entrypoint".format(name)
     tmpl = Label("@aspect_rules_py//uv/private/py_entrypoint_binary:entrypoint.tmpl")
@@ -76,6 +78,10 @@ def py_console_script_binary(
     search = "_{}_search".format(name)
 
     visibility = kwargs.pop("visibility", None)
+
+    # The genrule only understands universally-shared attributes; forwarding
+    # py_binary-specific kwargs (python_version, ...) is a load-time error.
+    genrule_kwargs = {k: kwargs[k] for k in ("tags", "testonly") if k in kwargs}
 
     py_binary(
         name = search_tool,
@@ -100,7 +106,7 @@ def py_console_script_binary(
         ],
         cmd = "$(location {}) --template=\"$(location {})\" --script=\"{}\" >\"$@\"".format(search_tool, tmpl, console_script_name(name, script)),
         visibility = ["//visibility:private"],
-        **kwargs
+        **genrule_kwargs
     )
 
     py_binary(


### PR DESCRIPTION
`py_console_script_binary` forwards `**kwargs` to every generated target, including the internal genrule that runs the entry-point search tool. Any `py_binary`-specific attribute — `python_version` being the common one — is a load-time error there:

```
no such attribute 'python_version' in 'genrule' rule
```

This makes the macro unusable in repos whose default python toolchain differs from the hub's packages: the generated binaries are analysis-time incompatible with the default toolchain, and there is no way to thread `python_version` through (the docstring says kwargs are "forwarded to every generated target", so the collision is inherent, not user error).

The fix forwards only the universally-shared attributes (`tags`, `testonly`) to the genrule; everything else goes to the generated `py_binary` targets, matching the docstring's intent that the search tool and genrule are private implementation details.

Found while adopting `py_console_script_binary` in a monorepo whose default toolchain is python 3.11 while the uv lock universe is 3.13-only — with this fix, `python_version = "3.13"` (together with `dep_group`) makes the macro work there.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (the `**kwargs` docstring now states the genrule forwarding rule)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

fix(uv): `py_console_script_binary` no longer forwards `py_binary`-specific kwargs (e.g. `python_version`) to its internal genrule, which was a load-time error; only `tags`/`testonly` reach the genrule.

### Test plan

- New test cases added: the `uv-console-script-binary` e2e case gains a `whoowns_kwargs` target passing `python_version` and `tags`. Loading it is the regression assertion — it reproduces the original load-time error on `main` without the fix — and the case's `sh_test` also executes the resulting binary.
