### PR TITLE
docs: generate Starlark API reference with stardoc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,11 @@ import %workspace%/bazel/defaults.bazelrc
 common --test_output=errors
 common --incompatible_disallow_empty_glob=False
 
+# protobuf (any released version) has a protoc_authenticity run_shell action without
+# the toolchain parameter that Bazel 9 requires; fixed on protobuf main but unreleased.
+# No-op on Bazel 8. Remove once a protobuf release carries the fix.
+common --noincompatible_enable_proto_toolchain_resolution
+
 # Define value used by tests
 common --define=SOME_VAR=SOME_VALUE
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -108,6 +108,13 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = Tr
 bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2", dev_dependency = True)
 bazel_dep(name = "bazel_env.bzl", version = "0.5.0", dev_dependency = True)
 bazel_dep(name = "rules_multitool", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
+
+# The stardoc renderer is this repo's only Java target; its toolchain resolution
+# validates the go toolchains registered via gazelle, and rules_go 0.51 (resolved
+# by gazelle 0.40) uses the CcInfo symbol removed in Bazel 9. 0.61.1 is the fix
+# without dragging rules_android (which rules_jvm_external pulls via newer protobuf).
+bazel_dep(name = "rules_go", version = "0.61.1", dev_dependency = True)
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool", dev_dependency = True)
 multitool.hub(lockfile = "//tools:tools.lock.json")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -21,6 +21,7 @@
     "https://bcr.bazel.build/modules/bazel_env.bzl/0.5.0/MODULE.bazel": "116884119669ff3ced7535dc6ed5344f08d92cbc514cbcb474b2eb94c840b891",
     "https://bcr.bazel.build/modules/bazel_env.bzl/0.5.0/source.json": "e88a7d73547512d987c37541ffe57ed6f946222d448a3117554bdff1ae816ef0",
     "https://bcr.bazel.build/modules/bazel_features/1.0.0/MODULE.bazel": "d7f022dc887efb96e1ee51cec7b2e48d41e36ff59a6e4f216c40e4029e1585bf",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
@@ -33,6 +34,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.31.0/MODULE.bazel": "eca40770b202b2161c1e20be7f1c323c8836dc959ae48dcf02ee7a051ffe4e8e",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
+    "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.0/MODULE.bazel": "e8ca15cb2639c5f12183db6dcb678735555d0cdd739b32a0418b6532b5e565f8",
     "https://bcr.bazel.build/modules/bazel_features/1.43.0/MODULE.bazel": "defa2226f06ba20550d6548c3a2ea2a7929634437a52973869c20c225450eb91",
@@ -68,6 +70,12 @@
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/MODULE.bazel": "f1b7bb2dd53e8f2ef984b39485ec8a44e9076dda5c4b8efd2fb4c6a6e856a31d",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.7/MODULE.bazel": "1e5e03c383fa64ebbe0942a225c32168fd6ef6b270351bbec481d47d19d1b96d",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.7/source.json": "34a83d58ae2f1ef6731d1fc8a1b6f07825741aff3f5993b67b67ec21d2c2946e",
+    "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
+    "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
+    "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
+    "https://bcr.bazel.build/modules/gazelle/0.51.3/MODULE.bazel": "618a729142f66de1e2cb776d026413763be5b80d5e3d29ffb9d3d90c5defde90",
+    "https://bcr.bazel.build/modules/gazelle/0.51.3/source.json": "fbe5312a01fb4a2a58caff4a0d40dcf384b6f0bda75e85546663360da1d7538a",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -84,7 +92,8 @@
     "https://bcr.bazel.build/modules/llvm/0.8.3/source.json": "4b11874c26a9de53c03a25a517ebc36dee6b458c920fe9ed65e3ca279ff19775",
     "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
     "https://bcr.bazel.build/modules/package_metadata/0.0.3/MODULE.bazel": "77890552ecea9e284b5424c9de827a58099348763a4359e975c359a83d4faa83",
-    "https://bcr.bazel.build/modules/package_metadata/0.0.3/source.json": "742075a428ad12a3fa18a69014c2f57f01af910c6d9d18646c990200853e641a",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/source.json": "2326db2f6592578177751c3e1f74786b79382cd6008834c9d01ec865b9126a85",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
@@ -98,11 +107,14 @@
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "52f4126f63a2f0bbf36b99c2a87648f08467a4eaf92ba726bc7d6a500bbf770c",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
     "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
+    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
     "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
@@ -129,6 +141,12 @@
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
+    "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
+    "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
+    "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
+    "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
+    "https://bcr.bazel.build/modules/rules_go/0.61.1/MODULE.bazel": "b599cc67f98e8dbe040631129fbd23f190a557f7be506d4781619d0fd4dbbbec",
+    "https://bcr.bazel.build/modules/rules_go/0.61.1/source.json": "ff52d46fca8e2ac87c610c11f05c3a9f0fa08dc4294664c6a31449092409c5aa",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
@@ -145,13 +163,15 @@
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.0/MODULE.bazel": "9c064c434606d75a086f15ade5edb514308cccd1544c2b2a89bbac4310e41c71",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.6/MODULE.bazel": "153042249c7060536dc95b6bb9f9bb8063b8a0b0cb7acdb381bddbc2374aed55",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.6/source.json": "b1d7ffc3877e5a76e6e48e6bce459cbb1712c90eba14861b112bd299587a534d",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
@@ -180,6 +200,7 @@
     "https://bcr.bazel.build/modules/rules_python/1.9.0/MODULE.bazel": "afc3a05f29f09f2d3ee95ad99a145250dab41a2b2d8d6f82cc91936b3213282c",
     "https://bcr.bazel.build/modules/rules_python/1.9.0/source.json": "3921ea0b65298d51aead5b9e4a82203d7be9b5918619b58b53f1c259f4e63169",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
@@ -190,7 +211,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
     "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
-    "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
+    "https://bcr.bazel.build/modules/stardoc/0.8.1/MODULE.bazel": "176fef488dce8e5943c8fac37eade418b80b3846fdfd69f0457165375b6b0e68",
+    "https://bcr.bazel.build/modules/stardoc/0.8.1/source.json": "96482be3dc73e845e2dabb94103121d57a0f3f49663aa4cc4150b44c68fb4a55",
     "https://bcr.bazel.build/modules/tar.bzl/0.10.1/MODULE.bazel": "bf5fda5b5ccef8c3c4a5f4886144377386e0baa382972f257acb42dcf40ea908",
     "https://bcr.bazel.build/modules/tar.bzl/0.10.4/MODULE.bazel": "e8f9ff79199e8d9eaad7f1b0a77ad74b30bb82d794b87d8ca942bead5de83ae9",
     "https://bcr.bazel.build/modules/tar.bzl/0.10.4/source.json": "20143442376c03426f6135292ba02d825cb75308aa47e6bf42dd4cc5a435c2ff",
@@ -201,6 +223,7 @@
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/source.json": "2d2bad780a9f2b9195a4a370314d2c17ae95eaa745cefc2e12fbc49759b15aa3",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
@@ -282,7 +305,7 @@
                 "aspect_rules_py": "",
                 "aspect_tools_telemetry": "0.5.2"
               },
-              "last_notice": 2
+              "last_notice": 3
             }
           }
         },
@@ -300,6 +323,197 @@
             "aspect_tools_telemetry+",
             "bazel_skylib",
             "bazel_skylib+"
+          ]
+        ]
+      }
+    },
+    "@@llvm+//3rd_party/gcc/extension:gcc.bzl%gcc": {
+      "general": {
+        "bzlTransitiveDigest": "XUWTels9SzO7xhmQBqYtaFYFMTjrFMSDFi/Q7hv4f34=",
+        "usagesDigest": "9IP/e++b81Ga1zICxzXu+yqfe5i4DX5F/SsrgV5a568=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "gcc": {
+            "repoRuleId": "@@llvm+//:http_bsdtar_archive.bzl%http_bsdtar_archive",
+            "attributes": {
+              "build_file": "@@llvm+//3rd_party/gcc:gcc.BUILD.bazel",
+              "includes": [
+                "gcc/BASE-VER",
+                "gcc/DATESTAMP",
+                "gcc/ginclude/unwind-arm-common.h",
+                "config/acx.m4",
+                "config/cet.m4",
+                "config/futex.m4",
+                "config/gc++filt.m4",
+                "config/gthr.m4",
+                "config/hwcaps.m4",
+                "config/iconv.m4",
+                "config/lthostflags.m4",
+                "config/multi.m4",
+                "config/no-executables.m4",
+                "config/tls.m4",
+                "config/toolexeclibdir.m4",
+                "config/unwind_ipinfo.m4",
+                "include/ansidecl.h",
+                "include/demangle.h",
+                "include/dyn-string.h",
+                "include/getopt.h",
+                "include/libiberty.h",
+                "libgcc/gthr-posix.h",
+                "libgcc/gthr-single.h",
+                "libgcc/gthr.h",
+                "libgcc/config/arm/unwind-arm.h",
+                "libgcc/unwind-generic.h",
+                "libgcc/unwind-pe.h",
+                "libiberty/cp-demangle.c",
+                "libiberty/cp-demangle.h",
+                "libstdc++-v3/acinclude.m4",
+                "libstdc++-v3/config/**",
+                "libstdc++-v3/configure.ac",
+                "libstdc++-v3/configure.host",
+                "libstdc++-v3/crossconfig.m4",
+                "libstdc++-v3/linkage.m4",
+                "libstdc++-v3/include/**",
+                "libstdc++-v3/libsupc++/**",
+                "libstdc++-v3/src/**"
+              ],
+              "sha256": "dc033fdfd79caf199113446af6d082004534437b6ebd276f9732815d86cbe723",
+              "strip_prefix": "gcc-2bfd402f8569511901ec8fe7628f57471e6d240a",
+              "urls": [
+                "https://github.com/gcc-mirror/gcc/archive/2bfd402f8569511901ec8fe7628f57471e6d240a.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "llvm+",
+            "bazel_lib",
+            "bazel_lib+"
+          ],
+          [
+            "llvm+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel+//:python_configure.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "D2/qWHU6yQFwRG7Bb+caqrYMha5avsASao2vERrxK24=",
+        "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_python": {
+            "repoRuleId": "@@pybind11_bazel+//:python_configure.bzl%python_configure",
+            "attributes": {}
+          },
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11.BUILD",
+              "strip_prefix": "pybind11-2.11.1",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.11.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "4LouzhF/yT117s7peGnNs9ROomiJXC6Zl5R0oI21jho=",
+        "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "platforms": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_python": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "bazel_skylib": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "repoRuleId": "@@rules_fuzzing+//fuzzing/private/oss_fuzz:repository.bzl%oss_fuzz_repository",
+            "attributes": {}
+          },
+          "honggfuzz": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@rules_fuzzing+//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_fuzzing+",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }
@@ -817,6 +1031,170 @@
     },
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "notice_version": "3"
+    },
+    "@@rules_go+//go:extensions.bzl%go_sdk": {
+      "1.25.0": {
+        "aix_ppc64": [
+          "go1.25.0.aix-ppc64.tar.gz",
+          "e5234a7dac67bc86c528fe9752fc9d63557918627707a733ab4cac1a6faed2d4"
+        ],
+        "darwin_amd64": [
+          "go1.25.0.darwin-amd64.tar.gz",
+          "5bd60e823037062c2307c71e8111809865116714d6f6b410597cf5075dfd80ef"
+        ],
+        "darwin_arm64": [
+          "go1.25.0.darwin-arm64.tar.gz",
+          "544932844156d8172f7a28f77f2ac9c15a23046698b6243f633b0a0b00c0749c"
+        ],
+        "dragonfly_amd64": [
+          "go1.25.0.dragonfly-amd64.tar.gz",
+          "5ed3cf9a810a1483822538674f1336c06b51aa1b94d6d545a1a0319a48177120"
+        ],
+        "freebsd_386": [
+          "go1.25.0.freebsd-386.tar.gz",
+          "abea5d5c6697e6b5c224731f2158fe87c602996a2a233ac0c4730cd57bf8374e"
+        ],
+        "freebsd_amd64": [
+          "go1.25.0.freebsd-amd64.tar.gz",
+          "86e6fe0a29698d7601c4442052dac48bd58d532c51cccb8f1917df648138730b"
+        ],
+        "freebsd_arm": [
+          "go1.25.0.freebsd-arm.tar.gz",
+          "d90b78e41921f72f30e8bbc81d9dec2cff7ff384a33d8d8debb24053e4336bfe"
+        ],
+        "freebsd_arm64": [
+          "go1.25.0.freebsd-arm64.tar.gz",
+          "451d0da1affd886bfb291b7c63a6018527b269505db21ce6e14724f22ab0662e"
+        ],
+        "freebsd_riscv64": [
+          "go1.25.0.freebsd-riscv64.tar.gz",
+          "7b565f76bd8bda46549eeaaefe0e53b251e644c230577290c0f66b1ecdb3cdbe"
+        ],
+        "illumos_amd64": [
+          "go1.25.0.illumos-amd64.tar.gz",
+          "b1e1fdaab1ad25aa1c08d7a36c97d45d74b98b89c3f78c6d2145f77face54a2c"
+        ],
+        "linux_386": [
+          "go1.25.0.linux-386.tar.gz",
+          "8c602dd9d99bc9453b3995d20ce4baf382cc50855900a0ece5de9929df4a993a"
+        ],
+        "linux_amd64": [
+          "go1.25.0.linux-amd64.tar.gz",
+          "2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613"
+        ],
+        "linux_arm64": [
+          "go1.25.0.linux-arm64.tar.gz",
+          "05de75d6994a2783699815ee553bd5a9327d8b79991de36e38b66862782f54ae"
+        ],
+        "linux_armv6l": [
+          "go1.25.0.linux-armv6l.tar.gz",
+          "a5a8f8198fcf00e1e485b8ecef9ee020778bf32a408a4e8873371bfce458cd09"
+        ],
+        "linux_loong64": [
+          "go1.25.0.linux-loong64.tar.gz",
+          "cab86b1cf761b1cb3bac86a8877cfc92e7b036fc0d3084123d77013d61432afc"
+        ],
+        "linux_mips": [
+          "go1.25.0.linux-mips.tar.gz",
+          "d66b6fb74c3d91b9829dc95ec10ca1f047ef5e89332152f92e136cf0e2da5be1"
+        ],
+        "linux_mips64": [
+          "go1.25.0.linux-mips64.tar.gz",
+          "4082e4381a8661bc2a839ff94ba3daf4f6cde20f8fb771b5b3d4762dc84198a2"
+        ],
+        "linux_mips64le": [
+          "go1.25.0.linux-mips64le.tar.gz",
+          "70002c299ec7f7175ac2ef673b1b347eecfa54ae11f34416a6053c17f855afcc"
+        ],
+        "linux_mipsle": [
+          "go1.25.0.linux-mipsle.tar.gz",
+          "b00a3a39eff099f6df9f1c7355bf28e4589d0586f42d7d4a394efb763d145a73"
+        ],
+        "linux_ppc64": [
+          "go1.25.0.linux-ppc64.tar.gz",
+          "df166f33bd98160662560a72ff0b4ba731f969a80f088922bddcf566a88c1ec1"
+        ],
+        "linux_ppc64le": [
+          "go1.25.0.linux-ppc64le.tar.gz",
+          "0f18a89e7576cf2c5fa0b487a1635d9bcbf843df5f110e9982c64df52a983ad0"
+        ],
+        "linux_riscv64": [
+          "go1.25.0.linux-riscv64.tar.gz",
+          "c018ff74a2c48d55c8ca9b07c8e24163558ffec8bea08b326d6336905d956b67"
+        ],
+        "linux_s390x": [
+          "go1.25.0.linux-s390x.tar.gz",
+          "34e5a2e19f2292fbaf8783e3a241e6e49689276aef6510a8060ea5ef54eee408"
+        ],
+        "netbsd_386": [
+          "go1.25.0.netbsd-386.tar.gz",
+          "f8586cdb7aa855657609a5c5f6dbf523efa00c2bbd7c76d3936bec80aa6c0aba"
+        ],
+        "netbsd_amd64": [
+          "go1.25.0.netbsd-amd64.tar.gz",
+          "ae8dc1469385b86a157a423bb56304ba45730de8a897615874f57dd096db2c2a"
+        ],
+        "netbsd_arm": [
+          "go1.25.0.netbsd-arm.tar.gz",
+          "1ff7e4cc764425fc9dd6825eaee79d02b3c7cafffbb3691687c8d672ade76cb7"
+        ],
+        "netbsd_arm64": [
+          "go1.25.0.netbsd-arm64.tar.gz",
+          "e1b310739f26724216aa6d7d7208c4031f9ff54c9b5b9a796ddc8bebcb4a5f16"
+        ],
+        "openbsd_386": [
+          "go1.25.0.openbsd-386.tar.gz",
+          "4802a9b20e533da91adb84aab42e94aa56cfe3e5475d0550bed3385b182e69d8"
+        ],
+        "openbsd_amd64": [
+          "go1.25.0.openbsd-amd64.tar.gz",
+          "c016cd984bebe317b19a4f297c4f50def120dc9788490540c89f28e42f1dabe1"
+        ],
+        "openbsd_arm": [
+          "go1.25.0.openbsd-arm.tar.gz",
+          "a1e31d0bf22172ddde42edf5ec811ef81be43433df0948ece52fecb247ccfd8d"
+        ],
+        "openbsd_arm64": [
+          "go1.25.0.openbsd-arm64.tar.gz",
+          "343ea8edd8c218196e15a859c6072d0dd3246fbbb168481ab665eb4c4140458d"
+        ],
+        "openbsd_ppc64": [
+          "go1.25.0.openbsd-ppc64.tar.gz",
+          "694c14da1bcaeb5e3332d49bdc2b6d155067648f8fe1540c5de8f3cf8e157154"
+        ],
+        "openbsd_riscv64": [
+          "go1.25.0.openbsd-riscv64.tar.gz",
+          "aa510ad25cf54c06cd9c70b6d80ded69cb20188ac6e1735655eef29ff7e7885f"
+        ],
+        "plan9_386": [
+          "go1.25.0.plan9-386.tar.gz",
+          "46f8cef02086cf04bf186c5912776b56535178d4cb319cd19c9fdbdd29231986"
+        ],
+        "plan9_amd64": [
+          "go1.25.0.plan9-amd64.tar.gz",
+          "29b34391d84095e44608a228f63f2f88113a37b74a79781353ec043dfbcb427b"
+        ],
+        "plan9_arm": [
+          "go1.25.0.plan9-arm.tar.gz",
+          "0a047107d13ebe7943aaa6d54b1d7bbd2e45e68ce449b52915a818da715799c2"
+        ],
+        "solaris_amd64": [
+          "go1.25.0.solaris-amd64.tar.gz",
+          "9977f9e4351984364a3b2b78f8b88bfd1d339812356d5237678514594b7d3611"
+        ],
+        "windows_386": [
+          "go1.25.0.windows-386.zip",
+          "df9f39db82a803af0db639e3613a36681ab7a42866b1384b3f3a1045663961a7"
+        ],
+        "windows_amd64": [
+          "go1.25.0.windows-amd64.zip",
+          "89efb4f9b30812eee083cc1770fdd2913c14d301064f6454851428f9707d190b"
+        ],
+        "windows_arm64": [
+          "go1.25.0.windows-arm64.zip",
+          "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
+        ]
+      }
     }
   }
 }

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,0 +1,37 @@
+"""Stardoc API docs, written into the source tree.
+
+The stardoc targets are centralized in this dev-only package on purpose: the
+@stardoc load must never reach packages downstream consumers evaluate (//py is
+loaded by --@aspect_rules_py//py:python_version users, the current_py_cc_*
+aliases, etc., and stardoc is a dev_dependency, invisible outside the root
+module). The cost is exports_files() in py/ and uv/, scoped to this package.
+
+Usage:
+    bazel run //docs:update_docs   # regenerate docs/api/py.md and docs/api/uv.md
+    bazel test //docs:all          # diff tests fail if committed docs are stale
+"""
+
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
+
+stardoc(
+    name = "py_api",
+    out = "py_api.md",
+    input = "//py:defs.bzl",
+    deps = ["//py:defs"],
+)
+
+stardoc(
+    name = "uv_api",
+    out = "uv_api.md",
+    input = "//uv:defs.bzl",
+    deps = ["//uv:defs"],
+)
+
+write_source_files(
+    name = "update_docs",
+    files = {
+        "api/py.md": ":py_api",
+        "api/uv.md": ":uv_api",
+    },
+)

--- a/docs/api/py.md
+++ b/docs/api/py.md
@@ -1,0 +1,838 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Re-implementations of [py_binary](https://bazel.build/reference/be/python#py_binary)
+and [py_test](https://bazel.build/reference/be/python#py_test)
+
+## Choosing the Python version
+
+The `python_version` attribute must refer to a python toolchain version
+which has been registered in the `MODULE.bazel` file, e.g.:
+
+```starlark
+interpreters = use_extension("@aspect_rules_py//py:extensions.bzl", "python_interpreters")
+interpreters.toolchain(python_version = "3.10")
+interpreters.toolchain(python_version = "3.12")
+use_repo(interpreters, "python_interpreters")
+
+register_toolchains("@python_interpreters//:all")
+```
+
+<a id="current_py_toolchain"></a>
+
+## current_py_toolchain
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "current_py_toolchain")
+
+current_py_toolchain(<a href="#current_py_toolchain-name">name</a>)
+</pre>
+
+Exposes the resolved Python 3 toolchain as Make variables.
+
+After toolchain resolution, this rule provides `$(PYTHON3)` and
+`$(PYTHON3_ROOTPATH)` for Make variable expansion in rules like
+`genrule` and `bazel_env`.
+
+An instance is automatically available at
+`@python_interpreters//:current_py_toolchain` when using the
+`python_interpreters` module extension.
+
+Example usage with `genrule`:
+
+```starlark
+genrule(
+    name = "run_python",
+    outs = ["output.txt"],
+    cmd = "$(PYTHON3) -c 'print(42)' > $@",
+    toolchains = ["@python_interpreters//:current_py_toolchain"],
+)
+```
+
+Example usage with `bazel_env`:
+
+```starlark
+bazel_env(
+    name = "bazel_env",
+    toolchains = {
+        "python": "@python_interpreters//:current_py_toolchain",
+    },
+    tools = {
+        "python": "$(PYTHON3)",
+    },
+)
+```
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="current_py_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+
+
+<a id="py_layer_tier"></a>
+
+## py_layer_tier
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_layer_tier")
+
+py_layer_tier(<a href="#py_layer_tier-name">name</a>, <a href="#py_layer_tier-compression">compression</a>, <a href="#py_layer_tier-group">group</a>, <a href="#py_layer_tier-groups">groups</a>, <a href="#py_layer_tier-interpreter_group">interpreter_group</a>, <a href="#py_layer_tier-owner">owner</a>, <a href="#py_layer_tier-root">root</a>, <a href="#py_layer_tier-strip_prefix">strip_prefix</a>)
+</pre>
+
+Grouping and compression plan for `py_image_layer`.
+
+Must not be testonly. `py_image_layer` transitions the `//py:layer_tier` flag to the tier, and the layer aspect reads that flag from every target it visits — including non-testonly ones outside the image, such as the interpreter toolchain and third-party installs. In a `package(default_testonly = True)`, set `testonly = False` on the tier.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="py_layer_tier-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_layer_tier-compression"></a>compression |  Maps group name → [algorithm, level] for pip-derived layers. Applies to the whole-group tar, each subpath-split tar, and the multi-member merged tar — anything routed through py_layer_tier.groups. Example: {"heavy_pkgs": ["zstd", "1"]}. Untouched groups default to gzip -6.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> List of strings</a> | optional |  `{}`  |
+| <a id="py_layer_tier-group"></a>group |  Numeric gid owning every file in every layer this tier produces. Default: '0' (root).   | String | optional |  `"0"`  |
+| <a id="py_layer_tier-groups"></a>groups |  Maps @pip//package → group name (whole pip package), @pip//package:glob → group name (pip subpath split), or //some/first_party:lib → group name (first-party PyInfo target). First-party main-repo labels may be written as //pkg:name; fully-qualified forms like @@//pkg:name are also accepted. A pip package may appear as a whole-package key OR with subpath globs, not both.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="py_layer_tier-interpreter_group"></a>interpreter_group |  When non-empty, the Python interpreter runfiles resolved from the binary's py toolchain are emitted as their own layer under this name instead of being bundled into the default source layer.   | String | optional |  `""`  |
+| <a id="py_layer_tier-owner"></a>owner |  Numeric uid owning every file in every layer this tier produces. Default: '0' (root).   | String | optional |  `"0"`  |
+| <a id="py_layer_tier-root"></a>root |  Root path in the image. Default: '/app'.   | String | optional |  `"/app"`  |
+| <a id="py_layer_tier-strip_prefix"></a>strip_prefix |  Prefix stripped from source file paths. Empty means use the binary's short_path.   | String | optional |  `""`  |
+
+
+<a id="py_library"></a>
+
+## py_library
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+
+py_library(<a href="#py_library-name">name</a>, <a href="#py_library-deps">deps</a>, <a href="#py_library-srcs">srcs</a>, <a href="#py_library-data">data</a>, <a href="#py_library-imports">imports</a>, <a href="#py_library-resolutions">resolutions</a>, <a href="#py_library-virtual_deps">virtual_deps</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="py_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_library-deps"></a>deps |  Targets that produce Python code, commonly `py_library` rules.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="py_library-srcs"></a>srcs |  Python source files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="py_library-data"></a>data |  Runtime dependencies of the program.<br><br>The transitive closure of the `data` dependencies will be available in the `.runfiles` folder for this binary/test. The program may optionally use the Runfiles lookup library to locate the data files, see https://pypi.org/project/bazel-runfiles/. Data is analyzed in the inherited caller configuration. Put artifacts that must match the terminal's Python environment in `deps`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="py_library-imports"></a>imports |  List of import directories to be added to the PYTHONPATH.   | List of strings | optional |  `[]`  |
+| <a id="py_library-resolutions"></a>resolutions |  Satisfy a virtual_dep with a mapping from external package name to the label of an installed package that provides it. See virtual_deps.   | Dictionary: String -> Label | optional |  `{}`  |
+| <a id="py_library-virtual_deps"></a>virtual_deps |  -   | List of strings | optional |  `[]`  |
+
+
+<a id="py_pex_binary"></a>
+
+## py_pex_binary
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_pex_binary")
+
+py_pex_binary(<a href="#py_pex_binary-name">name</a>, <a href="#py_pex_binary-binary">binary</a>, <a href="#py_pex_binary-inherit_path">inherit_path</a>, <a href="#py_pex_binary-inject_env">inject_env</a>, <a href="#py_pex_binary-python_interpreter_constraints">python_interpreter_constraints</a>,
+              <a href="#py_pex_binary-python_shebang">python_shebang</a>)
+</pre>
+
+Build a pex executable from a py_binary
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="py_pex_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_pex_binary-binary"></a>binary |  The py_binary target to package.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="py_pex_binary-inherit_path"></a>inherit_path |  Whether to inherit the `sys.path` (aka PYTHONPATH) of the environment that the binary runs in.<br><br>Use `false` to not inherit `sys.path`; use `fallback` to inherit `sys.path` after packaged dependencies; and use `prefer` to inherit `sys.path` before packaged dependencies.   | String | optional |  `""`  |
+| <a id="py_pex_binary-inject_env"></a>inject_env |  Environment variables to set when running the pex binary.   | <a href="https://bazel.build/rules/lib/core/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="py_pex_binary-python_interpreter_constraints"></a>python_interpreter_constraints |  Python interpreter versions this PEX binary is compatible with. A list of semver strings. The placeholder strings `{major}`, `{minor}`, `{patch}` are substituted with the version of the `binary`'s own interpreter, the one the PEX is built for.   | List of strings | optional |  `["CPython=={major}.{minor}.*"]`  |
+| <a id="py_pex_binary-python_shebang"></a>python_shebang |  -   | String | optional |  `"#!/usr/bin/env python3"`  |
+
+
+<a id="py_unpacked_wheel"></a>
+
+## py_unpacked_wheel
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_unpacked_wheel")
+
+py_unpacked_wheel(<a href="#py_unpacked_wheel-name">name</a>, <a href="#py_unpacked_wheel-src">src</a>, <a href="#py_unpacked_wheel-console_scripts">console_scripts</a>, <a href="#py_unpacked_wheel-data_files">data_files</a>, <a href="#py_unpacked_wheel-namespace_entries">namespace_entries</a>, <a href="#py_unpacked_wheel-namespace_top_levels">namespace_top_levels</a>,
+                  <a href="#py_unpacked_wheel-top_levels">top_levels</a>)
+</pre>
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="py_unpacked_wheel-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="py_unpacked_wheel-src"></a>src |  The Wheel file, as defined by https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="py_unpacked_wheel-console_scripts"></a>console_scripts |  Console-script entry points declared by this wheel, in the form `"name=module:func"`.<br><br>`py_binary` consumes these via `PyWheelsInfo` to generate executable wrappers under `<venv>/bin/<name>`. Typically populated from the wheel's `*.dist-info/entry_points.txt` `[console_scripts]` section.   | List of strings | optional |  `[]`  |
+| <a id="py_unpacked_wheel-data_files"></a>data_files |  PEP 427 `.data/data/` prefix-relative install paths (e.g. `share/foo/bar.txt`).<br><br>Venv assembly projects these into the venv prefix via `ctx.actions.symlink`. Typically populated by the `uv` wheel-install repo rule; hand-written `py_unpacked_wheel` targets may set it to expose data files shipped under the wheel's `<name>-<version>.data/data/` tree.<br><br>Must list the wheel's prefix tree **completely**. Assembly binds a whole directory with a single symlink when one wheel owns everything resolved beneath it, so an undeclared file sitting next to a declared one is still reachable under `sys.prefix` — an under-declared list changes which collisions are reported, not what the venv exposes.   | List of strings | optional |  `[]`  |
+| <a id="py_unpacked_wheel-namespace_entries"></a>namespace_entries |  Concrete entries this wheel installs beneath its `namespace_top_levels`.<br><br>See the equivalent attribute on the `whl_install` rule for the full story; short version: `/`-joined paths like `jaraco/functools` that let venv assembly materialise a merged namespace directory out of per-entry symlinks, so static tools that inspect `site-packages/` directly see the package. When empty, namespace merging falls back to `.pth`-based resolution (runtime-only).   | List of strings | optional |  `[]`  |
+| <a id="py_unpacked_wheel-namespace_top_levels"></a>namespace_top_levels |  Subset of `top_levels` that are PEP 420 namespace packages.<br><br>See the equivalent attribute on the `whl_install` rule for the full story; short version: names listed here suppress collision errors when multiple wheels claim the same top-level, because Python's namespace machinery is meant to merge their contributions.   | List of strings | optional |  `[]`  |
+| <a id="py_unpacked_wheel-top_levels"></a>top_levels |  Complete list of immediate entries the wheel installs into site-packages.<br><br>When set, downstream rules can assemble a merged `site-packages/` tree via `ctx.actions.symlink` instead of relying on `.pth` entries. The list must include packages, modules, `.pth` files, and `*.dist-info` directories. If left empty (the default), other rules preserve the complete wheel root and fall back to `.pth`-based import resolution.<br><br>Typically populated by the `uv` wheel-install repo rule. Hand-written `py_unpacked_wheel` targets may populate this to opt into symlink-based venv assembly.   | List of strings | optional |  `[]`  |
+
+
+<a id="whl_filegroup"></a>
+
+## whl_filegroup
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "whl_filegroup")
+
+whl_filegroup(<a href="#whl_filegroup-name">name</a>, <a href="#whl_filegroup-pattern">pattern</a>, <a href="#whl_filegroup-runfiles">runfiles</a>, <a href="#whl_filegroup-whl">whl</a>)
+</pre>
+
+Extract files matching a regular expression from a wheel file.
+
+An empty pattern will match all files.
+
+Example usage:
+```starlark
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_python//python:pip.bzl", "whl_filegroup")
+
+whl_filegroup(
+    name = "numpy_includes",
+    pattern = "numpy/core/include/numpy",
+    whl = "@pypi//numpy:whl",
+)
+
+cc_library(
+    name = "numpy_headers",
+    hdrs = [":numpy_includes"],
+    includes = ["numpy_includes/numpy/core/include"],
+    deps = ["@rules_python//python/cc:current_py_cc_headers"],
+)
+
+```
+
+:::{seealso}
+
+The `:extracted_whl_files` target, which is a filegroup of all the files
+from the already extracted whl file.
+:::
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="whl_filegroup-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="whl_filegroup-pattern"></a>pattern |  Only file paths matching this regex pattern will be extracted.   | String | optional |  `""`  |
+| <a id="whl_filegroup-runfiles"></a>runfiles |  Whether to include the output TreeArtifact in this target's runfiles.   | Boolean | optional |  `False`  |
+| <a id="whl_filegroup-whl"></a>whl |  The wheel to extract files from.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+
+<a id="PyInfo"></a>
+
+## PyInfo
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "PyInfo")
+
+PyInfo(<a href="#PyInfo-transitive_sources">transitive_sources</a>, <a href="#PyInfo-imports">imports</a>, <a href="#PyInfo-virtual_dependencies">virtual_dependencies</a>, <a href="#PyInfo-virtual_resolutions">virtual_resolutions</a>)
+</pre>
+
+Python source, import-path, and virtual-dependency information for a target's dependency closure.
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PyInfo-transitive_sources"></a>transitive_sources |  depset[File] — postorder depset of first-party `.py` sources in the transitive closure.    |
+| <a id="PyInfo-imports"></a>imports |  depset[str] — import roots to place on `sys.path` (rlocation-root-relative).    |
+| <a id="PyInfo-virtual_dependencies"></a>virtual_dependencies |  depset[str] — names of required virtual dependencies, independent of their resolution status.    |
+| <a id="PyInfo-virtual_resolutions"></a>virtual_resolutions |  depset[struct(virtual, target)] — virtual-dependency-name to concrete-target resolutions.    |
+
+
+<a id="PyLayerTierInfo"></a>
+
+## PyLayerTierInfo
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "PyLayerTierInfo")
+
+PyLayerTierInfo(<a href="#PyLayerTierInfo-whole_groups">whole_groups</a>, <a href="#PyLayerTierInfo-subpath_groups">subpath_groups</a>, <a href="#PyLayerTierInfo-compression">compression</a>, <a href="#PyLayerTierInfo-multi_member_groups">multi_member_groups</a>, <a href="#PyLayerTierInfo-interpreter_group">interpreter_group</a>,
+                <a href="#PyLayerTierInfo-root">root</a>, <a href="#PyLayerTierInfo-strip_prefix">strip_prefix</a>, <a href="#PyLayerTierInfo-owner">owner</a>, <a href="#PyLayerTierInfo-group">group</a>)
+</pre>
+
+Layer tier for py_image_layer: how pip packages are grouped and compressed.
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PyLayerTierInfo-whole_groups"></a>whole_groups |  dict[str, str] — normalized pip label → group name.    |
+| <a id="PyLayerTierInfo-subpath_groups"></a>subpath_groups |  dict[str, dict[str, list[str]]] — label → {group_name: [glob_patterns]}.    |
+| <a id="PyLayerTierInfo-compression"></a>compression |  dict[str, list[str]] — group name → [algorithm, level].    |
+| <a id="PyLayerTierInfo-multi_member_groups"></a>multi_member_groups |  dict[str, True] — group names with 2+ members in whole_groups.    |
+| <a id="PyLayerTierInfo-interpreter_group"></a>interpreter_group |  str — group name for the Python interpreter layer; '' disables.    |
+| <a id="PyLayerTierInfo-root"></a>root |  str — root path in the image (e.g. '/app').    |
+| <a id="PyLayerTierInfo-strip_prefix"></a>strip_prefix |  str — prefix stripped from source file paths; empty means use binary short_path.    |
+| <a id="PyLayerTierInfo-owner"></a>owner |  str — numeric uid owning files in the layer.    |
+| <a id="PyLayerTierInfo-group"></a>group |  str — numeric gid owning files in the layer.    |
+
+
+<a id="PyRuntimeInfo"></a>
+
+## PyRuntimeInfo
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "PyRuntimeInfo")
+
+PyRuntimeInfo(*, <a href="#PyRuntimeInfo-implementation_name">implementation_name</a>, <a href="#PyRuntimeInfo-interpreter_path">interpreter_path</a>, <a href="#PyRuntimeInfo-interpreter">interpreter</a>, <a href="#PyRuntimeInfo-files">files</a>, <a href="#PyRuntimeInfo-coverage_tool">coverage_tool</a>,
+              <a href="#PyRuntimeInfo-coverage_files">coverage_files</a>, <a href="#PyRuntimeInfo-pyc_tag">pyc_tag</a>, <a href="#PyRuntimeInfo-python_version">python_version</a>, <a href="#PyRuntimeInfo-stub_shebang">stub_shebang</a>, <a href="#PyRuntimeInfo-bootstrap_template">bootstrap_template</a>,
+              <a href="#PyRuntimeInfo-interpreter_version_info">interpreter_version_info</a>, <a href="#PyRuntimeInfo-stage2_bootstrap_template">stage2_bootstrap_template</a>, <a href="#PyRuntimeInfo-zip_main_template">zip_main_template</a>, <a href="#PyRuntimeInfo-abi_flags">abi_flags</a>,
+              <a href="#PyRuntimeInfo-site_init_template">site_init_template</a>, <a href="#PyRuntimeInfo-supports_build_time_venv">supports_build_time_venv</a>)
+</pre>
+
+Contains information about a Python runtime, as returned by the `py_runtime`
+rule.
+
+:::{warning}
+This is an **unstable public** API. It may change more frequently and has weaker
+compatibility guarantees.
+:::
+
+A Python runtime describes either a *platform runtime* or an *in-build runtime*.
+A platform runtime accesses a system-installed interpreter at a known path,
+whereas an in-build runtime points to a `File` that acts as the interpreter. In
+both cases, an "interpreter" is really any executable binary or wrapper script
+that is capable of running a Python script passed on the command line, following
+the same conventions as the standard CPython interpreter.
+
+**FIELDS**
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="PyRuntimeInfo-implementation_name"></a>implementation_name | :type: str \| None<br><br>The Python implementation name (`sys.implementation.name`) | `None` |
+| <a id="PyRuntimeInfo-interpreter_path"></a>interpreter_path | :type: str \| None<br><br>If this is a platform runtime, this field is the absolute filesystem path to the interpreter on the target platform. Otherwise, this is `None`. | `None` |
+| <a id="PyRuntimeInfo-interpreter"></a>interpreter | :type: File \| None<br><br>If this is an in-build runtime, this field is a `File` representing the interpreter. Otherwise, this is `None`. Note that an in-build runtime can use either a prebuilt, checked-in interpreter or an interpreter built from source. | `None` |
+| <a id="PyRuntimeInfo-files"></a>files | :type: depset[File] \| None<br><br>If this is an in-build runtime, this field is a `depset` of `File`s that need to be added to the runfiles of an executable target that uses this runtime (in particular, files needed by `interpreter`). The value of `interpreter` need not be included in this field. If this is a platform runtime then this field is `None`. | `None` |
+| <a id="PyRuntimeInfo-coverage_tool"></a>coverage_tool | :type: File \| None<br><br>If set, this field is a `File` representing tool used for collecting code coverage information from python tests. Otherwise, this is `None`. | `None` |
+| <a id="PyRuntimeInfo-coverage_files"></a>coverage_files | :type: depset[File] \| None<br><br>The files required at runtime for using `coverage_tool`. Will be `None` if no `coverage_tool` was provided. | `None` |
+| <a id="PyRuntimeInfo-pyc_tag"></a>pyc_tag | :type: str \| None<br><br>The tag portion of a pyc filename, e.g. the `cpython-39` infix of `foo.cpython-39.pyc`. See PEP 3147. If not specified, it will be computed from {obj}`implementation_name` and {obj}`interpreter_version_info`. If no pyc_tag is available, then only source-less pyc generation will function correctly. | `None` |
+| <a id="PyRuntimeInfo-python_version"></a>python_version | :type: str<br><br>Indicates whether this runtime uses Python major version 2 or 3. Valid values are (only) `"PY2"` and `"PY3"`. | none |
+| <a id="PyRuntimeInfo-stub_shebang"></a>stub_shebang | :type: str<br><br>"Shebang" expression prepended to the bootstrapping Python stub script used when executing {obj}`py_binary` targets.  Does not apply to Windows. | `None` |
+| <a id="PyRuntimeInfo-bootstrap_template"></a>bootstrap_template | :type: File<br><br>A template of code responsible for the initial startup of a program.<br><br>This code is responsible for:<br><br>* Locating the target interpreter. Typically it is in runfiles, but not always. * Setting necessary environment variables, command line flags, or other   configuration that can't be modified after the interpreter starts. * Invoking the appropriate entry point. This is usually a second-stage bootstrap   that performs additional setup prior to running a program's actual entry point.<br><br>The {obj}`--bootstrap_impl` flag affects how this stage 1 bootstrap is expected to behave and the substutitions performed.<br><br>* `--bootstrap_impl=system_python` substitutions: `%is_zipfile%`, `%python_binary%`,   `%target%`, `%workspace_name`, `%coverage_tool%`, `%import_all%`, `%imports%`,   `%main%`, `%shebang%` * `--bootstrap_impl=script` substititions: `%is_zipfile%`, `%python_binary%`,   `%python_binary_actual%`, `%target%`, `%workspace_name`,   `%shebang%`, `%stage2_bootstrap%`<br><br>Substitution definitions:<br><br>* `%shebang%`: The shebang to use with the bootstrap; the bootstrap template   may choose to ignore this. * `%stage2_bootstrap%`: A runfiles-relative path to the stage 2 bootstrap. * `%python_binary%`: The path to the target Python interpreter. There are three   types of paths:   * An absolute path to a system interpreter (e.g. begins with `/`).   * A runfiles-relative path to an interpreter (e.g. `somerepo/bin/python3`)   * A program to search for on PATH, i.e. a word without spaces, e.g. `python3`.<br><br>  When `--bootstrap_impl=script` is used, this is always a runfiles-relative   path to a venv-based interpreter executable.<br><br>* `%python_binary_actual%`: The path to the interpreter that   `%python_binary%` invokes. There are three types of paths:   * An absolute path to a system interpreter (e.g. begins with `/`).   * A runfiles-relative path to an interpreter (e.g. `somerepo/bin/python3`)   * A program to search for on PATH, i.e. a word without spaces, e.g. `python3`.<br><br>  Only set for zip builds with `--bootstrap_impl=script`; other builds will use   an empty string.<br><br>* `%workspace_name%`: The name of the workspace the target belongs to. * `%is_zipfile%`: The string `1` if this template is prepended to a zipfile to   create a self-executable zip file. The string `0` otherwise.<br><br>For the other substitution definitions, see the {obj}`stage2_bootstrap_template` docs.<br><br>:::{versionchanged} 0.33.0 The set of substitutions depends on {obj}`--bootstrap_impl` ::: | `None` |
+| <a id="PyRuntimeInfo-interpreter_version_info"></a>interpreter_version_info | :type: struct<br><br>Version information about the interpreter this runtime provides. It should match the format given by `sys.version_info`, however for simplicity, the micro, releaselevel, and serial values are optional. A struct with the following fields: * `major`: {type}`int`, the major version number * `minor`: {type}`int`, the minor version number * `micro`: {type}`int \| None`, the micro version number * `releaselevel`: {type}`str \| None`, the release level * `serial`: {type}`int \| None`, the serial number of the release | `None` |
+| <a id="PyRuntimeInfo-stage2_bootstrap_template"></a>stage2_bootstrap_template | :type: File<br><br>A template of Python code that runs under the desired interpreter and is responsible for orchestrating calling the program's actual main code. This bootstrap is responsible for affecting the current runtime's state, such as import paths or enabling coverage, so that, when it runs the program's actual main code, it works properly under Bazel.<br><br>The following substitutions are made during template expansion: * `%main%`: A runfiles-relative path to the program's actual main file. This   can be a `.py` or `.pyc` file, depending on precompile settings. * `%coverage_tool%`: Runfiles-relative path to the coverage library's entry point.   If coverage is not enabled or available, an empty string. * `%import_all%`: The string `True` if all repositories in the runfiles should   be added to sys.path. The string `False` otherwise. * `%imports%`: A colon-delimited string of runfiles-relative paths to add to   sys.path. * `%target%`: The name of the target this is for. * `%workspace_name%`: The name of the workspace the target belongs to.<br><br>:::{versionadded} 0.33.0 ::: | `None` |
+| <a id="PyRuntimeInfo-zip_main_template"></a>zip_main_template | :type: File<br><br>A template of Python code that becomes a zip file's top-level `__main__.py` file. The top-level `__main__.py` file is used when the zip file is explicitly passed to a Python interpreter. See PEP 441 for more information about zipapp support. Note that py_binary-generated zip files are self-executing and skip calling `__main__.py`.<br><br>The following substitutions are made during template expansion: * `%stage2_bootstrap%`: A runfiles-relative string to the stage 2 bootstrap file. * `%python_binary%`: The path to the target Python interpreter. There are three   types of paths:   * An absolute path to a system interpreter (e.g. begins with `/`).   * A runfiles-relative path to an interpreter (e.g. `somerepo/bin/python3`)   * A program to search for on PATH, i.e. a word without spaces, e.g. `python3`. * `%workspace_name%`: The name of the workspace for the built target.<br><br>:::{versionadded} 0.33.0 ::: | `None` |
+| <a id="PyRuntimeInfo-abi_flags"></a>abi_flags | :type: str<br><br>The runtime's ABI flags, i.e. `sys.abiflags`.<br><br>:::{versionadded} 1.0.0 ::: | `""` |
+| <a id="PyRuntimeInfo-site_init_template"></a>site_init_template | :type: File<br><br>The template to use for the binary-specific site-init hook run by the interpreter at startup.<br><br>:::{versionadded} 1.0.0 ::: | `None` |
+| <a id="PyRuntimeInfo-supports_build_time_venv"></a>supports_build_time_venv | :type: bool<br><br>True if this toolchain supports the build-time created virtual environment. False if not or unknown. If build-time venv creation isn't supported, then binaries may fallback to non-venv solutions or creating a venv at runtime.<br><br>In order to use the build-time created virtual environment, a toolchain needs to meet two criteria: 1. Specifying the underlying executable (e.g. `/usr/bin/python3`, as reported by    `sys._base_executable`) for the venv executable (`$venv/bin/python3`, as reported    by `sys.executable`). This typically requires relative symlinking the venv    path to the underlying path at build time, or using the `PYTHONEXECUTABLE`    environment variable (Python 3.11+) at runtime. 2. Having the build-time created site-packages directory    (`<venv>/lib/python{version}/site-packages`) recognized by the runtime    interpreter. This typically requires the Python version to be known at    build-time and match at runtime.<br><br>:::{versionadded} 1.5.0 ::: | `True` |
+
+
+<a id="PyWheelsInfo"></a>
+
+## PyWheelsInfo
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "PyWheelsInfo")
+
+PyWheelsInfo(<a href="#PyWheelsInfo-wheels">wheels</a>)
+</pre>
+
+Installed wheel records used by venv assembly and image layering.
+
+Each element of `wheels` describes one wheel in the transitive closure of a
+target. Every record carries the complete installed tree. Repository-inspected
+wheels also carry their site-packages layout and console scripts; source-built
+wheels may leave that analysis-time metadata empty.
+
+Venv rules project known layouts and generate console-script wrappers. Image
+rules use `install_tree` to retain each wheel as a package leaf independently
+of whether its metadata was available during analysis.
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="PyWheelsInfo-wheels"></a>wheels |  Depset of wheel record structs, one per wheel in the transitive closure. rules_py aggregates this field in postorder. Producers must use `default` or `postorder`, the orders Bazel permits in that aggregate. For collision classes that select one claimant, permissive handling gives the later distinct element in the flattened sequence precedence. Duplicate dependency edges do not create another precedence position. Fields:   * `top_levels`: tuple[str] — complete set of immediate `site-packages`     entry names when nonempty; an empty tuple means the layout is unknown.   * `top_level_dirs`: tuple[str] — subset of non-metadata top_levels that     are directories in the RECORD-derived install tree rather than single-file     modules.   * `namespace_top_levels`: tuple[str] — subset of top_levels that are PEP 420 namespace packages.   * `namespace_entries`: tuple[str] — `/`-joined paths of the concrete entries beneath     the namespace top-levels (e.g. `jaraco/functools`), used to materialise a merged     namespace directory out of per-entry symlinks. May be absent on structs from     older producers; consumers use `getattr` with a `()` default.   * `namespace_dirs`: tuple[str] — implicit-namespace directory skeleton under the     namespace top-levels (site-packages-relative `/`-joined paths). May be absent     on structs from older producers; consumers use `getattr` with a `()` default.   * `regular_roots`: tuple[str] — minimal directories under the namespace     top-levels carrying an `__init__.py`. Cross-referencing a wheel's     `regular_roots` with another wheel's `namespace_dirs` detects regular     packages spanning wheels, which venv assembly must physically merge.     May be absent on structs from older producers.   * `native_roots`: tuple[str] — collision-relevant top-level directories,     namespace directories, and regular roots containing RECORD entries with     native-library suffixes. A colliding root in this set cannot be copied     into a merge tree without changing the library's physical origin.   * `site_packages_rfpath`: str — runfiles-root-relative path to the wheel's site-packages.   * `console_scripts`: tuple[str] — entry points encoded as `"name=module:func"`.   * `data_files`: tuple[str] — PEP 427 `.data/data/` prefix-relative install     paths (e.g. `share/jupyter/...`), projected into the venv prefix. Must     enumerate the wheel's prefix tree completely: venv assembly binds a whole     directory when one wheel owns everything resolved beneath it, so an     undeclared sibling file in that directory is still exposed under     `sys.prefix`. Validated by `make_wheel_record`. May be absent on structs     from older producers; consumers use `getattr` with `()`.   * `install_tree`: File — complete installed wheel tree.   * `tl_claims`, `metadata_top_levels`, `cs_claims`: derived fields     precomputed by `make_wheel_record` so venv assembly's collision     resolution does per-wheel parsing once instead of per consuming binary.     Each `tl_claims` entry carries the top-level's namespace, directory,     native-root, namespace-entry, and namespace-directory facts.<br><br>Records must be built with `make_wheel_record` so the derived fields are present and consistent with the raw ones.    |
+
+
+<a id="py_binary"></a>
+
+## py_binary
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+
+py_binary(<a href="#py_binary-name">name</a>, <a href="#py_binary-srcs">srcs</a>, <a href="#py_binary-main">main</a>, <a href="#py_binary-kwargs">**kwargs</a>)
+</pre>
+
+Build and run a Python binary.
+
+Splits the call into a sibling `py_venv` (which carries srcs / deps
+/ imports / virtual_deps / resolutions / package_collisions /
+include_*_site_packages / interpreter_options) plus a thin launcher
+rule that exec's that venv's interpreter. Set `expose_venv = True`
+to make the sibling a first-class `:{name}.venv` target — runnable
+(`bazel run :{name}.venv` drops into the hermetic interpreter) and
+pairable with `py_venv_link` for IDE integration. For the common
+case where you want both the venv target *and* an IDE-pointable
+workspace symlink in one step, set `expose_venv_link = True`.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_binary-name"></a>name |  Name of the rule.   |  none |
+| <a id="py_binary-srcs"></a>srcs |  Python source files.   |  `[]` |
+| <a id="py_binary-main"></a>main |  Entry point. Like rules_python, this is treated as a suffix of a file that should appear among the srcs. If absent, then `[name].py` is tried. As a final fallback, if the srcs has a single file, that is used as the main.<br><br>Note: the fallback runs at macro-evaluation time and operates on label strings, not resolved files — it cannot inspect a generated target's output basename. If `main` would resolve to a file produced by another rule (e.g. a `genrule` whose output happens to be `<name>.py`), the macro can't see that and you must pass `main =` explicitly.   |  `None` |
+| <a id="py_binary-kwargs"></a>kwargs |  additional named parameters forwarded to the underlying rule and the sibling py_venv. Two extras are handled by this macro:<br><br>* `expose_venv` (bool, default `False`) — when `True`, emit   a sibling `:{name}.venv` py_venv carrying all venv-shaping   attrs (deps, imports, package_collisions,   include_*_site_packages, interpreter_options). The `.venv`   target is runnable (`bazel run :{name}.venv` drops into   the hermetic interpreter). * `expose_venv_link` (bool, default `False`) — when `True`,   additionally emit a `:{name}.venv_link` py_venv_link.   `bazel run :{name}.venv_link` links the target's runfiles   tree into the workspace and prints the nested venv path   suitable for an IDE's interpreter setting. Implies   `expose_venv = True`; passing   `expose_venv = False, expose_venv_link = True` explicitly   is rejected with a clear error. Equivalent to declaring an   explicit   `py_venv_link(name = "{name}.venv_link", venv = ":{name}.venv")`   alongside the binary.   |  none |
+
+
+<a id="py_image_layer"></a>
+
+## py_image_layer
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer")
+
+py_image_layer(<a href="#py_image_layer-name">name</a>, <a href="#py_image_layer-binary">binary</a>, <a href="#py_image_layer-groups">groups</a>, <a href="#py_image_layer-group_execution_requirements">group_execution_requirements</a>, <a href="#py_image_layer-group_compress_levels">group_compress_levels</a>,
+               <a href="#py_image_layer-warn_remote_cache_threshold_mb">warn_remote_cache_threshold_mb</a>, <a href="#py_image_layer-warn_layer_count">warn_layer_count</a>, <a href="#py_image_layer-platform">platform</a>, <a href="#py_image_layer-layer_tier">layer_tier</a>, <a href="#py_image_layer-launcher_dir">launcher_dir</a>,
+               <a href="#py_image_layer-binaries">binaries</a>, <a href="#py_image_layer-kwargs">**kwargs</a>)
+</pre>
+
+Create OCI-compatible tars from one or more py_binary targets.
+
+Pip-package grouping + compression is resolved from the `//py:layer_tier`
+label_flag. Override globally with `--//py:layer_tier=//path:custom_tier`,
+or pin a tier to a specific rule via the `py_layer_tier` attr below.
+
+## Output layers
+
+  1. Non-pip deps listed in `groups` → one rule-created tar per group.
+  2. First-party py_library targets matched by `py_layer_tier.groups` → one
+     rule-created tar per group (aggregated across all matched targets in the
+     binary inputs' dep closures).
+  3. Solo-group and subpath-split pip tars — built by `_layer_aspect` at each pip
+     target's own namespace; globally shared across every rule using that package.
+  4. Multi-member merged tars — action-shared for a single binary or one per
+     group from the closure-filtered union across multiple binaries.
+  5. Ungrouped pip packages → one squashed rule-created tar.
+  6. Remaining first-party Python source files → the "default" layer.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_image_layer-name"></a>name |  Name of the generated target.   |  none |
+| <a id="py_image_layer-binary"></a>binary |  A py_binary target.   |  `None` |
+| <a id="py_image_layer-groups"></a>groups |  Maps a NON-PIP dep label to a group name. Each gets its own rule-created tar. All pip-package grouping (whole-package, subpath, multi-member) belongs in py_layer_tier — subpath glob keys passed here fail loudly.   |  `{}` |
+| <a id="py_image_layer-group_execution_requirements"></a>group_execution_requirements |  Maps a group name to execution requirement strings. The group name "packages" applies to the squashed ungrouped-pip tar.   |  `{}` |
+| <a id="py_image_layer-group_compress_levels"></a>group_compress_levels |  Maps a group name to a gzip compression level (1-9) for rule-created tars (non-pip deps, squashed ungrouped pip tar, source). Default 6. Does NOT apply to aspect-created pip tars (configure via the py_layer_tier target).   |  `{}` |
+| <a id="py_image_layer-warn_remote_cache_threshold_mb"></a>warn_remote_cache_threshold_mb |  Threshold for large package warnings.   |  `200` |
+| <a id="py_image_layer-warn_layer_count"></a>warn_layer_count |  Warn when total layers exceed this. Default: 90.   |  `90` |
+| <a id="py_image_layer-platform"></a>platform |  Platform transition target.   |  `None` |
+| <a id="py_image_layer-layer_tier"></a>layer_tier |  Optional py_layer_tier target pinned for this rule. Sets the `@aspect_rules_py//py:layer_tier` label_flag via the rule transition, overriding any command-line value for this rule's subgraph.   |  `None` |
+| <a id="py_image_layer-launcher_dir"></a>launcher_dir |  Absolute image directory for the binary launchers. Defaults to /app/bin with multiple binaries. Set RUNFILES_DIR=/app.runfiles in the image.   |  `""` |
+| <a id="py_image_layer-binaries"></a>binaries |  Alternative to binary. A nonempty list of py_binary targets to include in the image.   |  `None` |
+| <a id="py_image_layer-kwargs"></a>kwargs |  Forwarded to inner rule.   |  none |
+
+
+<a id="py_pytest_main"></a>
+
+## py_pytest_main
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_pytest_main")
+
+py_pytest_main(<a href="#py_pytest_main-name">name</a>, <a href="#py_pytest_main-py_library">py_library</a>, <a href="#py_pytest_main-deps">deps</a>, <a href="#py_pytest_main-data">data</a>, <a href="#py_pytest_main-testonly">testonly</a>, <a href="#py_pytest_main-kwargs">**kwargs</a>)
+</pre>
+
+py_pytest_main wraps the template rendering target and the final py_library.
+
+Low-level escape hatch: prefer [py_pytest_test](#py_pytest_test) for pytest
+suites. Use this only for hand-written or wrapped entrypoints (e.g. exposing
+an importable `main()` for custom setup/teardown around pytest).
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_pytest_main-name"></a>name |  The name of the runable target that updates the test entry file.   |  none |
+| <a id="py_pytest_main-py_library"></a>py_library |  Use this attribute to override the default py_library rule.   |  `<rule py_library>` |
+| <a id="py_pytest_main-deps"></a>deps |  A list containing the pytest library target, e.g., @pypi_pytest//:pkg.   |  `[]` |
+| <a id="py_pytest_main-data"></a>data |  A list of data dependencies to pass to the py_library target.   |  `[]` |
+| <a id="py_pytest_main-testonly"></a>testonly |  A boolean indicating if the py_library target is testonly.   |  `True` |
+| <a id="py_pytest_main-kwargs"></a>kwargs |  The extra arguments passed to the template rendering target.   |  none |
+
+
+<a id="py_pytest_test"></a>
+
+## py_pytest_test
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_pytest_test")
+
+py_pytest_test(<a href="#py_pytest_test-name">name</a>, <a href="#py_pytest_test-srcs">srcs</a>, <a href="#py_pytest_test-deps">deps</a>, <a href="#py_pytest_test-pytest_args">pytest_args</a>, <a href="#py_pytest_test-chdir">chdir</a>, <a href="#py_pytest_test-resolutions">resolutions</a>, <a href="#py_pytest_test-kwargs">**kwargs</a>)
+</pre>
+
+A `py_test` that always runs under pytest.
+
+Pytest is always the driver, so the entrypoint wiring is unambiguous.
+Include the `pytest` package (and `coverage`, if you want coverage) in
+`deps`.
+
+Every file in `srcs` is a test module that pytest collects (scoped to the
+target, not the whole runfiles tree). Put importable support code in `deps`
+and pytest's `conftest.py` in `data`; to select tests by name pattern, use
+Bazel's `glob()` in the `srcs` list.
+
+If a package directory here shares its name with a distribution in `deps`,
+see the module docs above: pytest may name test modules by a truncated path
+and shadow that distribution for the code under test. `consider_namespace_packages`
+(pytest 8.1+), via `env` or `pytest_args`, is the fix.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_pytest_test-name"></a>name |  Name of the rule.   |  none |
+| <a id="py_pytest_test-srcs"></a>srcs |  Python test source files; pytest collects exactly these.   |  `[]` |
+| <a id="py_pytest_test-deps"></a>deps |  Dependencies; must include the pytest package (e.g. `@pypi_pytest//:pkg`).   |  `[]` |
+| <a id="py_pytest_test-pytest_args"></a>pytest_args |  Extra arguments baked into the pytest invocation. Setting this renders a private per-test entrypoint instead of reusing the shared main.   |  `[]` |
+| <a id="py_pytest_test-chdir"></a>chdir |  Optional directory to change into before pytest runs, relative to the runfiles root. Also forces a private per-test entrypoint.   |  `None` |
+| <a id="py_pytest_test-resolutions"></a>resolutions |  virtual-dep resolutions, a dict of virtual dependency name to the label of an installed package providing it.   |  `None` |
+| <a id="py_pytest_test-kwargs"></a>kwargs |  forwarded to the underlying test rule and sibling py_venv.   |  none |
+
+
+<a id="py_runtime"></a>
+
+## py_runtime
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_runtime")
+
+py_runtime(<a href="#py_runtime-attrs">**attrs</a>)
+</pre>
+
+Creates an executable Python program.
+
+This is the public macro wrapping the underlying rule. Args are forwarded
+on as-is unless otherwise specified. See
+{rule}`py_runtime`
+for detailed attribute documentation.
+
+This macro affects the following args:
+* `python_version`: cannot be `PY2`
+* `srcs_version`: cannot be `PY2` or `PY2ONLY`
+* `tags`: May have special marker values added, if not already present.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_runtime-attrs"></a>attrs |  Rule attributes forwarded onto {rule}`py_runtime`.   |  none |
+
+
+<a id="py_runtime_pair"></a>
+
+## py_runtime_pair
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_runtime_pair")
+
+py_runtime_pair(<a href="#py_runtime_pair-name">name</a>, <a href="#py_runtime_pair-py2_runtime">py2_runtime</a>, <a href="#py_runtime_pair-py3_runtime">py3_runtime</a>, <a href="#py_runtime_pair-attrs">**attrs</a>)
+</pre>
+
+A toolchain rule for Python.
+
+This is a macro around the underlying {rule}`py_runtime_pair` rule.
+
+This used to wrap up to two Python runtimes, one for Python 2 and one for Python 3.
+However, Python 2 is no longer supported, so it now only wraps a single Python 3
+runtime.
+
+Usually the wrapped runtimes are declared using the `py_runtime` rule, but any
+rule returning a `PyRuntimeInfo` provider may be used.
+
+This rule returns a `platform_common.ToolchainInfo` provider with the following
+schema:
+
+```python
+platform_common.ToolchainInfo(
+    py2_runtime = None,
+    py3_runtime = <PyRuntimeInfo or None>,
+)
+```
+
+Example usage:
+
+```python
+# In your BUILD file...
+
+load("@rules_python//python:py_runtime.bzl", "py_runtime")
+load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
+
+py_runtime(
+    name = "my_py3_runtime",
+    interpreter_path = "/system/python3",
+    python_version = "PY3",
+)
+
+py_runtime_pair(
+    name = "my_py_runtime_pair",
+    py3_runtime = ":my_py3_runtime",
+)
+
+toolchain(
+    name = "my_toolchain",
+    target_compatible_with = <...>,
+    toolchain = ":my_py_runtime_pair",
+    toolchain_type = "@rules_python//python:toolchain_type",
+)
+```
+
+```python
+# In your WORKSPACE...
+
+register_toolchains("//my_pkg:my_toolchain")
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_runtime_pair-name"></a>name |  str, the name of the target   |  none |
+| <a id="py_runtime_pair-py2_runtime"></a>py2_runtime |  optional Label; must be unset or None; an error is raised otherwise.   |  `None` |
+| <a id="py_runtime_pair-py3_runtime"></a>py3_runtime |  Label; a target with `PyRuntimeInfo` for Python 3.   |  `None` |
+| <a id="py_runtime_pair-attrs"></a>attrs |  Extra attrs passed onto the native rule   |  none |
+
+
+<a id="py_test"></a>
+
+## py_test
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+py_test(<a href="#py_test-name">name</a>, <a href="#py_test-srcs">srcs</a>, <a href="#py_test-main">main</a>, <a href="#py_test-kwargs">**kwargs</a>)
+</pre>
+
+Identical to [py_binary](#function-py_binary), but produces a target that can be used with `bazel test`.
+
+`py_test` is a generic test rule: it runs a Python file as a test, nothing
+more. To drive a suite with a framework, use the purpose-oriented macros
+[py_pytest_test](#py_pytest_test) (pytest) or
+[py_unittest_test](#py_unittest_test) (stdlib unittest).
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_test-name"></a>name |  Name of the rule.   |  none |
+| <a id="py_test-srcs"></a>srcs |  Python source files.   |  `[]` |
+| <a id="py_test-main"></a>main |  Entry point. This is treated as a suffix of a file that should appear among the srcs. If absent, then `[name].py` is tried. As a final fallback, if the srcs has a single file, that is used as the main.   |  `None` |
+| <a id="py_test-kwargs"></a>kwargs |  additional named parameters forwarded to the underlying rule and the sibling py_venv.   |  none |
+
+
+<a id="py_unittest_test"></a>
+
+## py_unittest_test
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_unittest_test")
+
+py_unittest_test(<a href="#py_unittest_test-name">name</a>, <a href="#py_unittest_test-srcs">srcs</a>, <a href="#py_unittest_test-deps">deps</a>, <a href="#py_unittest_test-resolutions">resolutions</a>, <a href="#py_unittest_test-kwargs">**kwargs</a>)
+</pre>
+
+A `py_test` that runs under the stdlib `unittest` framework.
+
+Loads each `srcs` file and collects its `unittest.TestCase`s. Integrates
+with Bazel coverage, sharding, JUnit XML, and `--test_filter`. No pytest
+dependency required.
+
+Every file in `srcs` is a test module. Put importable support code in
+`deps`; to select tests by name pattern, use Bazel's `glob()` in the `srcs`
+list.
+
+Runtime `args` are parsed by the driver: `-v`/`-q`, `-f`/`--failfast`,
+`-b`/`--buffer`, and `-k PATTERN` (native unittest `-k`: repeatable,
+ORed, `*` is fnmatch). Unknown args are rejected rather than ignored.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_unittest_test-name"></a>name |  Name of the rule.   |  none |
+| <a id="py_unittest_test-srcs"></a>srcs |  Python test source files; each is loaded as a test module.   |  `[]` |
+| <a id="py_unittest_test-deps"></a>deps |  Dependencies. `coverage` is required only for coverage; JUnit XML is emitted by a built-in writer, so no third-party runner is needed.   |  `[]` |
+| <a id="py_unittest_test-resolutions"></a>resolutions |  virtual-dep resolutions, a dict of virtual dependency name to the label of an installed package providing it.   |  `None` |
+| <a id="py_unittest_test-kwargs"></a>kwargs |  forwarded to the underlying test rule and sibling py_venv.   |  none |
+
+
+<a id="py_venv"></a>
+
+## py_venv
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_venv")
+
+py_venv(<a href="#py_venv-kwargs">**kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_venv-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
+<a id="py_venv_link"></a>
+
+## py_venv_link
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_venv_link")
+
+py_venv_link(<a href="#py_venv_link-name">name</a>, <a href="#py_venv_link-venv">venv</a>, <a href="#py_venv_link-link_name">link_name</a>, <a href="#py_venv_link-kwargs">**kwargs</a>)
+</pre>
+
+Emit a runnable target that materialises `venv` into the workspace.
+
+`bazel run :<name>` creates a symlink in `$BUILD_WORKING_DIRECTORY`
+(typically the workspace root) that points at the target's complete
+runfiles tree. The command prints `venv`'s nested path below that link;
+preserving the runfiles directory layout keeps the venv's relative paths
+valid for Python and IDEs. This requires directory-based runfiles; a
+manifest alone cannot expose a runfiles tree.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_venv_link-name"></a>name |  Runnable target name. `bazel run :<name>` materialises the runfiles symlink.   |  none |
+| <a id="py_venv_link-venv"></a>venv |  Label of a `py_venv` target to link. Typically the `:<binary_name>.venv` target auto-emitted by `py_binary(expose_venv = True, ...)`, or a standalone `py_venv` shared across many binaries.   |  none |
+| <a id="py_venv_link-link_name"></a>link_name |  Workspace-relative basename for the created runfiles symlink. Defaults to a safely-escaped version of the target's package + venv name.   |  `None` |
+| <a id="py_venv_link-kwargs"></a>kwargs |  Forwarded to the underlying `py_binary`.   |  none |
+
+
+<a id="py_wheel"></a>
+
+## py_wheel
+
+<pre>
+load("@aspect_rules_py//py:defs.bzl", "py_wheel")
+
+py_wheel(<a href="#py_wheel-name">name</a>, <a href="#py_wheel-twine">twine</a>, <a href="#py_wheel-twine_binary">twine_binary</a>, <a href="#py_wheel-publish_args">publish_args</a>, <a href="#py_wheel-kwargs">**kwargs</a>)
+</pre>
+
+Builds a Python Wheel.
+
+Wheels are Python distribution format defined in https://www.python.org/dev/peps/pep-0427/.
+
+This macro packages a set of targets into a single wheel.
+It wraps the [py_wheel rule](#py_wheel_rule).
+
+Currently only pure-python wheels are supported.
+
+:::{versionchanged} 1.4.0
+From now on, an empty `requires_file` is treated as if it were omitted, resulting in a valid
+`METADATA` file.
+:::
+
+Examples:
+
+```python
+# Package some specific py_library targets, without their dependencies
+py_wheel(
+    name = "minimal_with_py_library",
+    # Package data. We're building "example_minimal_library-0.0.1-py3-none-any.whl"
+    distribution = "example_minimal_library",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [
+        "//examples/wheel/lib:module_with_data",
+        "//examples/wheel/lib:simple_module",
+    ],
+)
+
+# Use py_package to collect all transitive dependencies of a target,
+# selecting just the files within a specific python package.
+py_package(
+    name = "example_pkg",
+    # Only include these Python packages.
+    packages = ["examples.wheel"],
+    deps = [":main"],
+)
+
+py_wheel(
+    name = "minimal_with_py_package",
+    # Package data. We're building "example_minimal_package-0.0.1-py3-none-any.whl"
+    distribution = "example_minimal_package",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [":example_pkg"],
+)
+```
+
+To publish the wheel to PyPI, the twine package is required and it is installed
+by default on `bzlmod` setups. On legacy `WORKSPACE`, `rules_python`
+doesn't provide `twine` itself
+(see https://github.com/bazel-contrib/rules_python/issues/1016), but
+you can install it with `pip_parse`, just like we do any other dependencies.
+
+Once you've installed twine, you can pass its label to the `twine`
+attribute of this macro, to get a "[name].publish" target.
+
+Example:
+
+```python
+py_wheel(
+    name = "my_wheel",
+    twine = "@publish_deps//twine",
+    ...
+)
+```
+
+Now you can run a command like the following, which publishes to https://test.pypi.org/
+
+```sh
+% TWINE_USERNAME=__token__ TWINE_PASSWORD=pypi-*** \
+    bazel run --stamp --embed_label=1.2.4 -- \
+    //path/to:my_wheel.publish --repository testpypi
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_wheel-name"></a>name |  A unique name for this target.   |  none |
+| <a id="py_wheel-twine"></a>twine |  A label of the external location of the py_library target for twine   |  `None` |
+| <a id="py_wheel-twine_binary"></a>twine_binary |  A label of the external location of a binary target for twine.   |  `Label("@rules_python//tools/publish:twine")` |
+| <a id="py_wheel-publish_args"></a>publish_args |  arguments passed to twine, e.g. ["--repository-url", "https://pypi.my.org/simple/"]. These are subject to make var expansion, as with the `args` attribute. Note that you can also pass additional args to the bazel run command as in the example above.   |  `[]` |
+| <a id="py_wheel-kwargs"></a>kwargs |  other named parameters passed to the underlying [py_wheel rule](#py_wheel_rule)   |  none |
+
+

--- a/docs/api/uv.md
+++ b/docs/api/uv.md
@@ -1,0 +1,78 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Stable public API for uv rules.
+
+Graduated from `@aspect_rules_py//uv/unstable:defs.bzl` in rules_py v2.0.0.
+
+<a id="gazelle_python_manifest"></a>
+
+## gazelle_python_manifest
+
+<pre>
+load("@aspect_rules_py//uv:defs.bzl", "gazelle_python_manifest")
+
+gazelle_python_manifest(<a href="#gazelle_python_manifest-name">name</a>, <a href="#gazelle_python_manifest-hub">hub</a>, <a href="#gazelle_python_manifest-venvs">venvs</a>, <a href="#gazelle_python_manifest-include_stub_packages">include_stub_packages</a>, <a href="#gazelle_python_manifest-platform_parent">platform_parent</a>)
+</pre>
+
+Generates a Gazelle Python manifest from uv-managed wheels.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="gazelle_python_manifest-name"></a>name |  Name of the generated manifest target.   |  none |
+| <a id="gazelle_python_manifest-hub"></a>hub |  Name of the uv hub containing the wheels.   |  none |
+| <a id="gazelle_python_manifest-venvs"></a>venvs |  Dependency groups whose wheels should be indexed.   |  `[]` |
+| <a id="gazelle_python_manifest-include_stub_packages"></a>include_stub_packages |  Whether conventional stub distributions should be indexed for Gazelle's automatic stub dependency resolution.   |  `False` |
+| <a id="gazelle_python_manifest-platform_parent"></a>platform_parent |  Parent platform for the synthetic platforms this macro uses to select each venv's wheels. Defaults to `Label("@platforms//host")`, resolved in rules_py's own repository — you do not need a `bazel_dep` on `platforms` to use the default. The host platform carries only OS and CPU constraints; point this at the platform the wheels should be resolved for when that is not enough:<br><br>- If the build sets a custom `--host_platform` (for example to carry   the constraints hermetic C++ toolchains require), pass that   platform here so sdist builds inside the hub can still resolve a   cc toolchain. - When cross-compiling, pass the target platform so wheel selection   follows it instead of snapping back to the host. Note this makes   `bazel run <name>.update` build any sdist fallbacks *for that   platform*, which requires an execution platform able to run the   build (e.g. remote execution) unless every indexed package   resolves to a wheel.   |  `None` |
+
+
+<a id="py_console_script_binary"></a>
+
+## py_console_script_binary
+
+<pre>
+load("@aspect_rules_py//uv:defs.bzl", "py_console_script_binary")
+
+py_console_script_binary(<a href="#py_console_script_binary-name">name</a>, <a href="#py_console_script_binary-pkg">pkg</a>, <a href="#py_console_script_binary-script">script</a>, <a href="#py_console_script_binary-deps">deps</a>, <a href="#py_console_script_binary-dep_group">dep_group</a>, <a href="#py_console_script_binary-kwargs">**kwargs</a>)
+</pre>
+
+Build a binary for a console_script entrypoint of a package.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_console_script_binary-name"></a>name |  Name of the binary target.   |  none |
+| <a id="py_console_script_binary-pkg"></a>pkg |  The package providing the console script (e.g. `@pypi//mkdocs`).   |  none |
+| <a id="py_console_script_binary-script"></a>script |  Name of the console script as declared in the package's entry points. Defaults to `name`.   |  `None` |
+| <a id="py_console_script_binary-deps"></a>deps |  Additional dependencies made available at runtime, beyond `pkg` and its own dependencies. Used for packages discovered dynamically via entry points, such as mkdocs or pytest plugins.   |  `[]` |
+| <a id="py_console_script_binary-dep_group"></a>dep_group |  The dependency group within which to resolve dependencies, forwarded to the underlying `py_binary` targets.   |  `None` |
+| <a id="py_console_script_binary-kwargs"></a>kwargs |  Attributes forwarded to the generated `py_binary` targets (e.g. `python_version`); `visibility` is applied only to the binary, since the search tool and genrule are private implementation details. Only universally-shared attributes (`tags`, `testonly`) are forwarded to the internal genrule.   |  none |
+
+
+<a id="py_entrypoint_binary"></a>
+
+## py_entrypoint_binary
+
+<pre>
+load("@aspect_rules_py//uv:defs.bzl", "py_entrypoint_binary")
+
+py_entrypoint_binary(<a href="#py_entrypoint_binary-name">name</a>, <a href="#py_entrypoint_binary-entrypoint">entrypoint</a>, <a href="#py_entrypoint_binary-pkg">pkg</a>, <a href="#py_entrypoint_binary-visibility">visibility</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="py_entrypoint_binary-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="py_entrypoint_binary-entrypoint"></a>entrypoint |  <p align="center"> - </p>   |  none |
+| <a id="py_entrypoint_binary-pkg"></a>pkg |  <p align="center"> - </p>   |  none |
+| <a id="py_entrypoint_binary-visibility"></a>visibility |  <p align="center"> - </p>   |  `["//visibility:public"]` |
+
+

--- a/py/BUILD.bazel
+++ b/py/BUILD.bazel
@@ -1,6 +1,13 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("//py/private/interpreter:launcher.bzl", "py_interpreter_launcher")
 
+# Consumed by //docs:py_api (stardoc). exports_files gives the implicit .bzl file
+# target cross-package visibility; scoped to the docs package only.
+exports_files(
+    ["defs.bzl"],
+    visibility = ["//docs:__pkg__"],
+)
+
 # Users can set, e.g. --@aspect_rules_py//py:python_version=3.12
 alias(
     name = "python_version",

--- a/uv/BUILD.bazel
+++ b/uv/BUILD.bazel
@@ -1,5 +1,12 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 
+# Consumed by //docs:uv_api (stardoc). exports_files gives the implicit .bzl file
+# target cross-package visibility; scoped to the docs package only.
+exports_files(
+    ["defs.bzl"],
+    visibility = ["//docs:__pkg__"],
+)
+
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],


### PR DESCRIPTION
Generates the Starlark API reference for the public API (`//py:defs`, `//uv:defs`) with [stardoc](https://registry.bazel.build/modules/stardoc), written into the source tree via `write_source_files`:

- `docs/api/py.md` and `docs/api/uv.md` are committed, reviewable artifacts
- `bazel run //docs:update_docs` regenerates them
- `bazel test //docs:all` runs the generated diff tests, which fail when committed docs go stale (CI guard)

**How I arrived at this design — placement:** the stardoc targets are centralized in the dev-only `//docs` package because stardoc is a `dev_dependency`, so its repo does not exist in downstream resolution. The alternative considered — same-package targets next to each `bzl_library`, avoiding `exports_files` entirely — breaks consumers evaluating those packages: an `@stardoc` load in `//py` fails for anyone setting `--@aspect_rules_py//py:python_version` per the README, or using the `current_py_cc_*` aliases. Verified with a consumer workspace (`local_path_override` to this repo, no dev deps): those labels fail to resolve with the load in `//py`, and resolve cleanly with this placement. The cost is `exports_files` in `py/` and `uv/`, scoped to `//docs:__pkg__`.

**Bazel 9 compatibility:** stardoc is this repo's only Java target, and its arrival surfaced two dev-graph incompatibilities under Bazel 9 — protobuf's `protoc_authenticity` `run_shell` action lacks the `toolchain` parameter Bazel 9 now requires (no released protobuf carries the fix; worked around with `--noincompatible_enable_proto_toolchain_resolution`, a no-op on Bazel 8), and gazelle's resolved rules_go 0.51 uses the `CcInfo` symbol removed in Bazel 9 (bumped to 0.61.1 as a dev dep — the minimal version that avoids pulling `rules_android` via `rules_kotlin`, which breaks under this repo's `--incompatible_disable_native_repo_rules`). Verified with the full `bazel test //...` suite on both 8.6 and 9.x: 311/312 pass with only pre-existing skips.

**Deps:** the stardoc targets' `deps` point at the existing `bzl_library` targets, which is how stardoc resolves the `load()` aliases that the public `defs.bzl` files re-export.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Release notes:** added a generated Starlark API reference under `docs/api/` (`py.md`, `uv.md`), kept up to date by stardoc diff tests in CI. Regenerate with `bazel run //docs:update_docs`.

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:
  - `bazel run //docs:update_docs` regenerates `docs/api/{py,uv}.md` (838 + 78 lines); `bazel test //docs:all` → 2/2 pass.
  - Staleness detection: edit a committed doc → `bazel test //docs:all` fails → `bazel run //docs:update_docs` → passes again.
  - Downstream safety: consumer workspace with `local_path_override`, no dev deps — `@aspect_rules_py//py:python_version`, `@aspect_rules_py//uv:defs`, and `@aspect_rules_py//py:current_py_cc_headers` all resolve.
