### PR TITLE
fix(py): capture flag baselines only when a terminal changes a flag

### DIFF
--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -298,7 +298,10 @@ This interpreter provisioning is designed to coexist with `rules_python`:
 - The standard `@bazel_tools//tools/python:toolchain_type` is used for toolchain
   registration, so these interpreters work with all existing Python rules.
 - The `@rules_python//python/config_settings:python_version` flag is kept in
-  sync with our own version flag via build transitions.
+  sync with our own version flag via build transitions. Set both flags to the
+  same value in `.bazelrc` so a terminal without a `python_version` override
+  stays in the caller's configuration; otherwise the synchronization alone
+  moves its subtree into a second configuration.
 - The `@rules_python//python/config_settings:py_freethreaded` flag is likewise
   synchronized with Aspect's free-threading setting inside Python terminals.
 - File-based runtimes registered with `rules_python`'s `py_runtime` /

--- a/py/private/transitions.bzl
+++ b/py/private/transitions.bzl
@@ -1,10 +1,10 @@
 """Common transition implementation used by the various terminals."""
 
-DEP_GROUP_FLAG = "@aspect_rules_py//uv/private/constraints/dep_group:dep_group"
+_DEP_GROUP_FLAG = "@aspect_rules_py//uv/private/constraints/dep_group:dep_group"
 _DEP_GROUP_BASELINE_FLAG = "@aspect_rules_py//uv/private/constraints/dep_group:baseline"
 
 # Our own python_version flag, replacing the rules_python one.
-PYTHON_VERSION_FLAG = "@aspect_rules_py//py/private/interpreter:python_version"
+_PYTHON_VERSION_FLAG = "@aspect_rules_py//py/private/interpreter:python_version"
 _PYTHON_VERSION_BASELINE_FLAG = "@aspect_rules_py//py/private/interpreter:baseline_python_version"
 
 # rules_python's flag, kept for backward compatibility during migration.
@@ -18,40 +18,33 @@ _RPY_FREETHREADED_BASELINE_FLAG = "@aspect_rules_py//py/private/interpreter:base
 
 _BASELINE_UNSET = "<unset>"
 
-# Every terminal-attr-driven flag with its baseline shadow. The attr value
-# overrides the flag for the target's subtree; the baseline records the
-# inherited value so `reset_python_flags_transition` can restore it on
-# runtime-data edges (bool flags are stringified as yes/no in the baseline).
-# Adding a flag here sizes both transitions' inputs and outputs;
-# `_python_transition_impl` supplies the override logic.
+# Every terminal-attr-driven flag with its baseline shadow. A baseline records
+# the inherited value the first time a terminal changes the flag so
+# `reset_python_flags_transition` can restore it on runtime-data edges (the
+# bool flag is stored as "true"/"false"). A terminal that leaves every flag at
+# its inherited value is a no-op: it captures no baseline, so its subtree
+# shares the caller's configuration.
 _FLAG_BASELINE_PAIRS = [
-    (PYTHON_VERSION_FLAG, _PYTHON_VERSION_BASELINE_FLAG),
-    (_RPY_VERSION_FLAG, _RPY_VERSION_BASELINE_FLAG),
+    (_PYTHON_VERSION_FLAG, _PYTHON_VERSION_BASELINE_FLAG),
     (_FREETHREADED_FLAG, _FREETHREADED_BASELINE_FLAG),
+    (_DEP_GROUP_FLAG, _DEP_GROUP_BASELINE_FLAG),
+
+    # rules_python's flags are kept in sync with ours, so they share the same baseline.
+    (_RPY_VERSION_FLAG, _RPY_VERSION_BASELINE_FLAG),
     (_RPY_FREETHREADED_FLAG, _RPY_FREETHREADED_BASELINE_FLAG),
-    (DEP_GROUP_FLAG, _DEP_GROUP_BASELINE_FLAG),
 ]
 
 _ALL_FLAGS = [flag for pair in _FLAG_BASELINE_PAIRS for flag in pair]
 
-def _baseline(settings, flag, current):
-    baseline = settings[flag]
-    if baseline == _BASELINE_UNSET:
-        return current
-    return baseline
+def _stringify(value):
+    if type(value) == "bool":
+        return "true" if value else "false"
+    return value
 
-def _python_version(settings):
-    return settings[PYTHON_VERSION_FLAG] or settings[_RPY_VERSION_FLAG]
-
-def _freethreaded_mode(settings):
-    return "true" if settings[_FREETHREADED_FLAG] else "false"
-
-# The bool flag has no unset state, so inheriting also honors rules_python's
-# flag, mirroring _python_version.
-def _inherited_freethreaded_mode(settings):
-    if settings[_FREETHREADED_FLAG] or settings[_RPY_FREETHREADED_FLAG] == "yes":
-        return "true"
-    return "false"
+def _capture_baseline(settings, flag, baseline_flag, new_value):
+    if settings[baseline_flag] == _BASELINE_UNSET and new_value != settings[flag]:
+        return _stringify(settings[flag])
+    return settings[baseline_flag]
 
 # Free-threaded CPython builds exist from 3.13 onward; toolchain resolution
 # remains the authority for which exact versions ship one.
@@ -61,68 +54,38 @@ def _freethreaded_available(version):
         return True
     return (int(parts[0]), int(parts[1])) >= (3, 13)
 
-def _python_transition_impl(settings, attr):
-    return _python_transition_base(settings, attr, validate = True)
-
 def _python_transition_base(settings, attr, validate):
-    acc = {}
-    acc[_FREETHREADED_BASELINE_FLAG] = _baseline(
-        settings,
-        _FREETHREADED_BASELINE_FLAG,
-        _freethreaded_mode(settings),
-    )
-    acc[_RPY_FREETHREADED_BASELINE_FLAG] = _baseline(
-        settings,
-        _RPY_FREETHREADED_BASELINE_FLAG,
-        settings[_RPY_FREETHREADED_FLAG],
-    )
-    mode = getattr(attr, "freethreaded", "") or _inherited_freethreaded_mode(settings)
-    acc[_FREETHREADED_FLAG] = mode == "true"
-
-    # Keep rules_python native extensions on the interpreter's ABI,
-    # translated into that flag's own yes/no vocabulary.
-    acc[_RPY_FREETHREADED_FLAG] = "yes" if mode == "true" else "no"
-    acc[_PYTHON_VERSION_BASELINE_FLAG] = _baseline(
-        settings,
-        _PYTHON_VERSION_BASELINE_FLAG,
-        settings[PYTHON_VERSION_FLAG],
-    )
-    acc[_RPY_VERSION_BASELINE_FLAG] = _baseline(
-        settings,
-        _RPY_VERSION_BASELINE_FLAG,
-        settings[_RPY_VERSION_FLAG],
-    )
-    if attr.python_version:
-        version = str(attr.python_version)
+    if attr.freethreaded:
+        freethreaded = attr.freethreaded == "true"
     else:
-        version = _python_version(settings)
+        # The bool flag has no unset state, so inheriting also honors
+        # rules_python's flag.
+        freethreaded = settings[_FREETHREADED_FLAG] or settings[_RPY_FREETHREADED_FLAG] == "yes"
 
-    if validate and mode == "true" and version and not _freethreaded_available(version):
+    version = attr.python_version or settings[_PYTHON_VERSION_FLAG] or settings[_RPY_VERSION_FLAG]
+
+    if validate and freethreaded and version and not _freethreaded_available(version):
         fail("{}: free-threaded mode requires Python 3.13+, but the selected python_version is \"{}\"; set freethreaded = False or raise python_version".format(
             attr.name,
             version,
         ))
 
-    acc[PYTHON_VERSION_FLAG] = version
-    acc[_RPY_VERSION_FLAG] = version
+    acc = {
+        _FREETHREADED_FLAG: freethreaded,
+        _PYTHON_VERSION_FLAG: version,
+        # Only `py_venv` carries the attr; other rules inherit the group.
+        _DEP_GROUP_FLAG: getattr(attr, "dep_group", "") or settings[_DEP_GROUP_FLAG],
 
-    # Set the dep_group transition. The attr is only present on `py_venv`
-    # (rules without it propagate the inherited setting; `py_venv_exec`
-    # is config-agnostic — its runfiles inherit the venv's wheels at
-    # whatever DEP_GROUP_FLAG the venv resolved under).
-    dep_group = getattr(attr, "dep_group", None)
-    if dep_group:
-        acc[DEP_GROUP_FLAG] = str(dep_group)
-        acc[_DEP_GROUP_BASELINE_FLAG] = _baseline(
-            settings,
-            _DEP_GROUP_BASELINE_FLAG,
-            settings[DEP_GROUP_FLAG],
-        )
-    else:
-        acc[DEP_GROUP_FLAG] = settings[DEP_GROUP_FLAG]
-        acc[_DEP_GROUP_BASELINE_FLAG] = settings[_DEP_GROUP_BASELINE_FLAG]
-
+        # Keep rules_python names alive
+        _RPY_FREETHREADED_FLAG: "yes" if freethreaded else "no",
+        _RPY_VERSION_FLAG: version,
+    }
+    for flag, baseline_flag in _FLAG_BASELINE_PAIRS:
+        acc[baseline_flag] = _capture_baseline(settings, flag, baseline_flag, acc[flag])
     return acc
+
+def _python_transition_impl(settings, attr):
+    return _python_transition_base(settings, attr, validate = True)
 
 python_transition = transition(
     implementation = _python_transition_impl,
@@ -130,15 +93,10 @@ python_transition = transition(
     outputs = _ALL_FLAGS,
 )
 
-# The launcher -> venv edge. With no launcher `python_version` or
-# `freethreaded` the inherited settings pass through untouched. Validation
-# never runs here: the edge produces an intermediate configuration, and the
-# venv's own rule transition — which always applies next and may override
-# either half of a version/GIL combination — is the sole authority for
-# rejecting an incompatible final configuration.
+# The launcher -> venv edge. Validation never runs here: the venv's own rule
+# transition always applies next, may override either half of a version/GIL
+# combination, and is the sole authority for rejecting the final configuration.
 def _venv_python_transition_impl(settings, attr):
-    if not attr.python_version and not attr.freethreaded:
-        return {flag: settings[flag] for flag in _ALL_FLAGS}
     return _python_transition_base(settings, attr, validate = False)
 
 venv_python_transition = transition(
@@ -154,10 +112,13 @@ venv_python_transition = transition(
 def _reset_python_flags_transition_impl(settings, _attr):
     acc = {}
     for flag, baseline_flag in _FLAG_BASELINE_PAIRS:
-        is_bool = type(settings[flag]) == "bool"
-        current = ("true" if settings[flag] else "false") if is_bool else settings[flag]
-        restored = _baseline(settings, baseline_flag, current)
-        acc[flag] = restored == "true" if is_bool else restored
+        baseline = settings[baseline_flag]
+        if baseline == _BASELINE_UNSET:
+            acc[flag] = settings[flag]
+        elif type(settings[flag]) == "bool":
+            acc[flag] = baseline == "true"
+        else:
+            acc[flag] = baseline
         acc[baseline_flag] = _BASELINE_UNSET
     return acc
 

--- a/py/tests/reset-data-edges/BUILD.bazel
+++ b/py/tests/reset-data-edges/BUILD.bazel
@@ -91,4 +91,74 @@ root(
     ],
 )
 
+# Terminals whose attrs leave every flag at its inherited value capture no
+# baseline; their deps stay in the caller's configuration.
+terminal(
+    name = "passthrough_terminal",
+    tags = ["manual"],
+    deps = [":probe"],
+)
+
+terminal(
+    name = "same_value_terminal",
+    dep_group = "baseline",
+    freethreaded = "false",
+    tags = ["manual"],
+    deps = [":probe"],
+)
+
+root(
+    name = "synced_root",
+    synced = True,
+    tags = ["manual"],
+    deps = [
+        ":passthrough_terminal",
+        ":probe",
+        ":same_value_terminal",
+    ],
+)
+
+# Real binaries with no overrides: their venvs and shared deps must analyze in
+# the caller's configuration, so the generated source is one File and every
+# node reports the caller's bin_dir.
+genrule(
+    name = "gen",
+    outs = ["gen.py"],
+    cmd = "touch $@",
+    tags = ["manual"],
+)
+
+py_library(
+    name = "shared",
+    srcs = ["gen.py"],
+    tags = ["manual"],
+)
+
+py_binary(
+    name = "bin_a",
+    srcs = ["main.py"],
+    main = "main.py",
+    tags = ["manual"],
+    deps = [":shared"],
+)
+
+py_binary(
+    name = "bin_b",
+    srcs = ["main.py"],
+    main = "main.py",
+    tags = ["manual"],
+    deps = [":shared"],
+)
+
+root(
+    name = "binaries_root",
+    synced = True,
+    tags = ["manual"],
+    deps = [
+        ":bin_a",
+        ":bin_b",
+        ":shared",
+    ],
+)
+
 reset_data_edges_test_suite()

--- a/py/tests/reset-data-edges/tests.bzl
+++ b/py/tests/reset-data-edges/tests.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//py/private:py_info.bzl", "PyInfo")
 load("//py/private:transitions.bzl", "python_transition", "reset_python_flags_transition")
 
 _DEP_GROUP_FLAG = "@aspect_rules_py//uv/private/constraints/dep_group:dep_group"
@@ -11,7 +12,7 @@ _FREETHREADED_FLAG = "@aspect_rules_py//py/private/interpreter:freethreaded"
 _RPY_FREETHREADED_FLAG = "@rules_python//python/config_settings:py_freethreaded"
 
 _ProbeInfo = provider(fields = ["file"])
-_ProbeFilesInfo = provider(fields = ["files", "modes"])
+_ProbeFilesInfo = provider(fields = ["files", "modes", "bin_dirs"])
 
 def _probe_impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name + ".txt")
@@ -28,9 +29,12 @@ def _probe_aspect_impl(target, ctx):
     direct = []
     if _ProbeInfo in target:
         direct.append(target[_ProbeInfo].file)
+    if ctx.rule.kind == "py_library":
+        direct.extend([f for f in target[PyInfo].transitive_sources.to_list() if not f.is_source])
 
     transitive = []
     transitive_modes = []
+    transitive_bin_dirs = []
     deps = []
     for attr_name in ["data", "deps"]:
         deps.extend(getattr(ctx.rule.attr, attr_name, []))
@@ -44,6 +48,7 @@ def _probe_aspect_impl(target, ctx):
         if _ProbeFilesInfo in dep:
             transitive.append(dep[_ProbeFilesInfo].files)
             transitive_modes.append(dep[_ProbeFilesInfo].modes)
+            transitive_bin_dirs.append(dep[_ProbeFilesInfo].bin_dirs)
 
     # Record every visited target; the test impl filters to the names it
     # asserts on, keeping the fixture-name coupling in one place.
@@ -52,9 +57,14 @@ def _probe_aspect_impl(target, ctx):
         ctx.attr._freethreaded[BuildSettingInfo].value,
         ctx.attr._rpy_freethreaded[BuildSettingInfo].value,
     )]
+
+    # bin_dir carries the configuration's output segment, so equal paths mean
+    # one configuration.
+    bin_dirs = [(ctx.label.name, ctx.bin_dir.path)]
     return [_ProbeFilesInfo(
         files = depset(direct = direct, transitive = transitive),
         modes = depset(direct = modes, transitive = transitive_modes),
+        bin_dirs = depset(direct = bin_dirs, transitive = transitive_bin_dirs),
     )]
 
 _probe_aspect = aspect(
@@ -94,22 +104,37 @@ def _root_impl(ctx):
     return [_ProbeFilesInfo(
         files = depset(transitive = transitive),
         modes = depset(transitive = [dep[_ProbeFilesInfo].modes for dep in ctx.attr.deps]),
+        bin_dirs = depset(transitive = [dep[_ProbeFilesInfo].bin_dirs for dep in ctx.attr.deps]),
     )]
 
-def _baseline_transition_impl(_settings, _attr):
+def _baseline_transition_impl(settings, attr):
+    if attr.synced:
+        # Keep the configured version so real venvs resolve the registered
+        # toolchain; only make rules_python's flag agree with it.
+        return {
+            _DEP_GROUP_FLAG: "baseline",
+            _PYTHON_VERSION_FLAG: settings[_PYTHON_VERSION_FLAG],
+            _RPY_VERSION_FLAG: settings[_PYTHON_VERSION_FLAG] or settings[_RPY_VERSION_FLAG],
+            _FREETHREADED_FLAG: False,
+            _RPY_FREETHREADED_FLAG: "no",
+        }
+
+    # A caller may set only one flag. Terminals synchronize their subtree,
+    # but data must restore both original values to share one configuration.
     return {
         _DEP_GROUP_FLAG: "baseline",
         _PYTHON_VERSION_FLAG: "",
-        _RPY_VERSION_FLAG: "3.10",
-        # A caller may set only one flag. Terminals synchronize their subtree,
-        # but data must restore both original values to share one configuration.
+        _RPY_VERSION_FLAG: settings[_RPY_VERSION_FLAG],
         _FREETHREADED_FLAG: False,
         _RPY_FREETHREADED_FLAG: "yes",
     }
 
 _baseline_transition = transition(
     implementation = _baseline_transition_impl,
-    inputs = [],
+    inputs = [
+        _PYTHON_VERSION_FLAG,
+        _RPY_VERSION_FLAG,
+    ],
     outputs = [
         _DEP_GROUP_FLAG,
         _PYTHON_VERSION_FLAG,
@@ -127,6 +152,9 @@ root = rule(
             cfg = _baseline_transition,
             allow_empty = False,
         ),
+        # Both flag pairs already agree, so a terminal that keeps their values
+        # has nothing to synchronize.
+        "synced": attr.bool(default = False),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
@@ -163,8 +191,50 @@ def _reset_data_edges_test_impl(ctx):
 
 _reset_data_edges_test = analysistest.make(_reset_data_edges_test_impl)
 
+def _passthrough_terminals_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    files = analysistest.target_under_test(env)[_ProbeFilesInfo].files.to_list()
+    asserts.equals(
+        env,
+        1,
+        len(files),
+        "terminals that keep the inherited flags should share the caller's configuration",
+    )
+    return analysistest.end(env)
+
+_passthrough_terminals_test = analysistest.make(_passthrough_terminals_test_impl)
+
+def _shared_binaries_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    under_test = analysistest.target_under_test(env)[_ProbeFilesInfo]
+    generated = [f for f in under_test.files.to_list() if f.basename == "gen.py"]
+    asserts.equals(
+        env,
+        1,
+        len(generated),
+        "a generated source shared by the binaries and the caller should be one File",
+    )
+
+    bin_dirs = {}
+    for name, path in under_test.bin_dirs.to_list():
+        bin_dirs.setdefault(name, {})[path] = True
+    caller = bin_dirs["bin_a"].keys()
+    for name in ["bin_b", "_bin_a.venv", "_bin_b.venv", "shared"]:
+        asserts.equals(env, caller, bin_dirs[name].keys(), name + " should analyze in the caller's configuration")
+    return analysistest.end(env)
+
+_shared_binaries_test = analysistest.make(_shared_binaries_test_impl)
+
 def reset_data_edges_test_suite():
     _reset_data_edges_test(
         name = "reset_data_edges_test",
         target_under_test = ":root",
+    )
+    _passthrough_terminals_test(
+        name = "passthrough_terminals_test",
+        target_under_test = ":synced_root",
+    )
+    _shared_binaries_test(
+        name = "shared_binaries_test",
+        target_under_test = ":binaries_root",
     )


### PR DESCRIPTION
Previously every `py_venv` transition wrote the four baseline shadow flags, so the `deps` of a terminal with no `python_version`, `freethreaded` or `dep_group` override landed in a configuration distinct from the caller's. Any cc/proto library shared between a Python terminal and a non-Python one was analyzed and built twice.

A baseline now records the inherited value only when the transition actually changes its flag. Terminals that keep every inherited value are no-ops and share the caller's configuration; overrides equal to the inherited value are no-ops too.

This may have been a regression introduced by https://github.com/aspect-build/rules_py/pull/1294

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Python terminals with no `python_version`/`freethreaded`/`dep_group` override no longer fork their deps into a second configuration; baselines are captured only when a flag actually changes.

### Test plan

- Covered by existing test cases
