### PR TITLE
feat(uv): cross-compile setuptools sdists end to end

### DIFF
--- a/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_fallback.cowsay.BUILD.bazel
@@ -1,5 +1,6 @@
 
 load("@aspect_rules_py//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:frontend.bzl", "pep517_frontend")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(
@@ -9,10 +10,15 @@ py_binary(
     deps = ["@aspect_rules_py//uv/private/pep517_whl/tools:tools", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:packaging", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:build", "@@aspect_rules_py++uv+project__uv_sdist_fallback//:setuptools", "@whl_install__uv_sdist_fallback__setuptools__80_10_2//:install"],
 )
 
+pep517_frontend(
+    name = "frontend",
+    actual = ":build_tool",
+)
+
 pep517_native_whl(
     name = "whl",
     src = "@@aspect_rules_py++uv+sdist__cowsay__47445cb273684618//file:file",
-    tool = ":build_tool",
+    tool = ":frontend",
     version = "6.0",
     console_scripts = ["cowsay=cowsay.__main__:cli"],
     monitor_memory = True,

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
@@ -1,5 +1,6 @@
 
 load("@aspect_rules_py//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:frontend.bzl", "pep517_frontend")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(
@@ -9,10 +10,15 @@ py_binary(
     deps = ["@@aspect_rules_py++uv+project__uv_sdist_jdk_build//:scikit_build_core", "@@aspect_rules_py++uv+project__uv_sdist_jdk_build//:setuptools", "@@aspect_rules_py++uv+project__uv_sdist_jdk_build//:wheel", "@@aspect_rules_py++uv+project__uv_sdist_jdk_build//:build", "@whl_install__uv_sdist_jdk_build__scikit_build_core__0_12_2//:install"],
 )
 
+pep517_frontend(
+    name = "frontend",
+    actual = ":build_tool",
+)
+
 pep517_native_whl(
     name = "whl",
     src = "@@aspect_rules_py++uv+sdist__jpype1__3cd88838dc3d2d54//file:file",
-    tool = ":build_tool",
+    tool = ":frontend",
     version = "1.7.1",
     toolchains = [
         "@@bazel_tools//tools/jdk:current_java_runtime",

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_native_build.python_geohash.BUILD.bazel
@@ -1,5 +1,6 @@
 
 load("@aspect_rules_py//uv/private/pep517_whl:pep517_native_whl.bzl", "pep517_native_whl")
+load("@aspect_rules_py//uv/private/pep517_whl:frontend.bzl", "pep517_frontend")
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(
@@ -9,10 +10,15 @@ py_binary(
     deps = ["@@aspect_rules_py++uv+project__uv_sdist_native_build//:build", "@@aspect_rules_py++uv+project__uv_sdist_native_build//:setuptools", "@whl_install__uv_sdist_native_build__setuptools__75_8_2//:install"],
 )
 
+pep517_frontend(
+    name = "frontend",
+    actual = ":build_tool",
+)
+
 pep517_native_whl(
     name = "whl",
     src = "@@aspect_rules_py++uv+sdist__python_geohash__05a21fcf4eda1a5e//file:file",
-    tool = ":build_tool",
+    tool = ":frontend",
     version = "0.8.5",
     resource_set = "mem_4g",
     pre_build_patches = ["@@//uv-sdist-native-build:require_cxx_driver.patch"],

--- a/e2e/crossbuild/pycross-setuptools/BUILD.bazel
+++ b/e2e/crossbuild/pycross-setuptools/BUILD.bazel
@@ -4,6 +4,7 @@
 # imported at runtime for the host.
 
 load("@aspect_rules_py//py:defs.bzl", "py_test")
+load("//tools:collect_wheels.bzl", "collect_wheels")
 
 exports_files(["require_extension.patch"])
 
@@ -36,4 +37,55 @@ py_test(
     main = "test_pyyaml.py",
     python_version = _PY,
     deps = ["@pypi_pycross_setuptools//pyyaml"],
+)
+
+# The wheel targets under `collect_wheels` are reached through a platform
+# transition rather than a py_venv, so nothing sets the dep_group flag for
+# them — the platform carries it alongside the libc/version flags the wheel
+# resolver needs.
+_PLATFORM_FLAGS = [
+    "--@aspect_rules_py//uv/private/constraints/platform:platform_libc=glibc",
+    "--@aspect_rules_py//uv/private/constraints/platform:platform_version=2.39",
+    "--@aspect_rules_py//uv/private/constraints/dep_group:dep_group=" + _DEP_GROUP,
+    "--@aspect_rules_py//py/private/interpreter:python_version=" + _PY,
+]
+
+platform(
+    name = "amd64_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    flags = _PLATFORM_FLAGS,
+)
+
+platform(
+    name = "arm64_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+    flags = _PLATFORM_FLAGS,
+)
+
+# Native C-extension sdists cross-compiled for both linux CPUs: the CC layer
+# extracted from the llvm toolchain drives the backend's compiler, the target
+# interpreter's sysconfig fakes the platform identity, and the produced
+# wheels' Tag metadata must name the destination platform (build_helper's
+# --target-os/--target-cpu validation fails the action otherwise).
+collect_wheels(
+    name = "setuptools_wheels",
+    expected_tags = [
+        "linux_x86_64",
+        "linux_aarch64",
+    ],
+    platforms = [
+        ":amd64_linux",
+        ":arm64_linux",
+    ],
+    wheels = [
+        "@sdist_build__pycross_setuptools__pyyaml__6_0_1//:whl",
+        "@sdist_build__pycross_setuptools__setproctitle__1_3_2//:whl",
+        "@sdist_build__pycross_setuptools__zstandard__0_22_0//:whl",
+    ],
 )

--- a/e2e/crossbuild/pycross-setuptools/setup.MODULE.bazel
+++ b/e2e/crossbuild/pycross-setuptools/setup.MODULE.bazel
@@ -67,4 +67,10 @@ uv.override_package(
     lock = "//pycross-setuptools:uv.lock",
     resource_set = "mem_4g",
 )
-use_repo(uv, "pypi_pycross_setuptools")
+use_repo(
+    uv,
+    "pypi_pycross_setuptools",
+    "sdist_build__pycross_setuptools__pyyaml__6_0_1",
+    "sdist_build__pycross_setuptools__setproctitle__1_3_2",
+    "sdist_build__pycross_setuptools__zstandard__0_22_0",
+)

--- a/uv/private/pep517_whl/BUILD.bazel
+++ b/uv/private/pep517_whl/BUILD.bazel
@@ -18,10 +18,20 @@ bzl_library(
     name = "pep517_native_whl",
     srcs = ["pep517_native_whl.bzl"],
     deps = [
+        ":cc_layer",
         ":common",
         "//py/private/interpreter:versions",
         "//py/private/toolchain:types",
         "@bazel_lib//lib:resource_sets",
+        "@rules_cc//cc:action_names_bzl",
+        "@rules_cc//cc/common",
+    ],
+)
+
+bzl_library(
+    name = "cc_layer",
+    srcs = ["cc_layer.bzl"],
+    deps = [
         "@rules_cc//cc:action_names_bzl",
         "@rules_cc//cc/common",
     ],

--- a/uv/private/pep517_whl/cc_layer.bzl
+++ b/uv/private/pep517_whl/cc_layer.bzl
@@ -1,0 +1,197 @@
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+
+_EXECROOT_MARKER = "__ASPECT_RULES_PY_EXECROOT__"
+
+_CC_DISABLED_FEATURES = [
+    "thin_lto",
+    "module_maps",
+    "fdo_instrument",
+    "fdo_optimize",
+    "layering_check",
+]
+
+_PATH_FLAG_PREFIXES = ("-I", "-L", "-isysroot", "-iwithsysroot", "-isystem", "-B")
+
+CC_LAYER_ATTRS = {
+    "_os_linux": attr.label(default = "@platforms//os:linux"),
+    "_os_macos": attr.label(default = "@platforms//os:macos"),
+    "_os_windows": attr.label(default = "@platforms//os:windows"),
+    "_cpu_x86_64": attr.label(default = "@platforms//cpu:x86_64"),
+    "_cpu_aarch64": attr.label(default = "@platforms//cpu:aarch64"),
+    "_cpu_arm": attr.label(default = "@platforms//cpu:arm"),
+    "_cpu_x86_32": attr.label(default = "@platforms//cpu:x86_32"),
+}
+
+def _absolutize_flag(flag):
+    """Prefix execroot-relative paths with the EXECROOT marker.
+
+    The marker is replaced with os.getcwd() at execution time by
+    build_helper.py's _compiler_env, so paths survive the backend's
+    chdir into the unpacked sdist worktree.
+    """
+    if not flag:
+        return flag
+    if not flag.startswith("-"):
+        if "/" in flag:
+            return _EXECROOT_MARKER + "/" + flag
+        return flag
+    for pfx in _PATH_FLAG_PREFIXES:
+        if flag.startswith(pfx) and len(flag) > len(pfx):
+            rest = flag[len(pfx):]
+            if rest and not rest.startswith("/") and "/" in rest:
+                return pfx + _EXECROOT_MARKER + "/" + rest
+    return flag
+
+def get_target_platform(ctx):
+    """Determine target OS and CPU from platform constraints.
+
+    Returns Python-sysconfig-style names: (target_os, target_cpu).
+    Each may be None if the target platform lacks a recognized constraint.
+    """
+    target_os = None
+    target_cpu = None
+
+    if ctx.target_platform_has_constraint(ctx.attr._os_linux[platform_common.ConstraintValueInfo]):
+        target_os = "linux"
+    elif ctx.target_platform_has_constraint(ctx.attr._os_macos[platform_common.ConstraintValueInfo]):
+        target_os = "darwin"
+    elif ctx.target_platform_has_constraint(ctx.attr._os_windows[platform_common.ConstraintValueInfo]):
+        target_os = "windows"
+
+    if ctx.target_platform_has_constraint(ctx.attr._cpu_x86_64[platform_common.ConstraintValueInfo]):
+        target_cpu = "x86_64"
+    elif ctx.target_platform_has_constraint(ctx.attr._cpu_aarch64[platform_common.ConstraintValueInfo]):
+        target_cpu = "aarch64"
+    elif ctx.target_platform_has_constraint(ctx.attr._cpu_arm[platform_common.ConstraintValueInfo]):
+        target_cpu = "arm"
+    elif ctx.target_platform_has_constraint(ctx.attr._cpu_x86_32[platform_common.ConstraintValueInfo]):
+        target_cpu = "x86"
+
+    return target_os, target_cpu
+
+def extract_cc_layer(ctx, cc_toolchain):
+    """Extract CC toolchain tools, flags, and target platform info.
+
+    Called only in cross-compilation mode. The native path relies on the
+    existing _cc_toolchain_inputs_and_tools + backend self-discovery.
+
+    Reduced for setuptools-family backends: -nostdlib++ static runtime
+    extraction (BCR llvm's libc++/libunwind archives) is deferred to the
+    slice whose backends link C++ through it.
+
+    Args:
+        ctx: The rule context. Must include CC_LAYER_ATTRS and
+            fragments = ["cpp"].
+        cc_toolchain: The resolved CcToolchainInfo-like object from
+            ctx.exec_groups[_TARGET_EXEC_GROUP].toolchains[_CC_TOOLCHAIN_TYPE].
+
+    Returns:
+        struct(
+            cc, cxx, ar       — tool execpaths,
+            cflags, cxxflags  — joined compile flags (absolutized),
+            ldflags           — joined executable linker flags (absolutized),
+            ldshared_flags    — joined shared-lib linker flags (absolutized),
+            ccshared          — "-fPIC" or "",
+            target_os         — "linux" | "darwin" | "windows" | None,
+            target_cpu        — "x86_64" | "aarch64" | "arm" | "x86" | None,
+        )
+    """
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features + _CC_DISABLED_FEATURES,
+    )
+
+    action_map = {
+        "cc": ACTION_NAMES.c_compile,
+        "cxx": ACTION_NAMES.cpp_compile,
+        "ldshared": ACTION_NAMES.cpp_link_dynamic_library,
+        "ld": ACTION_NAMES.cpp_link_executable,
+        "ar": ACTION_NAMES.cpp_link_static_library,
+    }
+
+    tools = {}
+    for key, action_name in action_map.items():
+        if cc_common.action_is_enabled(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+        ):
+            tools[key] = cc_common.get_tool_for_action(
+                feature_configuration = feature_configuration,
+                action_name = action_name,
+            )
+
+    compile_vars = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+    )
+    cxx_vars = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        add_legacy_cxx_options = True,
+    )
+    link_shared_vars = cc_common.create_link_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        is_using_linker = True,
+        is_linking_dynamic_library = True,
+        must_keep_debug = False,
+    )
+    link_exe_vars = cc_common.create_link_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        is_using_linker = True,
+        is_linking_dynamic_library = False,
+        must_keep_debug = False,
+    )
+    link_static_vars = cc_common.create_link_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        is_using_linker = False,
+        is_linking_dynamic_library = False,
+        must_keep_debug = False,
+    )
+
+    vars_map = {
+        "cc": compile_vars,
+        "cxx": cxx_vars,
+        "ldshared": link_shared_vars,
+        "ld": link_exe_vars,
+        "ar": link_static_vars,
+    }
+
+    flags = {}
+    for key, action_name in action_map.items():
+        if not cc_common.action_is_enabled(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+        ):
+            continue
+        raw = cc_common.get_memory_inefficient_command_line(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+            variables = vars_map[key],
+        )
+        flags[key] = " ".join([_absolutize_flag(f) for f in raw])
+
+    needs_pic = cc_common.action_is_enabled(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.cpp_link_dynamic_library,
+    )
+
+    target_os, target_cpu = get_target_platform(ctx)
+
+    return struct(
+        cc = tools.get("cc"),
+        cxx = tools.get("cxx"),
+        ar = tools.get("ar"),
+        cflags = flags.get("cc", ""),
+        cxxflags = flags.get("cxx", ""),
+        ldflags = flags.get("ld", ""),
+        ldshared_flags = flags.get("ldshared", ""),
+        ccshared = "-fPIC" if needs_pic else "",
+        target_os = target_os,
+        target_cpu = target_cpu,
+    )

--- a/uv/private/pep517_whl/cc_layer.bzl
+++ b/uv/private/pep517_whl/cc_layer.bzl
@@ -33,7 +33,7 @@ def _absolutize_flag(flag):
     if not flag:
         return flag
     if not flag.startswith("-"):
-        if "/" in flag:
+        if "/" in flag and not flag.startswith("/"):
             return _EXECROOT_MARKER + "/" + flag
         return flag
     for pfx in _PATH_FLAG_PREFIXES:
@@ -195,3 +195,9 @@ def extract_cc_layer(ctx, cc_toolchain):
         target_os = target_os,
         target_cpu = target_cpu,
     )
+
+# Exposed for the unit tests in tests/pep517_whl_test.bzl only.
+cc_layer_test_util = struct(
+    absolutize_flag = _absolutize_flag,
+    execroot_marker = _EXECROOT_MARKER,
+)

--- a/uv/private/pep517_whl/frontend.bzl
+++ b/uv/private/pep517_whl/frontend.bzl
@@ -16,11 +16,13 @@ wraps the real frontend, applies a self-transition inside the already-exec
 configuration that resets both flags to the host's values, and forwards
 the wrapped executable and its runfiles.
 
-Nothing wires this wrapper up yet: it belongs on the cross code path only,
-where "host" is exactly where the frontend executes. Wrapping native
-builds would be wrong under remote execution — their leaked target flags
-match the worker by definition, while the host-probe constants used here
-describe the client.
+Generated sdist repos route the native rule's `tool` through this wrapper
+unconditionally: besides fixing cross builds, the reset keeps the
+frontend's own dependency resolution consistent under any target
+configuration — a plain exec edge carries the target's flags, which can
+make its venv's wheel selection unsatisfiable (or cyclic) under a cross
+transition. Local native builds are unaffected (host values equal the
+leaked ones there).
 
 The reset values default to the host probe's, which is exact when the
 execution platform is the host and an approximation otherwise: no

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -9,6 +9,7 @@ load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//py/private/interpreter:versions.bzl", "PLATFORMS")
 load("//py/private/toolchain:types.bzl", "EXEC_TOOLS_TOOLCHAIN", "NATIVE_BUILD_TOOLCHAIN", "PY_TOOLCHAIN")
+load(":cc_layer.bzl", "CC_LAYER_ATTRS", "extract_cc_layer")
 load(
     ":common.bzl",
     "PEP517_WHL_ATTRS",
@@ -117,6 +118,67 @@ def _cc_toolchain_inputs_and_tools(ctx):
     infer_cxx = infer_cxx or tools.get("CXX") == tools.get("CC")
     return files, {key: value for key, value in tools.items() if value}, infer_cxx
 
+_PYTHON_CPU_MAP = {
+    "x86_64": "x86_64",
+    "aarch64": "aarch64",
+    "x86": "i686",
+    # armv7 CPython reports "linux-armv7l"; build_helper's tag validation
+    # expects the same spelling.
+    "arm": "armv7l",
+}
+
+# Deployment-target floor for the macOS platform string when the real value
+# is unknown: 11.0 is the first macOS release with arm64 support, so it is
+# the most conservative version every hermetic arm64 interpreter satisfies.
+# build_helper re-derives the real value from the target sysconfigdata's
+# MACOSX_DEPLOYMENT_TARGET whenever that file is available.
+_MACOS_DEPLOYMENT_FALLBACK = "11.0"
+
+def _target_python_artifacts(runtime):
+    """Collect the target interpreter files a cross build must see.
+
+    One pass over the runtime's file tree: the _sysconfigdata*.py module
+    (faked into the backend via _PYTHON_SYSCONFIGDATA_NAME) and the
+    include/pythonX.Y header tree — the compile must use the target's
+    Python.h/pyconfig.h, not the exec runtime's, or the wheel is built
+    against the wrong ABI.
+    """
+    if not runtime or not hasattr(runtime, "interpreter_version_info"):
+        return struct(sysconfig = None, include_files = [], include_dir = None)
+    info = runtime.interpreter_version_info
+    lib_prefix = "lib/python{}.{}".format(info.major, info.minor)
+    include_marker = "/include/python{}.{}".format(info.major, info.minor)
+    sysconfig_file = None
+    include_files = []
+    include_dir = None
+    for f in runtime.files.to_list():
+        if f.basename.startswith("_sysconfigdata") and f.basename.endswith(".py") and lib_prefix in f.path:
+            sysconfig_file = f
+        elif include_marker in f.path:
+            include_files.append(f)
+            if f.basename == "pyconfig.h":
+                include_dir = f.dirname
+    return struct(
+        sysconfig = sysconfig_file,
+        include_files = include_files,
+        include_dir = include_dir,
+    )
+
+def _derive_python_host_platform(target_os, target_cpu):
+    """Derive _PYTHON_HOST_PLATFORM from target platform constraints.
+
+    Linux: libc does not affect the platform string — always linux-{cpu}.
+    macOS: uses arm64 (not aarch64) and requires a version component,
+    defaulting to _MACOS_DEPLOYMENT_FALLBACK when the interpreter's real
+    deployment target is not known.
+    """
+    if target_os == "linux":
+        return "linux-" + _PYTHON_CPU_MAP.get(target_cpu, target_cpu)
+    if target_os == "darwin":
+        cpu = "arm64" if target_cpu == "aarch64" else target_cpu
+        return "macosx-{}-{}".format(_MACOS_DEPLOYMENT_FALLBACK, cpu)
+    return None
+
 def _interpreter_platform_triple(runtime):
     """Best-effort platform triple of the repo a PyRuntimeInfo comes from.
 
@@ -163,27 +225,30 @@ cross_detection_test_util = struct(
     cross_decision = _cross_decision,
 )
 
+# Exposed for the unit tests in tests/pep517_whl_test.bzl only.
+cross_identity_test_util = struct(
+    derive_python_host_platform = _derive_python_host_platform,
+    target_python_artifacts = _target_python_artifacts,
+)
+
 def _pep517_native_whl(ctx):
     archive = ctx.file.src
 
     eg_toolchains = ctx.exec_groups[TARGET_EXEC_GROUP].toolchains
-    cross, exec_triple, target_triple = _cross_compile(ctx, eg_toolchains)
-    if cross:
-        detail = ""
-        if exec_triple and target_triple:
-            detail = " (execution platform interpreter: {}, target interpreter: {})".format(exec_triple, target_triple)
-        fail(
-            "{}: building this sdist would cross-compile its native extensions{}. ".format(ctx.label, detail) +
-            "Cross-compilation of sdists is not supported: build on an execution " +
-            "platform matching the target platform, or supply a prebuilt wheel " +
-            "for the target instead of building from source.",
-        )
+    cross, _exec_triple, _target_triple = _cross_compile(ctx, eg_toolchains)
 
-    # Native build classified: a missing C++ toolchain must stay an explicit
-    # analysis error (it used to be a resolution failure when the type was
-    # mandatory) — otherwise the backend compiles with whatever ambient
-    # compiler the sandbox exposes, or fails at execution time.
-    if eg_toolchains[_CC_TOOLCHAIN_TYPE] == None:
+    # A missing C++ toolchain must stay an explicit analysis error (it used
+    # to be a resolution failure when the type was mandatory) — otherwise the
+    # backend compiles with whatever ambient compiler the sandbox exposes,
+    # or fails at execution time.
+    cc_toolchain_raw = eg_toolchains[_CC_TOOLCHAIN_TYPE]
+    if cc_toolchain_raw == None:
+        if cross:
+            fail(
+                "{}: cross-compiling this sdist requires a C++ toolchain that ".format(ctx.label) +
+                "can target the destination platform (e.g. the BCR llvm module); " +
+                "none resolved for the current exec/target combination.",
+            )
         fail(
             "{}: no C++ toolchain resolved for this native sdist build. ".format(ctx.label) +
             "Building native extensions requires a registered C++ toolchain " +
@@ -216,12 +281,64 @@ def _pep517_native_whl(ctx):
     if "CXX" not in ctx.attr.env and cc_tools.get("CXX") and infer_cxx:
         env[_INFER_CXX_COMPANION] = "1"
 
+    cross_args = []
+    if cross:
+        cc_toolchain = cc_toolchain_raw
+        if hasattr(cc_toolchain, "cc_provider_in_toolchain") and hasattr(cc_toolchain, "cc"):
+            cc_toolchain = cc_toolchain.cc
+        cc_layer = extract_cc_layer(ctx, cc_toolchain)
+
+        # Toolchain flags first, then any flags the package set via `env`
+        # (uv.override_package): the package's -D/-std/feature-baseline
+        # additions must survive, and trailing position lets them override.
+        # Values inherited from the ambient shell env stay excluded — only
+        # an explicit `env` entry merges.
+        for key, toolchain_flags in (
+            ("CFLAGS", cc_layer.cflags),
+            ("CXXFLAGS", cc_layer.cxxflags),
+            ("LDFLAGS", cc_layer.ldflags),
+            ("LDSHAREDFLAGS", cc_layer.ldshared_flags),
+        ):
+            if not toolchain_flags:
+                continue
+            package_flags = env.get(key) if key in ctx.attr.env else None
+            env[key] = toolchain_flags + " " + package_flags if package_flags else toolchain_flags
+        if cc_layer.ccshared:
+            env["CFLAGS"] = (env.get("CFLAGS", "") + " " + cc_layer.ccshared).strip()
+            env["CXXFLAGS"] = (env.get("CXXFLAGS", "") + " " + cc_layer.ccshared).strip()
+
+        cross_args = [
+            "--cross",
+            "--target-os",
+            cc_layer.target_os or "",
+            "--target-cpu",
+            cc_layer.target_cpu or "",
+        ]
+
+        py_toolchain = ctx.toolchains[PY_TOOLCHAIN]
+        if py_toolchain != None:
+            runtime = getattr(py_toolchain, "py3_runtime", None)
+            if runtime:
+                artifacts = _target_python_artifacts(runtime)
+                if artifacts.sysconfig:
+                    extra_inputs.append(depset([artifacts.sysconfig]))
+                    env["RULES_PY_TARGET_SYSCONFIGDATA"] = artifacts.sysconfig.path
+                if artifacts.include_dir:
+                    extra_inputs.append(depset(artifacts.include_files))
+                    env["RULES_PY_TARGET_INCLUDE"] = artifacts.include_dir
+
+        host_platform = _derive_python_host_platform(cc_layer.target_os, cc_layer.target_cpu)
+        if host_platform:
+            env["_PYTHON_HOST_PLATFORM"] = host_platform
+
+    tool = ctx.attr.tool[DefaultInfo].files_to_run
+
     ctx.actions.run(
         mnemonic = "PySdistNativeBuild",
         progress_message = "Native source compiling {} to a whl".format(archive.basename),
-        executable = ctx.executable.tool,
+        executable = tool,
         toolchain = None,
-        arguments = ctx.attr.args + patch_args + memory_args(ctx) + [
+        arguments = ctx.attr.args + patch_args + memory_args(ctx) + cross_args + [
             "--execroot-marker",
             _EXECROOT_MARKER,
             archive.path,
@@ -231,7 +348,7 @@ def _pep517_native_whl(ctx):
             [archive] + patch_inputs,
             transitive = extra_inputs,
         ),
-        tools = [ctx.attr.tool[DefaultInfo].files_to_run],
+        tools = [tool],
         outputs = [wheel_file],
         env = env,
         exec_group = TARGET_EXEC_GROUP,
@@ -271,7 +388,7 @@ constraints of the target platform.
                   "the unpacked source tree. Omit CC/CXX/AR/LD/STRIP to use the " +
                   "configured C++ action tools.",
         ),
-    },
+    } | CC_LAYER_ATTRS,
     fragments = ["cpp"],
     toolchains = [
         # Target-configured interpreter, read only for its platform triple in
@@ -293,8 +410,9 @@ constraints of the target platform.
         # exactly when the exec and target platforms match — optional, its
         # absence is a cross signal, not a resolution error. The exec- and
         # target-configured interpreters' platform triples refine that signal
-        # (see _cross_decision). The rule fails with an explicit message
-        # instead of the toolchain-resolution error it used to surface.
+        # (see _cross_decision); a cross decision switches the action into
+        # cross mode (cc_layer extraction + target-identity env) instead of
+        # failing.
         TARGET_EXEC_GROUP: exec_group(
             toolchains = [
                 PY_TOOLCHAIN,

--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -22,6 +22,7 @@ load(
 )
 load(
     ":pep517_whl_test.bzl",
+    "absolutize_flag_test",
     "cross_decision_test",
     "execroot_collision_toolchain",
     "hostile_python_env_target",
@@ -42,6 +43,8 @@ package(
 interpreter_platform_triple_test(name = "interpreter_platform_triple_test")
 
 cross_decision_test(name = "cross_decision_test")
+
+absolutize_flag_test(name = "absolutize_flag_test")
 
 platform(
     name = "cross_target_platform",

--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -26,10 +26,12 @@ load(
     "execroot_collision_toolchain",
     "hostile_python_env_target",
     "interpreter_platform_triple_test",
-    "pep517_native_whl_cross_unsupported_test",
+    "pep517_native_whl_cross_mode_test",
     "pep517_native_whl_execroot_collision_test",
     "pep517_native_whl_toolchain_env_test",
     "pep517_whl_console_scripts_test",
+    "python_host_platform_test",
+    "target_python_artifacts_test",
 )
 
 package(
@@ -91,8 +93,12 @@ exec_platform_prefers_native_match_test(
     target_under_test = ":__cross_fixture",
 )
 
-pep517_native_whl_cross_unsupported_test(
-    name = "cross_unsupported_test",
+python_host_platform_test(name = "python_host_platform_test")
+
+target_python_artifacts_test(name = "target_python_artifacts_test")
+
+pep517_native_whl_cross_mode_test(
+    name = "cross_mode_test",
     # On a linux-aarch64 host the fixed cross target platform IS the host —
     # the build would be native and the expected failure never fires.
     target_compatible_with = select({

--- a/uv/private/pep517_whl/tests/build_helper_test.py
+++ b/uv/private/pep517_whl/tests/build_helper_test.py
@@ -329,5 +329,138 @@ class TargetFlagsTest(unittest.TestCase):
 
 
 
+def _run_wrapper(wrapper: str, args: list[str]) -> list[str]:
+    import subprocess
+
+    result = subprocess.run(
+        [wrapper] + args, capture_output=True, text=True, check=True
+    )
+    return result.stdout.split()
+
+
+class CrossCompilerWrapperTest(unittest.TestCase):
+    """Generates a cross wrapper around an argv-echoing fake compiler and
+    asserts the transformed command line."""
+
+    def _wrapper(self, tmp: str, is_darwin: bool = False, wrapper_flags: list[str] | None = None) -> str:
+        echo = path.join(tmp, "echo_cc")
+        with open(echo, "w") as f:
+            f.write('#!/bin/sh\nprintf \'%s\\n\' "$@"\n')
+        os.chmod(echo, 0o755)
+        return build_helper._make_cross_compiler_wrapper(
+            tmp, "cc", echo, wrapper_flags or [], is_darwin=is_darwin
+        )
+
+    def test_identity_flags_are_reinjected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = self._wrapper(tmp, wrapper_flags=["-target", "aarch64-linux-gnu"])
+            argv = _run_wrapper(wrapper, ["-c", "x.c"])
+            self.assertEqual(["-target", "aarch64-linux-gnu", "-c", "x.c"], argv)
+
+    def test_host_linker_leaks_are_dropped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = self._wrapper(tmp)
+            argv = _run_wrapper(
+                wrapper,
+                ["-bundle", "-undefined", "dynamic_lookup", "-arch", "arm64", "-shared", "a.o"],
+            )
+            self.assertEqual(["-shared", "a.o"], argv)
+
+    def test_darwin_target_keeps_bundle_and_adds_dynamic_lookup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = self._wrapper(tmp, is_darwin=True)
+            argv = _run_wrapper(wrapper, ["-bundle", "a.o"])
+            self.assertEqual(["-bundle", "a.o", "-Wl,-undefined,dynamic_lookup"], argv)
+
+    def test_darwin_target_respects_existing_dynamic_lookup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = self._wrapper(tmp, is_darwin=True)
+            argv = _run_wrapper(wrapper, ["-bundle", "-undefined", "dynamic_lookup", "a.o"])
+            self.assertEqual(["-bundle", "-undefined", "dynamic_lookup", "a.o"], argv)
+
+    def test_probe_invocations_are_left_alone(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = self._wrapper(tmp, is_darwin=True)
+            argv = _run_wrapper(wrapper, ["--version"])
+            self.assertEqual(["--version"], argv)
+
+    def test_debug_flag_is_stripped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = self._wrapper(tmp)
+            argv = _run_wrapper(wrapper, [build_helper._DEBUG_FLAG, "-c", "x.c"])
+            self.assertEqual(["-c", "x.c"], argv)
+
+
+class WrapperFlagExtractionTest(unittest.TestCase):
+    def test_identity_flags_extracted_from_cflags(self) -> None:
+        self.assertEqual(
+            ["-target", "aarch64-linux-gnu", "--sysroot=/abs/sysroot"],
+            build_helper._get_wrapper_flags(
+                "-O2 -target aarch64-linux-gnu --sysroot=/abs/sysroot -fPIC"
+            ),
+        )
+
+    def test_relative_sysroot_is_marked(self) -> None:
+        flags = build_helper._get_wrapper_flags("--sysroot=external/llvm/sysroot")
+        self.assertEqual(1, len(flags))
+        self.assertTrue(flags[0].startswith("--sysroot="))
+        self.assertIn("external/llvm/sysroot", flags[0])
+        self.assertNotEqual("--sysroot=external/llvm/sysroot", flags[0])
+
+    def test_no_identity_flags(self) -> None:
+        self.assertEqual([], build_helper._get_wrapper_flags("-O2 -fPIC"))
+
+
+class GenerateCrossSiteTest(unittest.TestCase):
+    def _site(self, target_os: str, target_cpu: str) -> str:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        site_dir = build_helper._generate_cross_site(self.tmp.name, target_os, target_cpu)
+        with open(path.join(site_dir, "sitecustomize.py")) as f:
+            return f.read()
+
+    def test_linux_identity(self) -> None:
+        content = self._site("linux", "aarch64")
+        self.assertIn("'aarch64'", content)
+        self.assertIn("'Linux'", content)
+        self.assertIn("sys.platform = 'linux'", content)
+
+    def test_darwin_machine_is_arm64(self) -> None:
+        content = self._site("darwin", "aarch64")
+        self.assertIn("'arm64'", content)
+        self.assertNotIn("'aarch64'", content)
+        self.assertIn("sys.platform = 'darwin'", content)
+
+    def test_manylinux_hook_refuses_compatibility(self) -> None:
+        self._site("linux", "x86_64")
+        with open(path.join(self.tmp.name, ".cross_site", "_manylinux.py")) as f:
+            hook = f.read()
+        self.assertIn("return False", hook)
+
+
+class DarwinKernelReleaseTest(unittest.TestCase):
+    def test_known_versions(self) -> None:
+        for deployment, expected_major in (("11.0", 20), ("12.5", 21), ("15.0", 24), ("26.0", 25)):
+            release = build_helper._darwin_kernel_release(deployment)
+            self.assertEqual(expected_major, int(release.split(".")[0]))
+
+    def test_unknown_falls_back(self) -> None:
+        self.assertEqual("20.0.0", build_helper._darwin_kernel_release(None))
+        self.assertEqual("20.0.0", build_helper._darwin_kernel_release("bogus"))
+
+
+class MacosDeploymentTargetTest(unittest.TestCase):
+    def test_parses_sysconfigdata_literal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            f = path.join(tmp, "_sysconfigdata__darwin_arm64.py")
+            with open(f, "w") as fh:
+                fh.write("build_time_vars = {'MACOSX_DEPLOYMENT_TARGET': '11.0'}\n")
+            self.assertEqual("11.0", build_helper._macosx_deployment_target(f))
+
+    def test_missing_file_returns_none(self) -> None:
+        self.assertIsNone(build_helper._macosx_deployment_target("/nonexistent"))
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/uv/private/pep517_whl/tests/pep517_whl_test.bzl
+++ b/uv/private/pep517_whl/tests/pep517_whl_test.bzl
@@ -7,6 +7,7 @@ build to verify the env wiring.
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
+load("//uv/private/pep517_whl:cc_layer.bzl", "cc_layer_test_util")
 load("//uv/private/pep517_whl:pep517_native_whl.bzl", "cross_detection_test_util", "cross_identity_test_util")
 
 _ACTION_ENV = "//command_line_option:action_env"
@@ -283,3 +284,29 @@ def _target_python_artifacts_test_impl(ctx):
     return unittest.end(env)
 
 target_python_artifacts_test = unittest.make(_target_python_artifacts_test_impl)
+
+def _absolutize_flag_test_impl(ctx):
+    env = unittest.begin(ctx)
+    absolutize = cc_layer_test_util.absolutize_flag
+    marker = cc_layer_test_util.execroot_marker
+    for flag, expected in (
+        # Bare relative paths get the execroot marker; bare absolute paths
+        # and pathless arguments pass through.
+        ("external/llvm/lib/crt1.o", marker + "/external/llvm/lib/crt1.o"),
+        ("/usr/lib/crt1.o", "/usr/lib/crt1.o"),
+        ("-lm", "-lm"),
+        ("", ""),
+        # Path-flag prefixes: relative values marked, absolute untouched.
+        ("-Iexternal/llvm/include", "-I" + marker + "/external/llvm/include"),
+        ("-I/usr/include", "-I/usr/include"),
+        ("-Bexternal/llvm/bin", "-B" + marker + "/external/llvm/bin"),
+        # "--sysroot=" is deliberately not cc_layer's job: build_helper's
+        # _absolutize_sysroot_flags rewrites it at execution time (it also
+        # handles values the backend re-splices after the chdir).
+        ("--sysroot=external/llvm/sysroot", "--sysroot=external/llvm/sysroot"),
+        ("-O2", "-O2"),
+    ):
+        asserts.equals(env, expected, absolutize(flag))
+    return unittest.end(env)
+
+absolutize_flag_test = unittest.make(_absolutize_flag_test_impl)

--- a/uv/private/pep517_whl/tests/pep517_whl_test.bzl
+++ b/uv/private/pep517_whl/tests/pep517_whl_test.bzl
@@ -7,7 +7,7 @@ build to verify the env wiring.
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("//uv/private:source_built_wheel.bzl", "SourceBuiltWheelInfo")
-load("//uv/private/pep517_whl:pep517_native_whl.bzl", "cross_detection_test_util")
+load("//uv/private/pep517_whl:pep517_native_whl.bzl", "cross_detection_test_util", "cross_identity_test_util")
 
 _ACTION_ENV = "//command_line_option:action_env"
 _HOST_ENV = [
@@ -184,15 +184,102 @@ def _cross_decision_test_impl(ctx):
 
 cross_decision_test = unittest.make(_cross_decision_test_impl)
 
-def _cross_unsupported_test_impl(ctx):
+def _cross_mode_test_impl(ctx):
     env = analysistest.begin(ctx)
-    asserts.expect_failure(env, "would cross-compile its native extensions")
+    target = analysistest.target_under_test(env)
+    actions = [a for a in target.actions if a.mnemonic == "PySdistNativeBuild"]
+    asserts.equals(env, 1, len(actions), "expected the cross build action to analyze")
+    if actions:
+        action = actions[0]
+        argv = action.argv
+        asserts.true(env, "--cross" in argv, "cross mode must reach the helper")
+        for flag, value in (("--target-os", "linux"), ("--target-cpu", "aarch64")):
+            asserts.true(
+                env,
+                flag in argv and argv[argv.index(flag) + 1] == value,
+                "expected {} {} in argv; got: {}".format(flag, value, list(argv)),
+            )
+        asserts.equals(
+            env,
+            "linux-aarch64",
+            action.env.get("_PYTHON_HOST_PLATFORM"),
+            "the target's python platform identity must reach the backend",
+        )
+        asserts.true(
+            env,
+            action.env.get("CFLAGS"),
+            "the target CC toolchain's compile flags must reach the backend",
+        )
+        asserts.true(
+            env,
+            action.env.get("RULES_PY_TARGET_INCLUDE"),
+            "the target interpreter's include dir must reach the backend",
+        )
+        input_basenames = [f.basename for f in action.inputs.to_list()]
+        asserts.true(
+            env,
+            "pyconfig.h" in input_basenames,
+            "the target interpreter's headers must be action inputs — the " +
+            "compile must not fall back to the exec runtime's pyconfig.h",
+        )
     return analysistest.end(env)
 
-pep517_native_whl_cross_unsupported_test = analysistest.make(
-    _cross_unsupported_test_impl,
-    expect_failure = True,
+# Runs against the repo's own dev llvm toolchain, which can target
+# linux-aarch64 from any host; the wheel-producing end-to-end version lives
+# in e2e/crossbuild/pycross-setuptools.
+pep517_native_whl_cross_mode_test = analysistest.make(
+    _cross_mode_test_impl,
     config_settings = {
         "//command_line_option:platforms": [Label("//uv/private/pep517_whl/tests:cross_target_platform")],
     },
 )
+
+def _python_host_platform_test_impl(ctx):
+    env = unittest.begin(ctx)
+    derive = cross_identity_test_util.derive_python_host_platform
+    for target_os, target_cpu, expected in (
+        ("linux", "x86_64", "linux-x86_64"),
+        ("linux", "aarch64", "linux-aarch64"),
+        ("linux", "x86", "linux-i686"),
+        ("linux", "arm", "linux-armv7l"),
+        ("darwin", "aarch64", "macosx-11.0-arm64"),
+        ("darwin", "x86_64", "macosx-11.0-x86_64"),
+        ("windows", "x86_64", None),
+        (None, None, None),
+    ):
+        asserts.equals(env, expected, derive(target_os, target_cpu))
+    return unittest.end(env)
+
+python_host_platform_test = unittest.make(_python_host_platform_test_impl)
+
+def _fake_runtime_file(p):
+    return struct(basename = p.split("/")[-1], dirname = p.rsplit("/", 1)[0], path = p)
+
+def _target_python_artifacts_test_impl(ctx):
+    env = unittest.begin(ctx)
+    collect = cross_identity_test_util.target_python_artifacts
+    runtime = struct(
+        interpreter_version_info = struct(major = 3, minor = 12),
+        files = depset([
+            _fake_runtime_file("repo/lib/python3.12/_sysconfigdata__linux_aarch64-linux-gnu.py"),
+            _fake_runtime_file("repo/lib/python3.12/os.py"),
+            _fake_runtime_file("repo/include/python3.12/Python.h"),
+            _fake_runtime_file("repo/include/python3.12/pyconfig.h"),
+            _fake_runtime_file("repo/bin/python3"),
+        ]),
+    )
+    artifacts = collect(runtime)
+    asserts.equals(
+        env,
+        "repo/lib/python3.12/_sysconfigdata__linux_aarch64-linux-gnu.py",
+        artifacts.sysconfig.path,
+    )
+    asserts.equals(env, "repo/include/python3.12", artifacts.include_dir)
+    asserts.equals(env, 2, len(artifacts.include_files))
+
+    empty = collect(None)
+    asserts.equals(env, None, empty.sysconfig)
+    asserts.equals(env, None, empty.include_dir)
+    return unittest.end(env)
+
+target_python_artifacts_test = unittest.make(_target_python_artifacts_test_impl)

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -12,6 +12,7 @@ from argparse import ArgumentParser
 import importlib
 import os
 import platform as _platform
+import re
 import shlex
 import shutil
 import sys
@@ -153,7 +154,355 @@ def _absolutize_tool_paths(env: dict[str, str]) -> None:
             env[key] = shlex.join(parts)
 
 
-def _compiler_env(tmpdir: str, execroot_marker: str | None = None) -> dict[str, str]:
+
+# --- Cross-compilation support -------------------------------------------
+#
+# Reduced to what setuptools-family backends need. Deferred to the slices
+# that exercise them: meson cross files, CMake toolchain files, cargo env,
+# lld discovery, -nostdlib++ static runtime archives, probe-executable
+# static linking, and the darwin-exec ar/libtool translation.
+
+
+
+
+
+
+def _write_generated_file(file_path: str, content: str, executable: bool = False) -> str:
+    """Write content to file_path, creating parent dirs. Returns file_path for chaining."""
+    makedirs(path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w") as f:
+        f.write(content)
+    if executable:
+        chmod(file_path, 0o755)
+    return file_path
+
+
+_SYSROOT_FLAG_PREFIXES = ("--sysroot", "-isysroot")
+
+
+def _absolutize_sysroot_flags(flags: str) -> str:
+    """Absolutize sysroot values inside a flag string (CFLAGS, LDSHAREDFLAGS).
+
+    Must run while the process is still in the execroot; the backend splices
+    these env strings into commands it runs from inside the unpacked sdist,
+    where an execroot-relative sysroot no longer resolves. A later relative
+    "--sysroot" would also silently override the wrapper's absolute one —
+    the clang driver honors the last occurrence.
+    """
+    parts = shlex.split(flags)
+    result = []
+    i = 0
+    while i < len(parts):
+        p = parts[i]
+        flag, sep, value = p.partition("=")
+        if sep and flag in _SYSROOT_FLAG_PREFIXES:
+            p = "{}={}".format(flag, _absolutize_path(value))
+        elif p in _SYSROOT_FLAG_PREFIXES and i + 1 < len(parts):
+            result.append(p)
+            result.append(_absolutize_path(parts[i + 1]))
+            i += 2
+            continue
+        result.append(p)
+        i += 1
+    return shlex.join(result)
+
+
+_IDENTITY_FLAG_PREFIXES = (
+    "-target",
+    "--target",
+    "--sysroot",
+    "-isysroot",
+    "-mmacosx-version-min",
+)
+
+
+def _get_wrapper_flags(cflags: str) -> list[str]:
+    """Extract identity flags (-target, --sysroot, -isysroot, ...) from CFLAGS.
+
+    The PEP 517 backend (setuptools, meson-python) may strip these when
+    constructing its own compile commands; the cross wrapper re-injects them
+    on every invocation so the real compiler always targets the right
+    platform. Sysroot values are absolutized first (see
+    _absolutize_sysroot_flags for why that must happen in the execroot).
+    """
+    parts = shlex.split(_absolutize_sysroot_flags(cflags))
+    result = []
+    i = 0
+    while i < len(parts):
+        p = parts[i]
+        if any(p == prefix or p.startswith(prefix + "=") for prefix in _IDENTITY_FLAG_PREFIXES):
+            result.append(p)
+            if "=" not in p and i + 1 < len(parts) and not parts[i + 1].startswith("-"):
+                result.append(parts[i + 1])
+                i += 1
+        i += 1
+    return result
+
+
+_DROP_LINKER_FLAGS = frozenset({
+    "-Wl,--start-group",
+    "-Wl,--end-group",
+    "-Wl,--as-needed",
+    "-Wl,--allow-shlib-undefined",
+    "-Wl,-O1",
+    "-Wl,-start_group",
+    "-Wl,-end_group",
+    "-bundle",
+    "STRIP_DEBUG_SYMBOLS",
+})
+
+_DROP_LINKER_PAIRS = frozenset({
+    "-arch",
+    "-undefined",
+    "-current_version",
+    "-compatibility_version",
+    "-install_name",
+})
+
+_DROP_LINKER_PREFIXES = (
+    "-mmacosx-version-min",
+)
+
+_CROSS_COMPILER_WRAPPER = """#!/usr/bin/env python3
+import os
+import sys
+
+args = sys.argv[1:]
+wrapper_flags = {wrapper_flags!r}
+drop_exact = {drop_exact!r}
+drop_pairs = {drop_pairs!r}
+drop_prefixes = {drop_prefixes!r}
+debug_flag = {debug_flag!r}
+is_darwin = {is_darwin!r}
+
+# Not a link if compiling/preprocessing (-c/-E/-S/-fsyntax-only) or if this
+# is a compiler-introspection probe ("-print-*", "--version"): appending
+# link-only flags there is noise at best.
+is_link = True
+for a in args:
+    if a in ("-c", "-E", "-S", "-fsyntax-only", "--version", "-dumpmachine", "-dumpversion", "-###") or a.startswith("-print-"):
+        is_link = False
+        break
+
+filtered = []
+i = 0
+while i < len(args):
+    a = args[i]
+    if a == debug_flag or a in drop_exact or any(a.startswith(p) for p in drop_prefixes):
+        i += 1
+        continue
+    if a in drop_pairs and i + 1 < len(args):
+        i += 2
+        continue
+    filtered.append(a)
+    i += 1
+
+# Shared-link spellings: "-shared" (ELF), "-bundle"/"-dynamiclib" (ld64).
+# Scanned pre-filter: the darwin spellings are host-leak-dropped from
+# `filtered` when the target is not darwin.
+is_shared = any(a in ("-shared", "-bundle", "-dynamiclib") for a in args)
+if is_darwin and is_link and is_shared:
+    # Extension modules leave _Py* unresolved until dlopen; ld64 errors on
+    # them by default (ELF linkers don't), so mirror CPython's own LDSHARED
+    # unless the backend already passed it.
+    if "dynamic_lookup" not in filtered and "-Wl,-undefined,dynamic_lookup" not in filtered:
+        filtered.append("-Wl,-undefined,dynamic_lookup")
+
+real = {compiler_path!r}
+os.execv(real, [real] + wrapper_flags + filtered)
+"""
+
+
+def _make_cross_compiler_wrapper(
+    tmpdir: str,
+    name: str,
+    compiler_path: str,
+    wrapper_flags: list[str],
+    is_darwin: bool = False,
+) -> str:
+    wrapper = path.join(tmpdir, ".aspect_rules_py_compilers", name)
+
+    # "-bundle" and "-undefined dynamic_lookup" leak from a macOS *host*
+    # sysconfig and break ELF linkers, but when the *target* is darwin they
+    # are exactly how extension modules must link (unresolved _Py* symbols
+    # bind at dlopen time) — keep them there.
+    drop_exact = set(_DROP_LINKER_FLAGS)
+    drop_pairs = set(_DROP_LINKER_PAIRS)
+    if is_darwin:
+        drop_exact.discard("-bundle")
+        drop_pairs.discard("-undefined")
+
+    return _write_generated_file(
+        wrapper,
+        _CROSS_COMPILER_WRAPPER.format(
+            compiler_path=compiler_path,
+            wrapper_flags=wrapper_flags,
+            drop_exact=sorted(drop_exact),
+            drop_pairs=sorted(drop_pairs),
+            drop_prefixes=list(_DROP_LINKER_PREFIXES),
+            debug_flag=_DEBUG_FLAG,
+            is_darwin=is_darwin,
+        ),
+        executable=True,
+    )
+
+
+_MACOSX_DEPLOYMENT_TARGET_RE = re.compile(
+    r"[\"']MACOSX_DEPLOYMENT_TARGET[\"']\s*:\s*[\"']?([0-9][0-9.]*)"
+)
+
+
+def _macosx_deployment_target(sysconfigdata_path: str) -> str | None:
+    """The target interpreter's deployment target, from its sysconfigdata.
+
+    The deployment version in wheel/platform tags is a property of the target
+    interpreter's build, not a constant — regex the build_time_vars literal
+    rather than importing it, since the file belongs to a foreign-platform
+    interpreter this process must not execute code from.
+    """
+    try:
+        with open(sysconfigdata_path, encoding="utf-8") as f:
+            match = _MACOSX_DEPLOYMENT_TARGET_RE.search(f.read())
+    except OSError:
+        return None
+    return match.group(1) if match else None
+
+
+def _darwin_kernel_release(macos_deployment_target: str | None) -> str:
+    """Fake os.uname() release consistent with the macOS deployment target.
+
+    Darwin kernel majors track macOS marketing versions as 11→20 … 15→24;
+    from the year-based scheme (26 = Darwin 25) it's major−1. Only consumers
+    parsing a plausible kernel version matter here (ctypes' import does),
+    so unknown/missing values fall back to the macOS 11 baseline.
+    """
+    try:
+        major = int((macos_deployment_target or "").split(".")[0])
+    except ValueError:
+        major = 0
+    if 11 <= major <= 15:
+        return "{}.0.0".format(major + 9)
+    if major >= 26:
+        return "{}.0.0".format(major - 1)
+    return "20.0.0"
+
+
+_TITLECASE_OS = {"linux": "Linux", "darwin": "Darwin", "windows": "Windows"}
+_SYS_PLATFORM = {"linux": "linux", "darwin": "darwin", "windows": "win32"}
+
+
+_SITECUSTOMIZE_TEMPLATE = """\
+import os
+import platform
+import sys
+import collections
+
+# ctypes parses os.uname().release at import time when the *host* is Darwin.
+# Import it while uname and sys.platform are still real so the target's
+# faked values never reach that parse.
+try:
+    import ctypes
+except ImportError:
+    pass
+
+_machine = {machine!r}
+_sysname = {sysname!r}
+_release = {release!r}
+
+# setup.py scripts branch on sys.platform to decide which sources to compile
+# (psutil picks _psutil_osx.c vs _psutil_linux.c this way).
+sys.platform = {sys_platform!r}
+
+os.uname = lambda: os.uname_result((_sysname, "build", _release, "", _machine))
+
+# CS_GLIBC_LIB_VERSION otherwise leaks the *host's* glibc version, which
+# feeds manylinux-tag determination in pip/packaging/subprocess.
+if hasattr(os, "confstr"):
+    _real_confstr = os.confstr
+
+    def _confstr(name):
+        if name == "CS_GLIBC_LIB_VERSION":
+            return "glibc_unknown"
+        return _real_confstr(name)
+
+    os.confstr = _confstr
+
+# platform.uname_result.processor is a lazily-computed property that falls
+# back to the real host on this field, so build our own namedtuple instead
+# of the real type (mirrors crossenv's platform-patch.py).
+_PlatformUname = collections.namedtuple("uname_result", "system node release version machine processor")
+_platform_uname = _PlatformUname(_sysname, "build", _release, "", _machine, _machine)
+
+platform.uname = lambda: _platform_uname
+platform.system = lambda: _sysname
+platform.machine = lambda: _machine
+platform.libc_ver = lambda *a, **k: ("", "")
+
+# packaging.tags derives its arch from sysconfig.get_platform() (already
+# faked via $_PYTHON_HOST_PLATFORM); only the manylinux gate needs the
+# top-level _manylinux hook packaging itself looks for.
+"""
+
+_MANYLINUX_HOOK = """\
+# Cross build: we have no verified manylinux compatibility for the target
+# (no target glibc version is threaded through yet), so refuse rather than
+# silently claim host-arch manylinux tags are usable on the target.
+def manylinux_compatible(tag_major, tag_minor, tag_arch):
+    return False
+
+
+manylinux1_compatible = False
+manylinux2010_compatible = False
+manylinux2014_compatible = False
+"""
+
+
+def _generate_cross_site(
+    tmpdir: str,
+    target_os: str,
+    target_cpu: str,
+    macos_deployment_target: str | None = None,
+) -> str:
+    """sitecustomize + _manylinux hook faking the target's runtime identity.
+
+    sysconfig is already faked via env vars CPython itself reads
+    (_PYTHON_HOST_PLATFORM, _PYTHON_SYSCONFIGDATA_NAME), but setup.py
+    scripts also branch on os.uname()/platform.machine() directly, which
+    env vars can't reach. sitecustomize.py runs on interpreter startup —
+    before any backend code — and patches os/platform in place. Modeled on
+    crossenv, minus what rules_py doesn't need.
+    """
+    site_dir = path.join(tmpdir, ".cross_site")
+
+    # ctypes' own import does int(os.uname().release.split(".")[0]) on Darwin,
+    # so the faked release must parse as a Darwin kernel version there —
+    # derived from the target's deployment target so both stay consistent.
+    # Linux keeps "": nothing on that path parses it.
+    release = _darwin_kernel_release(macos_deployment_target) if target_os == "darwin" else ""
+    # macOS reports "arm64", never the Bazel constraint's "aarch64" —
+    # setup.py scripts branch on platform.machine() == "arm64", and the
+    # faked identity must agree with the wheel tag derived elsewhere.
+    machine = "arm64" if target_os == "darwin" and target_cpu == "aarch64" else target_cpu
+    _write_generated_file(
+        path.join(site_dir, "sitecustomize.py"),
+        _SITECUSTOMIZE_TEMPLATE.format(
+            machine=machine,
+            sysname=_TITLECASE_OS.get(target_os, target_os),
+            release=release,
+            sys_platform=_SYS_PLATFORM.get(target_os, target_os),
+        ),
+    )
+    _write_generated_file(path.join(site_dir, "_manylinux.py"), _MANYLINUX_HOOK)
+    return site_dir
+
+
+def _compiler_env(
+    tmpdir: str,
+    execroot_marker: str | None = None,
+    cross: bool = False,
+    target_os: str = "",
+    target_cpu: str = "",
+) -> dict[str, str]:
     env = dict(os.environ)
     if execroot_marker:
         execroot = os.getcwd()
@@ -191,11 +540,67 @@ def _compiler_env(tmpdir: str, execroot_marker: str | None = None) -> dict[str, 
 
     sysroot = _darwin_sysroot()
 
-    cc = _make_compiler_wrapper(tmpdir, "cc", cc_path, sysroot)
-    cxx = _make_compiler_wrapper(tmpdir, "c++", cxx_path, sysroot)
+    if cross:
+        # Toolchain flag strings (from cc_layer.bzl) contain execroot-relative
+        # sysroots; absolutize while still in the execroot, before the backend
+        # chdirs into the unpacked sdist.
+        # LDFLAGS included: distutils' customize_compiler appends $LDFLAGS
+        # after $LDSHARED, so a relative --sysroot there would override the
+        # wrapper's absolute one (the driver honors the last occurrence).
+        for key in ("CFLAGS", "CXXFLAGS", "CPPFLAGS", "LDFLAGS", "LDSHAREDFLAGS"):
+            if env.get(key):
+                env[key] = _absolutize_sysroot_flags(env[key])
+
+        # The target interpreter's Python.h/pyconfig.h must shadow the exec
+        # runtime's: distutils still injects the running interpreter's
+        # include path, but CFLAGS-supplied -I directories are searched
+        # first.
+        target_include = env.pop("RULES_PY_TARGET_INCLUDE", "")
+        if target_include:
+            include_flag = "-I" + _absolutize_path(target_include)
+            for key in ("CFLAGS", "CXXFLAGS"):
+                env[key] = (include_flag + " " + env.get(key, "")).strip()
+
+        wrapper_flags = _get_wrapper_flags(env.get("CFLAGS", ""))
+        is_darwin_target = target_os == "darwin"
+        cc = _make_cross_compiler_wrapper(tmpdir, "cc", cc_path, wrapper_flags, is_darwin=is_darwin_target)
+        cxx = _make_cross_compiler_wrapper(tmpdir, "c++", cxx_path, wrapper_flags, is_darwin=is_darwin_target)
+    else:
+        cc = _make_compiler_wrapper(tmpdir, "cc", cc_path, sysroot)
+        cxx = _make_compiler_wrapper(tmpdir, "c++", cxx_path, sysroot)
 
     env.setdefault("CC", cc)
     env.setdefault("CXX", cxx)
+
+    if cross:
+        ldshared_flags = env.get("LDSHAREDFLAGS", "")
+        env["LDSHARED"] = cc + ((" " + ldshared_flags) if ldshared_flags else "")
+        env["LDCXXSHARED"] = cxx + ((" " + ldshared_flags) if ldshared_flags else "")
+
+        deployment_target = None
+        target_sysconfig = env.get("RULES_PY_TARGET_SYSCONFIGDATA")
+        if target_sysconfig and path.exists(target_sysconfig):
+            sysconfig_dir = path.join(tmpdir, ".target_sysconfig")
+            makedirs(sysconfig_dir, exist_ok=True)
+            shutil.copy(target_sysconfig, sysconfig_dir)
+            module_name = path.basename(target_sysconfig)[:-3]
+            env["_PYTHON_SYSCONFIGDATA_NAME"] = module_name
+            env["PYTHONPATH"] = sysconfig_dir + pathsep + env.get("PYTHONPATH", "")
+
+            # The analysis-time _PYTHON_HOST_PLATFORM can only guess
+            # macosx-11.0; the target interpreter's sysconfig knows the real
+            # deployment version its wheel tags must carry. distutils'
+            # get_platform() also honors $MACOSX_DEPLOYMENT_TARGET directly.
+            if target_os == "darwin":
+                deployment_target = _macosx_deployment_target(target_sysconfig)
+                if deployment_target:
+                    env.setdefault("MACOSX_DEPLOYMENT_TARGET", deployment_target)
+                    cpu = "arm64" if target_cpu == "aarch64" else target_cpu
+                    env["_PYTHON_HOST_PLATFORM"] = "macosx-{}-{}".format(deployment_target, cpu)
+
+        if target_os and target_cpu:
+            site_dir = _generate_cross_site(tmpdir, target_os, target_cpu, deployment_target)
+            env["PYTHONPATH"] = site_dir + pathsep + env.get("PYTHONPATH", "")
 
     # MPI builds (e.g. mpi4py) consult $MPICC before searching PATH, so a
     # plain C compiler here would shadow the real mpicc. Only set it when
@@ -348,6 +753,7 @@ PARSER.add_argument("--validate-anyarch", action="store_true")
 PARSER.add_argument("--patch-strip", type=int, default=0, help="Strip count for patch (-p)")
 PARSER.add_argument("--patch", action="append", default=[], dest="patches", help="Patch file to apply (repeatable)")
 PARSER.add_argument("--execroot-marker", help="Token in env values to replace with the absolute execroot")
+PARSER.add_argument("--cross", action="store_true", help="Cross-compilation mode: target platform != exec platform")
 PARSER.add_argument("--target-os", default="", help="Target platform OS the wheel must be tagged for (linux, darwin, windows)")
 PARSER.add_argument("--target-cpu", default="", help="Target platform CPU the wheel must be tagged for (x86_64, aarch64, ...)")
 
@@ -397,7 +803,13 @@ def main() -> None:
     # and re-point CC/CXX/etc. through wrapper scripts in tmp_root so the
     # Bazel-supplied workspace-relative compiler paths survive the cwd
     # change into the worktree.
-    build_env = _compiler_env(tmp_root, opts.execroot_marker)
+    build_env = _compiler_env(
+        tmp_root,
+        opts.execroot_marker,
+        cross=opts.cross,
+        target_os=opts.target_os,
+        target_cpu=opts.target_cpu,
+    )
 
     if _legacy_metadata_conflicts_with_pyproject(t):
         print(

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -154,17 +154,12 @@ def _absolutize_tool_paths(env: dict[str, str]) -> None:
             env[key] = shlex.join(parts)
 
 
-
 # --- Cross-compilation support -------------------------------------------
 #
 # Reduced to what setuptools-family backends need. Deferred to the slices
 # that exercise them: meson cross files, CMake toolchain files, cargo env,
 # lld discovery, -nostdlib++ static runtime archives, probe-executable
 # static linking, and the darwin-exec ar/libtool translation.
-
-
-
-
 
 
 def _write_generated_file(file_path: str, content: str, executable: bool = False) -> str:

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -256,8 +256,28 @@ def _sdist_build_impl(repository_ctx):
 
     # Leave args unset: the pure rule validates anyarch wheels by default,
     # while the native rule defaults to no validation.
+    # Native-rule repos route the frontend through pep517_frontend, which
+    # resets the platform_libc/platform_version flags to the host's inside
+    # the exec configuration. One edge for every mode: the reset keeps the
+    # frontend's own dependency resolution consistent under any target
+    # configuration (a plain exec edge carries the target's flags, which can
+    # make its venv's wheel selection unsatisfiable — or cyclic — under a
+    # cross transition).
+    frontend_load = ""
+    frontend_target = ""
+    tool = ":build_tool"
+    if is_native:
+        frontend_load = "\nload(\"@aspect_rules_py//uv/private/pep517_whl:frontend.bzl\", \"pep517_frontend\")"
+        frontend_target = """
+pep517_frontend(
+    name = "frontend",
+    actual = ":build_tool",
+)
+"""
+        tool = ":frontend"
+
     repository_ctx.file("BUILD.bazel", content = """
-load("@aspect_rules_py//uv/private/pep517_whl:{rule}.bzl", "{rule}")
+load("@aspect_rules_py//uv/private/pep517_whl:{rule}.bzl", "{rule}"){frontend_load}
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 
 py_binary(
@@ -266,11 +286,11 @@ py_binary(
     srcs = ["@aspect_rules_py//uv/private/pep517_whl/tools:build_helper.py"],
     deps = {deps},
 )
-
+{frontend_target}
 {rule}(
     name = "whl",
     src = "{src}",
-    tool = ":build_tool",
+    tool = "{tool}",
     version = "{version}",{console_scripts_attr}{monitor_memory_attr}{resource_set_attr}{patch_attrs}{toolchain_attrs}
     visibility = ["//visibility:public"],
 )
@@ -285,6 +305,9 @@ exports_files(
         console_scripts_attr = console_scripts_attr,
         monitor_memory_attr = monitor_memory_attr,
         rule = "pep517_native_whl" if is_native else "pep517_whl",
+        frontend_load = frontend_load,
+        frontend_target = frontend_target,
+        tool = tool,
         version = repository_ctx.attr.version,
         resource_set_attr = resource_set_attr,
         patch_attrs = patch_attrs,


### PR DESCRIPTION
The cross detection from #1465 stops failing and becomes a working mode, scoped to setuptools-family backends — every piece lands with its consumer.

**`cc_layer.bzl`** (new) extracts the target-configured C++ toolchain via `cc_common`: per-action tools, compile/link flag lines with execroot-relative paths marked for post-chdir absolutization, and `-fPIC`. `-nostdlib++` static-runtime extraction is deferred to the backends that link C++ through it.

**`pep517_native_whl`'s cross branch** feeds the layer to the action: `CFLAGS`/`CXXFLAGS`/`LDFLAGS`/`LDSHAREDFLAGS` merge toolchain-first with any `uv.override_package` env (package flags survive and win), `--cross/--target-os/--target-cpu` reach the helper, and the target interpreter's sysconfigdata plus `_PYTHON_HOST_PLATFORM` carry the destination identity.

**`build_helper`'s cross environment**: compiler wrappers that re-inject target-identity flags and drop host-sysconfig linker leaks (keeping `-bundle`/`-undefined dynamic_lookup` when the target IS darwin), sysconfig override via `_PYTHON_SYSCONFIGDATA_NAME`, and a `sitecustomize` faking `os.uname`/`platform`/`sys.platform` (arm64 spelling on darwin) with a `_manylinux` hook that refuses unverifiable compatibility.

**One tool edge, wrapped**: generated native-rule repos route the frontend through `pep517_frontend` (#1483) unconditionally. Besides fixing cross frontends, the reset keeps the frontend venv's wheel selection consistent under any target configuration — a plain exec edge carries the target's flags, which turned cffi's install alias into a **dependency cycle** under a cross transition. That cycle is latent on main today: it aborts analysis before #1465's diagnostic can even fire.

### Changes are visible to end-users: yes

Native sdists cross-compile when a cross-capable C++ toolchain (e.g. the BCR `llvm` module) is registered; previously this failed analysis. Native builds keep their code path; generated repos gain an internal `:frontend` target (snapshots regenerated — the pure-rule template is untouched).

### Test plan

- **e2e**: `pycross-setuptools` grows the rules_pycross-style matrix — pyyaml, setproctitle and zstandard (plus cffi as a build dep) cross-built for linux amd64+arm64 and their WHEEL `Tag:` metadata asserted per platform. Verified from a darwin host against the BCR llvm toolchain; the existing native runtime tests keep passing.
- **`cross_mode_test`** pins the action shape under a cross transition (argv flags, `_PYTHON_HOST_PLATFORM`, toolchain CFLAGS) against the repo's dev llvm toolchain.
- **Unit tests**: wrapper argv transform against an argv-echoing fake compiler (identity re-injection, host-leak drops, darwin `dynamic_lookup`, probe passthrough, debug-flag strip), identity-flag extraction, sitecustomize content (arm64 fix pinned), `_darwin_kernel_release`, sysconfigdata parsing, and `_derive_python_host_platform` (armv7l spelling pinned).
- `bazel test //uv/...`: 174 passed, 2 skipped; `ruff`/`pyright`/`ty` clean on the helper