### PR TITLE
test(uv): frontend exec configuration must not inherit the target's platform flags

### DIFF
--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -12,6 +12,13 @@ load(
     "exec_platform_steering_test",
 )
 load(
+    ":frontend_config_test.bzl",
+    "flag_probe",
+    "frontend_exec_config_test",
+    "frontend_libc_leak_test",
+    "frontend_probe_plumbing_test",
+)
+load(
     ":pep517_whl_test.bzl",
     "cross_decision_test",
     "execroot_collision_toolchain",
@@ -252,4 +259,34 @@ platform(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
+)
+
+# --- Frontend configuration characterization ------------------------------
+
+flag_probe(
+    name = "__frontend_probe",
+    tags = ["manual"],
+)
+
+pep517_whl(
+    name = "__frontend_config_fixture",
+    src = ":__stub_sdist",
+    tags = ["manual"],
+    tool = ":__frontend_probe",
+    version = "0.0.1",
+)
+
+frontend_exec_config_test(
+    name = "frontend_exec_config_test",
+    target_under_test = ":__frontend_config_fixture",
+)
+
+frontend_probe_plumbing_test(
+    name = "frontend_probe_plumbing_test",
+    target_under_test = ":__frontend_config_fixture",
+)
+
+frontend_libc_leak_test(
+    name = "frontend_libc_leak_test",
+    target_under_test = ":__frontend_config_fixture",
 )

--- a/uv/private/pep517_whl/tests/frontend_config_test.bzl
+++ b/uv/private/pep517_whl/tests/frontend_config_test.bzl
@@ -1,0 +1,106 @@
+"""Characterization tests for the PEP 517 frontend's configuration.
+
+The `tool` attribute uses `cfg = config.exec(TARGET_EXEC_GROUP)`: the
+frontend must build for the execution platform the wheel action runs on.
+These tests pin what that means today, through a probe rule that encodes
+its observed configuration into its executable's *file name* — the only
+channel an analysis test can read, since file contents don't exist at
+analysis time and tool runfiles arrive as an opaque middleman.
+
+Two properties are pinned:
+
+- exec configuration: the frontend's executable lives in an `-exec` output
+  directory, proving the exec transition applied (a target-configuration
+  frontend would break remote execution — the binary must match the worker,
+  not the target).
+- Starlark flag leak: `--//uv/private/constraints/platform:platform_libc`
+  set in the target configuration SURVIVES the exec transition and reaches
+  the frontend (Bazel does not reset Starlark flags on exec edges). This is
+  a defect — the frontend's own Python build deps get selected with the
+  *target's* libc — pinned here as current behavior so the fix has to flip
+  this assertion explicitly.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+_PLATFORM_LIBC_FLAG = "//uv/private/constraints/platform:platform_libc"
+
+def _flag_probe_impl(ctx):
+    # Tool runfiles reach the action as an opaque middleman, so the only
+    # analysis-visible channel is the executable's own file name.
+    libc = ctx.attr._platform_libc[BuildSettingInfo].value or "unset"
+    exe = ctx.actions.declare_file("{}_saw_libc_{}.sh".format(ctx.label.name, libc))
+    ctx.actions.write(exe, "#!/bin/sh\nexit 0\n", is_executable = True)
+    return [DefaultInfo(executable = exe, files = depset([exe]))]
+
+flag_probe = rule(
+    implementation = _flag_probe_impl,
+    doc = "Executable named after the platform_libc value it was configured with.",
+    executable = True,
+    attrs = {
+        "_platform_libc": attr.label(default = Label(_PLATFORM_LIBC_FLAG)),
+    },
+)
+
+def _build_action(env):
+    target = analysistest.target_under_test(env)
+    actions = [a for a in target.actions if a.mnemonic == "PySdistBuild"]
+    asserts.equals(env, 1, len(actions), "expected exactly one PySdistBuild action")
+    return actions[0] if actions else None
+
+def _probe_libc_value(action):
+    basename = action.argv[0].split("/")[-1]
+    _, sep, value = basename.partition("_saw_libc_")
+    return value.removesuffix(".sh") if sep else None
+
+def _frontend_exec_config_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    action = _build_action(env)
+    if action:
+        tool_path = action.argv[0]
+        asserts.true(
+            env,
+            "-exec" in tool_path,
+            "the frontend must be built in an exec configuration " +
+            "(its binary runs on the execution platform); got: " + tool_path,
+        )
+    return analysistest.end(env)
+
+frontend_exec_config_test = analysistest.make(_frontend_exec_config_test_impl)
+
+def _frontend_libc_leak_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    action = _build_action(env)
+    if action:
+        asserts.equals(
+            env,
+            "musl",
+            _probe_libc_value(action),
+            "CURRENT BEHAVIOR (defect): the target configuration's " +
+            "platform_libc leaks through the exec transition into the " +
+            "frontend. The frontend-configuration fix must flip this " +
+            "assertion to the execution platform's libc.",
+        )
+    return analysistest.end(env)
+
+frontend_libc_leak_test = analysistest.make(
+    _frontend_libc_leak_test_impl,
+    config_settings = {
+        "@@//uv/private/constraints/platform:platform_libc": "musl",
+    },
+)
+
+def _frontend_probe_plumbing_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    action = _build_action(env)
+    if action:
+        asserts.true(
+            env,
+            _probe_libc_value(action) != None,
+            "the probe's flag value must be readable from the frontend's " +
+            "executable path; without it the leak test can pass vacuously",
+        )
+    return analysistest.end(env)
+
+frontend_probe_plumbing_test = analysistest.make(_frontend_probe_plumbing_test_impl)


### PR DESCRIPTION
Characterization first: three analysis tests pin what `cfg = config.exec(TARGET_EXEC_GROUP)` gives the PEP 517 frontend, via a probe rule that encodes the `platform_libc` value it was configured with into its executable's file name — the only channel visible at analysis time (tool runfiles arrive as an opaque middleman).

- **`frontend_exec_config_test`** — the frontend builds in an `-exec` output directory: the property remote execution depends on (the binary must match the worker, not the target).
- **`frontend_libc_leak_test`** — `--//uv/private/constraints/platform:platform_libc` set in the **target** configuration survives the exec transition and reaches the frontend, so the frontend's own Python build dependencies get selected with the *target's* libc. Pinned as **CURRENT BEHAVIOR (defect)**: the fix in this PR must flip this assertion explicitly.
- **`frontend_probe_plumbing_test`** — guards the probe channel itself so the leak test cannot pass vacuously (it already caught one dead channel: runfile-name markers never reach analysis-visible inputs).

The fix itself lands on top of these tests in this same PR; any approach that breaks the `-exec` assertion or leaves the leak assertion un-flipped is rejected by construction.

### Changes are visible to end-users: no (yet — tests only)

### Test plan

- The three new analysis tests above
- `bazel test //uv/private/pep517_whl/...`: 18 passed, 2 skipped (platform-incompatible locally)