### PR TITLE
feat(uv): parameterize the platform parent in gazelle_python_manifest

### DIFF
--- a/docs/uv.md
+++ b/docs/uv.md
@@ -421,6 +421,13 @@ gazelle_python_manifest(
 - `include_stub_packages` — Whether to index conventional stub distributions such as
   `types-requests` and `asyncpg-stubs`. The Gazelle Python extension then adds matching
   stub dependencies automatically. Defaults to `False`.
+- `platform_parents` — Single-element list holding the parent platform for the synthetic
+  platforms this rule uses to pin each venv's dependency group (Bazel's `platform()` rule
+  accepts at most one parent). Defaults to `["@platforms//host"]`, which carries only bare
+  OS and CPU constraints. Set it when that isn't enough: pass your custom `--host_platform`
+  when hermetic C++ toolchains gate on extra constraints, so sdist builds in the hub can
+  still resolve a cc toolchain; or pass the target platform when cross-compiling, so wheel
+  selection follows it instead of snapping back to the host.
 - `venvs` — List of dependency group names whose wheels should be indexed. Module mappings
   from all listed dependency groups are merged into a single manifest.
 

--- a/e2e/cases/BUILD.bazel
+++ b/e2e/cases/BUILD.bazel
@@ -241,5 +241,18 @@ write_source_files(
         # modules_mapping so generator drift (module additions, stub
         # synthesis, merge ordering) surfaces as a diff.
         "snapshots/uv_gazelle_778.gazelle_python.yaml": "//uv-gazelle-778:gazelle_python_manifest",
+
+        # Gazelle manifest built by //gazelle-platform-parents-1416 with a
+        # caller-supplied `platform_parents` (issue #1416). Pins that the
+        # manifest builds end-to-end when the macro's synthetic per-venv
+        # platforms parent onto a custom platform rather than
+        # `@platforms//host`.
+        "snapshots/gazelle_platform_parents_1416.gazelle_python.yaml": "//gazelle-platform-parents-1416:gazelle_python_manifest",
+        # Companion probe: a genrule transitioned onto the macro-generated
+        # platform, selecting on a constraint only the custom parent carries.
+        # Pins "custom-parent": if the macro ignores `platform_parents` the
+        # constraint is dropped and the diff test fails, rather than the
+        # regression silently building.
+        "snapshots/gazelle_platform_parents_1416.probe_out.txt": "//gazelle-platform-parents-1416:probe",
     },
 )

--- a/e2e/cases/gazelle-platform-parents-1416/BUILD.bazel
+++ b/e2e/cases/gazelle-platform-parents-1416/BUILD.bazel
@@ -1,0 +1,65 @@
+load("@aspect_rules_py//uv:defs.bzl", "gazelle_python_manifest")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+
+# Regression test for `gazelle_python_manifest(platform_parents = ...)`
+# (issue #1416: the macro's synthetic per-venv platforms were pinned to
+# `@platforms//host`, breaking cross-compilation and custom host platforms).
+# Reads from the //uv-deps-650 hub, which already declares an `extras` venv.
+#
+# Documented exception to per-case isolation: this test applies Gazelle to a
+# venv from another case (//uv-deps-650), so the cross-case reference is by
+# design.
+package(default_visibility = ["//:__pkg__"])
+
+# A case-local constraint that only `:parent_platform` carries: observing it
+# downstream proves the macro-generated platform inherited from
+# `:parent_platform`.
+constraint_setting(name = "parentage")
+
+constraint_value(
+    name = "custom_parent",
+    constraint_setting = ":parentage",
+)
+
+# Stands in for a user's custom `--host_platform` — e.g. one carrying the extra
+# constraints a hermetic C++ toolchain gates on. Parenting it on
+# `@platforms//host` keeps the case host-OS-agnostic.
+platform(
+    name = "parent_platform",
+    constraint_values = [":custom_parent"],
+    parents = ["@platforms//host"],
+)
+
+gazelle_python_manifest(
+    name = "gazelle_python_manifest",
+    hub = "pypi_uv_deps_650",
+    platform_parents = [":parent_platform"],
+    venvs = ["extras"],
+)
+
+# The macro generates a synthetic platform named `_{name}_{hub}_{venv}` in
+# this package; `:probe` depends on that naming scheme, so a rename inside the
+# macro breaks this target with a missing-target analysis error.
+#
+# The snapshot pins "custom-parent": if the macro ignores `platform_parents`,
+# the generated platform loses `:custom_parent`, the select falls through to
+# "default-parent", and the snapshot diff test fails.
+config_setting(
+    name = "under_custom_parent",
+    constraint_values = [":custom_parent"],
+)
+
+genrule(
+    name = "probe_src",
+    outs = ["probe_out.txt"],
+    cmd = select({
+        ":under_custom_parent": "echo custom-parent > $@",
+        "//conditions:default": "echo default-parent > $@",
+    }),
+)
+
+platform_transition_filegroup(
+    name = "probe",
+    srcs = [":probe_src"],
+    target_platform = ":_gazelle_python_manifest_pypi_uv_deps_650_extras",
+)

--- a/e2e/cases/snapshots/gazelle_platform_parents_1416.gazelle_python.yaml
+++ b/e2e/cases/snapshots/gazelle_platform_parents_1416.gazelle_python.yaml
@@ -1,0 +1,18 @@
+manifest:
+  modules_mapping:
+    brotli: brotli
+    brotlicffi: brotlicffi
+    build: build
+    certifi: certifi
+    cffi: cffi
+    charset_normalizer: charset_normalizer
+    colorama: colorama
+    idna: idna
+    packaging: packaging
+    pycparser: pycparser
+    pyproject_hooks: pyproject_hooks
+    requests: requests
+    setuptools: setuptools
+    urllib3: urllib3
+  pip_repository:
+    name: pypi_uv_deps_650

--- a/e2e/cases/snapshots/gazelle_platform_parents_1416.probe_out.txt
+++ b/e2e/cases/snapshots/gazelle_platform_parents_1416.probe_out.txt
@@ -1,0 +1,1 @@
+custom-parent

--- a/uv/private/gazelle_manifest/defs.bzl
+++ b/uv/private/gazelle_manifest/defs.bzl
@@ -70,7 +70,12 @@ _modules_mapping = rule(
 
 update = Label(":update.sh")
 
-def gazelle_python_manifest(name, hub, venvs = [], include_stub_packages = False):
+def gazelle_python_manifest(
+        name,
+        hub,
+        venvs = [],
+        include_stub_packages = False,
+        platform_parents = None):
     """Generates a Gazelle Python manifest from uv-managed wheels.
 
     Args:
@@ -79,7 +84,27 @@ def gazelle_python_manifest(name, hub, venvs = [], include_stub_packages = False
         venvs: Dependency groups whose wheels should be indexed.
         include_stub_packages: Whether conventional stub distributions should be
             indexed for Gazelle's automatic stub dependency resolution.
+        platform_parents: Single-element list holding the parent platform for the
+            synthetic platforms this macro uses to select each venv's wheels.
+            (Bazel's `platform()` rule accepts at most one parent; the list shape
+            mirrors its `parents` attribute.) Defaults to
+            `[Label("@platforms//host")]`, resolved in rules_py's own repository —
+            you do not need a `bazel_dep` on `platforms` to use the default. The
+            host platform carries only OS and CPU constraints; point this at the
+            platform the wheels should be resolved for when that is not enough:
+
+            - If the build sets a custom `--host_platform` (for example to carry
+              the constraints hermetic C++ toolchains require), pass that
+              platform here so sdist builds inside the hub can still resolve a
+              cc toolchain.
+            - When cross-compiling, pass the target platform so wheel selection
+              follows it instead of snapping back to the host.
     """
+    if platform_parents == None:
+        platform_parents = [Label("@platforms//host")]
+    if len(platform_parents) != 1:
+        fail("gazelle_python_manifest: platform_parents must contain exactly one platform label (Bazel's platform() rule accepts at most one parent); got {}".format(platform_parents))
+
     file = "gazelle_python.yaml"
     hub = hub.lstrip("@")
 
@@ -88,9 +113,7 @@ def gazelle_python_manifest(name, hub, venvs = [], include_stub_packages = False
         platform_name = "_{}_{}_{}".format(name, hub, venv)
         native.platform(
             name = platform_name,
-            parents = [
-                "@platforms//host",
-            ],
+            parents = platform_parents,
             flags = [
                 "--@{}//dep_group={}".format(hub, venv),
             ],


### PR DESCRIPTION
AI written, human reviewed.

Fixes #1416.

Per venv, `gazelle_python_manifest` declares a throwaway `platform()` whose flags force `--@<hub>//dep_group=<venv>`, then pushes the hub's `gazelle_index_whls` filegroup through `platform_transition_filegroup`. That synthetic platform hardcodes `parents = ["@platforms//host"]`, and the transition replaces `--platforms` wholesale, so everything that has to build under the transitioned configuration resolves toolchains against a bare os+cpu platform. Two real setups break:

1. **Custom `--host_platform` / hermetic toolchains.** With `common --host_platform=@host_platform//:platform` (a platform carrying libc/kernel/etc. constraints that hermetic cc toolchains gate on) and `--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1`, PEP 517 sdist builds in the hub (python-ldap, PyMuPDF, ...) fail analysis under the transition in our build:

   ```
   ERROR: While resolving toolchains for target
   @@aspect_rules_py++uv+sdist_build__diskover__python_ldap__3_4_5//:whl:
   No matching toolchains found for types:
     @@bazel_tools//tools/cpp:toolchain_type
   ```

Those sdists are the packages the manifest exists to index (python-ldap imports as `ldap`/`ldapurl`/`ldif`, PyMuPDF as `fitz`), so filtering them out isn't an option.

2. **Cross-compilation (#1416).** Building with `--platforms=<linux target>` from a darwin host, the transition pulls wheel selection back to the darwin host platform and fails with `No matching toolchains found for types: @@aspect_rules_py+//py/private/toolchain:native_build_toolchain_type`.

## The fix

A `platform_parents` parameter, threaded into the synthetic platform's `parents`. The default preserves current behavior exactly.

- The list must hold exactly one label, since `platform()` accepts at most one parent, and the macro fails eagerly at load time with a message naming the parameter otherwise. That also rejects the empty list, whose constraint-free platform would quietly degrade wheel selection to sdist fallbacks. The list shape mirrors the native `parents` attribute so callers can lift a `parents` list off an existing `platform()` unchanged.
- The default is built as `Label("@platforms//host")` in the defining module, so consumers need no direct `bazel_dep` on platforms to use it. Previously the hardcoded string resolved against the caller's repo mapping.

## Why parameterization and not something smarter

- The platform-with-flags mechanism can't become a plain Starlark transition. A transition setting `--@<hub>//dep_group` would have to statically declare that flag label as a transition output, but the hub name is a macro parameter, unknown at rule-definition time. `platform(flags = ...)` is data, constructible per hub at load time.
- `platform()` parents must be a static label; there's no "inherit the incoming platform". Deriving the parent from the incoming `--platforms` isn't implementable from a macro, and it would make the checked-in manifest depend on whatever `--platforms` a developer happened to pass. The explicit parameter keeps `bazel run :gazelle_python_manifest.update` reproducible, and covers the case where the desired parent is a target platform rather than the current one.

## Test coverage

New snapshot case `e2e/cases/gazelle-platform-parents-1416`: builds a manifest over the existing `pypi_uv_deps_650` hub's extras venv with a caller-supplied parent carrying a case-local constraint, and pins two goldens, the manifest YAML (built end-to-end) and a probe genrule whose `select()` keys on that constraint, transitioned through the macro-generated synthetic platform. If the macro ever ignores `platform_parents`, the probe golden flips from custom-parent to default-parent and the diff test fails (verified by reverting the fix).

---

- [x] Changes are visible to end-users: yes
- [x] Searched for relevant documentation and updated as needed: yes (`docs/uv.md` Gazelle section)
- [x] Breaking change (forces users to change their own code or config): no
- [x] Suggested release notes appear below: yes

`gazelle_python_manifest` now accepts `platform_parents`, letting the manifest's per-venv wheel selection parent onto a custom platform. Needed for repos with a custom `--host_platform` (hermetic C++ toolchains) and for cross-compilation.

## Test plan

- New e2e snapshot case as described above; `bazel run //:snapshots` plus all 36 snapshot diff tests pass.
- `bazel build //gazelle-platform-parents-1416:all` and the unmodified `//uv-gazelle-778:gazelle_python_manifest` (default-parent path through the new `Label()` substitution) both build.
- Verified on macOS (darwin_arm64, Bazel 8.6.0) in addition to Linux: `bazel run //:snapshots` reproduces both goldens byte-identically, and `bazel query --output=build` shows the synthetic platform's `parents` is the custom platform in the new case and `@platforms//host` for existing callers.
- `bazel test //uv/private/gazelle_manifest/tests:test` passes; buildifier clean on the changed files.