### PR TITLE
feat(py): add per-target free-threaded interpreter selection

### DIFF
--- a/docs/api/py.md
+++ b/docs/api/py.md
@@ -693,7 +693,7 @@ ORed, `*` is fnmatch). Unknown args are rejected rather than ignored.
 <pre>
 load("@aspect_rules_py//py:defs.bzl", "py_venv")
 
-py_venv(<a href="#py_venv-kwargs">**kwargs</a>)
+py_venv(<a href="#py_venv-freethreaded">freethreaded</a>, <a href="#py_venv-kwargs">**kwargs</a>)
 </pre>
 
 
@@ -703,6 +703,7 @@ py_venv(<a href="#py_venv-kwargs">**kwargs</a>)
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
+| <a id="py_venv-freethreaded"></a>freethreaded |  <p align="center"> - </p>   |  `None` |
 | <a id="py_venv-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -199,6 +199,32 @@ bazel build \
 `interpreters.toolchain()` chooses Python versions; the build setting above
 selects runtime mode.
 
+Python terminals can override this setting with `freethreaded = True` or
+`freethreaded = False`, alongside `python_version`. The default (`None`)
+inherits the caller's mode. For example:
+
+```starlark
+py_binary(
+    name = "free_threaded_app",
+    srcs = ["app.py"],
+    python_version = "3.13",
+    freethreaded = True,
+)
+```
+
+The transition keeps Aspect's interpreter setting and rules_python's
+`py_freethreaded` native-extension setting synchronized. When inheriting a
+mode, either flag set to free-threaded selects it, mirroring how
+`python_version` falls back to rules_python's version flag. Runtime `data`
+edges restore the original caller's mode, including across nested terminal
+overrides; Python-dependent native extensions belong in `deps`.
+
+Free-threaded mode requires Python 3.13 or newer. Free-threaded interpreters
+cannot load standard (GIL) native extensions, so wheel selection demands the
+`t` ABI (e.g. `cp313t`) — including for the build requirements of sdists,
+whose PEP 517 backends run under the target interpreter. Each native package
+in the closure needs a free-threaded wheel or an sdist in the lock.
+
 ## Build configuration
 
 PBS publishes each interpreter in several build configurations. `configure()`
@@ -273,6 +299,8 @@ This interpreter provisioning is designed to coexist with `rules_python`:
   registration, so these interpreters work with all existing Python rules.
 - The `@rules_python//python/config_settings:python_version` flag is kept in
   sync with our own version flag via build transitions.
+- The `@rules_python//python/config_settings:py_freethreaded` flag is likewise
+  synchronized with Aspect's free-threading setting inside Python terminals.
 - File-based runtimes registered with `rules_python`'s `py_runtime` /
   `py_runtime_pair` remain usable by rules_py rules, which read the runtime
   fields structurally. System interpreters (a `py_runtime` with

--- a/py/private/BUILD.bazel
+++ b/py/private/BUILD.bazel
@@ -161,6 +161,7 @@ bzl_library(
         ":py_info",
         "//py/private/py_venv:types",
         "//py/private/toolchain:types",
+        "@bazel_skylib//rules:common_settings",
     ],
 )
 

--- a/py/private/interpreter/BUILD.bazel
+++ b/py/private/interpreter/BUILD.bazel
@@ -42,6 +42,26 @@ string_flag(
     visibility = ["//py:__subpackages__"],
 )
 
+# Preserve the caller's GIL mode across nested terminal overrides.
+string_flag(
+    name = "baseline_freethreaded",
+    build_setting_default = "<unset>",
+    values = [
+        "<unset>",
+        "false",
+        "true",
+    ],
+    visibility = ["//py:__subpackages__"],
+)
+
+# No values constraint: this mirrors rules_python's py_freethreaded, whose
+# own flag validates, and whose domain may grow across versions.
+string_flag(
+    name = "baseline_rules_python_freethreaded",
+    build_setting_default = "<unset>",
+    visibility = ["//py:__subpackages__"],
+)
+
 # Interpreter feature exclusions. Pass one or more --exclude_feature flags to
 # strip optional components from interpreter filegroups. Supported values:
 #   headers, docs, tkinter, idle, ensurepip, config, pydoc, lib2to3, turtle

--- a/py/private/py_pex_binary.bzl
+++ b/py/private/py_pex_binary.bzl
@@ -19,6 +19,7 @@ py_pex_binary(
 """
 
 load("@bazel_lib//lib:paths.bzl", "to_rlocation_path")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//py/private:providers.bzl", "PyWheelsInfo")
 load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private/py_venv:types.bzl", "PY_VENV_KINDS", "VirtualenvInfo", "venv_root")
@@ -53,6 +54,7 @@ _PexClosureInfo = provider(
         "venv_roots": "depset[str] — runfiles-relative roots of every sibling py_venv in the closure.",
         "interpreter_roots": "depset[str] — runfiles-relative repo roots (`../<repo>/`) of every py_venv toolchain's hermetic interpreter in the closure.",
         "version": "struct(major, minor, micro) | None — the binary's own interpreter version; propagated only along the `venv`/`actual` edge, so it is the version the PEX is built for.",
+        "freethreaded": "bool | None — whether the binary's venv resolved under free-threaded mode; propagated with `version`.",
     },
 )
 
@@ -83,6 +85,7 @@ def _closure_aspect_impl(target, ctx):
             venv_roots = depset(),
             interpreter_roots = depset(roots.keys()),
             version = version,
+            freethreaded = None,
         )]
 
     wheels = []
@@ -91,8 +94,9 @@ def _closure_aspect_impl(target, ctx):
 
     # `version` is the binary's own interpreter version: it flows only from the
     # `venv`/`actual` hop or a venv node's toolchain, never from deps/data (which
-    # carry other binaries' interpreters).
+    # carry other binaries' interpreters). `freethreaded` travels with it.
     version = None
+    freethreaded = None
     for attr_name in ["deps", "data"]:
         for dep in _label_targets(getattr(ctx.rule.attr, attr_name, None)):
             if _PexClosureInfo in dep:
@@ -117,6 +121,7 @@ def _closure_aspect_impl(target, ctx):
             roots.append(venv[_PexClosureInfo].venv_roots)
             interp.append(venv[_PexClosureInfo].interpreter_roots)
             version = venv[_PexClosureInfo].version
+            freethreaded = venv[_PexClosureInfo].freethreaded
         if VirtualenvInfo in venv:
             roots.append(depset([venv_root(venv[VirtualenvInfo].bin_python)]))
 
@@ -129,6 +134,8 @@ def _closure_aspect_impl(target, ctx):
         interp.append(actual[_PexClosureInfo].interpreter_roots)
         if version == None:
             version = actual[_PexClosureInfo].version
+        if freethreaded == None:
+            freethreaded = actual[_PexClosureInfo].freethreaded
 
     # Fires on every py_library, not just wheel leaves: its PyWheelsInfo already
     # aggregates deps + `resolutions`, which is the only path by which
@@ -142,11 +149,16 @@ def _closure_aspect_impl(target, ctx):
             interp.append(py_tc[_PexClosureInfo].interpreter_roots)
             version = py_tc[_PexClosureInfo].version
 
+        # The venv node analyzes under its own transitioned configuration, so
+        # the flag here reflects the binary's resolved free-threaded mode.
+        freethreaded = ctx.attr._freethreaded[BuildSettingInfo].value
+
     return [_PexClosureInfo(
         wheels = depset(transitive = wheels),
         venv_roots = depset(transitive = roots),
         interpreter_roots = depset(transitive = interp),
         version = version,
+        freethreaded = freethreaded,
     )]
 
 _closure_aspect = aspect(
@@ -154,6 +166,9 @@ _closure_aspect = aspect(
     attr_aspects = ["deps", "data", "actual", "venv"],
     # Lets the aspect read `ctx.rule.toolchains[PY_TOOLCHAIN]` at py_venv nodes.
     toolchains_aspects = [PY_TOOLCHAIN],
+    attrs = {
+        "_freethreaded": attr.label(default = "//py/private/interpreter:freethreaded"),
+    },
     provides = [_PexClosureInfo],
 )
 
@@ -178,6 +193,12 @@ def _py_python_pex_impl(ctx):
     closure = binary[_PexClosureInfo]
     if closure.version == None:
         fail("py_pex_binary {}: could not resolve the binary's interpreter version from its venv toolchain.".format(ctx.label))
+
+    # PEX interpreter constraints cannot express the free-threaded ABI, so a
+    # standard (GIL) interpreter of the same version would accept the PEX and
+    # fail at import time on its cpXYt wheels.
+    if closure.freethreaded:
+        fail("py_pex_binary {}: `binary` targets a free-threaded interpreter, which PEX interpreter constraints cannot express; use freethreaded = False on the binary.".format(ctx.label))
 
     wheels = closure.wheels
     wheels_list = wheels.to_list()

--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -188,6 +188,17 @@ Only works with the Aspect rules_py uv machinery.
     "python_version": attr.string(
         doc = """Whether to build this target and its transitive deps for a specific python version.""",
     ),
+    "freethreaded": attr.string(
+        default = "",
+        values = ["", "false", "true"],
+        doc = """Select the free-threaded interpreter and native-extension ABI.
+
+"true" enables free threading, "false" disables it, and the default empty
+string inherits the caller's mode. The py_binary/py_test/py_venv macros take
+this as True/False/None instead; a configurable value must be a select() over
+the string form. Runtime data edges restore the caller's mode.
+""",
+    ),
     "package_collisions": attr.string(
         doc = """What to do when metadata-resolved wheel contents collide.
 
@@ -312,7 +323,13 @@ _py_venv_lib = rule(
 )
 
 def _wrap_with_debug(rule):
-    def helper(**kwargs):
+    # Macro callers pass freethreaded as None/True/False; the rule attr is a
+    # string tri-state ("" inherits) whose values reject anything else.
+    def helper(freethreaded = None, **kwargs):
+        if type(freethreaded) == "bool":
+            freethreaded = "true" if freethreaded else "false"
+        if freethreaded != None:
+            kwargs["freethreaded"] = freethreaded
         kwargs["debug"] = select({
             Label(":debug_venv_setting"): True,
             "//conditions:default": False,
@@ -366,7 +383,7 @@ def _split_kwargs_for_venv(kwargs, expose_venv):
                 venv_kwargs[name] = kwargs[name]
     return venv_kwargs
 
-def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], imports = [], tags = None, testonly = None, visibility = None, isolated = True, expose_venv = None, expose_venv_link = False, **kwargs):
+def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], imports = [], tags = None, testonly = None, visibility = None, isolated = True, expose_venv = None, expose_venv_link = False, freethreaded = None, **kwargs):
     """Split `py_rule(name, ...)` into a sibling py_venv target + a
     `py_rule` call routed at it via the internal `venv` rule
     attribute. Called for every `py_binary` / `py_test` macro invocation.
@@ -397,6 +414,10 @@ def py_binary_with_venv(py_rule, name, main, srcs = [], deps = [], data = [], im
         expose_venv = bool(expose_venv)
 
     venv_kwargs = _split_kwargs_for_venv(kwargs, expose_venv)
+    if type(freethreaded) == "bool":
+        freethreaded = "true" if freethreaded else "false"
+    if freethreaded != None:
+        venv_kwargs["freethreaded"] = freethreaded
     venv_kwargs["srcs"] = srcs
     venv_kwargs["deps"] = deps
     venv_kwargs["imports"] = imports

--- a/py/private/transitions.bzl
+++ b/py/private/transitions.bzl
@@ -11,16 +11,24 @@ _PYTHON_VERSION_BASELINE_FLAG = "@aspect_rules_py//py/private/interpreter:baseli
 _RPY_VERSION_FLAG = "@rules_python//python/config_settings:python_version"
 _RPY_VERSION_BASELINE_FLAG = "@aspect_rules_py//py/private/interpreter:baseline_rules_python_version"
 
+_FREETHREADED_FLAG = "@aspect_rules_py//py/private/interpreter:freethreaded"
+_FREETHREADED_BASELINE_FLAG = "@aspect_rules_py//py/private/interpreter:baseline_freethreaded"
+_RPY_FREETHREADED_FLAG = "@rules_python//python/config_settings:py_freethreaded"
+_RPY_FREETHREADED_BASELINE_FLAG = "@aspect_rules_py//py/private/interpreter:baseline_rules_python_freethreaded"
+
 _BASELINE_UNSET = "<unset>"
 
 # Every terminal-attr-driven flag with its baseline shadow. The attr value
 # overrides the flag for the target's subtree; the baseline records the
 # inherited value so `reset_python_flags_transition` can restore it on
-# runtime-data edges. Adding a flag here sizes both transitions' inputs
-# and outputs; `_python_transition_impl` supplies the override logic.
+# runtime-data edges (bool flags are stringified as yes/no in the baseline).
+# Adding a flag here sizes both transitions' inputs and outputs;
+# `_python_transition_impl` supplies the override logic.
 _FLAG_BASELINE_PAIRS = [
     (PYTHON_VERSION_FLAG, _PYTHON_VERSION_BASELINE_FLAG),
     (_RPY_VERSION_FLAG, _RPY_VERSION_BASELINE_FLAG),
+    (_FREETHREADED_FLAG, _FREETHREADED_BASELINE_FLAG),
+    (_RPY_FREETHREADED_FLAG, _RPY_FREETHREADED_BASELINE_FLAG),
     (DEP_GROUP_FLAG, _DEP_GROUP_BASELINE_FLAG),
 ]
 
@@ -35,8 +43,42 @@ def _baseline(settings, flag, current):
 def _python_version(settings):
     return settings[PYTHON_VERSION_FLAG] or settings[_RPY_VERSION_FLAG]
 
+def _freethreaded_mode(settings):
+    return "true" if settings[_FREETHREADED_FLAG] else "false"
+
+# The bool flag has no unset state, so inheriting also honors rules_python's
+# flag, mirroring _python_version.
+def _inherited_freethreaded_mode(settings):
+    if settings[_FREETHREADED_FLAG] or settings[_RPY_FREETHREADED_FLAG] == "yes":
+        return "true"
+    return "false"
+
+# Free-threaded CPython builds exist from 3.13 onward; toolchain resolution
+# remains the authority for which exact versions ship one.
+def _freethreaded_available(version):
+    parts = version.split(".")
+    if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
+        return True
+    return (int(parts[0]), int(parts[1])) >= (3, 13)
+
 def _python_transition_impl(settings, attr):
     acc = {}
+    acc[_FREETHREADED_BASELINE_FLAG] = _baseline(
+        settings,
+        _FREETHREADED_BASELINE_FLAG,
+        _freethreaded_mode(settings),
+    )
+    acc[_RPY_FREETHREADED_BASELINE_FLAG] = _baseline(
+        settings,
+        _RPY_FREETHREADED_BASELINE_FLAG,
+        settings[_RPY_FREETHREADED_FLAG],
+    )
+    mode = getattr(attr, "freethreaded", "") or _inherited_freethreaded_mode(settings)
+    acc[_FREETHREADED_FLAG] = mode == "true"
+
+    # Keep rules_python native extensions on the interpreter's ABI,
+    # translated into that flag's own yes/no vocabulary.
+    acc[_RPY_FREETHREADED_FLAG] = "yes" if mode == "true" else "no"
     acc[_PYTHON_VERSION_BASELINE_FLAG] = _baseline(
         settings,
         _PYTHON_VERSION_BASELINE_FLAG,
@@ -51,6 +93,12 @@ def _python_transition_impl(settings, attr):
         version = str(attr.python_version)
     else:
         version = _python_version(settings)
+
+    if mode == "true" and version and not _freethreaded_available(version):
+        fail("{}: free-threaded mode requires Python 3.13+, but the selected python_version is \"{}\"; set freethreaded = False or raise python_version".format(
+            attr.name,
+            version,
+        ))
 
     acc[PYTHON_VERSION_FLAG] = version
     acc[_RPY_VERSION_FLAG] = version
@@ -86,7 +134,10 @@ python_transition = transition(
 def _reset_python_flags_transition_impl(settings, _attr):
     acc = {}
     for flag, baseline_flag in _FLAG_BASELINE_PAIRS:
-        acc[flag] = _baseline(settings, baseline_flag, settings[flag])
+        is_bool = type(settings[flag]) == "bool"
+        current = ("true" if settings[flag] else "false") if is_bool else settings[flag]
+        restored = _baseline(settings, baseline_flag, current)
+        acc[flag] = restored == "true" if is_bool else restored
         acc[baseline_flag] = _BASELINE_UNSET
     return acc
 

--- a/py/tests/expose-venv-api/BUILD.bazel
+++ b/py/tests/expose-venv-api/BUILD.bazel
@@ -16,13 +16,16 @@ py_binary(
     name = "minimal_bin",
     srcs = ["main.py"],
     expose_venv = True,
+    freethreaded = True,
     main = "main.py",
 )
 
+# Configurable freethreaded uses the string form; bools are literal-only.
 py_test(
     name = "minimal_test",
     srcs = ["main.py"],
     expose_venv = True,
+    freethreaded = select({"//conditions:default": "false"}),
     main = "main.py",
 )
 

--- a/py/tests/reset-data-edges/BUILD.bazel
+++ b/py/tests/reset-data-edges/BUILD.bazel
@@ -26,7 +26,8 @@ py_venv(
     srcs = ["main.py"],
     data = [":probe"],
     dep_group = "first",
-    python_version = "3.12",
+    freethreaded = True,
+    python_version = "3.13",
     tags = ["manual"],
     deps = [
         ":launcher",
@@ -40,7 +41,8 @@ terminal(
     name = "parent_terminal",
     data = [":probe"],
     dep_group = "parent",
-    python_version = "3.12",
+    freethreaded = "true",
+    python_version = "3.13",
     tags = ["manual"],
     deps = [":nested_terminal"],
 )
@@ -49,6 +51,16 @@ terminal(
     name = "nested_terminal",
     data = [":probe"],
     dep_group = "nested",
+    freethreaded = "false",
+    python_version = "3.13",
+    tags = ["manual"],
+)
+
+# No freethreaded attr under the mismatched baseline (aspect flag unset,
+# rules_python flag "yes"): inheriting must honor rules_python's flag.
+terminal(
+    name = "inherit_terminal",
+    data = [":probe"],
     python_version = "3.13",
     tags = ["manual"],
 )
@@ -58,6 +70,7 @@ py_venv(
     srcs = ["main.py"],
     data = [":probe"],
     dep_group = "second",
+    freethreaded = False,
     python_version = "3.12",
     tags = ["manual"],
     deps = [
@@ -71,6 +84,7 @@ root(
     tags = ["manual"],
     deps = [
         ":first",
+        ":inherit_terminal",
         ":parent_terminal",
         ":probe",
         ":second",

--- a/py/tests/reset-data-edges/tests.bzl
+++ b/py/tests/reset-data-edges/tests.bzl
@@ -1,14 +1,17 @@
 """Analysis test for deduplicating runtime data across terminal overrides."""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//py/private:transitions.bzl", "python_transition", "reset_python_flags_transition")
 
 _DEP_GROUP_FLAG = "@aspect_rules_py//uv/private/constraints/dep_group:dep_group"
 _PYTHON_VERSION_FLAG = "@aspect_rules_py//py/private/interpreter:python_version"
 _RPY_VERSION_FLAG = "@rules_python//python/config_settings:python_version"
+_FREETHREADED_FLAG = "@aspect_rules_py//py/private/interpreter:freethreaded"
+_RPY_FREETHREADED_FLAG = "@rules_python//python/config_settings:py_freethreaded"
 
 _ProbeInfo = provider(fields = ["file"])
-_ProbeFilesInfo = provider(fields = ["files"])
+_ProbeFilesInfo = provider(fields = ["files", "modes"])
 
 def _probe_impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name + ".txt")
@@ -27,16 +30,37 @@ def _probe_aspect_impl(target, ctx):
         direct.append(target[_ProbeInfo].file)
 
     transitive = []
+    transitive_modes = []
+    deps = []
     for attr_name in ["data", "deps"]:
-        for dep in getattr(ctx.rule.attr, attr_name, []):
-            if _ProbeFilesInfo in dep:
-                transitive.append(dep[_ProbeFilesInfo].files)
+        deps.extend(getattr(ctx.rule.attr, attr_name, []))
+    venv = getattr(ctx.rule.attr, "venv", None)
+    if venv != None:
+        deps.append(venv)
+    for dep in deps:
+        if _ProbeFilesInfo in dep:
+            transitive.append(dep[_ProbeFilesInfo].files)
+            transitive_modes.append(dep[_ProbeFilesInfo].modes)
 
-    return [_ProbeFilesInfo(files = depset(direct = direct, transitive = transitive))]
+    # Record every visited target; the test impl filters to the names it
+    # asserts on, keeping the fixture-name coupling in one place.
+    modes = [(
+        ctx.label.name,
+        ctx.attr._freethreaded[BuildSettingInfo].value,
+        ctx.attr._rpy_freethreaded[BuildSettingInfo].value,
+    )]
+    return [_ProbeFilesInfo(
+        files = depset(direct = direct, transitive = transitive),
+        modes = depset(direct = modes, transitive = transitive_modes),
+    )]
 
 _probe_aspect = aspect(
     implementation = _probe_aspect_impl,
-    attr_aspects = ["data", "deps"],
+    attr_aspects = ["data", "deps", "venv"],
+    attrs = {
+        "_freethreaded": attr.label(default = _FREETHREADED_FLAG),
+        "_rpy_freethreaded": attr.label(default = _RPY_FREETHREADED_FLAG),
+    },
 )
 
 def _terminal_impl(_ctx):
@@ -53,6 +77,7 @@ terminal = rule(
         ),
         "deps": attr.label_list(),
         "dep_group": attr.string(default = ""),
+        "freethreaded": attr.string(default = "", values = ["", "false", "true"]),
         "python_version": attr.string(),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
@@ -63,13 +88,20 @@ terminal = rule(
 
 def _root_impl(ctx):
     transitive = [dep[_ProbeFilesInfo].files for dep in ctx.attr.deps]
-    return [_ProbeFilesInfo(files = depset(transitive = transitive))]
+    return [_ProbeFilesInfo(
+        files = depset(transitive = transitive),
+        modes = depset(transitive = [dep[_ProbeFilesInfo].modes for dep in ctx.attr.deps]),
+    )]
 
 def _baseline_transition_impl(_settings, _attr):
     return {
         _DEP_GROUP_FLAG: "baseline",
         _PYTHON_VERSION_FLAG: "",
         _RPY_VERSION_FLAG: "3.10",
+        # A caller may set only one flag. Terminals synchronize their subtree,
+        # but data must restore both original values to share one configuration.
+        _FREETHREADED_FLAG: False,
+        _RPY_FREETHREADED_FLAG: "yes",
     }
 
 _baseline_transition = transition(
@@ -79,6 +111,8 @@ _baseline_transition = transition(
         _DEP_GROUP_FLAG,
         _PYTHON_VERSION_FLAG,
         _RPY_VERSION_FLAG,
+        _FREETHREADED_FLAG,
+        _RPY_FREETHREADED_FLAG,
     ],
 )
 
@@ -105,6 +139,23 @@ def _reset_data_edges_test_impl(ctx):
         len(files),
         "runtime data should analyze the probe once across terminal overrides",
     )
+    expected = [
+        ("probe", False, "yes"),
+        ("first", True, "yes"),
+        ("second", False, "no"),
+        ("_launcher.venv", True, "yes"),
+        ("_launcher.venv", False, "no"),
+        ("parent_terminal", True, "yes"),
+        ("nested_terminal", False, "no"),
+        ("inherit_terminal", True, "yes"),
+    ]
+    tracked = {name: True for name, _, _ in expected}
+    modes = [
+        mode
+        for mode in analysistest.target_under_test(env)[_ProbeFilesInfo].modes.to_list()
+        if mode[0] in tracked
+    ]
+    asserts.equals(env, sorted(expected), sorted(modes))
     return analysistest.end(env)
 
 _reset_data_edges_test = analysistest.make(_reset_data_edges_test_impl)


### PR DESCRIPTION
## What

Allow `py_binary`, `py_test`, and `py_venv` to select free threading per target with `freethreaded = True|False`. The default `None` inherits the Aspect free-threading flag.

Keep rules_python's native-extension ABI setting synchronized within the selected Python dependency graph. Runtime `data` edges restore both original caller settings independently, including across nested terminal overrides.

Extend the existing transition and exposed-venv tests and document the attribute. Existing interpreter-version support and default runtime selection are preserved.

## Why

Mixed GIL-enabled and free-threaded targets need consistent interpreter and native-extension settings without changing a build-wide flag. Preserving the original settings on runtime data also lets shared data reuse one configuration across those targets.

Before this change, setting only Aspect's `freethreaded` flag to `True` leaves `rules_python`'s `py_freethreaded` at its default `"no"`. A binary can therefore use a free-threaded interpreter while its nanobind dependency is compiled without `NB_FREE_THREADED`. With `freethreaded = True` on the binary, this PR sets both flags together so the interpreter and native extension use the same GIL mode.
