### PR TITLE
test: add llvm registration to e2e MODULE

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -18,6 +18,12 @@ local_path_override(
     path = "..",
 )
 
+# Register the llvm cc toolchains directly. aspect_rules_py only registers them
+# when built from source (IS_RELEASE = False); in BCR presubmit the release
+# archive flips IS_RELEASE to True, so without this the native sdist builds
+# (e.g. cases/uv-sdist-native-inputs) find no cc toolchain.
+register_toolchains("@llvm//toolchain:all")
+
 # Ensure any transitive "aspect_bazel_lib" is latest to be forward compatible with bazel_lib 3+
 single_version_override(
     module_name = "aspect_bazel_lib",

--- a/e2e/cases/uv-sdist-native-inputs/BUILD.bazel
+++ b/e2e/cases/uv-sdist-native-inputs/BUILD.bazel
@@ -16,6 +16,9 @@ cc_library(
     srcs = ["native_check.c"],
     hdrs = ["include/rulespy_native_check.h"],
     includes = ["include"],
+    # Keep macOS BCR presubmit from resolving a cc toolchain, which would
+    # fetch the macOS SDK (Apple's swcdn 403s CI IPs).
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This is required when the `IS_RELEASE` flag is flipped and we no longer inherit the llvm dep from the root MODULE

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
