### PR TITLE
feat(oci): every bsdtar compression filter, plus custom compressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,87 @@ Cross-compile for Linux from macOS:
 bazel build //:image --platforms=//platforms:linux_amd64
 ```
 
+### Layer compression
+
+Layers are written by bsdtar, so any libarchive write filter can compress them:
+`none`, `gzip` (the default, level 6), `bzip2`, `xz`, `lzma`, `lzop`, `lz4`,
+`lrzip`, `zstd`, and `compress`. The file extension follows the filter, which is
+what image tooling reads the layer's media type from.
+
+**The OCI image spec only defines `tar`, `+gzip` and `+zstd` layers**, so those
+are the three you can put in an image. `rules_oci` identifies a layer's
+compression by sniffing its magic; a codec it cannot sniff is labelled an
+uncompressed tar and keeps the *compressed* digest as its `diffid`, which builds
+successfully and produces an invalid image. `py_image_layer` and `py_layer_tier`
+therefore reject the other filters unless you set `allow_non_oci_layers = True`,
+which declares that the tars are going somewhere other than an OCI image.
+
+`py_layer_tier` sets compression for the layers it names — pip packages, the
+interpreter, and first-party groups:
+
+```starlark
+load("@aspect_rules_py//py:defs.bzl", "py_layer_tier")
+
+py_layer_tier(
+    name = "tier",
+    groups = {
+        "@pip//torch": "heavy",
+        "//src/common": "common",
+    },
+    interpreter_group = "interpreter",
+    compression = {
+        "heavy": ["zstd", "19"],   # [algorithm, level]
+        "common": ["gzip"],        # level omitted: libarchive's default
+        "interpreter": ["none"],   # an uncompressed layer
+    },
+)
+```
+
+`py_image_layer` sets compression for the layers it creates itself — the
+`groups` tars, the squashed pip layer (`"packages"`), and the source layer
+(`"default"`) — and takes precedence over the tier for a group both name:
+
+```starlark
+py_image_layer(
+    name = "app_layers",
+    binary = ":app_bin",
+    layer_tier = ":tier",
+    group_compression = {"default": ["zstd", "3"]},
+)
+```
+
+For a different implementation of a codec — `pigz`, a tuned `zstd` — declare a
+`py_layer_compressor`. bsdtar pipes the archive through the program, so anything
+that reads stdin and writes compressed bytes to stdout works. The `extension` is
+how you declare what it emits, and it decides whether the result is OCI-valid:
+
+```starlark
+load("@aspect_rules_py//py:defs.bzl", "py_layer_compressor")
+
+py_layer_compressor(
+    name = "pigz",
+    tool = "//tools:pigz",
+    args = ["-11"],
+    extension = ".tar.gz",  # gzip bytes, so a valid OCI layer
+)
+
+py_layer_tier(
+    name = "tier",
+    groups = {"@pip//torch": "heavy"},
+    compressors = {":pigz": "heavy"},
+)
+```
+
+A compressor declaring anything other than `.tar`, `.tar.gz` or `.tar.zst` is
+treated as non-OCI and needs `allow_non_oci_layers = True` — the program's bytes
+are opaque, so the extension is the only claim available about what an image
+consumer would find.
+
+`py_image_layer` accepts the same mapping as `group_compressors` for its own
+tars. Note that `lzop` and `lrzip` are the two filters libarchive implements by
+shelling out to a same-named binary, which a sandboxed action is not guaranteed
+to have — prefer a `py_layer_compressor` there.
+
 ## IDE Integration
 
 `aspect_rules_py` generates standard virtualenv structures that IDEs understand.

--- a/docs/api/py.md
+++ b/docs/api/py.md
@@ -70,6 +70,55 @@ bazel_env(
 | <a id="current_py_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 
 
+<a id="py_layer_compressor"></a>
+
+## py_layer_compressor
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_layer_compressor")
+
+py_layer_compressor(<a href="#py_layer_compressor-name">name</a>, <a href="#py_layer_compressor-args">args</a>, <a href="#py_layer_compressor-extension">extension</a>, <a href="#py_layer_compressor-tool">tool</a>)
+</pre>
+
+A user-supplied program that compresses `py_image_layer` layer tars.
+
+bsdtar pipes the archive through `tool` (via `--use-compress-program`), so any
+program that reads an uncompressed stream on stdin and writes the compressed
+stream to stdout works — including compressors libarchive has no filter for.
+
+```starlark
+py_layer_compressor(
+    name = "pigz",
+    tool = "//tools:pigz",
+    args = ["-11"],
+    extension = ".tar.gz",
+)
+
+py_layer_tier(
+    name = "tier",
+    groups = {"@pip//torch": "heavy"},
+    compressors = {":pigz": "heavy"},
+)
+```
+
+`extension` is the only claim available about the program's output, so it also
+decides whether the layer is OCI-valid: anything but `.tar`, `.tar.gz` or
+`.tar.zst` needs `allow_non_oci_layers = True` on the tier or rule.
+
+The program runs inside the tar action, so prefer a Bazel-built binary or a
+`sh_binary` wrapper over something assumed to be on the host's PATH.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="py_layer_compressor-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_layer_compressor-args"></a>args |  Arguments passed after the program path. Each entry must be a single whitespace-free token — bsdtar splits the command line itself.   | List of strings | optional |  `[]`  |
+| <a id="py_layer_compressor-extension"></a>extension |  Extension for tars this compressor produces, e.g. '.tar.gz'. Must start with '.'. Also declares OCI validity: only '.tar', '.tar.gz' and '.tar.zst' are layer formats an image consumer can read.   | String | required |  |
+| <a id="py_layer_compressor-tool"></a>tool |  The compressor program. Reads stdin, writes compressed bytes to stdout.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+
 <a id="py_layer_tier"></a>
 
 ## py_layer_tier
@@ -77,7 +126,8 @@ bazel_env(
 <pre>
 load("@aspect_rules_py//py:defs.bzl", "py_layer_tier")
 
-py_layer_tier(<a href="#py_layer_tier-name">name</a>, <a href="#py_layer_tier-compression">compression</a>, <a href="#py_layer_tier-group">group</a>, <a href="#py_layer_tier-groups">groups</a>, <a href="#py_layer_tier-interpreter_group">interpreter_group</a>, <a href="#py_layer_tier-owner">owner</a>, <a href="#py_layer_tier-root">root</a>, <a href="#py_layer_tier-strip_prefix">strip_prefix</a>)
+py_layer_tier(<a href="#py_layer_tier-name">name</a>, <a href="#py_layer_tier-allow_non_oci_layers">allow_non_oci_layers</a>, <a href="#py_layer_tier-compression">compression</a>, <a href="#py_layer_tier-compressors">compressors</a>, <a href="#py_layer_tier-group">group</a>, <a href="#py_layer_tier-groups">groups</a>,
+              <a href="#py_layer_tier-interpreter_group">interpreter_group</a>, <a href="#py_layer_tier-owner">owner</a>, <a href="#py_layer_tier-root">root</a>, <a href="#py_layer_tier-strip_prefix">strip_prefix</a>)
 </pre>
 
 Grouping and compression plan for `py_image_layer`.
@@ -90,7 +140,9 @@ Must not be testonly. `py_image_layer` transitions the `//py:layer_tier` flag to
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="py_layer_tier-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="py_layer_tier-compression"></a>compression |  Maps group name → [algorithm, level] for pip-derived layers. Applies to the whole-group tar, each subpath-split tar, and the multi-member merged tar — anything routed through py_layer_tier.groups. Example: {"heavy_pkgs": ["zstd", "1"]}. Untouched groups default to gzip -6.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> List of strings</a> | optional |  `{}`  |
+| <a id="py_layer_tier-allow_non_oci_layers"></a>allow_non_oci_layers |  Permit compression the OCI image spec has no layer format for. The spec defines only tar, gzip and zstd; rules_oci labels anything else an uncompressed tar and records the compressed digest as the layer's diffid, so the image is invalid even though the build succeeds. Set this only when the tars are consumed by something other than an OCI image.   | Boolean | optional |  `False`  |
+| <a id="py_layer_tier-compression"></a>compression |  Maps group name → [algorithm] or [algorithm, level]. Applies to every layer this tier names: the whole-group tar, each subpath-split tar, the multi-member merged tar, the interpreter tar, and first-party group tars.<br><br>`algorithm` is any bsdtar (libarchive) write filter: `none`, `gzip`, `bzip2`, `xz`, `lzma`, `lzop`, `lz4`, `lrzip`, `zstd`, or `compress`. `lzop` and `lrzip` shell out to a same-named binary that must exist inside the action — use `compressors` for a hermetic equivalent. `none` and `compress` take no level.<br><br>`level` is optional; omit it to take libarchive's default for that filter. Example: {"heavy_pkgs": ["zstd", "19"], "cold": ["xz"]}. Untouched groups default to gzip -6.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> List of strings</a> | optional |  `{}`  |
+| <a id="py_layer_tier-compressors"></a>compressors |  Maps a `py_layer_compressor` target → group name, for compressors libarchive has no filter for. bsdtar pipes the layer through the program. A group may appear here or in `compression`, not both.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="py_layer_tier-group"></a>group |  Numeric gid owning every file in every layer this tier produces. Default: '0' (root).   | String | optional |  `"0"`  |
 | <a id="py_layer_tier-groups"></a>groups |  Maps @pip//package → group name (whole pip package), @pip//package:glob → group name (pip subpath split), or //some/first_party:lib → group name (first-party PyInfo target). First-party main-repo labels may be written as //pkg:name; fully-qualified forms like @@//pkg:name are also accepted. A pip package may appear as a whole-package key OR with subpath globs, not both.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="py_layer_tier-interpreter_group"></a>interpreter_group |  When non-empty, the Python interpreter runfiles resolved from the binary's py toolchain are emitted as their own layer under this name instead of being bundled into the default source layer.   | String | optional |  `""`  |
@@ -251,6 +303,28 @@ Python source, import-path, and virtual-dependency information for a target's de
 | <a id="PyInfo-virtual_resolutions"></a>virtual_resolutions |  depset[struct(virtual, target)] — virtual-dependency-name to concrete-target resolutions.    |
 
 
+<a id="PyLayerCompressorInfo"></a>
+
+## PyLayerCompressorInfo
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "PyLayerCompressorInfo")
+
+PyLayerCompressorInfo(<a href="#PyLayerCompressorInfo-args">args</a>, <a href="#PyLayerCompressorInfo-executable">executable</a>, <a href="#PyLayerCompressorInfo-extension">extension</a>, <a href="#PyLayerCompressorInfo-files_to_run">files_to_run</a>)
+</pre>
+
+A custom layer compressor: a program bsdtar pipes the archive through.
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PyLayerCompressorInfo-args"></a>args |  tuple[str] — arguments appended after the program path.    |
+| <a id="PyLayerCompressorInfo-executable"></a>executable |  File — the program bsdtar invokes via --use-compress-program.    |
+| <a id="PyLayerCompressorInfo-extension"></a>extension |  str — output file extension, e.g. '.tar.br'.    |
+| <a id="PyLayerCompressorInfo-files_to_run"></a>files_to_run |  FilesToRunProvider — the program plus its runfiles, for the tar action's `tools`.    |
+
+
 <a id="PyLayerTierInfo"></a>
 
 ## PyLayerTierInfo
@@ -258,8 +332,8 @@ Python source, import-path, and virtual-dependency information for a target's de
 <pre>
 load("@aspect_rules_py//py:defs.bzl", "PyLayerTierInfo")
 
-PyLayerTierInfo(<a href="#PyLayerTierInfo-whole_groups">whole_groups</a>, <a href="#PyLayerTierInfo-subpath_groups">subpath_groups</a>, <a href="#PyLayerTierInfo-compression">compression</a>, <a href="#PyLayerTierInfo-multi_member_groups">multi_member_groups</a>, <a href="#PyLayerTierInfo-interpreter_group">interpreter_group</a>,
-                <a href="#PyLayerTierInfo-root">root</a>, <a href="#PyLayerTierInfo-strip_prefix">strip_prefix</a>, <a href="#PyLayerTierInfo-owner">owner</a>, <a href="#PyLayerTierInfo-group">group</a>)
+PyLayerTierInfo(<a href="#PyLayerTierInfo-whole_groups">whole_groups</a>, <a href="#PyLayerTierInfo-subpath_groups">subpath_groups</a>, <a href="#PyLayerTierInfo-compression">compression</a>, <a href="#PyLayerTierInfo-compressors">compressors</a>, <a href="#PyLayerTierInfo-codecs">codecs</a>, <a href="#PyLayerTierInfo-multi_member_groups">multi_member_groups</a>,
+                <a href="#PyLayerTierInfo-interpreter_group">interpreter_group</a>, <a href="#PyLayerTierInfo-root">root</a>, <a href="#PyLayerTierInfo-strip_prefix">strip_prefix</a>, <a href="#PyLayerTierInfo-owner">owner</a>, <a href="#PyLayerTierInfo-group">group</a>)
 </pre>
 
 Layer tier for py_image_layer: how pip packages are grouped and compressed.
@@ -270,7 +344,9 @@ Layer tier for py_image_layer: how pip packages are grouped and compressed.
 | :------------- | :------------- |
 | <a id="PyLayerTierInfo-whole_groups"></a>whole_groups |  dict[str, str] — normalized pip label → group name.    |
 | <a id="PyLayerTierInfo-subpath_groups"></a>subpath_groups |  dict[str, dict[str, list[str]]] — label → {group_name: [glob_patterns]}.    |
-| <a id="PyLayerTierInfo-compression"></a>compression |  dict[str, list[str]] — group name → [algorithm, level].    |
+| <a id="PyLayerTierInfo-compression"></a>compression |  dict[str, list[str]] — group name → [algorithm, level], as written on the rule.    |
+| <a id="PyLayerTierInfo-compressors"></a>compressors |  dict[str, PyLayerCompressorInfo] — group name → custom compressor.    |
+| <a id="PyLayerTierInfo-codecs"></a>codecs |  dict[str, struct] — group name → resolved codec (bsdtar flags + file extension).    |
 | <a id="PyLayerTierInfo-multi_member_groups"></a>multi_member_groups |  dict[str, True] — group names with 2+ members in whole_groups.    |
 | <a id="PyLayerTierInfo-interpreter_group"></a>interpreter_group |  str — group name for the Python interpreter layer; '' disables.    |
 | <a id="PyLayerTierInfo-root"></a>root |  str — root path in the image (e.g. '/app').    |
@@ -399,6 +475,7 @@ workspace symlink in one step, set `expose_venv_link = True`.
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer")
 
 py_image_layer(<a href="#py_image_layer-name">name</a>, <a href="#py_image_layer-binary">binary</a>, <a href="#py_image_layer-groups">groups</a>, <a href="#py_image_layer-group_execution_requirements">group_execution_requirements</a>, <a href="#py_image_layer-group_compress_levels">group_compress_levels</a>,
+               <a href="#py_image_layer-group_compression">group_compression</a>, <a href="#py_image_layer-group_compressors">group_compressors</a>, <a href="#py_image_layer-allow_non_oci_layers">allow_non_oci_layers</a>,
                <a href="#py_image_layer-warn_remote_cache_threshold_mb">warn_remote_cache_threshold_mb</a>, <a href="#py_image_layer-warn_layer_count">warn_layer_count</a>, <a href="#py_image_layer-platform">platform</a>, <a href="#py_image_layer-layer_tier">layer_tier</a>, <a href="#py_image_layer-launcher_dir">launcher_dir</a>,
                <a href="#py_image_layer-binaries">binaries</a>, <a href="#py_image_layer-kwargs">**kwargs</a>)
 </pre>
@@ -432,7 +509,10 @@ or pin a tier to a specific rule via the `py_layer_tier` attr below.
 | <a id="py_image_layer-binary"></a>binary |  A py_binary target.   |  `None` |
 | <a id="py_image_layer-groups"></a>groups |  Maps a NON-PIP dep label to a group name. Each gets its own rule-created tar. All pip-package grouping (whole-package, subpath, multi-member) belongs in py_layer_tier — subpath glob keys passed here fail loudly.   |  `{}` |
 | <a id="py_image_layer-group_execution_requirements"></a>group_execution_requirements |  Maps a group name to execution requirement strings. The group name "packages" applies to the squashed ungrouped-pip tar.   |  `{}` |
-| <a id="py_image_layer-group_compress_levels"></a>group_compress_levels |  Maps a group name to a gzip compression level (1-9) for rule-created tars (non-pip deps, squashed ungrouped pip tar, source). Default 6. Does NOT apply to aspect-created pip tars (configure via the py_layer_tier target).   |  `{}` |
+| <a id="py_image_layer-group_compress_levels"></a>group_compress_levels |  gzip-only shorthand: maps a group name to a compression level (1-9) for rule-created tars. Default 6. Ignored for any group named by `group_compression`, `group_compressors`, or the tier's `compression`.   |  `{}` |
+| <a id="py_image_layer-group_compression"></a>group_compression |  Maps a group name to `[algorithm]` or `[algorithm, level]` for rule-created tars (non-pip deps, first-party groups, the squashed ungrouped-pip tar under the name "packages", and the source layer under the name "default"). `algorithm` is any bsdtar write filter — `none`, `gzip`, `bzip2`, `xz`, `lzma`, `lzop`, `lz4`, `lrzip`, `zstd`, `compress`. Takes precedence over the tier's `compression` for the same group. Does NOT apply to aspect-created pip tars; configure those on the py_layer_tier target.   |  `{}` |
+| <a id="py_image_layer-group_compressors"></a>group_compressors |  Maps a `py_layer_compressor` target to a group name, for rule-created tars that need a compressor libarchive has no filter for. Same precedence as `group_compression`; a group may appear in one or the other, not both.   |  `{}` |
+| <a id="py_image_layer-allow_non_oci_layers"></a>allow_non_oci_layers |  Permit compression the OCI image spec has no layer format for. The spec defines only tar, gzip and zstd, and rules_oci labels anything else an uncompressed tar with the compressed digest as its diffid — the build succeeds and the image is invalid. Set this only when the tars are consumed by something other than an OCI image.   |  `False` |
 | <a id="py_image_layer-warn_remote_cache_threshold_mb"></a>warn_remote_cache_threshold_mb |  Threshold for large package warnings.   |  `200` |
 | <a id="py_image_layer-warn_layer_count"></a>warn_layer_count |  Warn when total layers exceed this. Default: 90.   |  `90` |
 | <a id="py_image_layer-platform"></a>platform |  Platform transition target.   |  `None` |

--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -724,8 +724,8 @@ assert_tar_ownership(
 
 # Multi-member group coverage: two pip packages mapped to the same group name
 # produce a single merged tar from both install_dirs. Binary also adds
-# pyproject_hooks to make the closure non-trivial. Zstd-compressed to exercise
-# _compression_ext.
+# pyproject_hooks to make the closure non-trivial. Zstd-compressed so the merged
+# tar carries the tier's codec and extension.
 py_binary(
     name = "my_app_multi_bin",
     srcs = ["__main__.py"],
@@ -987,6 +987,52 @@ container_structure_test(
     image = ":amd64_launchers_image",
     platform = "linux/amd64",
     tags = ["requires-docker"],
+)
+
+# The OCI spec defines tar, gzip and zstd layers, and rules_oci recognises a
+# layer's compression by sniffing its magic. A codec it cannot sniff is labelled
+# an uncompressed tar and keeps the compressed digest as its diffid, so the
+# image builds and is invalid. Build a real image over the codecs py_image_layer
+# advertises as OCI-safe and check both halves of that contract on the layout.
+py_layer_tier(
+    name = "oci_codec_tier",
+    compression = {
+        "branding": [
+            "zstd",
+            "19",
+        ],
+        "interpreter": ["none"],
+    },
+    groups = {"//oci/py_image_layer/branding": "branding"},
+    interpreter_group = "interpreter",
+)
+
+py_image_layer(
+    name = "oci_codec_layers",
+    binary = ":my_app_bin",
+    group_compression = {"default": [
+        "gzip",
+        "9",
+    ]},
+    layer_tier = ":oci_codec_tier",
+)
+
+oci_image(
+    name = "oci_codec_image",
+    base = "@ubuntu",
+    tars = [":oci_codec_layers"],
+)
+
+py_test(
+    name = "oci_codec_media_type_test",
+    srcs = ["assert_oci_layer_media_types.py"],
+    args = [
+        "--min=zstd:1",
+        "--min=gzip:1",
+        "$(rootpath :oci_codec_image)",
+    ],
+    data = [":oci_codec_image"],
+    main = "assert_oci_layer_media_types.py",
 )
 
 image_layer_analysis_test_suite()

--- a/e2e/cases/oci/py_image_layer/assert_oci_layer_media_types.py
+++ b/e2e/cases/oci/py_image_layer/assert_oci_layer_media_types.py
@@ -1,0 +1,135 @@
+"""Assert an oci_image labels py_image_layer's tars as the layers they really are.
+
+rules_oci derives a layer's `mediaType` and `diffid` by sniffing the archive's
+magic: gzip and zstd are recognised, everything else falls through as an
+uncompressed tar whose `diffid` is left as the *compressed* digest. That failure
+is silent — the image builds and is invalid — so this walks the produced OCI
+layout and checks both halves of the contract for every layer:
+
+  * the layer's bytes really are the format its mediaType claims, and
+  * a compressed layer's diff_id differs from its digest, i.e. rules_oci
+    actually decompressed it to compute the uncompressed digest.
+
+The first check is the one that catches this bug, and it has to read the blob:
+a mislabelled bzip2 layer is indistinguishable from a genuine uncompressed tar
+by metadata alone, because rules_oci writes `mediaType: ...tar` and leaves
+`diff_id == digest` — exactly what an honest uncompressed layer looks like. The
+manifest is self-consistent and simply wrong about the bytes.
+
+Both run over every layer in the image, the base's included. The `--min` counts
+are minimums rather than exact figures for the same reason: the base contributes
+layers of its own, and how many is not this rule's business.
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, NoReturn
+
+# The three layer formats the OCI spec defines, by the name you pass to --min.
+SUFFIX_BY_NAME = {"none": "", "gzip": "+gzip", "zstd": "+zstd"}
+OCI_MEDIA_TYPES = frozenset(
+    "application/vnd.oci.image.layer.v1.tar{}".format(suffix) for suffix in SUFFIX_BY_NAME.values()
+)
+
+# What the blob must actually start with, per declared compression:
+# (human name, byte offset, magic). A POSIX tar carries "ustar" at 257.
+LAYER_MAGIC = {
+    "": ("an uncompressed tar", 257, b"ustar"),
+    "+gzip": ("gzip", 0, b"\x1f\x8b"),
+    "+zstd": ("zstd", 0, b"\x28\xb5\x2f\xfd"),
+}
+
+
+def fail(message: str) -> NoReturn:
+    print("FAIL: {}".format(message), file=sys.stderr)
+    sys.exit(1)
+
+
+def blob_path(layout: str, digest: str) -> str:
+    algorithm, _, hexdigest = digest.partition(":")
+    path = os.path.join(layout, "blobs", algorithm, hexdigest)
+    if not os.path.exists(path):
+        fail("blob {} missing from the layout at {}".format(digest, layout))
+    return path
+
+
+def read_blob(layout: str, digest: str) -> Any:
+    with open(blob_path(layout, digest), "rb") as handle:
+        return json.load(handle)
+
+
+def check_layer_bytes(layout: str, digest: str, suffix: str) -> None:
+    """Assert the blob really is the format its mediaType claims."""
+    name, offset, magic = LAYER_MAGIC[suffix]
+    with open(blob_path(layout, digest), "rb") as handle:
+        handle.seek(offset)
+        head = handle.read(len(magic))
+    if head != magic:
+        fail(
+            "layer {} is labelled {} but its bytes are not — expected {!r} at offset {}, "
+            "got {!r}. rules_oci did not recognise this compression.".format(
+                digest, name, magic, offset, head
+            )
+        )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    # --min=zstd:1 -- at least this many layers carry that compression. A
+    # minimum rather than an exact count because the base image contributes
+    # layers of its own, and how many is not this rule's business.
+    parser.add_argument("--min", action="append", default=[])
+    parser.add_argument("layout")
+    args = parser.parse_args(argv)
+
+    layout = args.layout
+    if not os.path.isdir(layout):
+        fail("{} is not an OCI layout directory".format(layout))
+
+    with open(os.path.join(layout, "index.json"), "rb") as handle:
+        index = json.load(handle)
+    manifest = read_blob(layout, index["manifests"][0]["digest"])
+    config = read_blob(layout, manifest["config"]["digest"])
+
+    layers = manifest["layers"]
+    diff_ids = config["rootfs"]["diff_ids"]
+    if len(layers) != len(diff_ids):
+        fail("{} layers but {} diff_ids".format(len(layers), len(diff_ids)))
+
+    seen: dict[str, int] = {}
+    for layer, diff_id in zip(layers, diff_ids):
+        media_type = layer["mediaType"]
+        suffix = media_type.partition("tar")[2]
+        if media_type not in OCI_MEDIA_TYPES:
+            fail("layer {} has media type {!r}, which is not an OCI layer format".format(layer["digest"], media_type))
+        seen[suffix] = seen.get(suffix, 0) + 1
+        check_layer_bytes(layout, layer["digest"], suffix)
+
+        # An uncompressed layer is its own diff; a compressed one must have been
+        # decompressed to get here, so the two digests cannot match.
+        if suffix and diff_id == layer["digest"]:
+            fail(
+                "layer {} is {} but its diff_id equals the compressed digest — "
+                "rules_oci did not recognise the compression".format(layer["digest"], media_type)
+            )
+        if not suffix and diff_id != layer["digest"]:
+            fail("uncompressed layer {} has a diff_id of {}".format(layer["digest"], diff_id))
+
+    for spec in args.min:
+        name, _, count = spec.rpartition(":")
+        if name not in SUFFIX_BY_NAME:
+            fail("--min takes one of {}, got {!r}".format(sorted(SUFFIX_BY_NAME), name))
+        found = seen.get(SUFFIX_BY_NAME[name], 0)
+        if found < int(count):
+            fail("expected at least {} {} layer(s), found {}".format(count, name, found))
+        print("ok: {} {} layer(s), at least {} required".format(found, name, count))
+
+    print("ok: all {} layers carry the bytes their mediaType claims, with matching diff_ids".format(len(layers)))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -83,6 +83,7 @@ bzl_library(
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//py/private:compression",
         "//py/private:providers",
         "//py/private:py_image_layer",
         "//py/private:py_info",

--- a/py/defs.bzl
+++ b/py/defs.bzl
@@ -20,6 +20,11 @@ load("@rules_python//python:packaging.bzl", _py_wheel = "py_wheel")
 load("@rules_python//python:pip.bzl", _whl_filegroup = "whl_filegroup")
 load("@rules_python//python:py_runtime.bzl", _py_runtime = "py_runtime")
 load("@rules_python//python:py_runtime_pair.bzl", _py_runtime_pair = "py_runtime_pair")
+load(
+    "//py/private:compression.bzl",
+    _PyLayerCompressorInfo = "PyLayerCompressorInfo",
+    _py_layer_compressor = "py_layer_compressor",
+)
 load("//py/private:providers.bzl", _PyWheelsInfo = "PyWheelsInfo")
 load(
     "//py/private:py_image_layer.bzl",
@@ -63,7 +68,9 @@ py_unpacked_wheel = _py_unpacked_wheel
 
 py_image_layer = _py_image_layer
 py_layer_tier = _py_layer_tier
+py_layer_compressor = _py_layer_compressor
 PyLayerTierInfo = _PyLayerTierInfo
+PyLayerCompressorInfo = _PyLayerCompressorInfo
 
 # The PyInfo provider used by rules_py
 PyInfo = _PyInfo

--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -60,6 +60,7 @@ bzl_library(
     name = "py_image_layer",
     srcs = ["py_image_layer.bzl"],
     deps = [
+        ":compression",
         ":providers",
         ":py_info",
         ":py_info_interop",
@@ -180,6 +181,11 @@ bzl_library(
         ":py_info",
         "@rules_python//python:defs_bzl",
     ],
+)
+
+bzl_library(
+    name = "compression",
+    srcs = ["compression.bzl"],
 )
 
 bzl_library(

--- a/py/private/compression.bzl
+++ b/py/private/compression.bzl
@@ -1,0 +1,279 @@
+"""Compression codecs for `py_image_layer` layer tars.
+
+Layer tars are written by bsdtar, so the usable set is libarchive's write-filter
+set, mapped here onto bsdtar flags and file extensions. `py_layer_compressor`
+covers everything else via `--use-compress-program`.
+
+libarchive implements lzop and lrzip by shelling out to a same-named binary,
+which a sandboxed action is not guaranteed to have; `py_layer_compressor` is
+the hermetic answer there.
+
+The OCI image spec only defines tar, gzip and zstd layers, and rules_oci sniffs
+exactly those two magics — anything else is labelled an uncompressed tar and
+gets the *compressed* digest as its `diffid`, which is a broken image rather
+than a build error. So `oci` marks the codecs an image consumer can actually
+read, and the rules refuse the rest unless `allow_non_oci_layers` says the tars
+are headed somewhere other than an OCI image.
+"""
+
+PyLayerCompressorInfo = provider(
+    doc = "A custom layer compressor: a program bsdtar pipes the archive through.",
+    fields = {
+        "args": "tuple[str] — arguments appended after the program path.",
+        "executable": "File — the program bsdtar invokes via --use-compress-program.",
+        "extension": "str — output file extension, e.g. '.tar.br'.",
+        "files_to_run": "FilesToRunProvider — the program plus its runfiles, for the tar action's `tools`.",
+    },
+)
+
+# flag: selects the write filter. filter: the `--options` module accepting
+# `compression-level`, None when the filter has no level knob. oci: the OCI
+# image spec defines a layer format for it.
+ALGORITHMS = {
+    "bzip2": struct(flag = "--bzip2", filter = "bzip2", ext = ".tar.bz2", min_level = 1, max_level = 9, oci = False),
+    "compress": struct(flag = "--compress", filter = None, ext = ".tar.Z", min_level = 0, max_level = 0, oci = False),
+    "gzip": struct(flag = "--gzip", filter = "gzip", ext = ".tar.gz", min_level = 0, max_level = 9, oci = True),
+    "lrzip": struct(flag = "--lrzip", filter = "lrzip", ext = ".tar.lrz", min_level = 1, max_level = 9, oci = False),
+    # lz4 rejects level 0 outright ("Undefined option"), unlike gzip/xz/lzma.
+    "lz4": struct(flag = "--lz4", filter = "lz4", ext = ".tar.lz4", min_level = 1, max_level = 9, oci = False),
+    "lzma": struct(flag = "--lzma", filter = "lzma", ext = ".tar.lzma", min_level = 0, max_level = 9, oci = False),
+    "lzop": struct(flag = "--lzop", filter = "lzop", ext = ".tar.lzo", min_level = 1, max_level = 9, oci = False),
+    "none": struct(flag = None, filter = None, ext = ".tar", min_level = 0, max_level = 0, oci = True),
+    "xz": struct(flag = "--xz", filter = "xz", ext = ".tar.xz", min_level = 0, max_level = 9, oci = False),
+    "zstd": struct(flag = "--zstd", filter = "zstd", ext = ".tar.zst", min_level = -131072, max_level = 22, oci = True),
+}
+
+SUPPORTED_ALGORITHMS = sorted(ALGORITHMS.keys())
+OCI_ALGORITHMS = sorted([name for name, spec in ALGORITHMS.items() if spec.oci])
+
+# A custom compressor declares what it emits through its extension; only these
+# three land on a layer an OCI consumer can read.
+_OCI_EXTENSIONS = {spec.ext: name for name, spec in ALGORITHMS.items() if spec.oci}
+
+# libarchive's gzip filter stamps wall-clock into the header's MTIME field, so
+# identical inputs would yield different layer digests. `!timestamp` zeroes it.
+# No other write filter has an equivalent field.
+_EXTRA_OPTIONS = {
+    "gzip": ["gzip:!timestamp"],
+}
+
+DEFAULT_ALGORITHM = "gzip"
+DEFAULT_LEVEL = "6"
+
+def _is_integer(value):
+    digits = value[1:] if value.startswith("-") else value
+    return len(digits) > 0 and digits.isdigit()
+
+def _attr_suffix(attr_path):
+    """Parenthesized ` (py_layer_tier.compression["x"])` for an error message, or "" when unknown."""
+    return " (%s)" % attr_path if attr_path else ""
+
+def make_codec(algorithm, level, attr_path = ""):
+    """Resolve a builtin bsdtar algorithm + level into a codec struct.
+
+    Args:
+        algorithm: One of `SUPPORTED_ALGORITHMS`.
+        level: Compression level as a string, or "" to use libarchive's default.
+        attr_path: The attribute the values came from, named in error messages,
+            e.g. `py_layer_tier.compression["x"]`. Omit when there is no
+            user-visible attribute to point at.
+
+    Returns:
+        A codec struct consumed by `codec_tar_args` / `codec_tools`.
+    """
+    spec = ALGORITHMS.get(algorithm, None)
+    if spec == None:
+        fail("unknown compression algorithm %r%s. Supported: %s. For anything else, " %
+             (algorithm, _attr_suffix(attr_path), ", ".join(SUPPORTED_ALGORITHMS)) +
+             "declare a py_layer_compressor and point `compressors` at it.")
+
+    options = list(_EXTRA_OPTIONS.get(algorithm, []))
+    if level:
+        if not _is_integer(level):
+            fail("compression level must be an integer, got %r%s" % (level, _attr_suffix(attr_path)))
+        if spec.filter == None:
+            fail("the %r compressor takes no compression level%s; drop the level or " %
+                 (algorithm, _attr_suffix(attr_path)) + "pick an algorithm that has one.")
+        as_int = int(level)
+        if as_int < spec.min_level or as_int > spec.max_level:
+            fail("compression level %s is out of range for %r%s: expected %d..%d" %
+                 (level, algorithm, _attr_suffix(attr_path), spec.min_level, spec.max_level))
+        options.append("{}:compression-level={}".format(spec.filter, level))
+
+    return struct(
+        algorithm = algorithm,
+        flag = spec.flag,
+        options = ",".join(options) if options else None,
+        ext = spec.ext,
+        oci_compatible = spec.oci,
+        program = None,
+        program_format = None,
+        files_to_run = None,
+    )
+
+def codec_from_compressor(info):
+    """Resolve a `PyLayerCompressorInfo` into a codec struct.
+
+    Args:
+        info: The `PyLayerCompressorInfo` of a `py_layer_compressor` target.
+
+    Returns:
+        A codec struct consumed by `codec_tar_args` / `codec_tools`.
+    """
+    suffix = "".join([" " + arg for arg in info.args])
+    return struct(
+        algorithm = "custom",
+        flag = None,
+        options = None,
+        ext = info.extension,
+        # The program's bytes are opaque to us; its declared extension is the
+        # only claim we have about what an image consumer would find.
+        oci_compatible = info.extension in _OCI_EXTENSIONS,
+        program = info.executable,
+        # bsdtar takes `program arg...` as one argv entry and splits it itself.
+        program_format = "%s" + suffix,
+        files_to_run = info.files_to_run,
+    )
+
+def check_oci_compatible(codec, group_name, attr_path, allowed):
+    """Reject a codec no OCI image consumer can read, unless opted out of OCI.
+
+    Args:
+        codec: A codec struct from `make_codec` or `codec_from_compressor`.
+        group_name: The layer group the codec was selected for, named in the error.
+        attr_path: The attribute that selected it, e.g. `py_layer_tier.compression`.
+        allowed: True when the target set `allow_non_oci_layers`.
+    """
+    if codec.oci_compatible or allowed:
+        return
+    if codec.program != None:
+        detail = ("a py_layer_compressor declaring extension %r" % codec.ext)
+    else:
+        detail = "%r" % codec.algorithm
+    fail(("group %r uses %s, which is not an OCI layer format. The spec defines " +
+          "only %s, and rules_oci labels anything else an uncompressed tar with " +
+          "the compressed digest as its diffid — the layer builds and the image " +
+          "is invalid.\n\nUse one of %s in %s, or set allow_non_oci_layers = True " +
+          "if these tars are not going into an OCI image.") %
+         (group_name, detail, ", ".join(OCI_ALGORITHMS), ", ".join(OCI_ALGORITHMS), attr_path))
+
+def codec_tar_args(codec, tar_args):
+    """Append the codec's filter selection to a bsdtar `--create` command line.
+
+    Args:
+        codec: A codec struct from `make_codec` or `codec_from_compressor`.
+        tar_args: The `ctx.actions.args()` object being built for bsdtar.
+    """
+    if codec.program != None:
+        tar_args.add("--use-compress-program")
+        tar_args.add(codec.program, format = codec.program_format)
+        return
+    if codec.flag != None:
+        tar_args.add(codec.flag)
+    if codec.options != None:
+        tar_args.add("--options", codec.options)
+
+def codec_tools(codec):
+    """Extra `tools` the tar action needs for this codec.
+
+    Args:
+        codec: A codec struct from `make_codec` or `codec_from_compressor`.
+
+    Returns:
+        A list to pass as `ctx.actions.run(tools = ...)`; empty for builtin filters.
+    """
+    return [codec.files_to_run] if codec.files_to_run != None else []
+
+def parse_compression(value, attr_path):
+    """Validate a `[algorithm]` / `[algorithm, level]` attr value into a codec.
+
+    Args:
+        value: The attribute value as written in the BUILD file.
+        attr_path: The attribute `value` came from, named in error messages,
+            e.g. `py_layer_tier.compression["x"]`.
+
+    Returns:
+        A codec struct consumed by `codec_tar_args` / `codec_tools`.
+    """
+    if len(value) == 0 or len(value) > 2:
+        fail("%s must be [algorithm] or [algorithm, level], got %r" % (attr_path, value))
+    return make_codec(value[0], value[1] if len(value) == 2 else "", attr_path)
+
+def _py_layer_compressor_impl(ctx):
+    files_to_run = ctx.attr.tool[DefaultInfo].files_to_run
+    if files_to_run == None or files_to_run.executable == None:
+        fail("py_layer_compressor.tool must be an executable target, got %s" % ctx.attr.tool.label)
+
+    if not ctx.attr.extension.startswith("."):
+        fail("py_layer_compressor.extension must start with '.', got %r" % ctx.attr.extension)
+
+    for arg in ctx.attr.args:
+        # libarchive splits the command line on whitespace before exec'ing, so
+        # anything needing quoting has to live in a wrapper script instead.
+        if arg != arg.strip() or " " in arg or "\t" in arg or '"' in arg or "'" in arg:
+            fail("py_layer_compressor.args entries must be single whitespace-free " +
+                 "tokens without quotes, got %r. Wrap the program in a shell script." % arg)
+        if "%" in arg:
+            fail("py_layer_compressor.args entries must not contain '%%', got %r" % arg)
+
+    return [
+        PyLayerCompressorInfo(
+            executable = files_to_run.executable,
+            files_to_run = files_to_run,
+            args = tuple(ctx.attr.args),
+            extension = ctx.attr.extension,
+        ),
+        DefaultInfo(files = depset([files_to_run.executable])),
+    ]
+
+py_layer_compressor = rule(
+    implementation = _py_layer_compressor_impl,
+    doc = """A user-supplied program that compresses `py_image_layer` layer tars.
+
+bsdtar pipes the archive through `tool` (via `--use-compress-program`), so any
+program that reads an uncompressed stream on stdin and writes the compressed
+stream to stdout works — including compressors libarchive has no filter for.
+
+```starlark
+py_layer_compressor(
+    name = "pigz",
+    tool = "//tools:pigz",
+    args = ["-11"],
+    extension = ".tar.gz",
+)
+
+py_layer_tier(
+    name = "tier",
+    groups = {"@pip//torch": "heavy"},
+    compressors = {":pigz": "heavy"},
+)
+```
+
+`extension` is the only claim available about the program's output, so it also
+decides whether the layer is OCI-valid: anything but `.tar`, `.tar.gz` or
+`.tar.zst` needs `allow_non_oci_layers = True` on the tier or rule.
+
+The program runs inside the tar action, so prefer a Bazel-built binary or a
+`sh_binary` wrapper over something assumed to be on the host's PATH.
+""",
+    attrs = {
+        "args": attr.string_list(
+            default = [],
+            doc = ("Arguments passed after the program path. Each entry must be a single " +
+                   "whitespace-free token — bsdtar splits the command line itself."),
+        ),
+        "extension": attr.string(
+            mandatory = True,
+            doc = ("Extension for tars this compressor produces, e.g. '.tar.gz'. Must start " +
+                   "with '.'. Also declares OCI validity: only '.tar', '.tar.gz' and " +
+                   "'.tar.zst' are layer formats an image consumer can read."),
+        ),
+        "tool": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "exec",
+            doc = "The compressor program. Reads stdin, writes compressed bytes to stdout.",
+        ),
+    },
+    provides = [PyLayerCompressorInfo],
+)

--- a/py/private/py_image_layer.bzl
+++ b/py/private/py_image_layer.bzl
@@ -30,6 +30,18 @@ Sharing model:
   - Ungrouped pip packages: squashed by the rule into one per-rule tar.
 """
 
+load(
+    "//py/private:compression.bzl",
+    "DEFAULT_ALGORITHM",
+    "DEFAULT_LEVEL",
+    "PyLayerCompressorInfo",
+    "check_oci_compatible",
+    "codec_from_compressor",
+    "codec_tar_args",
+    "codec_tools",
+    "make_codec",
+    "parse_compression",
+)
 load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private:py_info_interop.bzl", "has_py_info")
@@ -93,7 +105,9 @@ PyLayerTierInfo = provider(
     fields = {
         "whole_groups": "dict[str, str] — normalized pip label → group name.",
         "subpath_groups": "dict[str, dict[str, list[str]]] — label → {group_name: [glob_patterns]}.",
-        "compression": "dict[str, list[str]] — group name → [algorithm, level].",
+        "compression": "dict[str, list[str]] — group name → [algorithm, level], as written on the rule.",
+        "compressors": "dict[str, PyLayerCompressorInfo] — group name → custom compressor.",
+        "codecs": "dict[str, struct] — group name → resolved codec (bsdtar flags + file extension).",
         "multi_member_groups": "dict[str, True] — group names with 2+ members in whole_groups.",
         "interpreter_group": "str — group name for the Python interpreter layer; '' disables.",
         "root": "str — root path in the image (e.g. '/app').",
@@ -140,10 +154,38 @@ def _py_layer_tier_impl(ctx):
     _validate_numeric_id(ctx.attr.owner, "owner")
     _validate_numeric_id(ctx.attr.group, "group")
 
+    codecs = {}
+    for group_name, value in ctx.attr.compression.items():
+        codec = parse_compression(value, "py_layer_tier.compression[%r]" % group_name)
+        check_oci_compatible(codec, group_name, "py_layer_tier.compression", ctx.attr.allow_non_oci_layers)
+        codecs[group_name] = codec
+
+    compressors = {}
+    seen = {}
+    for dep, group_name in ctx.attr.compressors.items():
+        # Duplicates first: the group is already in `codecs` by then, so the
+        # `compression` check below would otherwise claim the wrong conflict.
+        if group_name in seen:
+            fail(("group %r is mapped to two py_layer_compressor targets (%s and %s) in " +
+                  "py_layer_tier.compressors. A group gets its bytes from exactly one " +
+                  "compressor.") % (group_name, seen[group_name], dep.label))
+        if group_name in codecs:
+            fail(("group %r is configured in both py_layer_tier.compression and " +
+                  "py_layer_tier.compressors. A group gets its bytes from exactly one " +
+                  "compressor — drop one of the two entries.") % group_name)
+        seen[group_name] = dep.label
+        info = dep[PyLayerCompressorInfo]
+        compressors[group_name] = info
+        codec = codec_from_compressor(info)
+        check_oci_compatible(codec, group_name, "py_layer_tier.compressors", ctx.attr.allow_non_oci_layers)
+        codecs[group_name] = codec
+
     return [PyLayerTierInfo(
         whole_groups = whole_groups,
         subpath_groups = subpath_groups,
         compression = dict(ctx.attr.compression),
+        compressors = compressors,
+        codecs = codecs,
         multi_member_groups = multi_member_groups,
         interpreter_group = ctx.attr.interpreter_group,
         root = ctx.attr.root,
@@ -172,10 +214,34 @@ py_layer_tier = rule(
         ),
         "compression": attr.string_list_dict(
             default = {},
-            doc = ("Maps group name → [algorithm, level] for pip-derived layers. " +
-                   "Applies to the whole-group tar, each subpath-split tar, and the " +
-                   "multi-member merged tar — anything routed through py_layer_tier.groups. " +
-                   "Example: {\"heavy_pkgs\": [\"zstd\", \"1\"]}. Untouched groups default to gzip -6."),
+            doc = ("Maps group name → [algorithm] or [algorithm, level]. Applies to every " +
+                   "layer this tier names: the whole-group tar, each subpath-split tar, the " +
+                   "multi-member merged tar, the interpreter tar, and first-party group tars.\n\n" +
+                   "`algorithm` is any bsdtar (libarchive) write filter: `none`, `gzip`, " +
+                   "`bzip2`, `xz`, `lzma`, `lzop`, `lz4`, `lrzip`, `zstd`, or `compress`. " +
+                   "`lzop` and `lrzip` shell out to a same-named binary that must exist inside " +
+                   "the action — use `compressors` for a hermetic equivalent. `none` and " +
+                   "`compress` take no level.\n\n" +
+                   "`level` is optional; omit it to take libarchive's default for that filter. " +
+                   "Example: {\"heavy_pkgs\": [\"zstd\", \"19\"], \"cold\": [\"xz\"]}. " +
+                   "Untouched groups default to gzip -6."),
+        ),
+        "compressors": attr.label_keyed_string_dict(
+            default = {},
+            cfg = "exec",
+            providers = [PyLayerCompressorInfo],
+            doc = ("Maps a `py_layer_compressor` target → group name, for compressors libarchive " +
+                   "has no filter for. bsdtar pipes the layer through the program. A group " +
+                   "may appear here or in `compression`, not both."),
+        ),
+        "allow_non_oci_layers": attr.bool(
+            default = False,
+            doc = ("Permit compression the OCI image spec has no layer format for. " +
+                   "The spec defines only tar, gzip and zstd; rules_oci labels anything " +
+                   "else an uncompressed tar and records the compressed digest as the " +
+                   "layer's diffid, so the image is invalid even though the build " +
+                   "succeeds. Set this only when the tars are consumed by something " +
+                   "other than an OCI image."),
         ),
         "interpreter_group": attr.string(
             default = "",
@@ -256,12 +322,13 @@ def _opaque_dep_files(rule_attr, attr_names):
                 parts.append(_runtime_files(dep))
     return parts
 
-def _compression_for(plan, group_name):
-    comp = plan.compression.get(group_name, None) if group_name else None
-    algorithm = comp[0] if comp else "gzip"
-    level = comp[1] if comp else "6"
-    ext = ".tar.zst" if algorithm == "zstd" else ".tar.gz"
-    return algorithm, level, ext
+_DEFAULT_CODEC = make_codec(DEFAULT_ALGORITHM, DEFAULT_LEVEL)
+
+def _codec_for(plan, group_name):
+    """Codec for a tier-named group; gzip -6 for groups the tier never mentions."""
+    if not group_name:
+        return _DEFAULT_CODEC
+    return plan.codecs.get(group_name, _DEFAULT_CODEC)
 
 def _tar_toolchain(ctx):
     tc = ctx.toolchains[_TAR_TOOLCHAIN]
@@ -296,8 +363,8 @@ def _build_pip_layers(ctx, plan, label, install_dir):
     if subpath_for_this:
         all_patterns = [p for pats in subpath_for_this.values() for p in pats]
         for grp_name, patterns in subpath_for_this.items():
-            algorithm, level, ext = _compression_for(plan, grp_name)
-            tar_out = ctx.actions.declare_file("_pip_layer_{}{}".format(grp_name, ext))
+            codec = _codec_for(plan, grp_name)
+            tar_out = ctx.actions.declare_file("_pip_layer_{}{}".format(grp_name, codec.ext))
             _run_tar_action(
                 ctx,
                 bsdtar,
@@ -305,16 +372,15 @@ def _build_pip_layers(ctx, plan, label, install_dir):
                 tar_out,
                 install_dir,
                 _make_glob_map_each(patterns, plan.owner, plan.group),
-                algorithm,
-                level,
+                codec,
                 {},
                 "PyImagePkgLayer",
                 "Creating pip layer %s[%s]" % (label, grp_name),
             )
             layers.append(struct(tar = tar_out, group = grp_name))
 
-        algorithm, level, ext = _compression_for(plan, whole_group)
-        rest_tar = ctx.actions.declare_file("_pip_layer_tar" + ext)
+        codec = _codec_for(plan, whole_group)
+        rest_tar = ctx.actions.declare_file("_pip_layer_tar" + codec.ext)
         _run_tar_action(
             ctx,
             bsdtar,
@@ -322,16 +388,15 @@ def _build_pip_layers(ctx, plan, label, install_dir):
             rest_tar,
             install_dir,
             _make_glob_map_each(all_patterns, plan.owner, plan.group, invert = True),
-            algorithm,
-            level,
+            codec,
             {},
             "PyImagePkgLayer",
             "Creating pip layer %s[rest]" % label,
         )
         layers.append(struct(tar = rest_tar, group = whole_group))
     else:
-        algorithm, level, ext = _compression_for(plan, whole_group)
-        tar_out = ctx.actions.declare_file("_pip_layer_tar" + ext)
+        codec = _codec_for(plan, whole_group)
+        tar_out = ctx.actions.declare_file("_pip_layer_tar" + codec.ext)
         _run_tar_action(
             ctx,
             bsdtar,
@@ -339,8 +404,7 @@ def _build_pip_layers(ctx, plan, label, install_dir):
             tar_out,
             install_dir,
             pkg_map,
-            algorithm,
-            level,
+            codec,
             {},
             "PyImagePkgLayer",
             "Creating pip layer %s" % label,
@@ -366,8 +430,8 @@ def _layer_aspect_impl(target, ctx):
         interp_layer = struct(tar = None, group = None, interpreter_files = interp_depset)
         if interp_group:
             bsdtar, bsdtar_files = _tar_toolchain(ctx)
-            algorithm, level, ext = _compression_for(plan, interp_group)
-            interp_tar = ctx.actions.declare_file("_interpreter_layer_{}{}".format(interp_group, ext))
+            codec = _codec_for(plan, interp_group)
+            interp_tar = ctx.actions.declare_file("_interpreter_layer_{}{}".format(interp_group, codec.ext))
             _run_tar_action(
                 ctx,
                 bsdtar,
@@ -375,8 +439,7 @@ def _layer_aspect_impl(target, ctx):
                 interp_tar,
                 interp_depset,
                 lambda f, d: _interpreter_file_to_mtree(f, d, plan.owner, plan.group),
-                algorithm,
-                level,
+                codec,
                 {},
                 "PyImagePkgLayer",
                 "Creating interpreter layer %s" % target.label,
@@ -548,8 +611,8 @@ def _merge_aspect_impl(target, ctx):
     merged_tars = {}
     for group_name in sorted(bucket):
         install_dirs = bucket[group_name]
-        algorithm, level, ext = _compression_for(plan, group_name)
-        tar_out = ctx.actions.declare_file("_merged_pip_layer_{}{}".format(group_name, ext))
+        codec = _codec_for(plan, group_name)
+        tar_out = ctx.actions.declare_file("_merged_pip_layer_{}{}".format(group_name, codec.ext))
         _run_tar_action(
             ctx,
             bsdtar,
@@ -557,8 +620,7 @@ def _merge_aspect_impl(target, ctx):
             tar_out,
             depset(transitive = install_dirs),
             lambda f, d: _pkg_file_to_mtree(f, d, plan.owner, plan.group),
-            algorithm,
-            level,
+            codec,
             {},
             "PyImageMergedLayer",
             "Merging %d pip packages into %s[%s]" % (len(install_dirs), target.label, group_name),
@@ -874,7 +936,7 @@ def _declare_symlink_mapping(ctx, mappings):
     )
     return mapping_out
 
-def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, compress, level, reqs, mnemonic, progress_msg, symlink_mappings = None, skip_files = None, chmod_files = None):
+def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, codec, reqs, mnemonic, progress_msg, symlink_mappings = None, skip_files = None, chmod_files = None):
     # mtree (param file) → gawk (readlinks `type=link`/`type=file content=`
     # rows; `contents=` rows pass through; END buffers, asort-sorts, and
     # writes the sorted mtree to a file) → bsdtar consumes the file.
@@ -929,16 +991,7 @@ def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, 
 
     tar_args = ctx.actions.args()
     tar_args.add("--create")
-    tar_args.add("--" + compress)
-    options = "{}:compression-level={}".format(compress, level)
-    if compress == "gzip":
-        # libarchive's gzip filter stores the current wall-clock time in the gzip
-        # header's MTIME field, so two executions of this action over byte-identical
-        # inputs emit different bytes — and therefore a different layer digest, which
-        # propagates into the oci_image manifest. `!timestamp` zeroes that field.
-        # zstd has no equivalent field, so this is gzip-only.
-        options += ",gzip:!timestamp"
-    tar_args.add("--options", options)
+    codec_tar_args(codec, tar_args)
     tar_args.add("--file", tar_out)
 
     # `@<file>` tells bsdtar to read the named file as an mtree archive
@@ -949,6 +1002,8 @@ def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, 
         inputs = depset(direct = [sorted_mtree], transitive = [files_depset, bsdtar_files.files]),
         outputs = [tar_out],
         arguments = [tar_args],
+        # bsdtar spawns a custom compressor from the execroot.
+        tools = codec_tools(codec),
         mnemonic = mnemonic,
         progress_message = progress_msg,
         execution_requirements = reqs,
@@ -956,9 +1011,42 @@ def _run_tar_action(ctx, bsdtar, bsdtar_files, tar_out, files_depset, map_each, 
         use_default_shell_env = False,
     )
 
-def _declare_group_tar(ctx, bsdtar, bsdtar_files, out_name, group_name, files, map_each, progress, symlink_mappings = None, skip_files = None, chmod_files = None):
-    tar_out = ctx.actions.declare_file(out_name)
-    level = ctx.attr.group_compress_levels.get(group_name, "6")
+def _rule_codecs(ctx):
+    """Codecs the rule's own attrs pin, group name → codec."""
+    codecs = {}
+    for group_name, value in ctx.attr.group_compression.items():
+        codec = parse_compression(value, "py_image_layer.group_compression[%r]" % group_name)
+        check_oci_compatible(codec, group_name, "py_image_layer.group_compression", ctx.attr.allow_non_oci_layers)
+        codecs[group_name] = codec
+    seen = {}
+    for dep, group_name in ctx.attr.group_compressors.items():
+        # Duplicates first, for the same reason as py_layer_tier above.
+        if group_name in seen:
+            fail(("group %r is mapped to two py_layer_compressor targets (%s and %s) in " +
+                  "py_image_layer.group_compressors. A group gets its bytes from exactly " +
+                  "one compressor.") % (group_name, seen[group_name], dep.label))
+        if group_name in codecs:
+            fail(("group %r is configured in both py_image_layer.group_compression and " +
+                  "py_image_layer.group_compressors. A group gets its bytes from exactly " +
+                  "one compressor — drop one of the two entries.") % group_name)
+        seen[group_name] = dep.label
+        codec = codec_from_compressor(dep[PyLayerCompressorInfo])
+        check_oci_compatible(codec, group_name, "py_image_layer.group_compressors", ctx.attr.allow_non_oci_layers)
+        codecs[group_name] = codec
+    return codecs
+
+def _rule_codec_for(ctx, rule_codecs, plan, group_name):
+    # Rule attrs win over the tier, so one image can deviate without forking a
+    # shared tier; `group_compress_levels` is the gzip-only fallback.
+    if group_name in rule_codecs:
+        return rule_codecs[group_name]
+    if group_name in plan.codecs:
+        return plan.codecs[group_name]
+    return make_codec(DEFAULT_ALGORITHM, ctx.attr.group_compress_levels.get(group_name, DEFAULT_LEVEL))
+
+def _declare_group_tar(ctx, rule_codecs, plan, bsdtar, bsdtar_files, out_basename, group_name, files, map_each, progress, symlink_mappings = None, skip_files = None, chmod_files = None):
+    codec = _rule_codec_for(ctx, rule_codecs, plan, group_name)
+    tar_out = ctx.actions.declare_file(out_basename + codec.ext)
     reqs = _parse_exec_requirements(ctx.attr.group_execution_requirements.get(group_name, []))
     _run_tar_action(
         ctx,
@@ -967,8 +1055,7 @@ def _declare_group_tar(ctx, bsdtar, bsdtar_files, out_name, group_name, files, m
         tar_out,
         files,
         map_each,
-        "gzip",
-        level,
+        codec,
         reqs,
         "PyImageLayer",
         progress,
@@ -999,6 +1086,7 @@ def _py_image_layer_impl(ctx):
     # `_platform_cfg` rewrites the `//py:layer_tier` flag from `attr.layer_tier`,
     # so `_layer_tier` always resolves to the effective tier.
     plan = ctx.attr._layer_tier[PyLayerTierInfo]
+    rule_codecs = _rule_codecs(ctx)
     root = plan.root
     strip_prefix = plan.strip_prefix
     owner = plan.owner
@@ -1149,9 +1237,11 @@ def _py_image_layer_impl(ctx):
     for group_name, files in rule_groups:
         tar_out = _declare_group_tar(
             ctx,
+            rule_codecs,
+            plan,
             bsdtar,
             bsdtar_files,
-            "{}_{}.tar.gz".format(ctx.attr.name, group_name),
+            "{}_{}".format(ctx.attr.name, group_name),
             group_name,
             files,
             rule_group_map,
@@ -1183,9 +1273,11 @@ def _py_image_layer_impl(ctx):
         else:
             tar_out = _declare_group_tar(
                 ctx,
+                rule_codecs,
+                plan,
                 bsdtar,
                 bsdtar_files,
-                "{}_{}.tar.gz".format(ctx.attr.name, group_name),
+                "{}_{}".format(ctx.attr.name, group_name),
                 group_name,
                 depset(transitive = fp_by_group[group_name]),
                 source_map,
@@ -1211,8 +1303,8 @@ def _py_image_layer_impl(ctx):
         all_tars.extend([tar for _group_name, tar in sorted(binaries[0][_MergedLayerInfo].merged_tars.items())])
     else:
         for group_name in sorted(merged):
-            algorithm, level, ext = _compression_for(plan, group_name)
-            tar_out = ctx.actions.declare_file("{}/merged_pip_layers/{}{}".format(ctx.attr.name, group_name, ext))
+            codec = _codec_for(plan, group_name)
+            tar_out = ctx.actions.declare_file("{}/merged_pip_layers/{}{}".format(ctx.attr.name, group_name, codec.ext))
             _run_tar_action(
                 ctx,
                 bsdtar,
@@ -1220,8 +1312,7 @@ def _py_image_layer_impl(ctx):
                 tar_out,
                 depset(transitive = merged[group_name]),
                 pkg_map,
-                algorithm,
-                level,
+                codec,
                 {},
                 "PyImageMergedLayer",
                 "Merging %d pip packages into %s[%s]" % (len(merged[group_name]), ctx.label, group_name),
@@ -1232,9 +1323,11 @@ def _py_image_layer_impl(ctx):
     if ungrouped_pkgs:
         squashed_tar = _declare_group_tar(
             ctx,
+            rule_codecs,
+            plan,
             bsdtar,
             bsdtar_files,
-            "{}_squashed.tar.gz".format(ctx.attr.name),
+            "{}_squashed".format(ctx.attr.name),
             "packages",
             depset(transitive = [p.files for p in ungrouped_pkgs]),
             pkg_map,
@@ -1248,9 +1341,11 @@ def _py_image_layer_impl(ctx):
 
     source_tar = _declare_group_tar(
         ctx,
+        rule_codecs,
+        plan,
         bsdtar,
         bsdtar_files,
-        "{}_default.tar.gz".format(ctx.attr.name),
+        "{}_default".format(ctx.attr.name),
         "default",
         source_files,
         source_map,
@@ -1326,7 +1421,14 @@ _py_image_layer = rule(
         ),
         "groups": attr.label_keyed_string_dict(default = {}),
         "group_execution_requirements": attr.string_list_dict(default = {}),
+        "allow_non_oci_layers": attr.bool(default = False),
         "group_compress_levels": attr.string_dict(default = {}),
+        "group_compression": attr.string_list_dict(default = {}),
+        "group_compressors": attr.label_keyed_string_dict(
+            default = {},
+            cfg = "exec",
+            providers = [PyLayerCompressorInfo],
+        ),
         "warn_remote_cache_threshold_mb": attr.int(default = 200),
         "warn_layer_count": attr.int(default = 90),
         "platform": attr.label(default = None, providers = [platform_common.PlatformInfo]),
@@ -1365,6 +1467,9 @@ def py_image_layer(
         groups = {},
         group_execution_requirements = {},
         group_compress_levels = {},
+        group_compression = {},
+        group_compressors = {},
+        allow_non_oci_layers = False,
         warn_remote_cache_threshold_mb = 200,
         warn_layer_count = 90,
         platform = None,
@@ -1399,9 +1504,24 @@ def py_image_layer(
             in py_layer_tier — subpath glob keys passed here fail loudly.
         group_execution_requirements: Maps a group name to execution requirement strings.
             The group name "packages" applies to the squashed ungrouped-pip tar.
-        group_compress_levels: Maps a group name to a gzip compression level (1-9) for
-            rule-created tars (non-pip deps, squashed ungrouped pip tar, source). Default 6.
-            Does NOT apply to aspect-created pip tars (configure via the py_layer_tier target).
+        group_compress_levels: gzip-only shorthand: maps a group name to a compression
+            level (1-9) for rule-created tars. Default 6. Ignored for any group named by
+            `group_compression`, `group_compressors`, or the tier's `compression`.
+        group_compression: Maps a group name to `[algorithm]` or `[algorithm, level]` for
+            rule-created tars (non-pip deps, first-party groups, the squashed ungrouped-pip
+            tar under the name "packages", and the source layer under the name "default").
+            `algorithm` is any bsdtar write filter — `none`, `gzip`, `bzip2`, `xz`, `lzma`,
+            `lzop`, `lz4`, `lrzip`, `zstd`, `compress`. Takes precedence over the tier's
+            `compression` for the same group. Does NOT apply to aspect-created pip tars;
+            configure those on the py_layer_tier target.
+        group_compressors: Maps a `py_layer_compressor` target to a group name, for rule-created
+            tars that need a compressor libarchive has no filter for. Same precedence as
+            `group_compression`; a group may appear in one or the other, not both.
+        allow_non_oci_layers: Permit compression the OCI image spec has no layer format
+            for. The spec defines only tar, gzip and zstd, and rules_oci labels anything
+            else an uncompressed tar with the compressed digest as its diffid — the build
+            succeeds and the image is invalid. Set this only when the tars are consumed by
+            something other than an OCI image.
         warn_remote_cache_threshold_mb: Threshold for large package warnings.
         warn_layer_count: Warn when total layers exceed this. Default: 90.
         platform: Platform transition target.
@@ -1439,6 +1559,9 @@ def py_image_layer(
         groups = groups,
         group_execution_requirements = group_execution_requirements,
         group_compress_levels = group_compress_levels,
+        group_compression = group_compression,
+        group_compressors = group_compressors,
+        allow_non_oci_layers = allow_non_oci_layers,
         warn_remote_cache_threshold_mb = warn_remote_cache_threshold_mb,
         warn_layer_count = warn_layer_count,
         platform = platform,

--- a/py/tests/image-layer-compression/BUILD.bazel
+++ b/py/tests/image-layer-compression/BUILD.bazel
@@ -1,0 +1,608 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//py:defs.bzl", "py_binary", "py_image_layer", "py_layer_compressor", "py_layer_tier", "py_library", "py_test")
+load(
+    ":tests.bzl",
+    "codec_table_test",
+    "custom_compressor_test",
+    "expected_failure_test",
+    "oci_compressor_test",
+    "rule_attrs_test",
+    "tier_compression_test",
+)
+
+py_library(
+    name = "branding",
+    srcs = ["branding/__init__.py"],
+    imports = ["."],
+)
+
+py_binary(
+    name = "app",
+    srcs = ["main.py"],
+    main = "main.py",
+    tags = ["manual"],
+    deps = [":branding"],
+)
+
+# The interpreter dominates every layer set here. Peeling it into its own cheap
+# layer keeps the tars these tests inspect small, and covers the aspect-created
+# interpreter tar honouring the tier's codec.
+py_layer_tier(
+    name = "cheap_tier",
+    compression = {"interpreter": [
+        "gzip",
+        "1",
+    ]},
+    interpreter_group = "interpreter",
+)
+
+################################################################################
+# Every libarchive write filter, over one tiny payload each. lzop and lrzip are
+# absent: libarchive shells out to a same-named binary for those two, which no
+# sandboxed action is guaranteed to have.
+FILTERS = {
+    "f_bzip2": [
+        "bzip2",
+        "9",
+    ],
+    "f_compress": ["compress"],
+    "f_gzip": [
+        "gzip",
+        "9",
+    ],
+    "f_lz4": ["lz4"],
+    "f_lzma": [
+        "lzma",
+        "6",
+    ],
+    "f_none": ["none"],
+    "f_xz": [
+        "xz",
+        "6",
+    ],
+    "f_zstd": [
+        "zstd",
+        "19",
+    ],
+}
+
+[
+    filegroup(
+        name = group_name,
+        srcs = ["payloads/%s.txt" % group_name[len("f_"):]],
+    )
+    for group_name in FILTERS
+]
+
+py_image_layer(
+    name = "filters_layers",
+    # Deliberately off-spec: this target exists to prove every libarchive filter
+    # writes readable bytes, not to feed an oci_image.
+    allow_non_oci_layers = True,
+    binary = ":app",
+    group_compression = FILTERS,
+    groups = {":" + group_name: group_name for group_name in FILTERS},
+    layer_tier = ":cheap_tier",
+)
+
+py_test(
+    name = "filters_test",
+    srcs = ["assert_compression.py"],
+    args = [
+        "--expect=_f_none.tar",
+        "--expect=_f_gzip.tar.gz",
+        "--expect=_f_bzip2.tar.bz2",
+        "--expect=_f_xz.tar.xz",
+        "--expect=_f_lzma.tar.lzma",
+        "--expect=_f_lz4.tar.lz4",
+        "--expect=_f_zstd.tar.zst",
+        "--expect=_f_compress.tar.Z",
+        "$(rootpaths :filters_layers)",
+    ],
+    data = [":filters_layers"],
+    main = "assert_compression.py",
+)
+
+################################################################################
+# Rule attributes: group_compression / group_compress_levels precedence.
+
+filegroup(
+    name = "assets",
+    srcs = ["payloads/xz.txt"],
+)
+
+filegroup(
+    name = "extras",
+    srcs = ["payloads/gzip.txt"],
+)
+
+py_image_layer(
+    name = "rule_attrs_layers",
+    allow_non_oci_layers = True,  # "assets" is xz
+    binary = ":app",
+    group_compress_levels = {"extras": "1"},
+    group_compression = {
+        "assets": ["xz"],
+        "default": [
+            "zstd",
+            "19",
+        ],
+    },
+    groups = {
+        ":assets": "assets",
+        ":extras": "extras",
+    },
+    layer_tier = ":cheap_tier",
+)
+
+rule_attrs_test(
+    name = "rule_attrs_test",
+    target_under_test = ":rule_attrs_layers",
+)
+
+################################################################################
+# Tier compression, and the rule overriding it for one group.
+
+py_layer_tier(
+    name = "branding_tier",
+    allow_non_oci_layers = True,  # "branding" is bzip2
+    compression = {
+        "branding": [
+            "bzip2",
+            "9",
+        ],
+        "default": [
+            "zstd",
+            "3",
+        ],
+        "interpreter": [
+            "gzip",
+            "1",
+        ],
+    },
+    groups = {"//py/tests/image-layer-compression:branding": "branding"},
+    interpreter_group = "interpreter",
+)
+
+py_image_layer(
+    name = "tier_compression_layers",
+    binary = ":app",
+    group_compression = {"default": ["none"]},
+    layer_tier = ":branding_tier",
+)
+
+tier_compression_test(
+    name = "tier_compression_test",
+    target_under_test = ":tier_compression_layers",
+)
+
+################################################################################
+# A compressor libarchive has no filter for.
+
+sh_binary(
+    name = "fake_compressor",
+    srcs = ["fake_compressor.sh"],
+)
+
+py_layer_compressor(
+    name = "lolz",
+    args = ["--loud"],
+    extension = ".tar.lolz",
+    tool = ":fake_compressor",
+)
+
+py_layer_compressor(
+    name = "lolz_rival",
+    args = ["--loud"],
+    extension = ".tar.rival",
+    tool = ":fake_compressor",
+)
+
+py_layer_tier(
+    name = "custom_tier",
+    allow_non_oci_layers = True,  # :lolz declares .tar.lolz
+    compression = {"interpreter": [
+        "gzip",
+        "1",
+    ]},
+    compressors = {":lolz": "branding"},
+    groups = {"//py/tests/image-layer-compression:branding": "branding"},
+    interpreter_group = "interpreter",
+)
+
+py_image_layer(
+    name = "custom_compressor_layers",
+    allow_non_oci_layers = True,  # :lolz declares .tar.lolz
+    binary = ":app",
+    group_compressors = {":lolz": "default"},
+    layer_tier = ":custom_tier",
+)
+
+custom_compressor_test(
+    name = "custom_compressor_test",
+    target_under_test = ":custom_compressor_layers",
+)
+
+# The program has to actually run, not just appear on the command line.
+py_test(
+    name = "custom_compressor_runtime_test",
+    srcs = ["assert_compression.py"],
+    args = [
+        "--expect=_default.tar.lolz",
+        "--expect=_branding.tar.lolz",
+        "--absent=.tar.zst",
+        "$(rootpaths :custom_compressor_layers)",
+    ],
+    data = [":custom_compressor_layers"],
+    main = "assert_compression.py",
+)
+
+################################################################################
+# Pip-package layers. Declared by the layer aspects at the pip target's own
+# namespace, so they resolve their codec straight from the tier.
+
+py_binary(
+    name = "pip_app",
+    srcs = ["pip_main.py"],
+    main = "pip_main.py",
+    tags = ["manual"],
+    deps = [
+        "@pypi//colorama",
+        "@pypi//six",
+    ],
+)
+
+# Two packages in one group merge into a single tar built by the merge aspect.
+py_layer_tier(
+    name = "merged_pip_tier",
+    allow_non_oci_layers = True,  # "third_party" is xz
+    compression = {
+        "interpreter": [
+            "gzip",
+            "1",
+        ],
+        "third_party": [
+            "xz",
+            "1",
+        ],
+    },
+    groups = {
+        "@pip//colorama": "third_party",
+        "@pip//six": "third_party",
+    },
+    interpreter_group = "interpreter",
+)
+
+py_image_layer(
+    name = "merged_pip_layers",
+    binary = ":pip_app",
+    layer_tier = ":merged_pip_tier",
+)
+
+py_test(
+    name = "merged_pip_test",
+    srcs = ["assert_compression.py"],
+    args = [
+        "--expect=_merged_pip_layer_third_party.tar.xz",
+        "$(rootpaths :merged_pip_layers)",
+    ],
+    data = [":merged_pip_layers"],
+    main = "assert_compression.py",
+)
+
+# A single-member group gets its own tar, and can use a custom compressor.
+py_layer_tier(
+    name = "solo_pip_tier",
+    allow_non_oci_layers = True,  # colorama is lz4, six uses :lolz
+    compression = {
+        "colorama": ["lz4"],
+        "interpreter": [
+            "gzip",
+            "1",
+        ],
+    },
+    compressors = {":lolz": "six"},
+    groups = {
+        "@pip//colorama": "colorama",
+        "@pip//six": "six",
+    },
+    interpreter_group = "interpreter",
+)
+
+py_image_layer(
+    name = "solo_pip_layers",
+    binary = ":pip_app",
+    layer_tier = ":solo_pip_tier",
+)
+
+py_test(
+    name = "solo_pip_test",
+    srcs = ["assert_compression.py"],
+    args = [
+        "--expect=_pip_layer_tar.tar.lz4",
+        "--expect=_pip_layer_tar.tar.lolz",
+        "$(rootpaths :solo_pip_layers)",
+    ],
+    data = [":solo_pip_layers"],
+    main = "assert_compression.py",
+)
+
+################################################################################
+# OCI compatibility. The spec defines tar, gzip and zstd layers; rules_oci
+# sniffs only the gzip and zstd magics and labels anything else an uncompressed
+# tar with the compressed digest as its diffid, so the image is invalid while
+# the build succeeds. Non-OCI codecs are therefore opt-in.
+
+py_layer_tier(
+    name = "oci_default_tier",
+    compression = {
+        "branding": [
+            "zstd",
+            "19",
+        ],
+        "interpreter": ["none"],
+    },
+    groups = {"//py/tests/image-layer-compression:branding": "branding"},
+    interpreter_group = "interpreter",
+)
+
+# The OCI-valid codecs need no opt-in; building this target is the assertion.
+py_image_layer(
+    name = "oci_default_layers",
+    binary = ":app",
+    group_compression = {"default": [
+        "gzip",
+        "9",
+    ]},
+    layer_tier = ":oci_default_tier",
+)
+
+py_test(
+    name = "oci_default_test",
+    srcs = ["assert_compression.py"],
+    args = [
+        "--expect=_branding.tar.zst",
+        "--expect=_default.tar.gz",
+        "--expect=_interpreter_layer_interpreter.tar",
+        "$(rootpaths :oci_default_layers)",
+    ],
+    data = [":oci_default_layers"],
+    main = "assert_compression.py",
+)
+
+py_layer_tier(
+    name = "non_oci_tier",
+    compression = {"grp": [
+        "bzip2",
+        "9",
+    ]},
+    tags = ["manual"],
+)
+
+expected_failure_test(
+    name = "non_oci_tier_test",
+    expected_error = "is not an OCI layer format",
+    target_under_test = ":non_oci_tier",
+)
+
+py_image_layer(
+    name = "non_oci_layers",
+    binary = ":app",
+    group_compression = {"default": ["xz"]},
+    layer_tier = ":cheap_tier",
+)
+
+expected_failure_test(
+    name = "non_oci_layers_test",
+    expected_error = "set allow_non_oci_layers = True",
+    target_under_test = ":non_oci_layers",
+)
+
+# A custom compressor is judged by the extension it declares: the program's
+# bytes are opaque, so `.tar.lolz` is assumed unreadable by an image consumer.
+py_image_layer(
+    name = "non_oci_compressor_layers",
+    binary = ":app",
+    group_compressors = {":lolz": "default"},
+    layer_tier = ":cheap_tier",
+)
+
+expected_failure_test(
+    name = "non_oci_compressor_test",
+    expected_error = "a py_layer_compressor declaring extension \".tar.lolz\"",
+    target_under_test = ":non_oci_compressor_layers",
+)
+
+# ...and one declaring .tar.gz (a pigz or tuned-gzip stand-in) needs no opt-in.
+py_layer_compressor(
+    name = "custom_gzip",
+    args = ["--loud"],
+    extension = ".tar.gz",
+    tool = ":fake_compressor",
+)
+
+py_image_layer(
+    name = "oci_compressor_layers",
+    binary = ":app",
+    group_compressors = {":custom_gzip": "default"},
+    layer_tier = ":cheap_tier",
+)
+
+oci_compressor_test(
+    name = "oci_compressor_test",
+    target_under_test = ":oci_compressor_layers",
+)
+
+################################################################################
+# Misconfigurations, all rejected during analysis.
+
+py_layer_tier(
+    name = "unknown_algorithm_tier",
+    compression = {"grp": [
+        "brotli",
+        "9",
+    ]},
+    tags = ["manual"],
+)
+
+expected_failure_test(
+    name = "unknown_algorithm_test",
+    expected_error = "unknown compression algorithm \"brotli\"",
+    target_under_test = ":unknown_algorithm_tier",
+)
+
+py_layer_tier(
+    name = "level_out_of_range_tier",
+    compression = {"grp": [
+        "zstd",
+        "99",
+    ]},
+    tags = ["manual"],
+)
+
+expected_failure_test(
+    name = "level_out_of_range_test",
+    expected_error = "compression level 99 is out of range for \"zstd\"",
+    target_under_test = ":level_out_of_range_tier",
+)
+
+py_layer_tier(
+    name = "non_numeric_level_tier",
+    compression = {"grp": [
+        "gzip",
+        "highest",
+    ]},
+    tags = ["manual"],
+)
+
+expected_failure_test(
+    name = "non_numeric_level_test",
+    expected_error = "compression level must be an integer",
+    target_under_test = ":non_numeric_level_tier",
+)
+
+py_layer_tier(
+    name = "levelless_algorithm_tier",
+    allow_non_oci_layers = True,
+    compression = {"grp": [
+        "compress",
+        "3",
+    ]},
+    tags = ["manual"],
+)
+
+expected_failure_test(
+    name = "levelless_algorithm_test",
+    expected_error = "the \"compress\" compressor takes no compression level",
+    target_under_test = ":levelless_algorithm_tier",
+)
+
+py_layer_tier(
+    name = "double_booked_tier",
+    allow_non_oci_layers = True,
+    compression = {"branding": ["xz"]},
+    compressors = {":lolz": "branding"},
+    tags = ["manual"],
+)
+
+expected_failure_test(
+    name = "double_booked_tier_test",
+    expected_error = "both py_layer_tier.compression and py_layer_tier.compressors",
+    target_under_test = ":double_booked_tier",
+)
+
+py_image_layer(
+    name = "double_booked_layers",
+    allow_non_oci_layers = True,
+    binary = ":app",
+    group_compression = {"default": ["xz"]},
+    group_compressors = {":lolz": "default"},
+    layer_tier = ":cheap_tier",
+)
+
+expected_failure_test(
+    name = "double_booked_layers_test",
+    expected_error = "both py_image_layer.group_compression and py_image_layer.group_compressors",
+    target_under_test = ":double_booked_layers",
+)
+
+# lz4 is the one filter that rejects level 0 outright, so the shared 0..9 range
+# would have let an unbuildable layer through.
+py_layer_tier(
+    name = "lz4_zero_tier",
+    allow_non_oci_layers = True,
+    compression = {"grp": [
+        "lz4",
+        "0",
+    ]},
+    tags = ["manual"],
+)
+
+expected_failure_test(
+    name = "lz4_zero_test",
+    expected_error = "compression level 0 is out of range for \"lz4\"",
+    target_under_test = ":lz4_zero_tier",
+)
+
+py_image_layer(
+    name = "rival_compressors_layers",
+    allow_non_oci_layers = True,
+    binary = ":app",
+    group_compressors = {
+        ":lolz": "default",
+        ":lolz_rival": "default",
+    },
+    layer_tier = ":cheap_tier",
+)
+
+expected_failure_test(
+    name = "rival_compressors_test",
+    expected_error = "mapped to two py_layer_compressor targets",
+    target_under_test = ":rival_compressors_layers",
+)
+
+py_layer_tier(
+    name = "rival_compressors_tier",
+    allow_non_oci_layers = True,
+    compressors = {
+        ":lolz": "branding",
+        ":lolz_rival": "branding",
+    },
+    groups = {"//py/tests/image-layer-compression:branding": "branding"},
+    tags = ["manual"],
+)
+
+expected_failure_test(
+    name = "rival_compressors_tier_test",
+    expected_error = "mapped to two py_layer_compressor targets",
+    target_under_test = ":rival_compressors_tier",
+)
+
+py_layer_compressor(
+    name = "bare_extension",
+    extension = "lolz",
+    tags = ["manual"],
+    tool = ":fake_compressor",
+)
+
+expected_failure_test(
+    name = "bare_extension_test",
+    expected_error = "py_layer_compressor.extension must start with '.'",
+    target_under_test = ":bare_extension",
+)
+
+py_layer_compressor(
+    name = "spaced_args",
+    args = ["-q 11"],
+    extension = ".tar.lolz",
+    tags = ["manual"],
+    tool = ":fake_compressor",
+)
+
+expected_failure_test(
+    name = "spaced_args_test",
+    expected_error = "must be single whitespace-free",
+    target_under_test = ":spaced_args",
+)
+
+codec_table_test(name = "codec_table_test")

--- a/py/tests/image-layer-compression/assert_compression.py
+++ b/py/tests/image-layer-compression/assert_compression.py
@@ -1,0 +1,113 @@
+"""Assert built layer tars carry the compression their file name advertises.
+
+Each `--expect SUFFIX` must match exactly one layer — usually
+`_<group>.tar.<container>`, since one image can hold several layers in the same
+container. `--absent SUFFIX` asserts no layer matches.
+"""
+
+import argparse
+import sys
+import tarfile
+from typing import NoReturn
+
+# libarchive picks the filter from the bsdtar flag, not the file name, so the
+# leading bytes are what actually prove the flag reached the tar action.
+MAGIC = {
+    ".tar.gz": b"\x1f\x8b",
+    ".tar.bz2": b"BZh",
+    ".tar.xz": b"\xfd7zXZ\x00",
+    ".tar.lzma": b"\x5d\x00\x00",
+    ".tar.lz4": b"\x04\x22\x4d\x18",
+    ".tar.zst": b"\x28\xb5\x2f\xfd",
+    ".tar.Z": b"\x1f\x9d",
+    # The fixture compressor's own container: a magic, then a gzip stream.
+    ".tar.lolz": b"LOLZ",
+}
+
+# Containers the standard library can open get checked for real; the rest
+# (zstd, lz4, .Z) stop at the magic check.
+TARFILE_MODES = {
+    ".tar": "r:",
+    ".tar.gz": "r:gz",
+    ".tar.bz2": "r:bz2",
+    ".tar.xz": "r:xz",
+    ".tar.lzma": "r:xz",
+}
+
+# The fixture compressor's container: strip its magic, and what is left is gzip.
+# Unwrapping it proves the program's bytes reached the layer.
+CUSTOM_PREFIX = {".tar.lolz": b"LOLZ"}
+
+
+def fail(message: str) -> NoReturn:
+    print("FAIL: {}".format(message), file=sys.stderr)
+    sys.exit(1)
+
+
+def find(paths: list[str], suffix: str) -> str:
+    matches = [p for p in paths if p.endswith(suffix)]
+    if not matches:
+        fail("no layer ending in {} among {}".format(suffix, sorted(paths)))
+    if len(matches) > 1:
+        fail("{} matched more than one layer: {}".format(suffix, sorted(matches)))
+    return matches[0]
+
+
+def container_of(path: str) -> str:
+    """The compression suffix of a layer file, e.g. `.tar.zst` for `x_grp.tar.zst`."""
+    index = path.rindex(".tar")
+    return path[index:]
+
+
+def check(path: str) -> None:
+    suffix = container_of(path)
+    magic = MAGIC.get(suffix)
+    if magic is not None:
+        with open(path, "rb") as handle:
+            head = handle.read(len(magic))
+        if head != magic:
+            fail("{} does not start with the {} magic {!r}, got {!r}".format(path, suffix, magic, head))
+
+    prefix = CUSTOM_PREFIX.get(suffix)
+    if prefix is not None:
+        with open(path, "rb") as handle:
+            handle.read(len(prefix))
+            with tarfile.open(fileobj=handle, mode="r:gz") as archive:
+                if not archive.getnames():
+                    fail("{} unwrapped to an empty archive".format(path))
+        return
+
+    mode = TARFILE_MODES.get(suffix)
+    if mode is None:
+        return
+    with tarfile.open(path, mode) as archive:
+        if not archive.getnames():
+            fail("{} decompressed to an empty archive".format(path))
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expect", action="append", default=[])
+    parser.add_argument("--absent", action="append", default=[])
+    parser.add_argument("paths", nargs="+")
+    args = parser.parse_args(argv)
+
+    # Matching is by full suffix, so `--expect .tar` accepts only an
+    # uncompressed layer.
+    paths = [p for p in args.paths if ".tar" in p and not p.endswith(".mtree")]
+
+    for suffix in args.expect:
+        path = find(paths, suffix)
+        check(path)
+        print("ok: {} is a valid {} layer".format(path, container_of(path)))
+
+    for suffix in args.absent:
+        found = [p for p in paths if p.endswith(suffix)]
+        if found:
+            fail("expected no {} layer, found {}".format(suffix, sorted(found)))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/py/tests/image-layer-compression/branding/__init__.py
+++ b/py/tests/image-layer-compression/branding/__init__.py
@@ -1,0 +1,1 @@
+BANNER = "rules_py image layer compression fixture"

--- a/py/tests/image-layer-compression/fake_compressor.sh
+++ b/py/tests/image-layer-compression/fake_compressor.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Stand-in for a compressor libarchive has no filter for. It reads the archive
+# on stdin and writes its own container to stdout: a 4-byte magic followed by a
+# gzip stream. The magic matters — it makes the output provably NOT gzip, so a
+# test that reads it back is exercising this program rather than accidentally
+# succeeding on bytes bsdtar could have written itself.
+set -euo pipefail
+if [[ "${1:-}" != "--loud" ]]; then
+    echo "fake_compressor: expected --loud, got '${1:-}'" >&2
+    exit 1
+fi
+printf 'LOLZ'
+exec gzip -9 -n

--- a/py/tests/image-layer-compression/main.py
+++ b/py/tests/image-layer-compression/main.py
@@ -1,0 +1,9 @@
+from branding import BANNER
+
+
+def main() -> None:
+    print(BANNER)
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tests/image-layer-compression/payloads/bzip2.txt
+++ b/py/tests/image-layer-compression/payloads/bzip2.txt
@@ -1,0 +1,1 @@
+payload for the bzip2 filter

--- a/py/tests/image-layer-compression/payloads/compress.txt
+++ b/py/tests/image-layer-compression/payloads/compress.txt
@@ -1,0 +1,1 @@
+payload for the compress filter

--- a/py/tests/image-layer-compression/payloads/gzip.txt
+++ b/py/tests/image-layer-compression/payloads/gzip.txt
@@ -1,0 +1,1 @@
+payload for the gzip filter

--- a/py/tests/image-layer-compression/payloads/lz4.txt
+++ b/py/tests/image-layer-compression/payloads/lz4.txt
@@ -1,0 +1,1 @@
+payload for the lz4 filter

--- a/py/tests/image-layer-compression/payloads/lzma.txt
+++ b/py/tests/image-layer-compression/payloads/lzma.txt
@@ -1,0 +1,1 @@
+payload for the lzma filter

--- a/py/tests/image-layer-compression/payloads/none.txt
+++ b/py/tests/image-layer-compression/payloads/none.txt
@@ -1,0 +1,1 @@
+payload for the none filter

--- a/py/tests/image-layer-compression/payloads/xz.txt
+++ b/py/tests/image-layer-compression/payloads/xz.txt
@@ -1,0 +1,1 @@
+payload for the xz filter

--- a/py/tests/image-layer-compression/payloads/zstd.txt
+++ b/py/tests/image-layer-compression/payloads/zstd.txt
@@ -1,0 +1,1 @@
+payload for the zstd filter

--- a/py/tests/image-layer-compression/pip_main.py
+++ b/py/tests/image-layer-compression/pip_main.py
@@ -1,0 +1,10 @@
+import colorama
+import six
+
+
+def main() -> None:
+    print(colorama.Fore.GREEN, six.PY3)
+
+
+if __name__ == "__main__":
+    main()

--- a/py/tests/image-layer-compression/tests.bzl
+++ b/py/tests/image-layer-compression/tests.bzl
@@ -1,0 +1,182 @@
+"""Compression coverage for `py_image_layer` layer tars.
+
+The codec table, the bsdtar command lines the rule emits, and every
+misconfiguration rejected at analysis time. That the bytes come out readable is
+covered separately by `assert_compression.py`, which runs over the built tars.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load(
+    "//py/private:compression.bzl",
+    "ALGORITHMS",
+    "OCI_ALGORITHMS",
+    "SUPPORTED_ALGORITHMS",
+    "make_codec",
+    "parse_compression",
+)
+
+_TAR_MNEMONICS = ["PyImageLayer", "PyImagePkgLayer", "PyImageMergedLayer"]
+
+def _codec_table_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    gzip = make_codec("gzip", "6")
+    asserts.equals(env, "--gzip", gzip.flag)
+    asserts.equals(env, ".tar.gz", gzip.ext)
+
+    # MTIME zeroed, so identical inputs keep producing identical layer digests.
+    asserts.equals(env, "gzip:!timestamp,gzip:compression-level=6", gzip.options)
+
+    zstd = make_codec("zstd", "19")
+    asserts.equals(env, "--zstd", zstd.flag)
+    asserts.equals(env, ".tar.zst", zstd.ext)
+    asserts.equals(env, "zstd:compression-level=19", zstd.options)
+
+    # No level: libarchive's own default, so no --options at all.
+    xz = make_codec("xz", "")
+    asserts.equals(env, "--xz", xz.flag)
+    asserts.equals(env, ".tar.xz", xz.ext)
+    asserts.equals(env, None, xz.options)
+
+    # "none" is a plain uncompressed tar.
+    none = make_codec("none", "")
+    asserts.equals(env, None, none.flag)
+    asserts.equals(env, ".tar", none.ext)
+    asserts.equals(env, None, none.options)
+
+    # libarchive rejects lz4 level 0 outright, unlike gzip/xz/lzma.
+    asserts.equals(env, 1, ALGORITHMS["lz4"].min_level)
+    asserts.equals(env, 0, ALGORITHMS["gzip"].min_level)
+
+    # `compress` has no compression-level option module.
+    asserts.equals(env, None, ALGORITHMS["compress"].filter)
+    asserts.equals(env, ".tar.Z", make_codec("compress", "").ext)
+
+    asserts.equals(env, make_codec("bzip2", ""), parse_compression(["bzip2"], "test"))
+    asserts.equals(env, make_codec("bzip2", "9"), parse_compression(["bzip2", "9"], "test"))
+
+    # The OCI image spec defines layer formats for exactly these three. Anything
+    # else needs allow_non_oci_layers, because rules_oci would label it an
+    # uncompressed tar and record the compressed digest as its diffid.
+    asserts.equals(env, ["gzip", "none", "zstd"], OCI_ALGORITHMS)
+    asserts.true(env, make_codec("zstd", "3").oci_compatible)
+    asserts.false(env, make_codec("bzip2", "9").oci_compatible)
+    asserts.false(env, make_codec("xz", "").oci_compatible)
+
+    # Layer files are keyed by name in one directory, so extensions must differ.
+    extensions = {}
+    for name in SUPPORTED_ALGORITHMS:
+        ext = ALGORITHMS[name].ext
+        asserts.false(env, ext in extensions, "%s and %s share the extension %s" % (name, extensions.get(ext), ext))
+        extensions[ext] = name
+
+    return unittest.end(env)
+
+codec_table_test = unittest.make(_codec_table_test_impl)
+
+def _tar_action(env, suffix):
+    """The tar action whose output ends with `suffix`, or None."""
+    for action in analysistest.target_actions(env):
+        if action.mnemonic not in _TAR_MNEMONICS:
+            continue
+        if action.outputs.to_list()[0].basename.endswith(suffix):
+            return action
+    return None
+
+def _assert_tar_flags(env, suffix, expected):
+    action = _tar_action(env, suffix)
+    if action == None:
+        names = [
+            a.outputs.to_list()[0].basename
+            for a in analysistest.target_actions(env)
+            if a.mnemonic in _TAR_MNEMONICS
+        ]
+        unittest.fail(env, "no tar action produced *%s; saw %s" % (suffix, names))
+        return
+    for flag in expected:
+        asserts.true(
+            env,
+            flag in action.argv,
+            "expected %r in the bsdtar command line for *%s, got %s" % (flag, suffix, action.argv),
+        )
+
+def _rule_attrs_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    _assert_tar_flags(env, "_default.tar.zst", ["--zstd", "--options", "zstd:compression-level=19"])
+    _assert_tar_flags(env, "_assets.tar.xz", ["--xz"])
+
+    # group_compress_levels stays the gzip shorthand for groups nothing else names.
+    _assert_tar_flags(env, "_extras.tar.gz", ["--gzip", "--options", "gzip:!timestamp,gzip:compression-level=1"])
+
+    return analysistest.end(env)
+
+rule_attrs_test = analysistest.make(_rule_attrs_impl)
+
+def _tier_compression_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    # A first-party group named only by the tier picks up the tier's codec...
+    _assert_tar_flags(env, "_branding.tar.bz2", ["--bzip2", "--options", "bzip2:compression-level=9"])
+
+    # ...and the rule's own attr overrides the tier for the group it names.
+    _assert_tar_flags(env, "_default.tar", [])
+    asserts.true(
+        env,
+        "--gzip" not in _tar_action(env, "_default.tar").argv,
+        "compression = none must not pass a filter flag",
+    )
+
+    return analysistest.end(env)
+
+tier_compression_test = analysistest.make(_tier_compression_impl)
+
+def _custom_compressor_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    action = _tar_action(env, "_default.tar.lolz")
+    if action == None:
+        unittest.fail(env, "no tar action produced the custom-compressed source layer")
+        return analysistest.end(env)
+
+    asserts.true(env, "--use-compress-program" in action.argv, "expected --use-compress-program, got %s" % action.argv)
+
+    cmdline = action.argv[action.argv.index("--use-compress-program") + 1]
+    asserts.true(env, cmdline.endswith(" --loud"), "compressor args must ride on the command line, got %r" % cmdline)
+    asserts.true(env, "fake_compressor" in cmdline, "expected the program path in %r" % cmdline)
+
+    # bsdtar spawns it from the execroot, so it has to be an action input.
+    asserts.true(
+        env,
+        any([f.basename == "fake_compressor" for f in action.inputs.to_list()]),
+        "the compressor binary must be an input of the tar action",
+    )
+
+    # The tier reaches a custom compressor the same way the rule attr does.
+    _assert_tar_flags(env, "_branding.tar.lolz", ["--use-compress-program"])
+
+    return analysistest.end(env)
+
+custom_compressor_test = analysistest.make(_custom_compressor_impl)
+
+def _oci_compressor_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    # A custom compressor declaring an OCI extension is accepted without the
+    # opt-in, and the layer still goes through --use-compress-program.
+    _assert_tar_flags(env, "_default.tar.gz", ["--use-compress-program"])
+
+    return analysistest.end(env)
+
+oci_compressor_test = analysistest.make(_oci_compressor_impl)
+
+def _expected_failure_impl(ctx):
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(env, ctx.attr.expected_error)
+    return analysistest.end(env)
+
+expected_failure_test = analysistest.make(
+    _expected_failure_impl,
+    attrs = {"expected_error": attr.string(mandatory = True)},
+    expect_failure = True,
+)


### PR DESCRIPTION
Add support for alternate compression algorithms by opening up libarchive's full write-filter set: none, gzip, bzip2, xz, lzma, lzop, lz4, lrzip, zstd, compress. New `py_layer_compressor` covers anything else by piping the archive through a user-supplied program.