### PR TITLE
feat(uv): config_settings on uv.override_package for PEP 517 backends

### DIFF
--- a/docs/uv.md
+++ b/docs/uv.md
@@ -400,6 +400,33 @@ reads; `$(ANT_HOME)` and `$(ANT_BIN_DIR)` likewise. Any other make-variable a
 toolchain exports still needs an explicit `env` entry (`"FOO": "$(FOO)"`),
 and an explicit entry always wins over the derived value.
 
+### Backend config settings
+
+PEP 517 backends take free-form `config_settings`; the `build` frontend
+spells them `-C key=value`. Declare them per package on the override and they
+reach the backend unchanged, for pure and native source builds alike:
+
+```starlark
+uv.override_package(
+    lock = "//:uv.lock",
+    name = "numpy",
+    config_settings = {
+        "setup-args": [
+            "-Dblas=none",
+            "-Dlapack=none",
+        ],
+    },
+)
+```
+
+Each listed value becomes one `-C key=value`; a key with several values
+reaches the backend as a list, a single value as a string. The keys are
+backend-specific: `setup-args` for meson-python, `cmake.define.<VAR>` or
+`cmake.args` for scikit-build-core, `--build-option` for setuptools. Packages
+that fall back to `setup.py bdist_wheel` (a `pyproject.toml` without the
+dynamic metadata setuptools still reads from `setup.py`) cannot take config
+settings and fail the build with an explicit error.
+
 ## Best practices
 
 **Consolidate your hubs**. In `rules_python`, environments with multiple depsets

--- a/docs/uv.md
+++ b/docs/uv.md
@@ -402,9 +402,9 @@ and an explicit entry always wins over the derived value.
 
 ### Backend config settings
 
-PEP 517 backends take free-form `config_settings`; the `build` frontend
-spells them `-C key=value`. Declare them per package on the override and they
-reach the backend unchanged, for pure and native source builds alike:
+PEP 517 backends take a free-form `config_settings` dictionary. Declare it
+per package on the override and it reaches the backend unchanged, for pure and
+native source builds alike:
 
 ```starlark
 uv.override_package(
@@ -419,10 +419,14 @@ uv.override_package(
 )
 ```
 
-Each listed value becomes one `-C key=value`; a key with several values
-reaches the backend as a list, a single value as a string. The keys are
-backend-specific: `setup-args` for meson-python, `cmake.define.<VAR>` or
-`cmake.args` for scikit-build-core, `--build-option` for setuptools. Packages
+Each key maps to a list of values: a single value reaches the backend as a
+string, several as a list. The keys and their meaning belong to the package's
+build backend, so look them up in its documentation: `setup-args` for
+meson-python, `cmake.define.<VAR>` or `cmake.args` for scikit-build-core,
+`--build-option` for setuptools. A sdist has exactly one build backend, so the
+settings have exactly one recipient. If a project's README shows
+`pip install --config-settings key=value` or `python -m build -C key=value`,
+the same `key` and `value` go here. Packages
 that fall back to `setup.py bdist_wheel` (a `pyproject.toml` without the
 dynamic metadata setuptools still reads from `setup.py`) cannot take config
 settings and fail the build with an explicit error.

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -274,6 +274,7 @@ def _parse_projects(module_ctx, hub_specs):
                 override.extra_data or
                 override.toolchains or
                 override.env or
+                override.config_settings or
                 override.monitor_memory or
                 override.resource_set != "default"
             )
@@ -524,6 +525,7 @@ def _parse_projects(module_ctx, hub_specs):
                         console_scripts = sbuild_console_scripts,
                         resource_set = pkg_override.resource_set,
                         env = pkg_override.env,
+                        config_settings = pkg_override.config_settings,
                         error = "uv.override_package() for '{}=={}' in lock '{}': build-only attributes require a source distribution, but the lock record has only wheels: {{}}".format(
                             package["name"],
                             package["version"],
@@ -581,11 +583,13 @@ def _parse_projects(module_ctx, hub_specs):
                     # they don't replace them. Empty == no augmentation.
                     extra_toolchains = []
                     extra_env = {}
+                    config_settings = {}
                     monitor_memory = False
                     resource_set = "default"
                     if pkg_override:
                         extra_toolchains = [str(t) for t in pkg_override.toolchains]
                         extra_env = pkg_override.env
+                        config_settings = pkg_override.config_settings
                         monitor_memory = pkg_override.monitor_memory
                         resource_set = pkg_override.resource_set
 
@@ -600,6 +604,7 @@ def _parse_projects(module_ctx, hub_specs):
                         package_install = install_target,
                         extra_toolchains = extra_toolchains,
                         extra_env = extra_env,
+                        config_settings = config_settings,
                         monitor_memory = monitor_memory,
                         resource_set = resource_set,
                     )
@@ -878,6 +883,8 @@ def _uv_impl(module_ctx):
             sbuild_kwargs["extra_toolchains"] = sbuild_cfg.extra_toolchains
         if sbuild_cfg.extra_env:
             sbuild_kwargs["extra_env"] = sbuild_cfg.extra_env
+        if sbuild_cfg.config_settings:
+            sbuild_kwargs["config_settings"] = sbuild_cfg.config_settings
         if sbuild_cfg.monitor_memory:
             sbuild_kwargs["monitor_memory"] = True
         if sbuild_cfg.resource_set != "default":
@@ -1015,6 +1022,10 @@ _override_package_tag = tag_class(
         "env": attr.string_dict(
             default = {},
             doc = "Extra environment variables merged into the build action's `env` dict. Values may reference $(VAR) make-variables sourced from extra `toolchains` listed above. Prefix an execroot-relative path with `$(EXECROOT)/` so it remains valid after the backend changes into the unpacked source tree. Omit CC/CXX/AR/LD/STRIP to use the configured C++ action tools.",
+        ),
+        "config_settings": attr.string_list_dict(
+            default = {},
+            doc = "PEP 517 config settings handed to the build backend through the frontend's `-C key=value`, one flag per listed value; a key with several values reaches the backend as a list. Backend-specific by nature, e.g. `{\"setup-args\": [\"-Dblas=none\"]}` for meson-python or `{\"cmake.define.FOO\": [\"1\"]}` for scikit-build-core. Applies to pure and native source builds.",
         ),
         "pre_build_patches": attr.label_list(
             default = [],

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -1025,7 +1025,7 @@ _override_package_tag = tag_class(
         ),
         "config_settings": attr.string_list_dict(
             default = {},
-            doc = "PEP 517 config settings handed to the build backend through the frontend's `-C key=value`, one flag per listed value; a key with several values reaches the backend as a list. Backend-specific by nature, e.g. `{\"setup-args\": [\"-Dblas=none\"]}` for meson-python or `{\"cmake.define.FOO\": [\"1\"]}` for scikit-build-core. Applies to pure and native source builds.",
+            doc = "PEP 517 `config_settings` for this package's build backend. Each key maps to a list of values: a single value reaches the backend as a string, several as a list. Keys and their meaning are defined by the backend, e.g. `{\"setup-args\": [\"-Dblas=none\"]}` for meson-python or `{\"cmake.define.FOO\": [\"1\"]}` for scikit-build-core. Applies to pure and native source builds.",
         ),
         "pre_build_patches": attr.label_list(
             default = [],

--- a/uv/private/pep517_whl/common.bzl
+++ b/uv/private/pep517_whl/common.bzl
@@ -51,6 +51,14 @@ def patch_args_and_inputs(ctx):
 def memory_args(ctx):
     return ["--monitor-memory"] if ctx.attr.monitor_memory else []
 
+def config_setting_args(ctx):
+    """`--config-setting key=value` per listed value, keys sorted for a stable action key."""
+    args = []
+    for key in sorted(ctx.attr.config_settings):
+        for value in ctx.attr.config_settings[key]:
+            args += ["--config-setting", "{}={}".format(key, value)]
+    return args
+
 _PATCH_ATTRS = {
     "pre_build_patches": attr.label_list(
         default = [],
@@ -74,6 +82,10 @@ PEP517_WHL_ATTRS = {
         doc = "Console scripts discovered from the source distribution's entry-point metadata.",
     ),
     "args": attr.string_list(default = ["--validate-anyarch"]),
+    "config_settings": attr.string_list_dict(
+        default = {},
+        doc = "PEP 517 config settings passed to the build frontend as `-C key=value`, one per listed value; repeated keys reach the backend as a list.",
+    ),
     "monitor_memory": attr.bool(
         default = False,
         doc = "Report approximate Linux process-tree RSS while building the wheel.",

--- a/uv/private/pep517_whl/common.bzl
+++ b/uv/private/pep517_whl/common.bzl
@@ -84,7 +84,7 @@ PEP517_WHL_ATTRS = {
     "args": attr.string_list(default = ["--validate-anyarch"]),
     "config_settings": attr.string_list_dict(
         default = {},
-        doc = "PEP 517 config settings passed to the build frontend as `-C key=value`, one per listed value; repeated keys reach the backend as a list.",
+        doc = "PEP 517 `config_settings` for the build backend. Each key maps to a list of values: a single value reaches the backend as a string, several as a list.",
     ),
     "monitor_memory": attr.bool(
         default = False,

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -16,6 +16,7 @@ load(
     "PEP517_WHL_ATTRS",
     "TARGET_EXEC_GROUP",
     "common_env",
+    "config_setting_args",
     "memory_args",
     "patch_args_and_inputs",
     "wheel_providers",
@@ -370,7 +371,7 @@ def _pep517_native_whl(ctx):
         progress_message = "Native source compiling {} to a whl".format(archive.basename),
         executable = tool,
         toolchain = None,
-        arguments = ctx.attr.args + [patch_args] + memory_args(ctx) + cross_args + [
+        arguments = ctx.attr.args + [patch_args] + memory_args(ctx) + config_setting_args(ctx) + cross_args + [
             "--execroot-marker",
             _EXECROOT_MARKER,
             archive.path,

--- a/uv/private/pep517_whl/pep517_whl.bzl
+++ b/uv/private/pep517_whl/pep517_whl.bzl
@@ -11,6 +11,7 @@ load(
     "PEP517_WHL_ATTRS",
     "TARGET_EXEC_GROUP",
     "common_env",
+    "config_setting_args",
     "memory_args",
     "patch_args_and_inputs",
     "wheel_providers",
@@ -34,7 +35,7 @@ def _pep517_whl(ctx):
         progress_message = "Source compiling {} to a whl".format(archive.basename),
         executable = ctx.executable.tool,
         toolchain = None,
-        arguments = ctx.attr.args + [patch_args] + memory_args(ctx) + [
+        arguments = ctx.attr.args + [patch_args] + memory_args(ctx) + config_setting_args(ctx) + [
             archive.path,
             wheel_file.path,
         ],

--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -23,6 +23,7 @@ load(
 load(
     ":pep517_whl_test.bzl",
     "absolutize_flag_test",
+    "config_settings_args_test",
     "cross_decision_test",
     "execroot_collision_toolchain",
     "hostile_python_env_target",
@@ -216,6 +217,75 @@ pep517_whl(
 hostile_python_env_target(
     name = "__ambient_env_under_hostile_config",
     target = ":__ambient_env_fixture",
+)
+
+# config_settings reach the backend through `build -C key=value`: the in-tree
+# backend compares what it receives against EXPECTED_CONFIG_SETTINGS (a single
+# value stays a str, repeated keys become a list).
+_CONFIG_SETTINGS = {
+    "setup-args": [
+        "-Dblas=none",
+        "-Dlapack=none",
+    ],
+    "single": ["one"],
+}
+
+_CONFIG_SETTING_FLAGS = [
+    "--config-setting",
+    "setup-args=-Dblas=none",
+    "--config-setting",
+    "setup-args=-Dlapack=none",
+    "--config-setting",
+    "single=one",
+]
+
+pep517_native_whl(
+    name = "__config_settings_fixture",
+    src = ":__python_env_sdist",
+    config_settings = _CONFIG_SETTINGS,
+    env = {
+        "EXPECTED_CONFIG_SETTINGS": '{"setup-args": ["-Dblas=none", "-Dlapack=none"], "single": "one"}',
+    },
+    tags = ["manual"],
+    tool = ":__build_helper_reset",
+    version = "0.0.1",
+)
+
+hostile_python_env_target(
+    name = "__config_settings_under_hostile_config",
+    target = ":__config_settings_fixture",
+)
+
+build_test(
+    name = "config_settings_test",
+    targets = [":__config_settings_under_hostile_config"],
+)
+
+config_settings_args_test(
+    name = "config_settings_native_args_test",
+    expected = _CONFIG_SETTING_FLAGS,
+    target_under_test = ":__config_settings_fixture",
+)
+
+pep517_whl(
+    name = "__config_settings_pure_fixture",
+    src = ":__stub_sdist",
+    config_settings = _CONFIG_SETTINGS,
+    tags = ["manual"],
+    tool = ":__stub_tool",
+    version = "0.0.1",
+)
+
+config_settings_args_test(
+    name = "config_settings_pure_args_test",
+    expected = _CONFIG_SETTING_FLAGS,
+    target_under_test = ":__config_settings_pure_fixture",
+)
+
+config_settings_args_test(
+    name = "config_settings_absent_test",
+    expected = [],
+    target_under_test = ":__frontend_config_fixture",
 )
 
 build_test(

--- a/uv/private/pep517_whl/tests/pep517_whl_test.bzl
+++ b/uv/private/pep517_whl/tests/pep517_whl_test.bzl
@@ -339,3 +339,31 @@ pep517_native_whl_derived_env_test = analysistest.make(
         "absent_keys": attr.string_list(doc = "Env keys that must not appear (make-variable names are not env keys)."),
     },
 )
+
+def _config_settings_args_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    actions = [a for a in target.actions if a.mnemonic in ("PySdistBuild", "PySdistNativeBuild")]
+    asserts.equals(env, 1, len(actions), "expected exactly one wheel build action")
+    if actions:
+        argv = list(actions[0].argv)
+        expected = ctx.attr.expected
+        if not expected:
+            asserts.false(env, "--config-setting" in argv, "no config_settings must mean no --config-setting; got: {}".format(argv))
+        else:
+            found = [argv[i:i + len(expected)] == expected for i in range(len(argv) - len(expected) + 1)]
+            asserts.true(
+                env,
+                any(found),
+                "expected the contiguous flags {} (keys sorted, values in declared order); got: {}".format(expected, argv),
+            )
+    return analysistest.end(env)
+
+config_settings_args_test = analysistest.make(
+    _config_settings_args_test_impl,
+    attrs = {
+        "expected": attr.string_list(
+            doc = "Exact `--config-setting key=value` flag sequence the helper must receive; empty asserts absence.",
+        ),
+    },
+)

--- a/uv/private/pep517_whl/tests/python_env_backend/backend.py
+++ b/uv/private/pep517_whl/tests/python_env_backend/backend.py
@@ -4,6 +4,7 @@ import base64
 import csv
 import hashlib
 import io
+import json
 import os
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -44,10 +45,19 @@ def _check_environment() -> None:
                 raise RuntimeError(f"{name} is not an absolute existing path: {value!r}")
 
 
+def _check_config_settings(config_settings: dict[str, object] | None) -> None:
+    # `build -C k=v` shapes: a single value stays a str, repeats become a list.
+    expected = os.environ.get("EXPECTED_CONFIG_SETTINGS")
+    if expected is None:
+        return
+    if (config_settings or {}) != json.loads(expected):
+        raise RuntimeError(f"config_settings mismatch: got {config_settings!r}, expected {expected}")
+
+
 def get_requires_for_build_wheel(
     config_settings: dict[str, object] | None = None,
 ) -> list[str]:
-    del config_settings
+    _check_config_settings(config_settings)
     _check_environment()
     return []
 
@@ -57,7 +67,8 @@ def build_wheel(
     config_settings: dict[str, object] | None = None,
     metadata_directory: str | None = None,
 ) -> str:
-    del config_settings, metadata_directory
+    del metadata_directory
+    _check_config_settings(config_settings)
     _check_environment()
 
     files = {

--- a/uv/private/pep517_whl/tools/build_helper.py
+++ b/uv/private/pep517_whl/tools/build_helper.py
@@ -1122,6 +1122,13 @@ PARSER = ArgumentParser()
 PARSER.add_argument("srcarchive")
 PARSER.add_argument("output", help="Path the single built wheel is written to")
 PARSER.add_argument("--monitor-memory", action="store_true")
+PARSER.add_argument(
+    "--config-setting",
+    action="append",
+    default=[],
+    dest="config_settings",
+    help="PEP 517 config setting KEY=VALUE forwarded to the backend via `build -C` (repeatable)",
+)
 PARSER.add_argument("--validate-anyarch", action="store_true")
 PARSER.add_argument("--patch-strip", type=int, default=1, help="Strip count for patch (-p)")
 PARSER.add_argument("--patch", action="append", default=[], dest="patches", help="Patch file to apply (repeatable)")
@@ -1191,6 +1198,11 @@ def main() -> None:
             "that setuptools still reads from setup.py/setup.cfg.",
             file=sys.stderr,
         )
+        if opts.config_settings:
+            raise SystemExit(
+                "Error: config_settings need the PEP 517 frontend, but this sdist falls back to "
+                "`setup.py bdist_wheel` (its pyproject.toml omits dynamic metadata setuptools reads from setup.py/setup.cfg)."
+            )
         cmd = [
             sys.executable,
             path.realpath(path.join(t, "setup.py")),
@@ -1222,6 +1234,10 @@ def main() -> None:
             "--skip-dependency-check",
             "--outdir", outdir,
         ]
+        # `build -C` accumulates repeated keys into a list for the backend, so
+        # package settings never collide with the -C the cross branch adds.
+        for setting in opts.config_settings:
+            cmd += ["-C", setting]
 
         # meson-python only synthesizes its own cross file for macOS
         # ARCHFLAGS/cibuildwheel shapes; everything else configures as a

--- a/uv/private/sdist_build/attrs.bzl
+++ b/uv/private/sdist_build/attrs.bzl
@@ -4,6 +4,7 @@ def validate_build_attrs(
         console_scripts,
         resource_set,
         env,
+        config_settings,
         monitor_memory,
         pre_build_patches,
         pre_build_patch_strip,
@@ -16,6 +17,7 @@ def validate_build_attrs(
         console_scripts: Complete source-build entry points, or None when unset.
         resource_set: Resource set name, where "default" means unset.
         env: Environment variables for the wheel-build action.
+        config_settings: PEP 517 config settings for the build frontend.
         monitor_memory: Whether to monitor the wheel-build action's memory.
         pre_build_patches: Patches applied before building the wheel.
         pre_build_patch_strip: Strip count for pre-build patches.
@@ -30,6 +32,8 @@ def validate_build_attrs(
         active.append("resource_set")
     if env:
         active.append("env")
+    if config_settings:
+        active.append("config_settings")
     if monitor_memory:
         active.append("monitor_memory")
     if pre_build_patches:

--- a/uv/private/sdist_build/repository.bzl
+++ b/uv/private/sdist_build/repository.bzl
@@ -139,6 +139,26 @@ def _resolve_archive_path(repository_ctx):
 
 # --- Repository rule implementation ---
 
+def _env_attr(env):
+    """Renders the generated rule call's `env` attribute, or "" when unset."""
+    if not env:
+        return ""
+
+    # repr() on both sides: user-supplied keys and values (a CFLAGS with quotes,
+    # a Windows path) must survive into the BUILD as valid Starlark literals.
+    lines = ["        {}: {},".format(repr(key), repr(env[key])) for key in sorted(env)]
+    return "\n    env = {{\n{}\n    }},".format("\n".join(lines))
+
+def _config_settings_attr(config_settings):
+    """Renders the generated rule call's `config_settings` attribute, or "" when unset."""
+    if not config_settings:
+        return ""
+
+    # repr() on both sides: keys are backend-defined free-form strings, so a
+    # quote or backslash in one must survive as a valid Starlark literal.
+    lines = ["        {}: {},".format(repr(key), repr(config_settings[key])) for key in sorted(config_settings)]
+    return "\n    config_settings = {{\n{}\n    }},".format("\n".join(lines))
+
 def _sdist_build_impl(repository_ctx):
     """Prepares a repository for building a wheel from a source distribution (sdist).
 
@@ -201,11 +221,13 @@ def _sdist_build_impl(repository_ctx):
             console_scripts = None,
             resource_set = repository_ctx.attr.resource_set,
             env = repository_ctx.attr.extra_env,
+            config_settings = repository_ctx.attr.config_settings,
             error = "sdist_build for '{}': the generated pure-Python `pep517_whl(...)` call cannot apply these native-build attributes: {{}}. Remove them, or configure this source distribution as native.".format(repository_ctx.name),
             monitor_memory = repository_ctx.attr.monitor_memory,
             pre_build_patches = repository_ctx.attr.pre_build_patches,
             pre_build_patch_strip = repository_ctx.attr.pre_build_patch_strip,
             supported = [
+                "config_settings",
                 "monitor_memory",
                 "pre_build_patches",
                 "pre_build_patch_strip",
@@ -270,22 +292,14 @@ def _sdist_build_impl(repository_ctx):
     if is_native:
         toolchains = repository_ctx.attr.extra_toolchains
         extra_env = repository_ctx.attr.extra_env
-        env_attr = ""
-        if extra_env:
-            env_attr = """
-    env = {{
-{env}
-    }},""".format(
-                env = "\n".join(["        \"{}\": \"{}\",".format(k, v) for k, v in sorted(extra_env.items())]),
-            )
         if toolchains:
             toolchain_attrs = """
     toolchains = [
 {toolchains}
     ],""".format(
-                toolchains = "\n".join(["        \"{}\",".format(t) for t in toolchains]),
+                toolchains = "\n".join(["        {},".format(repr(t)) for t in toolchains]),
             )
-        toolchain_attrs += env_attr
+        toolchain_attrs += _env_attr(extra_env)
 
     resource_set_attr = ""
     if repository_ctx.attr.resource_set != "default":
@@ -294,6 +308,7 @@ def _sdist_build_impl(repository_ctx):
     console_scripts_attr = ""
     if inspection and inspection.get("console_scripts"):
         console_scripts_attr = "\n    console_scripts = {},".format(repr(inspection["console_scripts"]))
+    config_settings_attr = _config_settings_attr(repository_ctx.attr.config_settings)
 
     # Leave args unset: the pure rule validates anyarch wheels by default,
     # while the native rule defaults to no validation.
@@ -332,7 +347,7 @@ py_binary(
     name = "whl",
     src = "{src}",
     tool = "{tool}",
-    version = "{version}",{console_scripts_attr}{monitor_memory_attr}{resource_set_attr}{patch_attrs}{toolchain_attrs}
+    version = "{version}",{console_scripts_attr}{config_settings_attr}{monitor_memory_attr}{resource_set_attr}{patch_attrs}{toolchain_attrs}
     visibility = ["//visibility:public"],
 )
 
@@ -344,6 +359,7 @@ exports_files(
         src = repository_ctx.attr.src,
         deps = repr(all_deps),
         console_scripts_attr = console_scripts_attr,
+        config_settings_attr = config_settings_attr,
         monitor_memory_attr = monitor_memory_attr,
         rule = "pep517_native_whl" if is_native else "pep517_whl",
         frontend_load = frontend_load,
@@ -401,5 +417,14 @@ sdist_build = repository_rule(
             default = {},
             doc = "Environment variables forwarded to the generated pep517_native_whl(...) `env` dict. Values may reference $(VAR) make-variables from extra toolchains. Prefix an execroot-relative path with `$(EXECROOT)/` so it remains valid after the backend changes into the unpacked source tree. Set via `uv.override_package(env = {...})`.",
         ),
+        "config_settings": attr.string_list_dict(
+            default = {},
+            doc = "PEP 517 config settings forwarded to the generated pep517_*whl(...) `config_settings` attribute. Set via `uv.override_package(config_settings = {...})`.",
+        ),
     },
+)
+
+sdist_build_test_util = struct(
+    config_settings_attr = _config_settings_attr,
+    env_attr = _env_attr,
 )

--- a/uv/private/sdist_build/tests/BUILD.bazel
+++ b/uv/private/sdist_build/tests/BUILD.bazel
@@ -7,8 +7,13 @@ building its `:whl` exercises the fallback the extension must preserve.
 """
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load(":repository_test.bzl", "config_settings_attr_test", "env_attr_test")
 
 build_test(
     name = "sdist_fallback_with_anyarch_wheel_build_test",
     targets = ["@sdist_build__aspect_rules_py__bravado__11_0_3//:whl"],
 )
+
+config_settings_attr_test(name = "config_settings_attr_test")
+
+env_attr_test(name = "env_attr_test")

--- a/uv/private/sdist_build/tests/repository_test.bzl
+++ b/uv/private/sdist_build/tests/repository_test.bzl
@@ -1,0 +1,46 @@
+"""Unit tests for sdist_build's BUILD-template helpers."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//uv/private/sdist_build:repository.bzl", "sdist_build_test_util")
+
+def _config_settings_attr_test_impl(ctx):
+    env = unittest.begin(ctx)
+    render = sdist_build_test_util.config_settings_attr
+
+    asserts.equals(env, "", render({}), "unset config_settings must add nothing to the rule call")
+    asserts.equals(
+        env,
+        '\n    config_settings = {\n        "cmake.define.FOO": ["1"],\n        "setup-args": ["-Dblas=none", "-Dlapack=none"],\n    },',
+        render({
+            "setup-args": ["-Dblas=none", "-Dlapack=none"],
+            "cmake.define.FOO": ["1"],
+        }),
+        "keys render sorted, values as Starlark string lists in declared order",
+    )
+    asserts.equals(
+        env,
+        '\n    config_settings = {\n        "quote\\"d": ["back\\\\slash"],\n    },',
+        render({'quote"d': ["back\\slash"]}),
+        "quotes and backslashes in keys and values must render as valid Starlark literals",
+    )
+    return unittest.end(env)
+
+config_settings_attr_test = unittest.make(_config_settings_attr_test_impl)
+
+def _env_attr_test_impl(ctx):
+    env = unittest.begin(ctx)
+    render = sdist_build_test_util.env_attr
+
+    asserts.equals(env, "", render({}), "unset env must add nothing to the rule call")
+    asserts.equals(
+        env,
+        '\n    env = {\n        "CFLAGS": "-DMSG=\\"hi\\"",\n        "JAVA_HOME": "$(JAVABASE)",\n    },',
+        render({
+            "JAVA_HOME": "$(JAVABASE)",
+            "CFLAGS": '-DMSG="hi"',
+        }),
+        "keys render sorted; quotes in values must render as valid Starlark literals",
+    )
+    return unittest.end(env)
+
+env_attr_test = unittest.make(_env_attr_test_impl)


### PR DESCRIPTION
Adds `config_settings` to `uv.override_package`, the PEP 517 way to pass backend options to a source build:

```starlark
uv.override_package(
    lock = "//:uv.lock",
    name = "numpy",
    config_settings = {"setup-args": ["-Dblas=none", "-Dlapack=none"]},
)
```

**Flow.** `sdist_build` renders the attribute into the generated `pep517_whl` / `pep517_native_whl` call; the rules pass one `--config-setting key=value` per listed value (keys sorted, so the action key is stable); `build_helper.py` hands them to `python -m build` as `-C key=value`. `build` folds repeated keys into a list, so package settings cannot collide with the `-C` the cross branch adds for meson/CMake. The `setup.py bdist_wheel` fallback path rejects them with an explicit error, since no frontend is involved there.

The keys are backend-specific (`setup-args` for meson-python, `cmake.define.<VAR>` for scikit-build-core, `--build-option` for setuptools), so this is one generic attribute instead of one environment variable per backend. Applies to pure and native source builds.

**Generated BUILD escaping.** `config_settings`, `env` and `toolchains` render through `repr()`: keys and values are free-form strings owned by the user or the backend, so a quote or backslash in one (a `CFLAGS` with `-DMSG="hi"`) must land in the external repo's `BUILD.bazel` as a valid Starlark literal. `env` previously interpolated raw.

**Tests.**
- `config_settings_{pure,native}_args_test`: analysis tests pin the exact argv on both rules; `config_settings_absent_test` pins that an unset attribute adds nothing.
- `config_settings_test`: a `build_test` drives the in-tree PEP 517 backend fixture, which compares the `config_settings` it receives against `EXPECTED_CONFIG_SETTINGS` (a single value arrives as `str`, repeated keys as `list`).
- `config_settings_attr_test`, `env_attr_test`: unit tests for the BUILD template rendering (sorted keys, Starlark literals with escaping, empty when unset).
- Existing `sdist_build` snapshots are unchanged.

Docs: new "Backend config settings" section in `docs/uv.md`.
