### PR TITLE
refactor: move sdist fallback test from root

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
-
 # Gazelle manages the bzl_library graph for the public //py/... and //uv/...
 # packages so release_prep.sh's starlark_doc_extract query has fresh deps.
 # gazelle:exclude py/tests
@@ -30,14 +28,4 @@ alias(
 alias(
     name = "buildifier",
     actual = "@buildifier_prebuilt//buildifier",
-)
-
-# Regression test: a package whose lockfile entry has both an sdist *and* a
-# `-none-any.whl` must still emit a `sdist_build__*` repo so the source-build
-# fallback is available for overrides, no-binary settings, and incomplete
-# wheel coverage. bravado 11.0.3 ships both shapes and is in the root lock;
-# building its `:whl` exercises the fallback the extension must preserve.
-build_test(
-    name = "sdist_fallback_with_anyarch_wheel_build_test",
-    targets = ["@sdist_build__aspect_rules_py__bravado__11_0_3//:whl"],
 )

--- a/uv/private/sdist_build/tests/BUILD.bazel
+++ b/uv/private/sdist_build/tests/BUILD.bazel
@@ -1,0 +1,14 @@
+"""
+Regression test: a package whose lockfile entry has both an sdist *and* a
+`-none-any.whl` must still emit a `sdist_build__*` repo so the source-build
+fallback is available for overrides, no-binary settings, and incomplete
+wheel coverage. bravado 11.0.3 ships both shapes and is in the root lock;
+building its `:whl` exercises the fallback the extension must preserve.
+"""
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+build_test(
+    name = "sdist_fallback_with_anyarch_wheel_build_test",
+    targets = ["@sdist_build__aspect_rules_py__bravado__11_0_3//:whl"],
+)


### PR DESCRIPTION


### Changes are visible to end-users: no


### Test plan

- Covered by existing test cases
