### PR TITLE
feat(uv): thread native_inputs into pep517 native sdist builds

### DIFF
--- a/docs/uv-patching.md
+++ b/docs/uv-patching.md
@@ -83,6 +83,50 @@ Pre-build patches are applied to the extracted source tree after archive extract
 - Removing problematic native build dependencies
 - Patching source code that affects the build output
 
+### Providing native build inputs to sdist builds
+
+Some sdists compile C/C++ extensions against headers and libraries that are
+not part of the CC toolchain sysroot. `native_inputs` threads Bazel targets
+into the hermetic `pep517_native_whl` build action:
+
+```starlark
+uv.override_package(
+    lock = "//:uv.lock",
+    name = "some-native-package",
+    native_inputs = [
+        "//third_party/zlib:zlib",
+    ],
+)
+```
+
+Semantics per target:
+
+- **Targets with `CcInfo`** (e.g. `cc_library`): the compilation context's
+  headers become action inputs and its include directories and defines are
+  passed to the compiler (`-I`/`-iquote`/`-isystem`/`-D` via
+  `CPPFLAGS`/`CFLAGS`/`CXXFLAGS`). Static libraries from the linking context
+  are force-loaded into the extension link (`LDFLAGS`); libraries that expose
+  only object files have those objects linked directly.
+- **Targets without `CcInfo`** (e.g. `filegroup`): files are staged into the
+  build sandbox and their absolute paths exposed via the
+  `PY_NATIVE_INPUT_PATHS` environment variable (path-separator delimited) for
+  the build backend (`setup.py` etc.) to consume explicitly.
+
+Only the **compile-time** case is supported: headers plus static libraries.
+A target whose linking context offers only shared libraries is rejected at
+analysis time — an installed wheel has no rpath into `bazel-out`, so a
+dynamically linked extension would fail at import time with unresolved
+symbols. Build the dependency as a static archive instead (a plain
+`cc_library` always provides one).
+
+`native_inputs` only applies to packages built from source. Declaring it for
+a package that never gets a source build (no sdist in the lockfile, or an
+anyarch wheel satisfies all installs) or for an sdist confidently classified
+as pure-Python is an error. When the classification is uncertain (sdist
+inspection unavailable) or `pre_build_patches` could introduce native
+sources, `native_inputs` acts as an explicit signal and the native build
+path is used.
+
 ### Adding extra dependencies or data
 
 Some packages have implicit runtime dependencies that aren't declared in their metadata:

--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -481,6 +481,33 @@ uv.project(
 )
 # }}}
 
+# For cases/uv-sdist-native-inputs
+# Regression: uv.override_package(native_inputs) must thread cc_library
+# headers/static libs into PySdistNativeBuild actions. python-geohash is
+# patched to add a C extension compiled against //cases/uv-sdist-native-inputs:native_check.
+# {{{
+# python-geohash is also in the "pypi" hub via cases/uv-sdist-native-build, so
+# this case gets its own hub to avoid cross-configuration package collisions.
+uv.declare_hub(hub_name = "pypi-native-inputs")
+uv.project(
+    default_build_dependencies = [
+        "build",
+        "setuptools",
+    ],
+    hub_name = "pypi-native-inputs",
+    lock = "//cases/uv-sdist-native-inputs:uv.lock",
+    pyproject = "//cases/uv-sdist-native-inputs:pyproject.toml",
+)
+uv.override_package(
+    name = "python-geohash",
+    lock = "//cases/uv-sdist-native-inputs:uv.lock",
+    native_inputs = ["//cases/uv-sdist-native-inputs:native_check"],
+    pre_build_patch_strip = 1,
+    pre_build_patches = ["//cases/uv-sdist-native-inputs/patches:add_native_check_ext.patch"],
+)
+use_repo(uv, "pypi-native-inputs")
+# }}}
+
 # For cases/unconstrained-dependencies
 # {{{
 uv.project(

--- a/e2e/cases/uv-sdist-native-inputs/BUILD.bazel
+++ b/e2e/cases/uv-sdist-native-inputs/BUILD.bazel
@@ -1,0 +1,29 @@
+# Regression test: uv.override_package(native_inputs = [...]) must thread the
+# headers and static libraries of a Bazel cc_library into PySdistNativeBuild
+# actions so that sdist C extensions can compile and link against them.
+#
+# The python-geohash sdist is patched (pre_build_patches) to add a second C
+# extension that #includes "rulespy_native_check.h" and calls
+# rulespy_native_check_value() — both provided ONLY by :native_check below,
+# never by the CC toolchain sysroot. Without native_inputs the build fails
+# with a missing-header compile error.
+
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "native_check",
+    srcs = ["native_check.c"],
+    hdrs = ["include/rulespy_native_check.h"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+
+py_venv_test(
+    name = "test",
+    srcs = ["__test__.py"],
+    main = "__test__.py",
+    target_compatible_with = ["@platforms//os:linux"],
+    venv = "uv-sdist-native-inputs",
+    deps = ["@pypi-native-inputs//python_geohash"],
+)

--- a/e2e/cases/uv-sdist-native-inputs/__test__.py
+++ b/e2e/cases/uv-sdist-native-inputs/__test__.py
@@ -1,0 +1,24 @@
+"""Verify that native_inputs threads a Bazel cc_library into the sdist build.
+
+_native_inputs_check is a C extension injected into python-geohash via
+pre_build_patches; it compiles against a header and links against a static
+library that only exist as Bazel targets (see BUILD.bazel).
+"""
+
+import _native_inputs_check
+import geohash
+
+
+def test_native_inputs_value():
+    assert _native_inputs_check.check_value() == 42
+
+
+def test_geohash_still_works():
+    encoded = geohash.encode(37.7749, -122.4194)
+    assert encoded, "geohash.encode should return a non-empty string"
+
+
+if __name__ == "__main__":
+    test_native_inputs_value()
+    test_geohash_still_works()
+    print("OK")

--- a/e2e/cases/uv-sdist-native-inputs/include/rulespy_native_check.h
+++ b/e2e/cases/uv-sdist-native-inputs/include/rulespy_native_check.h
@@ -1,0 +1,14 @@
+#ifndef RULESPY_NATIVE_CHECK_H
+#define RULESPY_NATIVE_CHECK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int rulespy_native_check_value(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/e2e/cases/uv-sdist-native-inputs/native_check.c
+++ b/e2e/cases/uv-sdist-native-inputs/native_check.c
@@ -1,0 +1,5 @@
+#include "rulespy_native_check.h"
+
+int rulespy_native_check_value(void) {
+    return 42;
+}

--- a/e2e/cases/uv-sdist-native-inputs/patches/BUILD.bazel
+++ b/e2e/cases/uv-sdist-native-inputs/patches/BUILD.bazel
@@ -1,0 +1,3 @@
+exports_files([
+    "add_native_check_ext.patch",
+])

--- a/e2e/cases/uv-sdist-native-inputs/patches/add_native_check_ext.patch
+++ b/e2e/cases/uv-sdist-native-inputs/patches/add_native_check_ext.patch
@@ -1,0 +1,45 @@
+--- a/setup.py	2026-08-19 10:00:00.063232078 -0600
++++ b/setup.py	2026-08-19 10:00:27.267945780 -0600
+@@ -8,11 +8,14 @@
+ 	sources=['src/geohash.cpp',],
+ 	define_macros = [('PYTHON_MODULE',1),])
+ 
++c2=Extension('_native_inputs_check',
++	sources=['src/native_inputs_check.c',])
++
+ setup(name='python-geohash',
+ 	version='0.8.5',
+ 	description='Fast, accurate python geohashing library',
+ 	author='Hiroaki Kawai',
+ 	url='http://code.google.com/p/python-geohash/',
+ 	py_modules=['geohash','quadtree','jpgrid','jpiarea'],
+-	ext_modules = [c1]
++	ext_modules = [c1,c2]
+ )
+--- a/src/native_inputs_check.c	1969-12-31 18:00:00.000000000 -0600
++++ b/src/native_inputs_check.c	2026-08-19 10:00:00.065155449 -0600
+@@ -0,0 +1,24 @@
++#include <Python.h>
++
++#include "rulespy_native_check.h"
++
++static PyObject *check_value(PyObject *self, PyObject *unused) {
++    return PyLong_FromLong(rulespy_native_check_value());
++}
++
++static PyMethodDef Methods[] = {
++    {"check_value", check_value, METH_NOARGS, "Value provided by the Bazel cc_library."},
++    {NULL, NULL, 0, NULL},
++};
++
++static struct PyModuleDef moduledef = {
++    PyModuleDef_HEAD_INIT,
++    "_native_inputs_check",
++    NULL,
++    -1,
++    Methods,
++};
++
++PyMODINIT_FUNC PyInit__native_inputs_check(void) {
++    return PyModule_Create(&moduledef);
++}

--- a/e2e/cases/uv-sdist-native-inputs/pyproject.toml
+++ b/e2e/cases/uv-sdist-native-inputs/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "uv-sdist-native-inputs"
+version = "0.0.0"
+requires-python = ">=3.11"
+# build and setuptools are root dependencies (not only build deps) so the
+# generated project repo exposes aliases for them; default_build_dependencies
+# resolution requires the packages to be activated in the dependency graph.
+dependencies = [
+    "python-geohash==0.8.5",
+    "build>=1.4.0",
+    "setuptools>=75.8.2",
+]

--- a/e2e/cases/uv-sdist-native-inputs/uv.lock
+++ b/e2e/cases/uv-sdist-native-inputs/uv.lock
@@ -1,0 +1,76 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "python-geohash"
+version = "0.8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/e2/1a3507af7c8f91f8a4975d651d4aeb6a846dfdf74713954186ade4205850/python-geohash-0.8.5.tar.gz", hash = "sha256:05a21fcf4eda1a5eddbd291890ade23fc5ddaa6bb98f2ee23d2d384ed14f086d", size = 17636, upload-time = "2014-08-13T07:09:57.318Z" }
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
+name = "uv-sdist-native-inputs"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "build" },
+    { name = "python-geohash" },
+    { name = "setuptools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "build", specifier = ">=1.4.0" },
+    { name = "python-geohash", specifier = "==0.8.5" },
+    { name = "setuptools", specifier = ">=75.8.2" },
+]

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -229,6 +229,7 @@ def _parse_projects(module_ctx, hub_specs):
                 has_modifications = (
                     override.pre_build_patches or
                     override.post_install_patches or
+                    override.native_inputs or
                     override.extra_deps or
                     override.extra_data
                 )
@@ -237,7 +238,7 @@ def _parse_projects(module_ctx, hub_specs):
                     fail("uv.override_package() for '{}': `target` is mutually exclusive with patch/exclude attributes. Use `target` for full replacement OR patch/exclude attributes for modifications, not both.".format(override.name))
 
                 if not has_target and not has_modifications:
-                    fail("uv.override_package() for '{}': must specify either `target` for full replacement or at least one modification attribute (pre_build_patches, post_install_patches, extra_deps, extra_data).".format(override.name))
+                    fail("uv.override_package() for '{}': must specify either `target` for full replacement or at least one modification attribute (pre_build_patches, post_install_patches, native_inputs, extra_deps, extra_data).".format(override.name))
 
                 package_overrides[override_key] = override
 
@@ -378,9 +379,12 @@ def _parse_projects(module_ctx, hub_specs):
                     pkg_override = package_overrides.get((normalize_name(package["name"]), package["version"]))
                     pre_build_patches = []
                     pre_build_patch_strip = 0
+                    native_inputs = []
                     if pkg_override and pkg_override.pre_build_patches:
                         pre_build_patches = [str(p) for p in pkg_override.pre_build_patches]
                         pre_build_patch_strip = pkg_override.pre_build_patch_strip
+                    if pkg_override and pkg_override.native_inputs:
+                        native_inputs = [str(t) for t in pkg_override.native_inputs]
 
                     sbuild_specs[sbuild_id] = struct(
                         src = sdist,
@@ -389,6 +393,7 @@ def _parse_projects(module_ctx, hub_specs):
                         version = package["version"],
                         pre_build_patches = pre_build_patches,
                         pre_build_patch_strip = pre_build_patch_strip,
+                        native_inputs = native_inputs,
                         available_deps = project_available_deps,
                         configure_command = project.unstable_configure_command,
                         subdirectory = package.get("source", {}).get("subdirectory", ""),
@@ -398,6 +403,18 @@ def _parse_projects(module_ctx, hub_specs):
 
                 # Look up post-install patches and BUILD modifications
                 pkg_override = package_overrides.get((normalize_name(package["name"]), package["version"]))
+
+                # native_inputs is only consumed by sdist builds; when the
+                # package installs from a wheel it would be silently ignored.
+                if pkg_override and pkg_override.native_inputs and not has_sbuild:
+                    fail(("uv.override_package() for '{}': native_inputs was provided but " +
+                          "no sdist build is created for this package ({}), so the native " +
+                          "inputs would be silently ignored. Remove native_inputs, or force " +
+                          "a source build via [tool.uv] no-binary-package.").format(
+                        package["name"],
+                        "the lockfile has no sdist" if not sdist else "an anyarch wheel satisfies all installs",
+                    ))
+
                 post_install_patches = []
                 post_install_patch_strip = 0
                 extra_deps = []
@@ -575,6 +592,8 @@ def _uv_impl(module_ctx):
         if sbuild_cfg.pre_build_patches:
             sbuild_kwargs["pre_build_patches"] = sbuild_cfg.pre_build_patches
             sbuild_kwargs["pre_build_patch_strip"] = sbuild_cfg.pre_build_patch_strip
+        if sbuild_cfg.native_inputs:
+            sbuild_kwargs["native_inputs"] = sbuild_cfg.native_inputs
         if sbuild_cfg.subdirectory:
             sbuild_kwargs["subdirectory"] = sbuild_cfg.subdirectory
         sdist_build(**sbuild_kwargs)
@@ -679,6 +698,21 @@ _override_package_tag = tag_class(
         "pre_build_patch_strip": attr.int(
             default = 0,
             doc = "Strip count for pre-build patches (-p flag to the patch tool).",
+        ),
+
+        # Native build inputs: Bazel targets whose artifacts are made available
+        # to the package's native (pep517_native_whl) sdist build.
+        "native_inputs": attr.label_list(
+            default = [],
+            allow_files = True,
+            doc = "Bazel targets providing native build-time inputs to the package's " +
+                  "sdist build. Targets with CcInfo (e.g. cc_library) contribute their " +
+                  "headers, include paths, defines, and static libraries to the compile " +
+                  "and link environment. Only static libraries are supported: a wheel " +
+                  "cannot carry Bazel-managed shared library paths at runtime. Targets " +
+                  "without CcInfo (e.g. filegroup) have their files staged into the " +
+                  "build sandbox and exposed via $PY_NATIVE_INPUT_PATHS for the build " +
+                  "backend to consume explicitly.",
         ),
 
         # Post-install patches: applied to the installed tree artifact after wheel unpacking.

--- a/uv/private/pep517_whl/build_helper.py
+++ b/uv/private/pep517_whl/build_helper.py
@@ -8,19 +8,32 @@ Mostly exists to allow debugging.
 
 from argparse import ArgumentParser
 import os
+import shlex
 import shutil
 import sys
 from os import listdir, mkdir, path
 from subprocess import CalledProcessError, check_call, STDOUT, run
 from tempfile import TemporaryFile
 
-PARSER = ArgumentParser()
+# fromfile: pep517_native_whl passes native-input flags via an Args object
+# that may spill to a Bazel multiline param file (@path, one arg per line).
+PARSER = ArgumentParser(fromfile_prefix_chars="@")
 PARSER.add_argument("srcarchive")
 PARSER.add_argument("outdir")
 PARSER.add_argument("--validate-anyarch", action="store_true")
 PARSER.add_argument("--patch-strip", type=int, default=0, help="Strip count for patch (-p)")
 PARSER.add_argument("--patch", action="append", default=[], dest="patches", help="Patch file to apply (repeatable)")
 PARSER.add_argument("--subdirectory", default="", help="Subdirectory within the archive containing pyproject.toml")
+# Native inputs: pep517_native_whl derives these from the CcInfo/DefaultInfo
+# providers of uv.override_package(native_inputs) targets. Paths are exec-root
+# relative; this helper only absolutizes them and maps each to its flag.
+PARSER.add_argument("--native-include", action="append", default=[], dest="native_includes", help="Include directory to compile against (-I) (repeatable)")
+PARSER.add_argument("--native-quote-include", action="append", default=[], dest="native_quote_includes", help="Quote include directory to compile against (-iquote) (repeatable)")
+PARSER.add_argument("--native-system-include", action="append", default=[], dest="native_system_includes", help="System include directory to compile against (-isystem) (repeatable)")
+PARSER.add_argument("--native-define", action="append", default=[], dest="native_defines", help="Preprocessor define (-D) (repeatable)")
+PARSER.add_argument("--native-static-lib", action="append", default=[], dest="native_static_libs", help="Static library archive to link into extensions (repeatable)")
+PARSER.add_argument("--native-link-object", action="append", default=[], dest="native_link_objects", help="Object file to link into extensions (repeatable)")
+PARSER.add_argument("--native-input-file", action="append", default=[], dest="native_input_files", help="Auxiliary input file exposed via $PY_NATIVE_INPUT_PATHS (repeatable)")
 opts, args = PARSER.parse_known_args()
 
 tmp_root = opts.outdir.lstrip("/") + ".tmp"
@@ -55,15 +68,6 @@ for _cc_var in ("CC", "CXX", "SYSROOT"):
     if _cc_var in os.environ and not path.isabs(os.environ[_cc_var]):
         os.environ[_cc_var] = path.abspath(os.environ[_cc_var])
 
-if "SYSROOT" in os.environ:
-    _sysroot = os.environ["SYSROOT"]
-    _sysroot_cflag = f'--sysroot="{_sysroot}"'
-    if "CFLAGS" in os.environ:
-        _cflags = os.environ["CFLAGS"]
-        os.environ["CFLAGS"] = f"{_cflags} {_sysroot_cflag}"
-    else:
-        os.environ["CFLAGS"] = _sysroot_cflag
-
 # Preserve PATH so native sdist builds can find compilers (clang, gcc).
 build_env = dict(os.environ)
 build_env.update({
@@ -71,6 +75,59 @@ build_env.update({
     "TEMP": tmp_root,
     "TEMPDIR": tmp_root,
 })
+
+
+def _append_env_flags(env, key, flags):
+    if not flags:
+        return
+    # distutils/setuptools re-tokenize these env vars with shlex.split, so
+    # quote each flag to survive whitespace in defines and paths.
+    joined = " ".join(shlex.quote(flag) for flag in flags)
+    env[key] = f"{env[key]} {joined}" if env.get(key) else joined
+
+
+if "SYSROOT" in build_env:
+    _sysroot_flag = "--sysroot=" + build_env["SYSROOT"]
+    for _flags_var in ("CPPFLAGS", "CFLAGS", "CXXFLAGS"):
+        _append_env_flags(build_env, _flags_var, [_sysroot_flag])
+
+
+_native_compile_flags = (
+    ["-I" + path.abspath(d) for d in opts.native_includes]
+    + ["-iquote" + path.abspath(d) for d in opts.native_quote_includes]
+    + ["-isystem" + path.abspath(d) for d in opts.native_system_includes]
+    + ["-D" + d for d in opts.native_defines]
+)
+# setuptools/distutils customize_compiler() folds CPPFLAGS into both C and C++
+# compile commands, but older vendored copies only honor CFLAGS/CXXFLAGS, so
+# set all three.
+_append_env_flags(build_env, "CPPFLAGS", _native_compile_flags)
+_append_env_flags(build_env, "CFLAGS", _native_compile_flags)
+_append_env_flags(build_env, "CXXFLAGS", _native_compile_flags)
+
+# distutils splices $LDFLAGS into $LDSHARED, BEFORE the object files on the
+# link line. With position-dependent archive scanning (GNU ld/lld) a plain
+# libfoo.a there would contribute no symbols and the extension would fail at
+# import time with unresolved symbols. Force-loading the whole archive makes
+# placement irrelevant; injected build-time libraries are expected to be small.
+if sys.platform == "darwin":
+    _native_link_flags = [
+        "-Wl,-force_load,{}".format(path.abspath(lib)) for lib in opts.native_static_libs
+    ]
+else:
+    _native_link_flags = [
+        flag
+        for lib in opts.native_static_libs
+        for flag in ("-Wl,--whole-archive", path.abspath(lib), "-Wl,--no-whole-archive")
+    ]
+# Bare object files always contribute their symbols regardless of position.
+_native_link_flags += [path.abspath(obj) for obj in opts.native_link_objects]
+_append_env_flags(build_env, "LDFLAGS", _native_link_flags)
+
+if opts.native_input_files:
+    build_env["PY_NATIVE_INPUT_PATHS"] = os.pathsep.join(
+        path.abspath(f) for f in opts.native_input_files
+    )
 
 if path.exists(path.join(t, "pyproject.toml")) or path.exists(path.join(t, "setup.py")):
     # Always use `python -m build` (PEP 517 frontend). For setup.py-only
@@ -99,6 +156,15 @@ with TemporaryFile(mode="w+") as build_log:
             sys.stderr.write(output)
             if not output.endswith("\n"):
                 sys.stderr.write("\n")
+        if opts.native_static_libs and "-fPIC" in output:
+            # PIC-ness of a prebuilt archive is undetectable at analysis time;
+            # this is the earliest point where the mismatch surfaces.
+            print(
+                "Hint: a native_inputs static library appears to contain non-PIC "
+                "objects, which cannot be linked into a Python extension (.so). "
+                "Provide a PIC archive (cc_library emits one; cc_import cannot).",
+                file=sys.stderr,
+            )
         print("Error: Build failed!\nSee {} for the sandbox".format(t), file=sys.stderr)
         exit(1)
 

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -6,7 +6,7 @@ build backend the sdist declares in its `[build-system]` table.
 """
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_cc_toolchain = "find_cpp_toolchain")
-load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
+load("@rules_cc//cc:action_names.bzl", "CPP_COMPILE_ACTION_NAME", "C_COMPILE_ACTION_NAME")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
 
@@ -60,13 +60,100 @@ def _pep517_whl(ctx):
 
     return [DefaultInfo(files = depset([wheel_dir]))]
 
+def _native_input_args_and_depsets(ctx):
+    """Derives explicit build flags and action inputs from native_inputs targets.
+
+    CcInfo targets contribute their compilation context (headers as inputs;
+    include dirs and defines as flags) and the static libraries or object
+    files of their linking context. Flag decisions are made here, in Starlark,
+    from provider data — build_helper.py only absolutizes the paths it is
+    handed (they are exec-root relative and the helper cds into the extracted
+    source tree).
+
+    Targets without CcInfo contribute their files verbatim; the helper exposes
+    their paths via $PY_NATIVE_INPUT_PATHS for the build backend to consume
+    explicitly.
+
+    Returns (args, transitive_input_depsets) where args is an Args object.
+    """
+    args = ctx.actions.args()
+    args.use_param_file("@%s")
+    args.set_param_file_format("multiline")
+    transitive = []
+
+    cc_infos = [target[CcInfo] for target in ctx.attr.native_inputs if CcInfo in target]
+    if cc_infos:
+        compilation_context = cc_common.merge_cc_infos(cc_infos = cc_infos).compilation_context
+        transitive.append(compilation_context.headers)
+        args.add_all(compilation_context.includes, format_each = "--native-include=%s", uniquify = True)
+        args.add_all(compilation_context.quote_includes, format_each = "--native-quote-include=%s", uniquify = True)
+        args.add_all(compilation_context.system_includes, format_each = "--native-system-include=%s", uniquify = True)
+        if hasattr(compilation_context, "external_includes"):
+            args.add_all(compilation_context.external_includes, format_each = "--native-system-include=%s", uniquify = True)
+        args.add_all(compilation_context.defines, format_each = "--native-define=%s", uniquify = True)
+
+    # Dicts as ordered sets: dedupe across targets while keeping stable order.
+    # This loop stays per-target (not merged) for per-target error attribution.
+    static_libs = {}
+    link_objects = {}
+
+    for target in ctx.attr.native_inputs:
+        if CcInfo not in target:
+            files = target[DefaultInfo].files
+            transitive.append(files)
+            args.add_all(files, format_each = "--native-input-file=%s")
+            continue
+
+        target_has_linkable = False
+        shared_only_library = None
+        for linker_input in target[CcInfo].linking_context.linker_inputs.to_list():
+            for library in linker_input.libraries:
+                static_library = library.pic_static_library or library.static_library
+
+                # Older Bazel doesn't expose the objects fields on LibraryToLink.
+                objects = getattr(library, "pic_objects", None) or getattr(library, "objects", None)
+                if static_library:
+                    static_libs[static_library] = None
+                    target_has_linkable = True
+                elif objects:
+                    for obj in objects:
+                        link_objects[obj] = None
+                    target_has_linkable = True
+                elif library.dynamic_library or library.interface_library:
+                    shared_only_library = library.dynamic_library or library.interface_library
+
+        if shared_only_library and not target_has_linkable:
+            # A wheel linked against a Bazel-built shared library would
+            # import-fail at runtime: the venv carries no rpath into
+            # bazel-out and we don't install the .so.
+            fail(("native_inputs target '{}' (for {}) provides only shared " +
+                  "libraries (e.g. '{}'). Sdist builds can only link against " +
+                  "static libraries; runtime resolution of Bazel-managed shared " +
+                  "libraries from an installed wheel is unsupported. " +
+                  "Provide a static variant (e.g. cc_library, which always " +
+                  "emits an archive).").format(
+                target.label,
+                ctx.label,
+                shared_only_library.basename,
+            ))
+
+    args.add_all(static_libs.keys(), format_each = "--native-static-lib=%s")
+    args.add_all(link_objects.keys(), format_each = "--native-link-object=%s")
+    if static_libs:
+        transitive.append(depset(static_libs.keys()))
+    if link_objects:
+        transitive.append(depset(link_objects.keys()))
+
+    return args, transitive
+
 def _pep517_native_whl(ctx):
     archive = ctx.attr.src[DefaultInfo].files.to_list()[0]
     wheel_dir = ctx.actions.declare_directory("whl")
     patch_args, patch_inputs = _patch_args_and_inputs(ctx)
+    native_input_args, native_input_depsets = _native_input_args_and_depsets(ctx)
 
     env = _common_env(ctx)
-    extra_inputs = []
+    extra_inputs = native_input_depsets
 
     # Resolve the CC toolchain so setuptools/distutils can find the compiler
     # rather than falling back to whatever is on the system PATH.
@@ -80,11 +167,19 @@ def _pep517_native_whl(ctx):
             feature_configuration = feature_configuration,
             action_name = C_COMPILE_ACTION_NAME,
         )
+        cpp_compiler_path = cc_common.get_tool_for_action(
+            feature_configuration = feature_configuration,
+            action_name = CPP_COMPILE_ACTION_NAME,
+        )
 
         # Note that these paths are relative to the bazel exec root,
         # and they need to be absolutized if they're to be invoked from any
         # other working directory. (e.g. in build_helper.py for sdist builds.)
         env["CC"] = c_compiler_path
+
+        # distutils compiles C++ sources with $CXX, falling back to a bare
+        # `clang++`/`g++` from PATH which doesn't exist in the sandbox.
+        env["CXX"] = cpp_compiler_path
         extra_inputs.append(cc_toolchain.all_files)
 
         # We can extract the relative path to the @llvm-provided sysroot from
@@ -102,6 +197,7 @@ def _pep517_native_whl(ctx):
         executable = ctx.executable.tool,
         toolchain = None,
         arguments = ctx.attr.args + patch_args + [
+            native_input_args,
             archive.path,
             wheel_dir.path,
         ],
@@ -172,6 +268,17 @@ constraints of the target platform.
 """,
     attrs = _pep517_whl_attrs | {
         "args": attr.string_list(),
+        "native_inputs": attr.label_list(
+            default = [],
+            allow_files = True,
+            doc = "Bazel targets providing native build-time inputs. Targets with " +
+                  "CcInfo contribute headers, include paths, defines, and static " +
+                  "libraries to the compile/link environment; shared-library-only " +
+                  "targets are rejected (wheels cannot resolve Bazel-managed shared " +
+                  "libraries at runtime). Targets without CcInfo have their files " +
+                  "staged into the action sandbox and exposed via " +
+                  "$PY_NATIVE_INPUT_PATHS.",
+        ),
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),

--- a/uv/private/pep517_whl/rule.bzl
+++ b/uv/private/pep517_whl/rule.bzl
@@ -8,6 +8,7 @@ build backend the sdist declares in its `[build-system]` table.
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_cc_toolchain = "find_cpp_toolchain")
 load("@rules_cc//cc:action_names.bzl", "CPP_COMPILE_ACTION_NAME", "C_COMPILE_ACTION_NAME")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//py/private/toolchain:types.bzl", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
 
 CC_TOOLCHAIN = "@bazel_tools//tools/cpp:toolchain_type"

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -162,6 +162,10 @@ def _sdist_build_impl(repository_ctx):
     is_native_override = repository_ctx.attr.is_native
     inspection = None
 
+    # False when is_native was assumed (inspection unavailable/failed) rather
+    # than explicitly set or actually derived from the sdist contents.
+    classification_confident = True
+
     if is_native_override == "auto":
         archive_path = _resolve_archive_path(repository_ctx)
         inspection = _run_configure_tool(repository_ctx, archive_path) if archive_path else None
@@ -170,6 +174,13 @@ def _sdist_build_impl(repository_ctx):
             # If the tool provided complete build file content, use it directly.
             build_file_content = inspection.get("build_file_content")
             if build_file_content:
+                if repository_ctx.attr.native_inputs:
+                    fail(("sdist_build repo '{}': native_inputs was provided via " +
+                          "uv.override_package() but the configure tool supplied complete " +
+                          "build_file_content, which would silently discard it. Wire the " +
+                          "native inputs into the custom build file instead.").format(
+                        repository_ctx.name,
+                    ))
                 repository_ctx.file("BUILD.bazel", content = build_file_content)
                 return
 
@@ -187,6 +198,7 @@ def _sdist_build_impl(repository_ctx):
             print("WARNING: Could not inspect sdist for {}; assuming pure-Python".format(
                 repository_ctx.name,
             ))
+            classification_confident = False
             is_native = False
     else:
         is_native = is_native_override == "true"
@@ -215,6 +227,36 @@ def _sdist_build_impl(repository_ctx):
     if repository_ctx.attr.subdirectory:
         subdir_args = '"--subdirectory={}"'.format(repository_ctx.attr.subdirectory)
 
+    # native_inputs only exists on pep517_native_whl; a confident pure-Python
+    # classification with native inputs is a contradiction worth failing on
+    # rather than silently dropping the user's targets.
+    native_inputs_attr = ""
+    if repository_ctx.attr.native_inputs:
+        if not is_native:
+            explicitly_pure = is_native_override == "false"
+            if explicitly_pure or (classification_confident and not pre_build_patches):
+                fail(("sdist_build repo '{}': native_inputs was provided via " +
+                      "uv.override_package() but the sdist was classified as pure-Python. " +
+                      "native_inputs only applies to native (pep517_native_whl) builds.").format(
+                    repository_ctx.name,
+                ))
+
+            # The classification is either an assumption (inspection
+            # unavailable) or ran on the pristine sdist while pre-build
+            # patches may introduce native sources it cannot see. Treat
+            # native_inputs as the user's explicit signal and build native;
+            # pep517_native_whl is a superset of pep517_whl so a genuinely
+            # pure package still builds correctly.
+            # buildifier: disable=print
+            print(("sdist_build repo '{}': native_inputs provided but the sdist was " +
+                   "not classified as native ({}); using the native build path.").format(
+                repository_ctx.name,
+                "pre-build patches may add native sources" if classification_confident else "inspection unavailable",
+            ))
+            is_native = True
+        native_inputs_attr = """
+    native_inputs = {},""".format(repr([str(it) for it in repository_ctx.attr.native_inputs]))
+
     repository_ctx.file("BUILD.bazel", content = """
 load("@aspect_rules_py//uv/private/pep517_whl:rule.bzl", "{rule}")
 load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_binary")
@@ -231,7 +273,7 @@ py_venv_binary(
     src = "{src}",
     tool = ":build_tool",
     version = "{version}",
-    args = [{subdir_args}],{patch_attrs}
+    args = [{subdir_args}],{patch_attrs}{native_inputs_attr}
     visibility = ["//visibility:public"],
 )
 """.format(
@@ -241,6 +283,7 @@ py_venv_binary(
         version = repository_ctx.attr.version,
         patch_attrs = patch_attrs,
         subdir_args = subdir_args,
+        native_inputs_attr = native_inputs_attr,
     ))
 
 sdist_build = repository_rule(
@@ -269,5 +312,12 @@ sdist_build = repository_rule(
         ),
         "pre_build_patches": attr.label_list(default = []),
         "pre_build_patch_strip": attr.int(default = 0),
+        "native_inputs": attr.label_list(
+            default = [],
+            allow_files = True,
+            doc = "Bazel targets providing native build-time inputs (headers, static " +
+                  "libraries, auxiliary files) to the pep517_native_whl build. " +
+                  "See uv.override_package(native_inputs).",
+        ),
     },
 )


### PR DESCRIPTION
## What

`uv.override_package(native_inputs = [...])` threads Bazel targets into the hermetic `PySdistNativeBuild` action, for sdists whose C/C++ extensions need headers/libraries that are not part of the CC toolchain sysroot.

Semantics per target:

- **`CcInfo` targets** (e.g. `cc_library`): headers become action inputs; include dirs and defines are passed via `CPPFLAGS`/`CFLAGS`/`CXXFLAGS`; static libraries are whole-archive-loaded via `LDFLAGS` (objects-only `LibraryToLink` entries are linked directly). Shared-library-only linking contexts are rejected at analysis time: an installed wheel carries no rpath into `bazel-out`, so the extension would import-fail at runtime.
- **Non-`CcInfo` targets** (e.g. `filegroup`): files are staged into the sandbox and exposed via `$PY_NATIVE_INPUT_PATHS` for the build backend to consume explicitly.

Flag decisions are made in Starlark from provider data; `build_helper.py` only absolutizes exec-root-relative paths after it cds into the extracted source tree. Compilation contexts are merged with `cc_common.merge_cc_infos` and passed lazily via `Args.add_all` + multiline param file (argparse `fromfile`), so no depset is flattened at analysis time and there is no argv-length ceiling.

## Misuse handling

- Declaring `native_inputs` for a package that never gets a source build (no sdist in the lockfile, or an anyarch wheel elides the sbuild) fails at extension eval instead of being silently ignored.
- A confident pure-Python classification with `native_inputs` fails at fetch time. When the classification is an assumption (sdist inspection unavailable) or `pre_build_patches` may introduce native sources the pristine-sdist inspection cannot see, `native_inputs` acts as an explicit signal and the native build path is used (`pep517_native_whl` is a superset of `pep517_whl`, so a genuinely pure package still builds).
- A configure tool returning custom `build_file_content` alongside `native_inputs` fails rather than silently discarding the targets.
- Non-PIC prebuilt archives are undetectable at analysis time; the build helper emits a pointed hint when the extension link fails with a `-fPIC` relocation error.

## Also in this change

- `--sysroot` is now applied to `CPPFLAGS`/`CFLAGS`/`CXXFLAGS` (previously only `CFLAGS`), so C++ compiles stay hermetic now that `$CXX` is set from the resolved toolchain.
- Env-var flags are `shlex.quote`d — distutils re-tokenizes them with `shlex.split`, so defines/paths containing whitespace previously broke.
- The shared-library rejection scans the target's whole linking context and only fails when it provides no static library or objects at all, naming the offending library. Previously any transitive dynamic-only `LibraryToLink` failed analysis even when the target provided static archives.

## Testing

New e2e case `uv-sdist-native-inputs` (own hub to avoid collisions with `uv-sdist-native-build`): python-geohash is pre-build-patched to add a C extension that compiles against a `cc_library`'s header and links its static archive; the test imports the extension and asserts the linked symbol's value.

Ran locally: buildifier, gazelle, and `bazel test //...` (Bazel 8.5.1) on the root, `e2e`, and `examples/uv_pip_compile` workspaces. Only failures are environmental: `//:requirements.test` (network timeout against PyPI) and `e2e //cases/interpreter-features-836:test` (no Docker daemon on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)