### PR TITLE
fix(uv): dedup sdist build deps discovered by the configure tool

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -508,6 +508,23 @@ uv.override_package(
 use_repo(uv, "pypi-native-inputs")
 # }}}
 
+# For cases/uv-sdist-dup-build-deps
+# Regression: build deps discovered by the sdist configure tool must be
+# deduplicated by package name against the explicit deps. With setuptools
+# locked at two versions, the duplicate labels resolve to different versions
+# and collide in the build_tool venv.
+# {{{
+uv.project(
+    default_build_dependencies = [
+        "build",
+        "setuptools",
+    ],
+    hub_name = "pypi",
+    lock = "//cases/uv-sdist-dup-build-deps:uv.lock",
+    pyproject = "//cases/uv-sdist-dup-build-deps:pyproject.toml",
+)
+# }}}
+
 # For cases/unconstrained-dependencies
 # {{{
 uv.project(

--- a/e2e/cases/uv-sdist-dup-build-deps/BUILD.bazel
+++ b/e2e/cases/uv-sdist-dup-build-deps/BUILD.bazel
@@ -1,0 +1,20 @@
+# Regression test: the sdist configure tool discovers build deps (setuptools
+# for a legacy setup.py package) that are already provided explicitly via
+# default_build_dependencies. With setuptools locked at two versions the
+# explicit label (@project__*//:setuptools) and the discovered label
+# (@whl_install__*__setuptools__*//:install) can resolve to different
+# versions, colliding in the build_tool venv unless deduplicated by name.
+
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "test",
+    srcs = ["__test__.py"],
+    main = "__test__.py",
+    python_version = "3.11",
+    venv = "uv-sdist-dup-build-deps",
+    deps = [
+        "@pypi//docopt",
+        "@pypi//setuptools",
+    ],
+)

--- a/e2e/cases/uv-sdist-dup-build-deps/__test__.py
+++ b/e2e/cases/uv-sdist-dup-build-deps/__test__.py
@@ -1,0 +1,7 @@
+import docopt
+import setuptools
+
+assert docopt.__version__ == "0.6.2", docopt.__version__
+
+# The 3.11 interpreter must select the python_full_version < '3.12' fork.
+assert setuptools.__version__ == "75.8.2", setuptools.__version__

--- a/e2e/cases/uv-sdist-dup-build-deps/pyproject.toml
+++ b/e2e/cases/uv-sdist-dup-build-deps/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "uv-sdist-dup-build-deps"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "build",
+    "docopt",
+    "setuptools>=80 ; python_full_version >= '3.12'",
+    "setuptools<76 ; python_full_version < '3.12'",
+    # docopt is a setup.py-only sdist, so the configure tool infers `wheel` as
+    # a build dep; it must be present in the lock for extra_deps resolution.
+    "wheel",
+]

--- a/e2e/cases/uv-sdist-dup-build-deps/uv.lock
+++ b/e2e/cases/uv-sdist-dup-build-deps/uv.lock
@@ -1,0 +1,108 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "build"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", size = 50054, upload-time = "2026-01-08T16:41:47.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/0d/84a4380f930db0010168e0aa7b7a8fed9ba1835a8fbb1472bc6d0201d529/build-1.4.0-py3-none-any.whl", hash = "sha256:6a07c1b8eb6f2b311b96fcbdbce5dab5fe637ffda0fd83c9cac622e927501596", size = 24141, upload-time = "2026-01-08T16:41:46.453Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "75.8.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/53/43d99d7687e8cdef5ab5f9ec5eaf2c0423c2b35133a2b7e7bc276fc32b21/setuptools-75.8.2.tar.gz", hash = "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2", size = 1344083, upload-time = "2025-02-26T20:45:19.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/38/7d7362e031bd6dc121e5081d8cb6aa6f6fedf2b67bf889962134c6da4705/setuptools-75.8.2-py3-none-any.whl", hash = "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f", size = 1229385, upload-time = "2025-02-26T20:45:17.259Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "uv-sdist-dup-build-deps"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "build" },
+    { name = "docopt" },
+    { name = "setuptools", version = "75.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "wheel" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "build" },
+    { name = "docopt" },
+    { name = "setuptools", marker = "python_full_version < '3.12'", specifier = "<76" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'", specifier = ">=80" },
+    { name = "wheel" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.45.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz", hash = "sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729", size = 107545, upload-time = "2024-11-23T00:18:23.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl", hash = "sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248", size = 72494, upload-time = "2024-11-23T00:18:21.207Z" },
+]

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -72,8 +72,23 @@ def _run_configure_tool(repository_ctx, archive_path):
 
 # --- Dep resolution ---
 
+def _label_target_name(label_str):
+    """Extract the target name from a label string.
+
+    Handles "@repo//:name", "@repo//pkg:name", "//pkg/name" (implicit target)
+    and bare target names.
+    """
+    tail = label_str.rsplit("//", 1)[-1]
+    if ":" in tail:
+        return tail.rsplit(":", 1)[-1]
+    return tail.rsplit("/", 1)[-1]
+
 def _resolve_extra_deps(repository_ctx, inspection):
     """Resolve extra_deps from the configure tool output into label strings.
+
+    Names already covered by the explicit deps are skipped: the explicit label
+    and the available_deps label live in different repos and can resolve to
+    different versions of the same package, colliding in the build_tool venv.
 
     Returns a list of label strings. Calls fail() if a dep cannot be resolved.
     """
@@ -87,27 +102,34 @@ def _resolve_extra_deps(repository_ctx, inspection):
     if repository_ctx.attr.available_deps:
         available_deps = json.decode(repository_ctx.attr.available_deps)
 
-    resolved = []
+    provided_names = {
+        normalize_name(_label_target_name(str(dep))): True
+        for dep in repository_ctx.attr.deps
+    }
+
+    resolved = {}
     unresolvable = []
     for name in extra_dep_names:
         normalized = normalize_name(name)
+        if normalized in provided_names:
+            continue
         label = available_deps.get(normalized)
         if label:
-            resolved.append(label)
+            resolved[label] = True
         else:
             unresolvable.append(normalized)
 
     if unresolvable:
         fail(
-            "sdist configure tool for {} reported build deps that are not in " +
-            "the lockfile: {}. Add these packages to your lockfile or provide " +
-            "them via uv.unstable_annotate_packages().".format(
+            ("sdist configure tool for {} reported build deps that are not in " +
+             "the lockfile: {}. Add these packages to your lockfile or provide " +
+             "them via uv.unstable_annotate_packages().").format(
                 repository_ctx.name,
                 ", ".join(unresolvable),
             ),
         )
 
-    return resolved
+    return resolved.keys()
 
 # --- Archive path resolution ---
 

--- a/uv/private/sdist_configure/defs.bzl
+++ b/uv/private/sdist_configure/defs.bzl
@@ -73,9 +73,12 @@ The JSON object MAY contain any of the following fields:
         Normalized package names of additional build-time dependencies
         discovered by the tool (e.g. from pyproject.toml [build-system]
         requires, or inferred from file extensions like .pyx -> cython).
-        These are resolved against `available_deps` from the context and
-        merged into the build target's deps. The repository rule will
-        fail() if a name cannot be resolved.
+        Names already covered by the repository's explicit deps (matched by
+        normalized package name) are skipped, so the tool does not need to
+        pre-filter them. The remaining names are resolved against
+        `available_deps` from the context, deduplicated by label, and merged
+        into the build target's deps. The repository rule will fail() if a
+        non-skipped name cannot be resolved.
 
     "native_files": [<string>, ...]
 

--- a/uv/private/sdist_configure/detect_native.py
+++ b/uv/private/sdist_configure/detect_native.py
@@ -72,6 +72,18 @@ def _extract_name(requirement_str):
     return None
 
 
+def _label_target_name(label):
+    """Extract the target name from a Bazel label string.
+
+    Handles "@repo//:name", "@repo//pkg:name", "//pkg/name" (implicit target)
+    and bare target names.
+    """
+    tail = label.rsplit("//", 1)[-1]
+    if ":" in tail:
+        return tail.rsplit(":", 1)[-1]
+    return tail.rsplit("/", 1)[-1]
+
+
 # --- Archive helpers ---
 
 def _read_tar_member(tf, member_name):
@@ -444,14 +456,21 @@ def detect(archive_path, context):
             declared_dedup.append(name)
 
     # Compute extra_deps: names from declared + inferred that are resolvable
-    # from available_deps but not already in the explicit deps list.
+    # from available_deps but not already in the explicit deps list. Explicit
+    # deps use per-project labels (e.g. @project__x//:setuptools) while
+    # available_deps maps to whl_install labels, so labels never match across
+    # the two namespaces — compare by normalized target name instead.
     available_deps = context.get("available_deps", {})
     provided_labels = set(context.get("deps", []))
+    provided_names = {
+        _normalize_name(_label_target_name(label)) for label in provided_labels
+    }
 
     all_discovered = set(declared_dedup) | inferred
     extra_deps = sorted(
         name for name in all_discovered
         if name in available_deps
+        and name not in provided_names
         and available_deps[name] not in provided_labels
     )
 

--- a/uv/private/sdist_configure/detect_native_test.py
+++ b/uv/private/sdist_configure/detect_native_test.py
@@ -242,7 +242,12 @@ build-backend = "setuptools.build_meta"
 
 @requires_tomllib
 def test_extra_deps_excludes_already_provided():
-    """Deps already in the explicit deps list are not reported as extra."""
+    """Deps already in the explicit deps list are not reported as extra.
+
+    Explicit deps arrive as per-project labels while available_deps maps to
+    whl_install labels, so the exclusion must match on package name rather
+    than label identity.
+    """
     pyproject = """\
 [build-system]
 requires = ["setuptools", "cython"]
@@ -254,16 +259,39 @@ build-backend = "setuptools.build_meta"
         "pkg-1.0/pkg/__init__.py": "",
     })
     context = {
-        "deps": ["@pypi//setuptools:install"],
+        "deps": ["@@rules_py++uv+project__proj//:setuptools"],
         "available_deps": {
-            "setuptools": "@pypi//setuptools:install",
-            "cython": "@pypi//cython:install",
+            "setuptools": "@@rules_py++uv+whl_install__proj__setuptools__75_8_2//:install",
+            "cython": "@@rules_py++uv+whl_install__proj__cython__3_0_11//:install",
         },
     }
     result = detect(archive, context)
     # setuptools is already provided, so only cython is extra
     assert "setuptools" not in result["extra_deps"]
     assert "cython" in result["extra_deps"]
+
+
+@requires_tomllib
+def test_extra_deps_excludes_provided_normalized_name():
+    """Name-based exclusion normalizes both sides (Foo.Bar vs foo-bar)."""
+    pyproject = """\
+[build-system]
+requires = ["Flit-Core"]
+build-backend = "flit_core.buildapi"
+"""
+    archive = _make_tar_gz({
+        "pkg-1.0/": None,
+        "pkg-1.0/pyproject.toml": pyproject,
+        "pkg-1.0/pkg/__init__.py": "",
+    })
+    context = {
+        "deps": ["@@rules_py++uv+project__proj//:flit_core"],
+        "available_deps": {
+            "flit_core": "@@rules_py++uv+whl_install__proj__flit_core__3_10_1//:install",
+        },
+    }
+    result = detect(archive, context)
+    assert "flit_core" not in result["extra_deps"]
 
 
 @requires_tomllib


### PR DESCRIPTION
## Problem

Build deps reported by the sdist configure tool (`extra_deps`) could duplicate the explicit deps of the generated build target. Because the explicit label (`@project__*//:pkg`) and the `available_deps` label (`@whl_install__*__pkg__*//:install`) live in different repos, they can resolve to different versions of the same package and collide in the `build_tool` venv when `package_collisions = "error"`.

## Fix

`_resolve_extra_deps` now skips `extra_deps` names already covered by the explicit deps (matched by normalized package name) and dedups resolved labels. The configure-tool contract doc is updated to reflect the skip/dedup behavior and the narrowed `fail()` condition.

## Test

New e2e case `uv-sdist-dup-build-deps`: `setuptools` locked at two versions (fork on `python_full_version`) and also provided via `default_build_dependencies`, so the explicit and discovered labels previously collided in the build_tool venv. `docopt` (setup.py-only sdist) exercises the inferred-build-dep path (`wheel` resolved from the lockfile).