### PR TITLE
fix(uv): fan out group dependencies over marker-gated locked versions

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -508,6 +508,18 @@ uv.override_package(
 use_repo(uv, "pypi-native-inputs")
 # }}}
 
+# For cases/uv-group-multi-version
+# Regression: the same package locked at multiple marker-gated versions
+# within a single dependency group must resolve per-platform instead of
+# collapsing to a single (last-written) version.
+# {{{
+uv.project(
+    hub_name = "pypi",
+    lock = "//cases/uv-group-multi-version:uv.lock",
+    pyproject = "//cases/uv-group-multi-version:pyproject.toml",
+)
+# }}}
+
 # For cases/unconstrained-dependencies
 # {{{
 uv.project(

--- a/e2e/cases/uv-group-multi-version/BUILD.bazel
+++ b/e2e/cases/uv-group-multi-version/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@aspect_rules_py//py/unstable:defs.bzl", "py_venv_test")
+
+py_venv_test(
+    name = "group_multi_version",
+    srcs = [
+        "__test__.py",
+    ],
+    main = "__test__.py",
+    python_version = "3.11",
+    venv = "depctx_py_multiver_uv",
+    deps = [
+        "@pypi//retrying",
+        "@pypi//six",
+    ],
+)

--- a/e2e/cases/uv-group-multi-version/__test__.py
+++ b/e2e/cases/uv-group-multi-version/__test__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Reproduce multi-version packages within a single dependency group.
+
+The `depctx_py_multiver_uv` group locks `six` at two versions gated by
+disjoint `sys_platform` markers, both directly and transitively through
+`retrying`. If the group preference resolution collapses the candidates
+(last-write-wins), the wrong version is wired for the active platform.
+"""
+
+import sys
+from importlib.metadata import version
+
+import retrying
+import six
+
+expected = "1.16.0" if sys.platform == "linux" else "1.17.0"
+actual = version("six")
+
+print(f"sys.platform: {sys.platform}")
+print(f"six: {actual} (expected {expected}) at {six.__file__}")
+print(f"retrying: {retrying.__file__}")
+
+assert actual == expected, f"six=={actual}, expected {expected} for {sys.platform}"

--- a/e2e/cases/uv-group-multi-version/pyproject.toml
+++ b/e2e/cases/uv-group-multi-version/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "group-multi-version"
+version = "0.0.0"
+requires-python = ">=3.10"
+dependencies = []
+
+[dependency-groups]
+depctx_py_multiver_uv = [
+    "retrying==1.3.4",
+    "six==1.16.0; sys_platform == 'linux'",
+    "six==1.17.0; sys_platform != 'linux'",
+]

--- a/e2e/cases/uv-group-multi-version/uv.lock
+++ b/e2e/cases/uv-group-multi-version/uv.lock
@@ -1,0 +1,65 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+resolution-markers = [
+    "sys_platform == 'linux'",
+    "sys_platform != 'linux'",
+]
+
+[[package]]
+name = "group-multi-version"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+depctx-py-multiver-uv = [
+    { name = "retrying" },
+    { name = "six", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "six", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+depctx-py-multiver-uv = [
+    { name = "retrying", specifier = "==1.3.4" },
+    { name = "six", marker = "sys_platform != 'linux'", specifier = "==1.17.0" },
+    { name = "six", marker = "sys_platform == 'linux'", specifier = "==1.16.0" },
+]
+
+[[package]]
+name = "retrying"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "six", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/70/15ce8551d65b324e18c5aa6ef6998880f21ead51ebe5ed743c0950d7d9dd/retrying-1.3.4.tar.gz", hash = "sha256:345da8c5765bd982b1d1915deb9102fd3d1f7ad16bd84a9700b85f64d24e8f3e", size = 10929, upload-time = "2022-11-25T09:57:49.43Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/04/9e36f28be4c0532c0e9207ff9dc01fb13a2b0eb036476a213b0000837d0e/retrying-1.3.4-py3-none-any.whl", hash = "sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35", size = 11602, upload-time = "2022-11-25T09:57:47.494Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform == 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041, upload-time = "2021-05-05T14:18:18.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053, upload-time = "2021-05-05T14:18:17.237Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform != 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]

--- a/uv/private/extension/graph_utils.bzl
+++ b/uv/private/extension/graph_utils.bzl
@@ -96,10 +96,14 @@ def combine_markers(lefts, rights):
     def _and(l, r):
         """
         We use "" as the empty/True marker, so if either side is true then we
-        need to return the other side.
+        need to return the other side. Identical markers conjoin to themselves
+        (idempotence), which keeps the common uv case — the lockfile marker
+        mirroring the requirement marker — from inflating select arms.
         """
 
-        if l == "":
+        if l == r:
+            return l
+        elif l == "":
             return r
         elif r == "":
             return l

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -5,6 +5,7 @@ Machinery specific to interacting with a pyproject.toml
 load("//uv/private:normalize_name.bzl", "normalize_name")
 load("//uv/private/versions:versions.bzl", "find_matching_version")
 load(":dep_groups.bzl", "resolve_dependency_group_specs")
+load(":graph_utils.bzl", "combine_markers")
 load(":marker_simplify.bzl", "simplify_markers_for_extras")
 
 def extract_requirement_marker_pairs(projectfile, lock_id, req_string, version_map, package_versions = {}, preferred_versions = {}):
@@ -120,8 +121,10 @@ def _extract_lockfile_group_versions(lock_id, lock_data):
     """Extracts resolved package versions per dependency group from the lockfile.
 
     uv.lock encodes the exact package versions selected for each dependency group
-    in the root package's `dev-dependencies` section. This function builds a map
-    that can be used as `preferred_versions` when resolving requirement strings.
+    in the root package's `dev-dependencies` section. A group may legitimately
+    lock the same package at several versions, each gated by a disjoint PEP 508
+    marker (platform/python forks or uv conflict routing), so every entry is
+    kept as a `(dep, marker)` candidate rather than collapsed to one version.
 
     Args:
         lock_id: The lockfile identifier used in dependency tuples.
@@ -129,7 +132,8 @@ def _extract_lockfile_group_versions(lock_id, lock_data):
 
     Returns:
         A dictionary mapping normalized group names to dictionaries of
-        {package_name: (lock_id, package_name, version, "__base__")}.
+        {package_name: [((lock_id, package_name, version, "__base__"), marker)]},
+        with candidates in lockfile order.
     """
     result = {}
     for pkg in lock_data.get("package", []):
@@ -140,8 +144,36 @@ def _extract_lockfile_group_versions(lock_id, lock_data):
             for dep in deps:
                 pkg_name = normalize_name(dep["name"])
                 if "version" in dep:
-                    result.setdefault(group_name, {})[pkg_name] = (lock_id, pkg_name, dep["version"], "__base__")
+                    candidate = ((lock_id, pkg_name, dep["version"], "__base__"), dep.get("marker", ""))
+                    result.setdefault(group_name, {}).setdefault(pkg_name, []).append(candidate)
     return result
+
+def _fan_out_candidates(dep, markers, candidates):
+    """Fans a dependency out over a group's marker-gated locked candidates.
+
+    Each candidate version is emitted gated by the conjunction of the incoming
+    markers and the candidate's lockfile marker; uv guarantees candidates
+    within a group carry disjoint markers, so at most one conjunction holds
+    per environment.
+
+    The candidates only cover the group's own locked entries for the package.
+    When the dependency's version is not among them (a transitive lockfile
+    resolution outside the dev-dependencies list), it is preserved as-is so
+    environments where no candidate marker holds still wire a version.
+
+    Returns:
+        A list of `(dep, markers)` pairs.
+    """
+    targets = [
+        (
+            (dep[0], dep[1], candidate[2], dep[3]),
+            combine_markers(markers, {candidate_marker: 1}),
+        )
+        for candidate, candidate_marker in candidates
+    ]
+    if dep[2] not in [candidate[2] for candidate, _ in candidates]:
+        targets.append((dep, markers))
+    return targets
 
 def collect_activated_extras(projectfile, lock_id, project_data, lock_data, default_versions, graph, package_versions = {}):
     """Collects the set of transitively activated extras for each configuration.
@@ -181,31 +213,64 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
 
     all_group_preferences = {}
 
+    all_group_fanout_candidates = {}
+
     lockfile_group_versions = _extract_lockfile_group_versions(lock_id, lock_data)
 
     for group_name in dep_groups.keys():
         resolved_specs = resolve_dependency_group_specs(dep_groups, group_name)
 
-        group_preferences = dict(lockfile_group_versions.get(group_name, {}))
+        group_candidates = lockfile_group_versions.get(group_name, {})
+
+        # A package the group locks under a marker — or at several marker-gated
+        # versions — cannot be collapsed to an unconditional preference. Those
+        # candidates fan out below, each gated by its lockfile marker, and the
+        # final choice happens at build time in the decide_marker select()
+        # layer. Only a single unconditional entry acts as a plain preference.
+        fanout_candidates = {}
+        group_preferences = {}
+        for pkg_name, candidates in group_candidates.items():
+            if len(candidates) == 1 and candidates[0][1] == "":
+                group_preferences[pkg_name] = candidates[0][0]
+            else:
+                fanout_candidates[pkg_name] = candidates
+
+        # Fanned-out packages still need *a* version so requirement specs
+        # resolve without falling through to the specifier matcher, which
+        # rejects legal forms such as direct references. The fan-out discards
+        # this placeholder version and re-expands every candidate.
+        resolution_versions = dict(group_preferences)
+        resolution_versions.update({
+            pkg_name: candidates[0][0]
+            for pkg_name, candidates in fanout_candidates.items()
+        })
 
         for spec in resolved_specs:
-            for dep, _marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, group_preferences):
-                group_preferences[dep[1]] = (dep[0], dep[1], dep[2], "__base__")
+            for dep, _marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, resolution_versions):
+                if dep[1] not in fanout_candidates:
+                    group_preferences[dep[1]] = (dep[0], dep[1], dep[2], "__base__")
+                    resolution_versions[dep[1]] = group_preferences[dep[1]]
 
         all_group_preferences[group_name] = group_preferences
+        all_group_fanout_candidates[group_name] = fanout_candidates
 
         for spec in resolved_specs:
-            for dep, marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, group_preferences):
-                normalized_dep_groups.setdefault(group_name, []).append(dep)
+            for dep, marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, resolution_versions):
+                candidates = fanout_candidates.get(dep[1])
+                seeds = _fan_out_candidates(dep, {marker: 1}, candidates) if candidates else [(dep, {marker: 1})]
 
                 # Note that this is the base case for the reach set walk below
                 # We do this here so it's easy to handle marker expressions
-                base = (dep[0], dep[1], dep[2], "__base__")
-                activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(dep, {}).update({marker: 1})
+                for seed_dep, seed_markers in seeds:
+                    normalized_dep_groups.setdefault(group_name, []).append(seed_dep)
+
+                    base = (seed_dep[0], seed_dep[1], seed_dep[2], "__base__")
+                    activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(seed_dep, {}).update(seed_markers)
 
     for group_name, deps in normalized_dep_groups.items():
         worklist = list(deps)
         group_prefs = all_group_preferences.get(group_name, {})
+        group_fanout = all_group_fanout_candidates.get(group_name, {})
         visited = {}
         idx = 0
         for _ in range(1000000):
@@ -213,6 +278,12 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
                 break
 
             it = worklist[idx]
+            idx += 1
+
+            # Seeds may repeat across specs and a node can be enqueued once
+            # per incoming edge; expand each node exactly once.
+            if it in visited:
+                continue
             visited[it] = 1
 
             # If we reached this node via an extra, any `extra == '...'` marker
@@ -221,20 +292,26 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
 
             for next_dep, markers in graph.get(it, {}).items():
                 pkg_name = next_dep[1]
-                pref = group_prefs.get(pkg_name)
-                target_dep = next_dep
-                if pref and pref[2] != next_dep[2]:
-                    target_dep = (next_dep[0], next_dep[1], pref[2], next_dep[3])
-
-                base = (target_dep[0], target_dep[1], target_dep[2], "__base__")
-
                 simplified_markers = simplify_markers_for_extras(markers, [origin_extra]) if origin_extra else markers
-                activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(target_dep, {}).update(simplified_markers)
-                if target_dep not in visited:
-                    visited[target_dep] = 1
-                    worklist.append(target_dep)
 
-            idx += 1
+                candidates = group_fanout.get(pkg_name)
+                if candidates:
+                    # Contradictory conjunctions decide to false at build
+                    # time, leaving only the compatible version per env.
+                    targets = _fan_out_candidates(next_dep, simplified_markers, candidates)
+                else:
+                    pref = group_prefs.get(pkg_name)
+                    target_dep = next_dep
+                    if pref and pref[2] != next_dep[2]:
+                        target_dep = (next_dep[0], next_dep[1], pref[2], next_dep[3])
+                    targets = [(target_dep, simplified_markers)]
+
+                for target_dep, target_markers in targets:
+                    base = (target_dep[0], target_dep[1], target_dep[2], "__base__")
+
+                    activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(target_dep, {}).update(target_markers)
+                    if target_dep not in visited:
+                        worklist.append(target_dep)
 
     return {it: 1 for it in dep_groups.keys()}, activated_extras
 

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -5,7 +5,6 @@ Machinery specific to interacting with a pyproject.toml
 load("//uv/private:normalize_name.bzl", "normalize_name")
 load("//uv/private/versions:versions.bzl", "find_matching_version")
 load(":dep_groups.bzl", "resolve_dependency_group_specs")
-load(":graph_utils.bzl", "combine_markers")
 load(":marker_simplify.bzl", "simplify_markers_for_extras")
 
 def extract_requirement_marker_pairs(projectfile, lock_id, req_string, version_map, package_versions = {}, preferred_versions = {}):
@@ -148,13 +147,57 @@ def _extract_lockfile_group_versions(lock_id, lock_data):
                     result.setdefault(group_name, {}).setdefault(pkg_name, []).append(candidate)
     return result
 
-def _fan_out_candidates(dep, markers, candidates):
+def _atom_sets(markers):
+    """Converts a `{marker: 1}` set into canonical conjunction form.
+
+    Activation conditions are tracked as dicts keyed by sorted tuples of
+    atomic marker expressions: each tuple is one conjunction, the dict is
+    their disjunction, and the empty tuple is the always-true condition.
+    Keeping conjunctions as canonical atom sets instead of formatted strings
+    makes conjunction idempotent, so the reach-set walk below reaches a
+    fixpoint even on dependency cycles instead of growing marker strings
+    forever.
+
+    Returns:
+        A dict of `{atom_tuple: 1}` conditions.
+    """
+    return {((marker,) if marker else ()): 1 for marker in markers.keys()}
+
+def _conjoin_conditions(lefts, rights):
+    """Conjoins two atom-set conditions: cross product, union of atoms.
+
+    Returns:
+        A dict of `{atom_tuple: 1}` conditions.
+    """
+    acc = {}
+    for l_atoms in lefts.keys():
+        for r_atoms in rights.keys():
+            merged = {atom: 1 for atom in l_atoms}
+            merged.update({atom: 1 for atom in r_atoms})
+            acc[tuple(sorted(merged.keys()))] = 1
+    return acc
+
+def _render_markers(conditions):
+    """Renders atom-set conditions back into `{marker: 1}` strings.
+
+    Returns:
+        A dict of `{marker: 1}` PEP 508 marker strings.
+    """
+    acc = {}
+    for atoms in conditions.keys():
+        if len(atoms) == 1:
+            acc[atoms[0]] = 1
+        else:
+            acc[" and ".join(["({})".format(atom) for atom in atoms])] = 1
+    return acc
+
+def _fan_out_candidates(dep, conditions, candidates):
     """Fans a dependency out over a group's marker-gated locked candidates.
 
     Each candidate version is emitted gated by the conjunction of the incoming
-    markers and the candidate's lockfile marker; uv guarantees candidates
-    within a group carry disjoint markers, so at most one conjunction holds
-    per environment.
+    atom-set conditions and the candidate's lockfile marker; uv guarantees
+    candidates within a group carry disjoint markers, so at most one
+    conjunction holds per environment.
 
     The candidates only cover the group's own locked entries for the package.
     When the dependency's version is not among them (a transitive lockfile
@@ -162,17 +205,17 @@ def _fan_out_candidates(dep, markers, candidates):
     environments where no candidate marker holds still wire a version.
 
     Returns:
-        A list of `(dep, markers)` pairs.
+        A list of `(dep, conditions)` pairs.
     """
     targets = [
         (
             (dep[0], dep[1], candidate[2], dep[3]),
-            combine_markers(markers, {candidate_marker: 1}),
+            _conjoin_conditions(conditions, _atom_sets({candidate_marker: 1})),
         )
         for candidate, candidate_marker in candidates
     ]
     if dep[2] not in [candidate[2] for candidate, _ in candidates]:
-        targets.append((dep, markers))
+        targets.append((dep, conditions))
     return targets
 
 def collect_activated_extras(projectfile, lock_id, project_data, lock_data, default_versions, graph, package_versions = {}):
@@ -257,34 +300,40 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
         for spec in resolved_specs:
             for dep, marker in extract_requirement_marker_pairs(projectfile, lock_id, spec, default_versions, package_versions, resolution_versions):
                 candidates = fanout_candidates.get(dep[1])
-                seeds = _fan_out_candidates(dep, {marker: 1}, candidates) if candidates else [(dep, {marker: 1})]
+                spec_condition = _atom_sets({marker: 1})
+                seeds = _fan_out_candidates(dep, spec_condition, candidates) if candidates else [(dep, spec_condition)]
 
                 # Note that this is the base case for the reach set walk below
                 # We do this here so it's easy to handle marker expressions
-                for seed_dep, seed_markers in seeds:
-                    normalized_dep_groups.setdefault(group_name, []).append(seed_dep)
+                for seed_dep, seed_conditions in seeds:
+                    normalized_dep_groups.setdefault(group_name, []).append((seed_dep, seed_conditions))
 
                     base = (seed_dep[0], seed_dep[1], seed_dep[2], "__base__")
-                    activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(seed_dep, {}).update(seed_markers)
+                    activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(seed_dep, {}).update(_render_markers(seed_conditions))
 
     for group_name, deps in normalized_dep_groups.items():
         worklist = list(deps)
         group_prefs = all_group_preferences.get(group_name, {})
         group_fanout = all_group_fanout_candidates.get(group_name, {})
-        visited = {}
+
+        # dep -> {atom_tuple: 1}: every condition the dep was already expanded
+        # under. A node re-expands only for genuinely new conditions, which
+        # both dedups the walk and bounds it: atom tuples are subsets of the
+        # finite marker universe, so cycles saturate instead of diverging.
+        expanded = {}
         idx = 0
         for _ in range(1000000):
             if idx == len(worklist):
                 break
 
-            it = worklist[idx]
+            it, conditions = worklist[idx]
             idx += 1
 
-            # Seeds may repeat across specs and a node can be enqueued once
-            # per incoming edge; expand each node exactly once.
-            if it in visited:
+            known = expanded.setdefault(it, {})
+            fresh = {atoms: 1 for atoms in conditions.keys() if atoms not in known}
+            if not fresh:
                 continue
-            visited[it] = 1
+            known.update(fresh)
 
             # If we reached this node via an extra, any `extra == '...'` marker
             # on outgoing edges can be resolved using that extra.
@@ -294,24 +343,31 @@ def collect_activated_extras(projectfile, lock_id, project_data, lock_data, defa
                 pkg_name = next_dep[1]
                 simplified_markers = simplify_markers_for_extras(markers, [origin_extra]) if origin_extra else markers
 
+                # Conjoin the conditions that (newly) activate this node with
+                # the edge's own markers, so transitive dependencies inherit
+                # the gates of the fanned-out versions that pull them in.
+                propagated = _conjoin_conditions(fresh, _atom_sets(simplified_markers))
+
                 candidates = group_fanout.get(pkg_name)
                 if candidates:
                     # Contradictory conjunctions decide to false at build
                     # time, leaving only the compatible version per env.
-                    targets = _fan_out_candidates(next_dep, simplified_markers, candidates)
+                    targets = _fan_out_candidates(next_dep, propagated, candidates)
                 else:
                     pref = group_prefs.get(pkg_name)
                     target_dep = next_dep
                     if pref and pref[2] != next_dep[2]:
                         target_dep = (next_dep[0], next_dep[1], pref[2], next_dep[3])
-                    targets = [(target_dep, simplified_markers)]
+                    targets = [(target_dep, propagated)]
 
-                for target_dep, target_markers in targets:
+                for target_dep, target_conditions in targets:
                     base = (target_dep[0], target_dep[1], target_dep[2], "__base__")
 
-                    activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(target_dep, {}).update(target_markers)
-                    if target_dep not in visited:
-                        worklist.append(target_dep)
+                    activated_extras.setdefault(base, {}).setdefault(group_name, {}).setdefault(target_dep, {}).update(_render_markers(target_conditions))
+
+                    known_target = expanded.get(target_dep, {})
+                    if any([atoms not in known_target for atoms in target_conditions.keys()]):
+                        worklist.append((target_dep, target_conditions))
 
     return {it: 1 for it in dep_groups.keys()}, activated_extras
 

--- a/uv/private/extension/projectfile.bzl
+++ b/uv/private/extension/projectfile.bzl
@@ -197,7 +197,12 @@ def _fan_out_candidates(dep, conditions, candidates):
     Each candidate version is emitted gated by the conjunction of the incoming
     atom-set conditions and the candidate's lockfile marker; uv guarantees
     candidates within a group carry disjoint markers, so at most one
-    conjunction holds per environment.
+    conjunction holds per environment. That same invariant makes any
+    conjunction mixing two sibling candidate markers unsatisfiable, so such
+    conjunctions are dropped instead of emitted: they could never activate
+    anything, and their canonical form is identical across the sibling
+    versions, which repository generation would reject as one marker gating
+    two packages.
 
     The candidates only cover the group's own locked entries for the package.
     When the dependency's version is not among them (a transitive lockfile
@@ -207,13 +212,20 @@ def _fan_out_candidates(dep, conditions, candidates):
     Returns:
         A list of `(dep, conditions)` pairs.
     """
-    targets = [
-        (
-            (dep[0], dep[1], candidate[2], dep[3]),
-            _conjoin_conditions(conditions, _atom_sets({candidate_marker: 1})),
-        )
-        for candidate, candidate_marker in candidates
-    ]
+    candidate_markers = {marker: 1 for _, marker in candidates if marker}
+
+    targets = []
+    for candidate, candidate_marker in candidates:
+        sibling_markers = {m: 1 for m in candidate_markers.keys() if m != candidate_marker}
+        conjoined = _conjoin_conditions(conditions, _atom_sets({candidate_marker: 1}))
+        live = {
+            atoms: 1
+            for atoms in conjoined.keys()
+            if not [atom for atom in atoms if atom in sibling_markers]
+        }
+        if live:
+            targets.append(((dep[0], dep[1], candidate[2], dep[3]), live))
+
     if dep[2] not in [candidate[2] for candidate, _ in candidates]:
         targets.append((dep, conditions))
     return targets

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -360,6 +360,81 @@ collect_activated_extras_group_marker_fallback_test = unittest.make(
     _collect_activated_extras_group_marker_fallback_test_impl,
 )
 
+def _collect_activated_extras_transitive_condition_propagation_test_impl(ctx):
+    env = unittest.begin(ctx)
+    project_data = {
+        "project": {"name": "test_project"},
+        "dependency-groups": {
+            "group_p": ["foo"],
+        },
+    }
+    lock_data = {
+        "manifest": {"members": ["test_project"]},
+        "package": [
+            {
+                "name": "test_project",
+                "version": "0.0.0",
+                "source": {"virtual": "."},
+                "dev-dependencies": {
+                    "group_p": [
+                        {"name": "foo", "version": "1.0", "marker": "sys_platform == 'linux'"},
+                        {"name": "foo", "version": "2.0", "marker": "sys_platform != 'linux'"},
+                    ],
+                },
+            },
+        ],
+    }
+    foo_1 = ("lock", "foo", "1.0", "__base__")
+    foo_2 = ("lock", "foo", "2.0", "__base__")
+    bar_1 = ("lock", "bar", "1.0", "__base__")
+    bar_2 = ("lock", "bar", "2.0", "__base__")
+
+    # Each foo version depends *unconditionally* on a different bar version;
+    # bar is transitive-only, so the group has no candidates for it.
+    graph = {
+        foo_1: {bar_1: {"": 1}},
+        foo_2: {bar_2: {"": 1}},
+        bar_1: {},
+        bar_2: {},
+    }
+    default_versions = {}
+    package_versions = {
+        "bar": {"1.0": 1, "2.0": 1},
+        "foo": {"1.0": 1, "2.0": 1},
+    }
+
+    _cfg_names, activated_extras = collect_activated_extras(
+        "//:pyproject.toml",
+        "lock",
+        project_data,
+        lock_data,
+        default_versions,
+        graph,
+        package_versions,
+    )
+
+    # Each bar version must inherit the platform gate of the foo candidate
+    # that pulls it in. If the walk drops path conditions, both bar versions
+    # become unconditional and repository generation reports two default
+    # package states for the same group.
+    markers_bar_1 = activated_extras[bar_1]["group_p"][bar_1]
+    markers_bar_2 = activated_extras[bar_2]["group_p"][bar_2]
+
+    asserts.false(env, "" in markers_bar_1)
+    asserts.false(env, "" in markers_bar_2)
+
+    asserts.true(env, "sys_platform == 'linux'" in markers_bar_1)
+    asserts.true(env, "sys_platform != 'linux'" in markers_bar_2)
+
+    asserts.false(env, "sys_platform != 'linux'" in markers_bar_1)
+    asserts.false(env, "sys_platform == 'linux'" in markers_bar_2)
+
+    return unittest.end(env)
+
+collect_activated_extras_transitive_condition_propagation_test = unittest.make(
+    _collect_activated_extras_transitive_condition_propagation_test_impl,
+)
+
 def projectfile_test_suite():
     unittest.suite(
         "extract_requirement_marker_pairs_tests",
@@ -372,4 +447,5 @@ def projectfile_test_suite():
         collect_activated_extras_transitive_remap_test,
         collect_activated_extras_group_multi_version_test,
         collect_activated_extras_group_marker_fallback_test,
+        collect_activated_extras_transitive_condition_propagation_test,
     )

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -200,6 +200,166 @@ collect_activated_extras_transitive_remap_test = unittest.make(
     _collect_activated_extras_transitive_remap_test_impl,
 )
 
+def _collect_activated_extras_group_multi_version_test_impl(ctx):
+    env = unittest.begin(ctx)
+    project_data = {
+        "project": {"name": "test_project"},
+        "dependency-groups": {
+            "group_m": [
+                "retrying==1.3.4",
+                "six==1.16.0; sys_platform == 'linux'",
+                "six==1.17.0; sys_platform != 'linux'",
+            ],
+        },
+    }
+    lock_data = {
+        "manifest": {"members": ["test_project"]},
+        "package": [
+            {
+                "name": "test_project",
+                "version": "0.0.0",
+                "source": {"virtual": "."},
+                "dev-dependencies": {
+                    "group_m": [
+                        {"name": "retrying"},
+                        {"name": "six", "version": "1.16.0", "marker": "sys_platform == 'linux'"},
+                        {"name": "six", "version": "1.17.0", "marker": "sys_platform != 'linux'"},
+                    ],
+                },
+            },
+        ],
+    }
+    six_116 = ("lock", "six", "1.16.0", "__base__")
+    six_117 = ("lock", "six", "1.17.0", "__base__")
+    retrying = ("lock", "retrying", "1.3.4", "__base__")
+    graph = {
+        retrying: {
+            six_116: {"sys_platform == 'linux'": 1},
+            six_117: {"sys_platform != 'linux'": 1},
+        },
+        six_116: {},
+        six_117: {},
+    }
+    default_versions = {"retrying": retrying}
+    package_versions = {
+        "retrying": {"1.3.4": 1},
+        "six": {"1.16.0": 1, "1.17.0": 1},
+    }
+
+    _cfg_names, activated_extras = collect_activated_extras(
+        "//:pyproject.toml",
+        "lock",
+        project_data,
+        lock_data,
+        default_versions,
+        graph,
+        package_versions,
+    )
+
+    asserts.true(env, retrying in activated_extras)
+    asserts.true(env, "group_m" in activated_extras[retrying])
+
+    # Both locked versions must be activated for the group, each gated by
+    # the conjunction of the requirement/edge marker and its lockfile marker.
+    asserts.true(env, six_116 in activated_extras)
+    asserts.true(env, "group_m" in activated_extras[six_116])
+    asserts.true(env, six_117 in activated_extras)
+    asserts.true(env, "group_m" in activated_extras[six_117])
+
+    markers_116 = activated_extras[six_116]["group_m"][six_116]
+    markers_117 = activated_extras[six_117]["group_m"][six_117]
+
+    # Neither version may be activated unconditionally.
+    asserts.false(env, "" in markers_116)
+    asserts.false(env, "" in markers_117)
+
+    asserts.true(env, "sys_platform == 'linux'" in markers_116)
+    asserts.true(env, "sys_platform != 'linux'" in markers_117)
+
+    # The satisfiable marker for one version must not gate the other.
+    asserts.false(env, "sys_platform == 'linux'" in markers_117)
+    asserts.false(env, "sys_platform != 'linux'" in markers_116)
+
+    return unittest.end(env)
+
+collect_activated_extras_group_multi_version_test = unittest.make(
+    _collect_activated_extras_group_multi_version_test_impl,
+)
+
+def _collect_activated_extras_group_marker_fallback_test_impl(ctx):
+    env = unittest.begin(ctx)
+    project_data = {
+        "project": {"name": "test_project"},
+        "dependency-groups": {
+            "group_f": [
+                "retrying==1.3.4",
+                "six==1.16.0; sys_platform == 'linux'",
+            ],
+        },
+    }
+    lock_data = {
+        "manifest": {"members": ["test_project"]},
+        "package": [
+            {
+                "name": "test_project",
+                "version": "0.0.0",
+                "source": {"virtual": "."},
+                "dev-dependencies": {
+                    "group_f": [
+                        {"name": "retrying"},
+                        {"name": "six", "version": "1.16.0", "marker": "sys_platform == 'linux'"},
+                    ],
+                },
+            },
+        ],
+    }
+    six_116 = ("lock", "six", "1.16.0", "__base__")
+    six_117 = ("lock", "six", "1.17.0", "__base__")
+    retrying = ("lock", "retrying", "1.3.4", "__base__")
+    graph = {
+        retrying: {
+            six_117: {"sys_platform != 'linux'": 1},
+        },
+        six_116: {},
+        six_117: {},
+    }
+    default_versions = {"retrying": retrying}
+    package_versions = {
+        "retrying": {"1.3.4": 1},
+        "six": {"1.16.0": 1, "1.17.0": 1},
+    }
+
+    _cfg_names, activated_extras = collect_activated_extras(
+        "//:pyproject.toml",
+        "lock",
+        project_data,
+        lock_data,
+        default_versions,
+        graph,
+        package_versions,
+    )
+
+    # The single lockfile candidate's marker must be preserved, not promoted
+    # to an unconditional preference.
+    markers_116 = activated_extras[six_116]["group_f"][six_116]
+    asserts.false(env, "" in markers_116)
+    asserts.true(env, "sys_platform == 'linux'" in markers_116)
+
+    # The transitive edge resolves a version outside the group's candidate
+    # set; it must survive the fan-out so non-linux environments still wire
+    # a version instead of remapping to the linux-only candidate.
+    asserts.true(env, six_117 in activated_extras)
+    asserts.true(env, "group_f" in activated_extras[six_117])
+    markers_117 = activated_extras[six_117]["group_f"][six_117]
+    asserts.true(env, "sys_platform != 'linux'" in markers_117)
+    asserts.false(env, "" in markers_117)
+
+    return unittest.end(env)
+
+collect_activated_extras_group_marker_fallback_test = unittest.make(
+    _collect_activated_extras_group_marker_fallback_test_impl,
+)
+
 def projectfile_test_suite():
     unittest.suite(
         "extract_requirement_marker_pairs_tests",
@@ -210,4 +370,6 @@ def projectfile_test_suite():
         extract_requirement_marker_pairs_preferred_overrides_version_map_test,
         extract_requirement_marker_pairs_preferred_overrides_multi_version_test,
         collect_activated_extras_transitive_remap_test,
+        collect_activated_extras_group_multi_version_test,
+        collect_activated_extras_group_marker_fallback_test,
     )

--- a/uv/private/extension/test_projectfile.bzl
+++ b/uv/private/extension/test_projectfile.bzl
@@ -269,16 +269,13 @@ def _collect_activated_extras_group_multi_version_test_impl(ctx):
     markers_116 = activated_extras[six_116]["group_m"][six_116]
     markers_117 = activated_extras[six_117]["group_m"][six_117]
 
-    # Neither version may be activated unconditionally.
-    asserts.false(env, "" in markers_116)
-    asserts.false(env, "" in markers_117)
-
-    asserts.true(env, "sys_platform == 'linux'" in markers_116)
-    asserts.true(env, "sys_platform != 'linux'" in markers_117)
-
-    # The satisfiable marker for one version must not gate the other.
-    asserts.false(env, "sys_platform == 'linux'" in markers_117)
-    asserts.false(env, "sys_platform != 'linux'" in markers_116)
+    # Each version is gated by exactly its satisfiable lockfile marker.
+    # Unconditional activation, the sibling's marker, and cross-candidate
+    # contradictions must all be absent: a contradictory conjunction has the
+    # same canonical form for both versions, which repository generation
+    # rejects as one marker gating two packages.
+    asserts.equals(env, {"sys_platform == 'linux'": 1}, markers_116)
+    asserts.equals(env, {"sys_platform != 'linux'": 1}, markers_117)
 
     return unittest.end(env)
 

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -149,35 +149,37 @@ load("@aspect_rules_py//py:defs.bzl", "py_library")
             # to true. It's a configuration and locking failure for there to be
             # more than one package which resolves at this point. So we just jam all the configurations into a single select.
             for scc, markers in scc_cfgs.items():
+                scc_target = "//private/sccs:" + scc
+
                 if "" in markers:
                     if "//conditions:default" in cfg_arms:
                         fail("Configuration conflict! Package {} specifies two or more default package states!\n{}".format(package, pprint(cfgs)))
 
-                    cfg_arms["//conditions:default"] = "//private/sccs:" + scc
+                    cfg_arms["//conditions:default"] = scc_target
 
                 elif all([is_extra_only_marker(m) for m in markers.keys()]):
                     # Extra-only markers cannot be evaluated at build time; they
                     # are already resolved by the active venv. Treat the SCC as
                     # the default for this configuration.
-                    if cfg_arms.get("//conditions:default", "//private/sccs:" + scc) != "//private/sccs:" + scc:
+                    if cfg_arms.get("//conditions:default", scc_target) != scc_target:
                         fail("Configuration conflict! Package {} resolves two or more packages via extra-only markers in the same configuration; the venv cannot disambiguate them at build time.\n{}".format(package, pprint(cfgs)))
 
-                    cfg_arms["//conditions:default"] = "//private/sccs:" + scc
+                    cfg_arms["//conditions:default"] = scc_target
 
                 else:
                     for marker in markers.keys():
                         if is_extra_only_marker(marker):
                             # Already resolved by the active venv.
-                            if cfg_arms.get("//conditions:default", "//private/sccs:" + scc) != "//private/sccs:" + scc:
+                            if cfg_arms.get("//conditions:default", scc_target) != scc_target:
                                 fail("Configuration conflict! Package {} resolves two or more packages via extra-only markers in the same configuration; the venv cannot disambiguate them at build time.\n{}".format(package, pprint(cfgs)))
 
-                            cfg_arms["//conditions:default"] = "//private/sccs:" + scc
+                            cfg_arms["//conditions:default"] = scc_target
                         else:
                             marker = _marker(marker)
                             if marker in cfg_arms:
                                 fail("Configuration conflict! Package {} specifies two or more configurations for the same marker!\n{}".format(package, pprint(cfgs)))
 
-                            cfg_arms[marker] = "//private/sccs:" + scc
+                            cfg_arms[marker] = scc_target
 
             # Ensure the alias resolves in exec configurations where the venv
             # flag is not set. Pick any available arm as the default.

--- a/uv/private/uv_project/repository.bzl
+++ b/uv/private/uv_project/repository.bzl
@@ -159,15 +159,19 @@ load("@aspect_rules_py//py:defs.bzl", "py_library")
                     # Extra-only markers cannot be evaluated at build time; they
                     # are already resolved by the active venv. Treat the SCC as
                     # the default for this configuration.
-                    if "//conditions:default" not in cfg_arms:
-                        cfg_arms["//conditions:default"] = "//private/sccs:" + scc
+                    if cfg_arms.get("//conditions:default", "//private/sccs:" + scc) != "//private/sccs:" + scc:
+                        fail("Configuration conflict! Package {} resolves two or more packages via extra-only markers in the same configuration; the venv cannot disambiguate them at build time.\n{}".format(package, pprint(cfgs)))
+
+                    cfg_arms["//conditions:default"] = "//private/sccs:" + scc
 
                 else:
                     for marker in markers.keys():
                         if is_extra_only_marker(marker):
                             # Already resolved by the active venv.
-                            if "//conditions:default" not in cfg_arms:
-                                cfg_arms["//conditions:default"] = "//private/sccs:" + scc
+                            if cfg_arms.get("//conditions:default", "//private/sccs:" + scc) != "//private/sccs:" + scc:
+                                fail("Configuration conflict! Package {} resolves two or more packages via extra-only markers in the same configuration; the venv cannot disambiguate them at build time.\n{}".format(package, pprint(cfgs)))
+
+                            cfg_arms["//conditions:default"] = "//private/sccs:" + scc
                         else:
                             marker = _marker(marker)
                             if marker in cfg_arms:


### PR DESCRIPTION
## Problem

A dependency group may lock the same package at several versions gated by disjoint PEP 508 markers (platform/python forks, uv conflict routing). `_extract_lockfile_group_versions` collapsed the group's `dev-dependencies` entries into a single-preference map last-write-wins, so the walk wired one arbitrary version of the package for every platform.

## Changes

- Keep every `dev-dependencies` entry as a `(dep, marker)` candidate. Marker-gated candidates fan out over every locked version — in the seeds and in the reach-set walk — conjoining the requirement/edge markers with each candidate's lockfile marker. uv guarantees candidates within a group carry disjoint markers, so the `decide_marker` select() layer resolves exactly one per environment.
- Preserve the marker of single marker-gated candidates instead of promoting them to unconditional preferences.
- Keep transitive edge versions outside the candidate set as a fallback, so environments where no candidate marker holds still wire a version instead of silently dropping the package.
- Resolve requirement specs for fanned-out packages through a placeholder version map so legal spec forms (direct references, `!=` against post-releases) do not fall through to the specifier matcher and `fail()`.
- Expand each reach-set walk node exactly once instead of re-expanding duplicated seeds.
- Make `combine_markers` idempotent (`(m) and (m)` → `m`); uv mirrors the requirement marker into the lockfile entry, so this was inflating select arms in the common case.
- `fail()` loudly when two packages claim the same configuration via extra-only markers instead of silently taking the first writer — build-time selection cannot disambiguate uv conflict extras, and a hard error beats a wrong wheel.

## Testing

- New unit tests: `collect_activated_extras_group_multi_version_test` (direct multi-version fan-out) and `collect_activated_extras_group_marker_fallback_test` (single marker-gated candidate + transitive version outside the candidate set).
- New e2e case `uv-group-multi-version`: `six` locked at 1.16.0 (`sys_platform == 'linux'`) and 1.17.0 (`sys_platform != 'linux'`) in one group, asserted at runtime.
- `bazel test //uv/...` (86/86) and full e2e suite green locally (the only failure is the docker-daemon-dependent `interpreter-features-836`, unrelated).