### PR TITLE
refactor(py): split venv runtime runfiles from first-party import sources

### DIFF
--- a/py/private/py_venv/py_venv.bzl
+++ b/py/private/py_venv/py_venv.bzl
@@ -100,21 +100,19 @@ def _assemble_venv_target(ctx):
         ],
     )
 
-    return struct(
-        info = VirtualenvInfo(
-            bin_python = assembled.bin_python,
-            imports = imports_depset,
-            transitive_sources = srcs_depset,
-            runtime_files = runtime_files,
-        ),
-        runfiles = runfiles,
+    return VirtualenvInfo(
+        bin_python = assembled.bin_python,
+        imports = imports_depset,
+        runtime_runfiles = runfiles,
+        transitive_sources = srcs_depset,
+        runtime_files = runtime_files,
     )
 
 def _venv_providers(ctx, venv, executable = None, include_sources = False):
     """Providers emitted by both the executable and lib variants."""
-    runfiles = venv.runfiles
+    runfiles = venv.runtime_runfiles
     if include_sources:
-        runfiles = runfiles.merge(ctx.runfiles(transitive_files = venv.info.transitive_sources))
+        runfiles = runfiles.merge(ctx.runfiles(transitive_files = venv.transitive_sources))
     return [
         DefaultInfo(
             files = depset([executable]) if executable != None else None,
@@ -122,7 +120,7 @@ def _venv_providers(ctx, venv, executable = None, include_sources = False):
             runfiles = runfiles,
         ),
         # Deliberately no PyInfo: a venv is a terminal artifact, not a source of imports.
-        venv.info,
+        venv,
         # `bazel coverage` finds this by walking the consumer's `venv` attr.
         coverage_common.instrumented_files_info(
             ctx,
@@ -144,7 +142,7 @@ def _py_venv_rule_impl(ctx):
         substitutions = {
             "{{BASH_RLOCATION_FN}}": BASH_RLOCATION_FUNCTION.strip(),
             "{{INTERPRETER_FLAGS}}": " ".join(_interpreter_flags(ctx)),
-            "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, venv.info.bin_python),
+            "{{ARG_VENV_PYTHON}}": to_rlocation_path(ctx, venv.bin_python),
             "{{DEBUG}}": str(ctx.attr.debug).lower(),
         },
         is_executable = True,
@@ -163,7 +161,7 @@ def _py_venv_rule_impl(ctx):
 
     # `VIRTUAL_ENV` as the venv root's rootpath. `venv.tmpl.sh`
     # overrides with its own absolute value when invoked directly.
-    passed_env["VIRTUAL_ENV"] = venv_root(venv.info.bin_python)
+    passed_env["VIRTUAL_ENV"] = venv_root(venv.bin_python)
 
     return _venv_providers(ctx, venv, executable = ctx.outputs.executable, include_sources = True) + [
         # Read by the sibling `expose_venv = True` py_binary/py_test;

--- a/py/private/py_venv/py_venv_exec.bzl
+++ b/py/private/py_venv/py_venv_exec.bzl
@@ -123,14 +123,16 @@ def _py_venv_exec_impl(ctx):
         for target in ctx.attr.data
         if has_py_info(target)
     ]
+
+    # First-party import sources attach explicitly; everything else the venv
+    # needs at runtime (venv files, wheels, data) comes from its
+    # runtime_runfiles, so a terminal can substitute the source set without
+    # re-deriving the rest.
     runfiles = ctx.runfiles(
         files = ctx.files.data + [main],
-        transitive_files = depset(
-            transitive = [vinfo.transitive_sources] + data_sources,
-        ),
-    ).merge_all(
-        [target[DefaultInfo].default_runfiles for target in ctx.attr.data] +
-        [venv[DefaultInfo].default_runfiles],
+        transitive_files = depset(transitive = [vinfo.transitive_sources] + data_sources),
+    ).merge(vinfo.runtime_runfiles).merge_all(
+        [target[DefaultInfo].default_runfiles for target in ctx.attr.data],
     )
 
     instrumented_files_info = coverage_common.instrumented_files_info(
@@ -200,7 +202,7 @@ user-facing attribute — direct settings on the rule are blocked at
 the macro layer in `//py:defs.bzl`.
 
 The binary's launcher exec's the referenced venv's `bin/python`; its
-runfiles inherit the venv's default_runfiles for wheels and runtime data,
+runfiles inherit the venv's runtime runfiles for wheels and runtime data,
 and add first-party sources from `VirtualenvInfo.transitive_sources` at
 their usual rlocation paths. The edge transition forwards this launcher's
 `python_version` / `freethreaded` choices to the venv's configuration, so

--- a/py/private/py_venv/types.bzl
+++ b/py/private/py_venv/types.bzl
@@ -22,6 +22,7 @@ binary's launcher exec's the venv's `bin_python`.
     fields = {
         "bin_python": "File — the venv's bin/python symlink. Callers needing a launcher target point here.",
         "imports": "depset[str] — rlocation-root-relative import paths covered by this venv. Mirrors `PyInfo.imports` of the venv's dep closure.",
+        "runtime_runfiles": "Runfiles — venv, wheels, and data without Python import sources.",
         "transitive_sources": "depset[File] — source artifacts carried by this venv: its own `srcs`, sources from `deps` that emit `PyInfo`, and files contributed by virtual-resolution targets. Surfaced by py_binary as `PyInfo.transitive_sources` so downstream consumers see the same source closure they'd see if srcs/deps lived on the binary directly.",
         "runtime_files": "depset[File] — generated venv support files and the runfiles library; excludes dependency and interpreter runfiles.",
     },


### PR DESCRIPTION
Reduce the use of `DefaultInfo` for transferring .py files to make it easier to swap .py/pyc

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
