### PR TITLE
test(uv): assert cross-built .so ELF machines match their wheel tags

### DIFF
--- a/e2e/crossbuild/tools/BUILD.bazel
+++ b/e2e/crossbuild/tools/BUILD.bazel
@@ -1,14 +1,29 @@
 # Shared helpers consumed by //... via load("//tools:...").
 
-load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library", "py_test")
 load(":ant_layer.bzl", "ant_home")
 load(":rust_layer.bzl", "rust_host_sysroot")
 
 # Consumed cross-package by the `collect_wheels` macro (//tools:collect_wheels.bzl),
 # which declares a py_test with this script as `main` in the caller's package.
 exports_files([
+    "check_so_arch.py",
     "check_wheel_tags.py",
 ])
+
+py_test(
+    name = "check_so_arch_test",
+    srcs = ["check_so_arch_test.py"],
+    imports = [".."],
+    main = "check_so_arch_test.py",
+    deps = ["//tools:check_so_arch_lib"],
+)
+
+py_library(
+    name = "check_so_arch_lib",
+    srcs = ["check_so_arch.py"],
+    visibility = ["//visibility:private"],
+)
 
 py_binary(
     name = "collect_wheels_tool",

--- a/e2e/crossbuild/tools/check_so_arch.py
+++ b/e2e/crossbuild/tools/check_so_arch.py
@@ -1,0 +1,120 @@
+"""Assert every native .so inside a collected wheel matches its platform tag.
+
+Usage: check_so_arch.py <dir>
+
+For each wheel in the directory, reads its dist-info WHEEL `Tag:` entries and
+verifies that every bundled native library (.so) is an ELF whose e_machine
+matches the architecture the tag claims. A cross build that produced a wheel
+tagged linux_aarch64 whose .so is actually x86_64 — wrong wrapper, leaked
+host sysroot, misdetected toolchain — fails here even if the tags test and
+the build both passed.
+
+Wheels with no native libraries (pure Python) are skipped, as are non-Linux
+tags (macOS uses Mach-O, not ELF; the cross matrix is Linux-only).
+"""
+
+import os
+import sys
+import zipfile
+
+ELF_MAGIC = b"\x7fELF"
+
+# ELF e_machine (2 bytes, little-endian, offset 18) by tag architecture.
+_E_MACHINE = {
+    "x86_64": 62,    # EM_X86_64
+    "aarch64": 183,  # EM_AARCH64
+}
+
+
+def _wheel_tags(zf: zipfile.ZipFile) -> list[str]:
+    for name in zf.namelist():
+        root, sep, rest = name.partition("/")
+        if sep and root.endswith(".dist-info") and rest == "WHEEL":
+            lines = zf.read(name).decode("utf-8").splitlines()
+            return [
+                line.split(":", 1)[1].strip()
+                for line in lines
+                if line.startswith("Tag:")
+            ]
+    return []
+
+
+def _native_libs(zf: zipfile.ZipFile) -> list[str]:
+    result = []
+    for name in zf.namelist():
+        basename = name.rsplit("/", 1)[-1]
+        if basename.endswith(".so") or ".so." in basename:
+            result.append(name)
+    return result
+
+
+def _tag_arch(tag: str) -> str | None:
+    """The architecture a platform tag claims, or None for non-Linux tags.
+
+    linux_x86_64 -> "x86_64", musllinux_1_2_aarch64 -> "aarch64".
+    """
+    platform = tag.rsplit("-", 1)[-1]
+    if not platform.startswith(("linux_", "musllinux_")):
+        return None
+    # The architecture is the trailing component(s); x86_64 itself contains
+    # an underscore, so match known arches by suffix rather than splitting.
+    for arch in _E_MACHINE:
+        if platform.endswith("_" + arch) or platform == arch:
+            return arch
+    return None
+
+
+def check_wheel(path: str) -> list[str]:
+    """Failures for one wheel: one string per (tag, .so) mismatch."""
+    failures = []
+    with zipfile.ZipFile(path) as zf:
+        arches = {
+            arch
+            for arch in (_tag_arch(tag) for tag in _wheel_tags(zf))
+            if arch is not None
+        }
+        if not arches:
+            return []
+        libs = _native_libs(zf)
+        for lib in libs:
+            with zf.open(lib) as f:
+                header = f.read(20)
+            if header[:4] != ELF_MAGIC:
+                failures.append("{}: {} is not ELF".format(path, lib))
+                continue
+            machine = int.from_bytes(header[18:20], "little")
+            if any(machine != _E_MACHINE.get(arch) for arch in arches):
+                failures.append(
+                    "{}: {} ELF e_machine={} but the wheel is tagged for {}".format(
+                        path, lib, machine, sorted(arches),
+                    )
+                )
+    return failures
+
+
+def main() -> None:
+    wheel_dir = sys.argv[1]
+    names = sorted(f for f in os.listdir(wheel_dir) if f.endswith(".whl"))
+    assert names, "no wheels collected under {}".format(wheel_dir)
+
+    checked = 0
+    failures = []
+    for name in names:
+        wheel = os.path.join(wheel_dir, name)
+        with zipfile.ZipFile(wheel) as zf:
+            libs = _native_libs(zf)
+        checked += len(libs)
+        failures.extend(check_wheel(wheel))
+
+    if failures:
+        for failure in failures:
+            print("FAIL:", failure)
+        raise SystemExit(1)
+    if checked == 0:
+        print("PASS: no native libraries to check (pure wheels)")
+    else:
+        print("PASS: {} native librar{} match their wheel tags".format(checked, "y" if checked == 1 else "ies"))
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/crossbuild/tools/check_so_arch_test.py
+++ b/e2e/crossbuild/tools/check_so_arch_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fixture tests for check_so_arch: tag/.so agreement, mismatch, and skips."""
+import os
+import tempfile
+import unittest
+import zipfile
+
+from tools import check_so_arch
+
+
+def _elf(machine: int) -> bytes:
+    return b"\x7fELF" + b"\x00" * 14 + machine.to_bytes(2, "little") + b"\x00" * 44
+
+
+def _wheel(path: str, tag: str, libs: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("pkg-1.0.dist-info/WHEEL", "Wheel-Version: 1.0\nTag: {}\n".format(tag))
+        for name, content in libs.items():
+            zf.writestr(name, content)
+
+
+class CheckSoArchTest(unittest.TestCase):
+    def test_matching_arch_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wheel = os.path.join(tmp, "pkg-1.0-cp312-cp312-linux_aarch64.whl")
+            _wheel(wheel, "cp312-cp312-linux_aarch64", {"pkg/ext.cpython-312-aarch64-linux-gnu.so": _elf(183)})
+            self.assertEqual([], check_so_arch.check_wheel(wheel))
+
+    def test_mismatched_arch_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wheel = os.path.join(tmp, "pkg-1.0-cp312-cp312-linux_aarch64.whl")
+            # Tagged aarch64 but the .so is x86_64 — the failure this test
+            # suite exists to catch.
+            _wheel(wheel, "cp312-cp312-linux_aarch64", {"pkg/ext.so": _elf(62)})
+            failures = check_so_arch.check_wheel(wheel)
+            self.assertEqual(1, len(failures))
+            self.assertIn("e_machine=62", failures[0])
+
+    def test_musllinux_tag_checked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wheel = os.path.join(tmp, "pkg-1.0-cp312-cp312-musllinux_1_2_x86_64.whl")
+            _wheel(wheel, "cp312-cp312-musllinux_1_2_x86_64", {"pkg/ext.so": _elf(62)})
+            self.assertEqual([], check_so_arch.check_wheel(wheel))
+
+    def test_pure_wheel_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wheel = os.path.join(tmp, "pkg-1.0-py3-none-any.whl")
+            _wheel(wheel, "py3-none-any", {"pkg/mod.py": b"x = 1\n"})
+            self.assertEqual([], check_so_arch.check_wheel(wheel))
+
+    def test_macos_tag_skipped(self) -> None:
+        # Mach-O is not ELF; the cross matrix is Linux-only, so darwin tags
+        # are out of scope for this check (documented in the module docstring).
+        with tempfile.TemporaryDirectory() as tmp:
+            wheel = os.path.join(tmp, "pkg-1.0-cp312-cp312-macosx_11_0_arm64.whl")
+            _wheel(wheel, "cp312-cp312-macosx_11_0_arm64", {"pkg/ext.so": b"\xcf\xfa\xed\xfe"})
+            self.assertEqual([], check_so_arch.check_wheel(wheel))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/e2e/crossbuild/tools/collect_wheels.bzl
+++ b/e2e/crossbuild/tools/collect_wheels.bzl
@@ -6,6 +6,9 @@ gathers the results into one directory. rules_pycross stops at "it builds";
 this version adds a runtime assertion over each wheel's WHEEL `Tag:` metadata
 so a wheel tagged for the wrong platform fails the test instead of passing
 silently.
+It also asserts, for each wheel, that every bundled native .so is an ELF whose
+e_machine matches the architecture its `Tag:` claims (see
+tools/check_so_arch.py); pure wheels are skipped.
 """
 
 load("@aspect_rules_py//py:defs.bzl", "py_test")
@@ -65,5 +68,13 @@ def collect_wheels(name, wheels, platforms, expected_tags):
         srcs = ["//tools:check_wheel_tags.py"],
         main = "//tools:check_wheel_tags.py",
         args = ["$(rootpath :{})".format(name)] + expected_tags,
+        data = [name],
+    )
+
+    py_test(
+        name = name + "_elf_test",
+        srcs = ["//tools:check_so_arch.py"],
+        main = "//tools:check_so_arch.py",
+        args = ["$(rootpath :{})".format(name)],
         data = [name],
     )


### PR DESCRIPTION
The final e2e slice of the cross-build series. The wheel-tags assertion (Slice A) proves the *metadata* is right; it says nothing about the *bytes*. A cross build that produced a wheel tagged `linux_aarch64` whose `.so` is actually x86_64 — wrong wrapper, leaked host sysroot, misdetected toolchain — passed both the build and the tags test.

## What it does

`collect_wheels` now also emits `<name>_elf_test`: for each collected wheel, every bundled native library must be an ELF whose `e_machine` matches the architecture its `Tag:` claims.

The design needs **no per-case parameters** (contrast with the spike's per-arch test pairs over py_image_layer tars): expected arch is derived from each wheel's own tag, so the check is internal consistency — tag says aarch64 *and* the `.so` really is aarch64. Pure wheels and non-Linux tags are skipped (Mach-O isn't ELF; the matrix is Linux-only), which is what lets all six pycross cases get the check automatically.

No execution of foreign-arch code anywhere — the check reads two bytes at offset 18.

## What's in it

- `tools/check_so_arch.py` — the assertion (pure, zipfile + header read).
- `tools/check_so_arch_test.py` — fixture wheels pinning both directions: matching arch passes, mismatched fails with `e_machine=62` in the message, musllinux tag parsing (the `x86_64` underscore trap), pure-wheel and macosx skips.
- `collect_wheels.bzl` — one extra `py_test` per case.

## Test plan

- `cd e2e/crossbuild && bazel test //...` — 26/26 pass, including the 6 new `*_elf_test` running against the real cross wheels (setuptools ×3 packages, meson, cmake, rust, jdk, pure-python)
- ruff / pyright clean
