### PR TITLE
test(py): pin venv src/data runfiles semantics for cross-package, data, and mapped files

### DIFF
--- a/py/tests/py-venv-multi-exec/BUILD.bazel
+++ b/py/tests/py-venv-multi-exec/BUILD.bazel
@@ -1,7 +1,9 @@
-load("//py:defs.bzl", "py_venv")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//py:defs.bzl", "py_library", "py_venv")
 load("//py/private/py_venv:defs.bzl", "py_venv_exec_test")
 load(":env_inherit_test.bzl", "contextual_keys_not_inherited_test", "env_inherit_test")
 load(":freethreaded_flag_test.bzl", "freethreaded_flag_test")
+load(":runfiles_mapping.bzl", "runfiles_mapping")
 
 package(default_testonly = True)
 
@@ -43,6 +45,71 @@ py_venv(
     deps = [
         "@pypi//cowsay",
     ],
+)
+
+# A venv may list a source file exported by another package; it ships at its
+# owning package's runfiles path.
+py_venv(
+    name = "foreign_source_venv",
+    srcs = [
+        "entry_foreign.py",
+        "//py/tests/py-venv-multi-exec/cross-pkg:foreign_source.py",
+    ],
+    imports = ["."],
+)
+
+py_venv_exec_test(
+    name = "test_foreign_source",
+    main = "entry_foreign.py",
+    venv = ":foreign_source_venv",
+)
+
+# A .py explicitly carried as a library's runtime `data` is data, not an
+# import: it ships as a plain file, reached only through the deps closure.
+py_library(
+    name = "runtime_data_library",
+    srcs = ["runtime_data_owner.py"],
+    data = ["runtime_data.py"],
+)
+
+py_venv(
+    name = "runtime_data_venv",
+    srcs = ["entry_runtime_data.py"],
+    imports = ["."],
+    deps = [":runtime_data_library"],
+)
+
+py_venv_exec_test(
+    name = "test_runtime_data",
+    main = "entry_runtime_data.py",
+    venv = ":runtime_data_venv",
+)
+
+# A `.py` used strictly as data must never be parsed or imported.
+filegroup(
+    name = "broken_python_data",
+    srcs = ["broken_data.py"],
+)
+
+py_venv_exec_test(
+    name = "test_broken_python_data",
+    data = [":broken_python_data"],
+    main = "entry_broken_data.py",
+    venv = ":shared_venv",
+)
+
+# Data targets may contribute runfiles symlinks/root_symlinks; the launcher's
+# runfiles merge must preserve both mappings.
+runfiles_mapping(
+    name = "entry_a_mapping",
+    src = "entry_a.py",
+)
+
+py_venv_exec_test(
+    name = "test_runfiles_mapping_data",
+    data = [":entry_a_mapping"],
+    main = "entry_mapped.py",
+    venv = ":shared_venv",
 )
 
 # Same shared venv, two different `main` entry points. Both reach

--- a/py/tests/py-venv-multi-exec/broken_data.py
+++ b/py/tests/py-venv-multi-exec/broken_data.py
@@ -1,0 +1,1 @@
+this is deliberately not valid Python

--- a/py/tests/py-venv-multi-exec/cross-pkg/BUILD.bazel
+++ b/py/tests/py-venv-multi-exec/cross-pkg/BUILD.bazel
@@ -2,6 +2,11 @@ load("//py/private/py_venv:defs.bzl", "py_venv_exec_test")
 
 package(default_testonly = True)
 
+exports_files(
+    ["foreign_source.py"],
+    visibility = ["//visibility:public"],
+)
+
 # A py_venv_exec_test consuming a `:shared_venv` defined in a sibling
 # package. Exercises cross-package visibility of the venv label and
 # rlocation paths spanning two packages: the venv's runfiles tree

--- a/py/tests/py-venv-multi-exec/cross-pkg/foreign_source.py
+++ b/py/tests/py-venv-multi-exec/cross-pkg/foreign_source.py
@@ -1,0 +1,1 @@
+VALUE = "foreign direct source"

--- a/py/tests/py-venv-multi-exec/entry_broken_data.py
+++ b/py/tests/py-venv-multi-exec/entry_broken_data.py
@@ -1,0 +1,5 @@
+"""A syntactically invalid .py used strictly as data is never parsed."""
+
+content = open("py/tests/py-venv-multi-exec/broken_data.py").read()
+assert "deliberately not valid" in content, content
+print("broken data ok")

--- a/py/tests/py-venv-multi-exec/entry_foreign.py
+++ b/py/tests/py-venv-multi-exec/entry_foreign.py
@@ -1,0 +1,5 @@
+"""A venv src listed from another package ships at that package's path."""
+
+content = open("py/tests/py-venv-multi-exec/cross-pkg/foreign_source.py").read()
+assert 'VALUE = "foreign direct source"' in content, content
+print("foreign source ok")

--- a/py/tests/py-venv-multi-exec/entry_mapped.py
+++ b/py/tests/py-venv-multi-exec/entry_mapped.py
@@ -1,0 +1,5 @@
+"""Data targets' runfiles symlink mappings survive the launcher's merge."""
+
+assert "entry_a" in open("mapped.py").read()
+assert "entry_a" in open("../root-mapped.py").read()
+print("runfiles mappings ok")

--- a/py/tests/py-venv-multi-exec/entry_runtime_data.py
+++ b/py/tests/py-venv-multi-exec/entry_runtime_data.py
@@ -1,0 +1,5 @@
+"""A .py carried as a library's `data` ships as a plain runtime file."""
+
+content = open("py/tests/py-venv-multi-exec/runtime_data.py").read()
+assert "runtime data" in content, content
+print("runtime-data fixture ok")

--- a/py/tests/py-venv-multi-exec/runfiles_mapping.bzl
+++ b/py/tests/py-venv-multi-exec/runfiles_mapping.bzl
@@ -1,0 +1,12 @@
+"""Runfiles mapping fixture: a data dep contributing symlinks and root_symlinks."""
+
+def _runfiles_mapping_impl(ctx):
+    return [DefaultInfo(runfiles = ctx.runfiles(
+        symlinks = {"mapped.py": ctx.file.src},
+        root_symlinks = {"root-mapped.py": ctx.file.src},
+    ))]
+
+runfiles_mapping = rule(
+    implementation = _runfiles_mapping_impl,
+    attrs = {"src": attr.label(allow_single_file = True, mandatory = True)},
+)

--- a/py/tests/py-venv-multi-exec/runtime_data.py
+++ b/py/tests/py-venv-multi-exec/runtime_data.py
@@ -1,0 +1,1 @@
+"""This file is runtime data, not an importable library source."""

--- a/py/tests/py-venv-multi-exec/runtime_data_owner.py
+++ b/py/tests/py-venv-multi-exec/runtime_data_owner.py
@@ -1,0 +1,1 @@
+"""Owns a transitive runtime-data file."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dev-dependencies = [
 [tool.ruff]
 target-version = "py39"
 extend-exclude = [
+   # Intentionally unparsable .py-as-data fixture.
+   "py/tests/py-venv-multi-exec/broken_data.py",
    # OCI layer snapshots pin the byte sizes of these fixtures.
    "e2e/cases/oci/py_image_layer/branding/**",
    "py/tests/internal-deps/adder/**",


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
