### PR TITLE
perf(py): native //py:python launcher via hermetic_launcher

### DIFF
--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("//py/private/interpreter:launcher.bzl", "py_interpreter_launcher")
 
 # Users can set, e.g. --@aspect_rules_py//py:python_version=3.12
 alias(
@@ -7,11 +8,11 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-# Actions that need a Python executable should not need a direct rules_python
-# dependency just to use its remote-safe interpreter launcher.
-alias(
+# Actions that need a Python executable get a native launcher (built with
+# hermetic_launcher) that execs the toolchain-resolved interpreter through
+# the runfiles mechanism. No rules_python dependency, bonus works on Windows too.
+py_interpreter_launcher(
     name = "python",
-    actual = "@rules_python//python/bin:python",
     visibility = ["//visibility:public"],
 )
 

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -107,6 +107,15 @@ bzl_library(
 )
 
 bzl_library(
+    name = "launcher",
+    srcs = ["launcher.bzl"],
+    deps = [
+        "//py/private/toolchain:types",
+        "@hermetic_launcher//launcher:lib_bzl",
+    ],
+)
+
+bzl_library(
     name = "resolve",
     srcs = ["resolve.bzl"],
     deps = [":sanitize"],

--- a/py/private/interpreter/launcher.bzl
+++ b/py/private/interpreter/launcher.bzl
@@ -1,0 +1,63 @@
+"""
+Rule to expose the resolved Python toolchain interpreter as an executable.
+
+A hermetic_launcher-based replacement for rules_python's interpreter_binary
+(`@rules_python//python/bin:python`): a small native binary that resolves the
+toolchain's interpreter through the Bazel runfiles mechanism at runtime and
+execs it, forwarding any additional arguments. Works identically on Linux,
+macOS, and Windows, both locally and under remote execution.
+"""
+
+load("@hermetic_launcher//launcher:lib.bzl", "launcher")
+load("//py/private/toolchain:types.bzl", "PY_TOOLCHAIN")
+
+def _py_interpreter_launcher_impl(ctx):
+    toolchain = ctx.toolchains[PY_TOOLCHAIN]
+    runtime = toolchain.py3_runtime
+    if not runtime or not runtime.interpreter:
+        fail("py3_runtime must provide an in-build `interpreter` file; " +
+             "system interpreters are not supported")
+
+    executable = ctx.actions.declare_file(runtime.interpreter.basename)
+
+    embedded_args, transformed_args = launcher.args_from_entrypoint(runtime.interpreter)
+    launcher.compile_stub(
+        ctx = ctx,
+        embedded_args = embedded_args,
+        transformed_args = transformed_args,
+        output_file = executable,
+    )
+
+    return [DefaultInfo(
+        executable = executable,
+        files = depset([executable]),
+        runfiles = ctx.runfiles(transitive_files = depset(
+            direct = [runtime.interpreter],
+            transitive = [runtime.files],
+        )),
+    )]
+
+py_interpreter_launcher = rule(
+    doc = """\
+Builds a native launcher executable for the resolved Python 3 interpreter.
+
+The launcher locates the toolchain interpreter through the Bazel runfiles
+mechanism at runtime and execs it, forwarding any extra arguments — so the
+same target works locally, under remote execution, and on Windows.
+
+Example usage in a `genrule`:
+
+```
+genrule(
+    name = "run_python",
+    outs = ["output.txt"],
+    cmd = "$(location @aspect_rules_py//py:python) -c 'print(42)' > $@",
+    tools = ["@aspect_rules_py//py:python"],
+)
+```
+
+""",
+    implementation = _py_interpreter_launcher_impl,
+    executable = True,
+    toolchains = [PY_TOOLCHAIN, launcher.finalizer_toolchain_type, launcher.template_toolchain_type],
+)


### PR DESCRIPTION
`//py:python` aliased rules_python's interpreter_binary, keeping a rules_python dependency alive just for a runfiles-safe way to exec the toolchain interpreter in actions. Reimplement it as a py_interpreter_launcher rule backed by hermetic_launcher (already a dependency, used by py_venv_exec): a small native binary that resolves the toolchain interpreter through the runfiles mechanism and execs it, forwarding extra arguments. Behavior is unchanged for consumers, and as a side effect the launcher now also works on Windows, where rules_python's shell-script wrapper is unsupported. 

### Changes are visible to end-users: no

### Test plan


- Covered by existing test cases
