### PR TITLE
test: directory symlink coverage for py_image_layer

### DIFF
--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -7,7 +7,7 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("//tools:asserts.bzl", "assert_tar_listing", "assert_tar_ownership")
 load(":image_layer_analysis_tests.bzl", "image_layer_analysis_test_suite")
 load(":runtime_wrapper.bzl", "runtime_wrapper")
-load(":tree_artifact.bzl", "symlink_target", "symlink_to_target", "tree_artifact")
+load(":tree_artifact.bzl", "dir_and_symlink", "relative_symlink", "symlink_target", "symlink_to_target", "tree_artifact")
 
 platform(
     name = "aarch64_linux",
@@ -69,6 +69,73 @@ py_test(
         "@aspect_rules_py//py/tests/internal-deps/adder",
         "@pypi_oci_py_image_layer//colorama",
     ],
+)
+
+# A directory symlink in runfiles must ship as a relative link that resolves
+# to the tree artifact's files riding in the same image.
+dir_and_symlink(name = "dir_symlink")
+
+py_binary(
+    name = "dir_symlink_bin",
+    srcs = ["server.py"],
+    data = [":dir_symlink"],
+)
+
+py_image_layer(
+    name = "dir_symlink_layers",
+    binary = ":dir_symlink_bin",
+)
+
+py_test(
+    name = "dir_symlink_layers_test",
+    srcs = ["assert_layer_symlink.py"],
+    args = [
+        "--link-tar=_default.tar.gz",
+        "--link-suffix=dir_symlink_link",
+        "--target-tar=_default.tar.gz",
+        "--through-file=payload.txt",
+        "$(rootpaths :dir_symlink_layers)",
+    ],
+    data = [":dir_symlink_layers"],
+    main = "assert_layer_symlink.py",
+)
+
+# A source-layer directory symlink whose target tree ships in a grouped
+# layer must still resolve across layers in the assembled image.
+tree_artifact(name = "cross_layer_tree")
+
+relative_symlink(
+    name = "cross_layer_dir_link",
+    target_path = "cross_layer_tree_tree",
+)
+
+py_binary(
+    name = "cross_layer_dir_symlink_bin",
+    srcs = ["server.py"],
+    data = [
+        ":cross_layer_dir_link",
+        ":cross_layer_tree",
+    ],
+)
+
+py_image_layer(
+    name = "cross_layer_dir_symlink_layers",
+    binary = ":cross_layer_dir_symlink_bin",
+    groups = {":cross_layer_tree": "tree_data"},
+)
+
+py_test(
+    name = "cross_layer_dir_symlink_layers_test",
+    srcs = ["assert_layer_symlink.py"],
+    args = [
+        "--link-tar=_default.tar.gz",
+        "--link-suffix=cross_layer_dir_link",
+        "--target-tar=_tree_data.tar.gz",
+        "--through-file=tree_payload.txt",
+        "$(rootpaths :cross_layer_dir_symlink_layers)",
+    ],
+    data = [":cross_layer_dir_symlink_layers"],
+    main = "assert_layer_symlink.py",
 )
 
 # Verify a grouped symlink can target another grouped layer.

--- a/e2e/cases/oci/py_image_layer/assert_layer_symlink.py
+++ b/e2e/cases/oci/py_image_layer/assert_layer_symlink.py
@@ -11,6 +11,10 @@ def main() -> int:
     parser.add_argument("--link-tar", required=True)
     parser.add_argument("--link-suffix", required=True)
     parser.add_argument("--target-tar", required=True)
+    parser.add_argument(
+        "--through-file",
+        help="Assert the link points at a directory by resolving this file under it.",
+    )
     parser.add_argument("archives", nargs="+")
     args = parser.parse_args()
 
@@ -22,6 +26,8 @@ def main() -> int:
         print("FAIL: symlink was not preserved as a relative link", file=sys.stderr)
         return 1
     target = posixpath.normpath(posixpath.join(posixpath.dirname(member.name), member.linkname))
+    if args.through_file:
+        target = posixpath.join(target, args.through_file)
     with tarfile.open(target_tar, "r:*") as archive:
         target_paths = {posixpath.normpath(item.name) for item in archive.getmembers()}
     if target not in target_paths:

--- a/e2e/cases/oci/py_image_layer/tree_artifact.bzl
+++ b/e2e/cases/oci/py_image_layer/tree_artifact.bzl
@@ -12,6 +12,34 @@ def _tree_artifact_impl(ctx):
 
 tree_artifact = rule(implementation = _tree_artifact_impl)
 
+def _dir_and_symlink_impl(ctx):
+    tree = ctx.actions.declare_directory(ctx.label.name + "_dir")
+    ctx.actions.run_shell(
+        outputs = [tree],
+        arguments = [tree.path],
+        command = 'mkdir -p "$1/sub" && printf dir-symlink-payload > "$1/payload.txt" && printf nested-payload > "$1/sub/nested.txt"',
+    )
+    link = ctx.actions.declare_symlink(ctx.label.name + "_link")
+    ctx.actions.symlink(output = link, target_path = ctx.label.name + "_dir")
+    files = depset([tree, link])
+    return [DefaultInfo(files = files, runfiles = ctx.runfiles(transitive_files = files))]
+
+dir_and_symlink = rule(
+    doc = "A tree artifact plus a relative directory symlink pointing at it.",
+    implementation = _dir_and_symlink_impl,
+)
+
+def _relative_symlink_impl(ctx):
+    link = ctx.actions.declare_symlink(ctx.label.name)
+    ctx.actions.symlink(output = link, target_path = ctx.attr.target_path)
+    return [DefaultInfo(files = depset([link]))]
+
+relative_symlink = rule(
+    doc = "A declared symlink with an authored relative target path.",
+    implementation = _relative_symlink_impl,
+    attrs = {"target_path": attr.string(mandatory = True)},
+)
+
 def _symlink_target_impl(ctx):
     output = ctx.actions.declare_file(ctx.label.name + ".txt")
     ctx.actions.write(output, "symlink target\n")


### PR DESCRIPTION
Locks in behavior that already works at HEAD: a relative directory symlink ships as a relative type=link tar entry resolving to the tree artifact's files, both within one layer and across layers (target tree grouped into its own layer). assert_layer_symlink.py gains --through-file to verify links that target a directory, which has no tar member row of its own.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
