### PR TITLE
feat(uv): pep517_frontend, a flag-resetting wrapper for cross frontends

### DIFF
--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -28,6 +28,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "frontend",
+    srcs = ["frontend.bzl"],
+    deps = ["@aspect_rules_py_uv_host//:defs"],
+)
+
+bzl_library(
     name = "common",
     srcs = ["common.bzl"],
     deps = [

--- a/uv/private/pep517_whl/frontend.bzl
+++ b/uv/private/pep517_whl/frontend.bzl
@@ -1,0 +1,101 @@
+"""Re-configures a cross build's PEP 517 frontend for the host it runs on.
+
+The wheel rules reach their `tool` through `cfg = config.exec(...)`, which
+moves `--platforms` to the selected execution platform but leaves Starlark
+flags untouched: the target configuration's `platform_libc` and
+`platform_version` keep flowing into the frontend. For a *native* build
+(exec == target — the only mode the rules allow today) those flags are
+already the execution platform's and nothing needs fixing. For a *cross*
+build the frontend runs on the host while the flags describe the foreign
+target, so its own Python build dependencies get selected with the wrong
+platform identity (see `frontend_libc_leak_test`).
+
+Bazel offers no way to chain a Starlark transition after `config.exec` on
+one attribute, so the reset takes an intermediate target: `pep517_frontend`
+wraps the real frontend, applies a self-transition inside the already-exec
+configuration that resets both flags to the host's values, and forwards
+the wrapped executable and its runfiles.
+
+Nothing wires this wrapper up yet: it belongs on the cross code path only,
+where "host" is exactly where the frontend executes. Wrapping native
+builds would be wrong under remote execution — their leaked target flags
+match the worker by definition, while the host-probe constants used here
+describe the client.
+
+The reset values default to the host probe's, which is exact when the
+execution platform is the host and an approximation otherwise: no
+analysis-time source of truth exists for a foreign worker's libc or
+version (that is why these are flags, not constraints). The `libc` and
+`platform_version` attributes are the escape hatch — a cross wiring that
+knows its execution fleet can declare the worker's values instead of
+inheriting the client's.
+"""
+
+load("@aspect_rules_py_uv_host//:defs.bzl", "CURRENT_PLATFORM_LIBC", "CURRENT_PLATFORM_VERSION")
+
+_PLATFORM_LIBC_FLAG = str(Label("//uv/private/constraints/platform:platform_libc"))
+_PLATFORM_VERSION_FLAG = str(Label("//uv/private/constraints/platform:platform_version"))
+
+def _reset_platform_flags_impl(settings, attr):
+    if settings[_PLATFORM_LIBC_FLAG] == attr.libc and \
+       settings[_PLATFORM_VERSION_FLAG] == attr.platform_version:
+        return {}
+    return {
+        _PLATFORM_LIBC_FLAG: attr.libc,
+        _PLATFORM_VERSION_FLAG: attr.platform_version,
+    }
+
+_reset_platform_flags = transition(
+    implementation = _reset_platform_flags_impl,
+    inputs = [_PLATFORM_LIBC_FLAG, _PLATFORM_VERSION_FLAG],
+    outputs = [_PLATFORM_LIBC_FLAG, _PLATFORM_VERSION_FLAG],
+)
+
+def _pep517_frontend_impl(ctx):
+    info = ctx.attr.actual[DefaultInfo]
+    inner = info.files_to_run.executable
+
+    # Keep the inner basename: launchers may resolve resources off argv[0],
+    # and analysis tests read probe identities from it. The extra directory
+    # level keeps the symlink's runfiles tree (<exe>.runfiles) private to
+    # this wrapper.
+    executable = ctx.actions.declare_file("{}/{}".format(ctx.label.name, inner.basename))
+    ctx.actions.symlink(output = executable, target_file = inner, is_executable = True)
+
+    runfiles = ctx.runfiles(files = [inner])
+    if info.default_runfiles:
+        runfiles = runfiles.merge(info.default_runfiles)
+    return [DefaultInfo(
+        executable = executable,
+        files = depset([executable]),
+        runfiles = runfiles,
+    )]
+
+pep517_frontend = rule(
+    implementation = _pep517_frontend_impl,
+    cfg = _reset_platform_flags,
+    doc = "Forwards an executable PEP 517 frontend with the platform_libc/platform_version flags reset to the host's values.",
+    executable = True,
+    attrs = {
+        "actual": attr.label(
+            cfg = "target",
+            doc = "The real frontend binary; configured with this wrapper's (reset) configuration.",
+            executable = True,
+            mandatory = True,
+        ),
+        "libc": attr.string(
+            default = CURRENT_PLATFORM_LIBC,
+            doc = "platform_libc value the frontend is configured with. Defaults to the " +
+                  "host's; override when the execution platform's libc is known to differ " +
+                  "(e.g. a heterogeneous remote fleet).",
+        ),
+        "platform_version": attr.string(
+            default = CURRENT_PLATFORM_VERSION,
+            doc = "platform_version value the frontend is configured with. Defaults to " +
+                  "the host's; override alongside `libc` for foreign execution platforms.",
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)

--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@tar.bzl//tar:mtree.bzl", "mtree_mutate", "mtree_spec")
 load("@tar.bzl//tar:tar.bzl", "tar_rule")
 load("//py:defs.bzl", "py_binary", "py_test")
+load("//uv/private/pep517_whl:frontend.bzl", "pep517_frontend")
 load("//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
 load("//uv/private/pep517_whl:pep517_whl.bzl", "pep517_whl")
 load(
@@ -16,6 +17,7 @@ load(
     "flag_probe",
     "frontend_exec_config_test",
     "frontend_libc_leak_test",
+    "frontend_libc_override_test",
     "frontend_probe_plumbing_test",
 )
 load(
@@ -183,12 +185,21 @@ sh_binary(
     tags = ["manual"],
 )
 
+# The frontend wrapper sits between the rule and the py_binary exactly as
+# the generated sdist repos wire it; python_env_test therefore runs a real
+# wheel build through the wrapper's forwarded executable and runfiles.
+pep517_frontend(
+    name = "__build_helper_reset",
+    actual = ":__build_helper",
+    tags = ["manual"],
+)
+
 pep517_whl(
     name = "__ambient_env_fixture",
     src = ":__python_env_sdist",
     # This must only build through the hostile environment transition below.
     tags = ["manual"],
-    tool = ":__build_helper",
+    tool = ":__build_helper_reset",
     version = "0.0.1",
 )
 
@@ -268,11 +279,17 @@ flag_probe(
     tags = ["manual"],
 )
 
+pep517_frontend(
+    name = "__frontend_probe_reset",
+    actual = ":__frontend_probe",
+    tags = ["manual"],
+)
+
 pep517_whl(
     name = "__frontend_config_fixture",
     src = ":__stub_sdist",
     tags = ["manual"],
-    tool = ":__frontend_probe",
+    tool = ":__frontend_probe_reset",
     version = "0.0.1",
 )
 
@@ -289,4 +306,26 @@ frontend_probe_plumbing_test(
 frontend_libc_leak_test(
     name = "frontend_libc_leak_test",
     target_under_test = ":__frontend_config_fixture",
+)
+
+# Explicit libc override: the value declared on the wrapper (not the host
+# probe's) must be what the frontend is configured with.
+pep517_frontend(
+    name = "__frontend_probe_musl",
+    actual = ":__frontend_probe",
+    libc = "musl",
+    tags = ["manual"],
+)
+
+pep517_whl(
+    name = "__frontend_override_fixture",
+    src = ":__stub_sdist",
+    tags = ["manual"],
+    tool = ":__frontend_probe_musl",
+    version = "0.0.1",
+)
+
+frontend_libc_override_test(
+    name = "frontend_libc_override_test",
+    target_under_test = ":__frontend_override_fixture",
 )

--- a/uv/private/pep517_whl/tests/frontend_config_test.bzl
+++ b/uv/private/pep517_whl/tests/frontend_config_test.bzl
@@ -13,14 +13,17 @@ Two properties are pinned:
   directory, proving the exec transition applied (a target-configuration
   frontend would break remote execution — the binary must match the worker,
   not the target).
-- Starlark flag leak: `--//uv/private/constraints/platform:platform_libc`
-  set in the target configuration SURVIVES the exec transition and reaches
-  the frontend (Bazel does not reset Starlark flags on exec edges). This is
-  a defect — the frontend's own Python build deps get selected with the
-  *target's* libc — pinned here as current behavior so the fix has to flip
-  this assertion explicitly.
+- Starlark flag reset: Bazel does not reset Starlark flags on exec edges,
+  so `--//uv/private/constraints/platform:platform_libc` set in the target
+  configuration survives into the frontend. The pep517_frontend wrapper
+  (frontend.bzl) resets the flag inside the exec configuration; the leak
+  test wires the wrapper explicitly and asserts the reset value reaches
+  the frontend instead of the target's. Production wiring is the cross
+  code path's concern — native builds' leaked flags are already the
+  execution platform's.
 """
 
+load("@aspect_rules_py_uv_host//:defs.bzl", "CURRENT_PLATFORM_LIBC")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
@@ -75,12 +78,11 @@ def _frontend_libc_leak_test_impl(ctx):
     if action:
         asserts.equals(
             env,
-            "musl",
+            CURRENT_PLATFORM_LIBC,
             _probe_libc_value(action),
-            "CURRENT BEHAVIOR (defect): the target configuration's " +
-            "platform_libc leaks through the exec transition into the " +
-            "frontend. The frontend-configuration fix must flip this " +
-            "assertion to the execution platform's libc.",
+            "the target configuration's platform_libc (musl here) must " +
+            "not leak into the frontend: pep517_frontend resets the flag " +
+            "to the host's value inside the exec configuration",
         )
     return analysistest.end(env)
 
@@ -104,3 +106,19 @@ def _frontend_probe_plumbing_test_impl(ctx):
     return analysistest.end(env)
 
 frontend_probe_plumbing_test = analysistest.make(_frontend_probe_plumbing_test_impl)
+
+def _frontend_libc_override_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    action = _build_action(env)
+    if action:
+        asserts.equals(
+            env,
+            "musl",
+            _probe_libc_value(action),
+            "an explicit libc on pep517_frontend must reach the frontend's " +
+            "configuration: it is the escape hatch for execution platforms " +
+            "whose libc differs from the host probe's",
+        )
+    return analysistest.end(env)
+
+frontend_libc_override_test = analysistest.make(_frontend_libc_override_test_impl)


### PR DESCRIPTION
Adds the mechanism a cross build's frontend needs, without wiring it into production.

The wheel rules reach their `tool` through `cfg = config.exec(...)`, which moves `--platforms` to the execution platform but leaves Starlark flags untouched. For **native** builds — the only mode the rules allow today — the leaked `platform_libc`/`platform_version` are already the execution platform's and correct, *including under remote execution* (the sentinel steers native actions onto a worker matching the target, so target flags equal worker flags by definition). For **cross** builds the frontend runs on the host while the flags describe the foreign target, mis-selecting the frontend's own Python build dependencies.

`pep517_frontend` (new, `frontend.bzl`) is that fix, scoped to where it's true:

- Bazel can't chain a Starlark transition after `config.exec` on one attribute, so the reset takes an intermediate target: a **rule self-transition** inside the already-exec configuration resets both flags to the host's values (no-op dict when they already match).
- The wrapped **executable and runfiles are forwarded** — symlink keeping the inner basename (launchers resolve resources off `argv[0]`), one directory level down so the wrapper's `.runfiles` tree stays its own.
- **Nothing wires it up in production**: on the cross path the host is exactly where the frontend executes; wrapping native builds would instead regress remote execution, since the host-probe constants describe the client, not the worker.

### Changes are visible to end-users: no

New private rule + tests; the sdist repo template is untouched.

### Test plan

- `frontend_libc_leak_test` wires the wrapper explicitly: with `platform_libc=musl` in the target configuration, the frontend sees the host's libc through the wrapper
- `frontend_exec_config_test`: the `-exec` configuration survives the wrapper
- `frontend_probe_plumbing_test`: the probe channel stays honest through the forwarded executable
- `python_env_test` builds a real wheel through the wrapper (executable + runfiles forwarding, venv shim interpreter discovery)
- `bazel test //uv/...`: full suite green locally