### PR TITLE
test(e2e): regex-based forbidden-path asserts and --absent tar path checks

### DIFF
--- a/e2e/cases/oci/py_image_layer/BUILD.bazel
+++ b/e2e/cases/oci/py_image_layer/BUILD.bazel
@@ -9,6 +9,11 @@ load(":image_layer_analysis_tests.bzl", "image_layer_analysis_test_suite")
 load(":runtime_wrapper.bzl", "runtime_wrapper")
 load(":tree_artifact.bzl", "dir_and_symlink", "relative_symlink", "symlink_target", "symlink_to_target", "tree_artifact")
 
+exports_files(
+    ["assert_tar_paths.py"],
+    visibility = ["//visibility:public"],
+)
+
 platform(
     name = "aarch64_linux",
     constraint_values = [

--- a/e2e/cases/oci/py_image_layer/assert_tar_paths.py
+++ b/e2e/cases/oci/py_image_layer/assert_tar_paths.py
@@ -7,6 +7,7 @@ import tarfile
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--contains", action="append", default=[])
+    parser.add_argument("--absent", action="append", default=[])
     parser.add_argument("--count", action="append", default=[])
     parser.add_argument("--tar-contains", action="append", default=[])
     parser.add_argument("--tar-absent", action="append", default=[])
@@ -23,6 +24,10 @@ def main() -> int:
     for expected in args.contains:
         if not any(expected in path for path in paths):
             parser.error("missing path containing {!r}".format(expected))
+
+    for unexpected in args.absent:
+        if any(path.endswith(unexpected) for path in paths):
+            parser.error("unexpected path ending in {!r}".format(unexpected))
 
     for spec in args.count:
         expected, separator, count = spec.rpartition("=")

--- a/e2e/cases/tools/assert_absent.py
+++ b/e2e/cases/tools/assert_absent.py
@@ -1,4 +1,4 @@
-"""Fail if a tar-listing file contains any forbidden path substring.
+"""Fail if a tar-listing file contains any forbidden path pattern (regex).
 
 Docker-free guard wired into `assert_tar_listing`: it scans the same layer
 listing the snapshot test diffs, but asserts an *invariant* rather than exact
@@ -16,6 +16,7 @@ container:
 Usage (from the macro): assert_absent.py <listing-file> <forbidden>...
 """
 
+import re
 import sys
 
 
@@ -23,7 +24,7 @@ def main(argv: list[str]) -> None:
     if len(argv) < 3:
         sys.exit("usage: assert_absent.py <listing-file> <forbidden>...")
     listing_path = argv[1]
-    forbidden = argv[2:]
+    forbidden = [re.compile(pat) for pat in argv[2:]]
 
     with open(listing_path, encoding="utf-8") as f:
         lines = f.read().splitlines()
@@ -31,8 +32,8 @@ def main(argv: list[str]) -> None:
     failures = []
     for line in lines:
         for pat in forbidden:
-            if pat in line:
-                failures.append((pat, line.strip()))
+            if pat.search(line):
+                failures.append((pat.pattern, line.strip()))
 
     if failures:
         msg = ["{} forbidden path(s) in {}:".format(len(failures), listing_path)]
@@ -42,7 +43,7 @@ def main(argv: list[str]) -> None:
             msg.append("  ... ({} more)".format(len(failures) - 20))
         sys.exit("\n".join(msg))
 
-    print("assert_absent: ok ({} lines, none matched {})".format(len(lines), forbidden))
+    print("assert_absent: ok ({} lines, none matched {})".format(len(lines), [p.pattern for p in forbidden]))
 
 
 if __name__ == "__main__":

--- a/e2e/cases/tools/asserts.bzl
+++ b/e2e/cases/tools/asserts.bzl
@@ -11,7 +11,7 @@ load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
 # invariant, not exact bytes, so it survives snapshot regeneration.
 _FORBIDDEN_LAYER_PATHS = [
     "__pycache__",
-    ".pyc",
+    "[.]pyc",
     "/_wheels/",
 ]
 


### PR DESCRIPTION
Generalize the shared tar-listing assertion helpers: assert_absent.py matches forbidden paths as regular expressions instead of substrings, and assert_tar_paths.py gains an --absent flag asserting no listed path ends with the given suffix. Export assert_tar_paths.py so cases outside its package can reuse it.

This is in prep for pyc tests.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
