### PR TITLE
feat(uv): map well-known toolchain make-variables into the sdist build env

### DIFF
--- a/docs/uv.md
+++ b/docs/uv.md
@@ -379,6 +379,27 @@ time, so the complete source-built wheel still participates in the normal
 An explicit `console_scripts = {}` suppresses all detected scripts, which is
 useful when a pre-build patch removes stale entry-point metadata.
 
+### Build-time toolchains
+
+A native sdist build may need tools beyond the C++ toolchain: a JDK for JNI
+extensions, cargo and rustc for Rust extensions, Ant. List them on the
+package's override and their well-known make-variables reach the build
+environment on their own:
+
+```starlark
+uv.override_package(
+    lock = "//:uv.lock",
+    name = "jpype1",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+)
+```
+
+`$(JAVA)` and `$(JAVABASE)` arrive as `JAVA` and `JAVA_HOME`; `$(CARGO)`,
+`$(RUSTC)` and `$(RUST_HOST_SYSROOT)` as the variables the Rust build path
+reads; `$(ANT_HOME)` and `$(ANT_BIN_DIR)` likewise. Any other make-variable a
+toolchain exports still needs an explicit `env` entry (`"FOO": "$(FOO)"`),
+and an explicit entry always wins over the derived value.
+
 ## Best practices
 
 **Consolidate your hubs**. In `rules_python`, environments with multiple depsets

--- a/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
+++ b/e2e/cases/snapshots/sdist_build.uv_sdist_jdk_build.jpype1.BUILD.bazel
@@ -23,10 +23,6 @@ pep517_native_whl(
     toolchains = [
         "@@bazel_tools//tools/jdk:current_java_runtime",
     ],
-    env = {
-        "JAVA": "$(JAVA)",
-        "JAVA_HOME": "$(JAVABASE)",
-    },
     visibility = ["//visibility:public"],
 )
 

--- a/e2e/cases/uv-sdist-jdk-build/setup.MODULE.bazel
+++ b/e2e/cases/uv-sdist-jdk-build/setup.MODULE.bazel
@@ -23,15 +23,12 @@ uv.annotate_packages(
     lock = "//uv-sdist-jdk-build:uv.lock",
 )
 
-# Layer a JDK runtime toolchain into the build env. `toolchains` and
-# `env` here are additive — these entries are appended to whatever
-# sdist_build's BUILD template emits by default.
+# Layer a JDK runtime toolchain into the build env. `toolchains` is
+# additive — appended to whatever sdist_build's BUILD template emits by
+# default. The JDK's $(JAVA)/$(JAVABASE) make variables reach the build as
+# JAVA/JAVA_HOME without an explicit `env` mapping.
 uv.override_package(
     name = "jpype1",
-    env = {
-        "JAVA": "$(JAVA)",
-        "JAVA_HOME": "$(JAVABASE)",
-    },
     lock = "//uv-sdist-jdk-build:uv.lock",
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
 )

--- a/e2e/crossbuild/pycross-jdk/setup.MODULE.bazel
+++ b/e2e/crossbuild/pycross-jdk/setup.MODULE.bazel
@@ -21,11 +21,6 @@ uv.project(
 )
 uv.override_package(
     name = "jpype1",
-    env = {
-        "JAVA": "$(JAVA)",
-        "JAVA_HOME": "$(JAVABASE)",
-        "RULES_PY_ANT_BIN_DIR": "$(ANT_BIN_DIR)",
-    },
     lock = "//pycross-jdk:uv.lock",
     toolchains = [
         "//pycross-jdk:jdk",

--- a/e2e/crossbuild/pycross-rust/setup.MODULE.bazel
+++ b/e2e/crossbuild/pycross-rust/setup.MODULE.bazel
@@ -8,9 +8,10 @@ and a rustc wrapper whose sysroot merges the target toolchain's std with
 the exec platform's std (build scripts/proc-macros are always exec
 artifacts).
 
-The override forwards the resolved rust toolchain (CARGO/RUSTC make
-variables) and the exec platform's sysroot (//tools:rust_host_sysroot) —
-both must stay in lockstep with the helper's expectations.
+The override lists the resolved rust toolchain and the exec platform's
+sysroot (//tools:rust_host_sysroot); pep517_native_whl maps their
+CARGO/RUSTC/RUST_HOST_SYSROOT make variables into the helper's env, so no
+`env` entry spells them out.
 """
 
 uv = use_extension("@aspect_rules_py//uv:extensions.bzl", "uv")
@@ -26,11 +27,6 @@ uv.project(
 )
 uv.override_package(
     name = "pydantic-core",
-    env = {
-        "CARGO": "$(CARGO)",
-        "RULES_PY_RUST_HOST_SYSROOT": "$(RUST_HOST_SYSROOT)",
-        "RUSTC": "$(RUSTC)",
-    },
     lock = "//pycross-rust:uv.lock",
     toolchains = [
         "@rules_rust//rust/toolchain:current_rust_toolchain",

--- a/uv/private/extension/defs.bzl
+++ b/uv/private/extension/defs.bzl
@@ -1010,7 +1010,7 @@ _override_package_tag = tag_class(
         ),
         "toolchains": attr.label_list(
             default = [],
-            doc = "Extra toolchain targets forwarded to the generated pep517_native_whl(...) call's `toolchains` list. Each target's TemplateVariableInfo make-variables become available for $(VAR) expansion in `env`.",
+            doc = "Extra toolchain targets forwarded to the generated pep517_native_whl(...) call's `toolchains` list. Each target's TemplateVariableInfo make-variables become available for $(VAR) expansion in `env`; the well-known ones (CARGO, RUSTC, RUST_HOST_SYSROOT, JAVA, JAVABASE, ANT_HOME, ANT_BIN_DIR) reach the build environment automatically.",
         ),
         "env": attr.string_dict(
             default = {},

--- a/uv/private/pep517_whl/pep517_native_whl.bzl
+++ b/uv/private/pep517_whl/pep517_native_whl.bzl
@@ -22,6 +22,22 @@ load(
 )
 
 _CC_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:toolchain_type")
+
+# TemplateVariableInfo make-variable -> build helper env key, for the
+# toolchains a native build commonly layers in: rules_rust's
+# current_rust_toolchain (CARGO/RUSTC), an exec-configured rust sysroot
+# layer (RUST_HOST_SYSROOT), a Java runtime (JAVA/JAVABASE) and an Ant layer
+# (ANT_HOME/ANT_BIN_DIR). The env keys are the helper's contract
+# (build_helper.py absolutizes exactly this set).
+_DERIVED_ENV = {
+    "CARGO": "CARGO",
+    "RUSTC": "RUSTC",
+    "RUST_HOST_SYSROOT": "RULES_PY_RUST_HOST_SYSROOT",
+    "JAVA": "JAVA",
+    "JAVABASE": "JAVA_HOME",
+    "ANT_HOME": "ANT_HOME",
+    "ANT_BIN_DIR": "RULES_PY_ANT_BIN_DIR",
+}
 _EXECROOT_MARKER = "__ASPECT_RULES_PY_EXECROOT__"
 _INFER_CXX_COMPANION = "ASPECT_RULES_PY_INFER_CXX_COMPANION"
 
@@ -270,6 +286,14 @@ def _pep517_native_whl(ctx):
     if cc_files:
         extra_inputs.append(cc_files)
     known_variables.update({key: value for key, value in cc_tools.items() if key not in known_variables})
+
+    # Listing a toolchain is enough for its well-known make-variables to reach
+    # the helper: no `"CARGO": "$(CARGO)"` boilerplate, and the RULES_PY_*
+    # names stay a contract between this rule and the helper. Explicit `env`
+    # entries win.
+    for make_var, env_key in _DERIVED_ENV.items():
+        if make_var in known_variables and env_key not in ctx.attr.env:
+            env[env_key] = known_variables[make_var]
 
     for k, v in ctx.attr.env.items():
         env[k] = ctx.expand_make_variables("env", v, known_variables)

--- a/uv/private/pep517_whl/tests/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/BUILD.bazel
@@ -28,6 +28,7 @@ load(
     "hostile_python_env_target",
     "interpreter_platform_triple_test",
     "pep517_native_whl_cross_mode_test",
+    "pep517_native_whl_derived_env_test",
     "pep517_native_whl_execroot_collision_test",
     "pep517_native_whl_toolchain_env_test",
     "pep517_whl_console_scripts_test",
@@ -255,6 +256,45 @@ pep517_whl_console_scripts_test(
     name = "console_scripts_native_test",
     expected_console_scripts = ["detected-native=demo.cli:native"],
     target_under_test = ":__toolchain_env_fixture",
+)
+
+# Listing the Java runtime is enough: its JAVA/JAVABASE make-variables reach
+# the action as JAVA/JAVA_HOME with no `env` entry. JAVABASE itself is a
+# make-variable name, not an env key.
+pep517_native_whl(
+    name = "__derived_env_fixture",
+    src = ":__stub_sdist",
+    tags = ["manual"],
+    tool = ":__stub_tool",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    version = "0.0.1",
+)
+
+pep517_native_whl_derived_env_test(
+    name = "derived_env_test",
+    absent_keys = ["JAVABASE"],
+    derived_keys = [
+        "JAVA",
+        "JAVA_HOME",
+    ],
+    target_under_test = ":__derived_env_fixture",
+)
+
+pep517_native_whl(
+    name = "__derived_env_override_fixture",
+    src = ":__stub_sdist",
+    env = {"JAVA_HOME": "/explicit/java_home"},
+    tags = ["manual"],
+    tool = ":__stub_tool",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    version = "0.0.1",
+)
+
+pep517_native_whl_derived_env_test(
+    name = "derived_env_explicit_wins_test",
+    derived_keys = ["JAVA"],
+    expected_env = {"JAVA_HOME": "/explicit/java_home"},
+    target_under_test = ":__derived_env_override_fixture",
 )
 
 execroot_collision_toolchain(name = "__execroot_collision_toolchain")

--- a/uv/private/pep517_whl/tests/explicit_env/BUILD.bazel
+++ b/uv/private/pep517_whl/tests/explicit_env/BUILD.bazel
@@ -8,9 +8,9 @@ pep517_native_whl(
     src = "//uv/private/pep517_whl/tests:__python_env_sdist",
     env = {
         "EXPECTED_PYTHONPATH": "/explicit/path",
+        # JAVA/JAVA_HOME come from the listed Java runtime's make-variables;
+        # the backend checks they arrive as absolute, existing paths.
         "EXPECT_JAVA_TOOL_PATHS": "1",
-        "JAVA": "$(JAVA)",
-        "JAVA_HOME": "$(JAVABASE)",
         "PYTHONPATH": "/explicit/path",
     },
     # This must only build through the hostile environment transition below.

--- a/uv/private/pep517_whl/tests/pep517_whl_test.bzl
+++ b/uv/private/pep517_whl/tests/pep517_whl_test.bzl
@@ -310,3 +310,32 @@ def _absolutize_flag_test_impl(ctx):
     return unittest.end(env)
 
 absolutize_flag_test = unittest.make(_absolutize_flag_test_impl)
+
+def _derived_env_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    build_actions = [a for a in target.actions if a.mnemonic == "PySdistNativeBuild"]
+    asserts.equals(env, 1, len(build_actions), "expected exactly one PySdistNativeBuild action")
+    if not build_actions:
+        return analysistest.end(env)
+    action_env = build_actions[0].env
+    for key in ctx.attr.derived_keys:
+        asserts.true(
+            env,
+            action_env.get(key),
+            "{} must be derived from the listed toolchain's make-variables; env keys: {}".format(key, sorted(action_env.keys())),
+        )
+    for key, value in ctx.attr.expected_env.items():
+        asserts.equals(env, value, action_env.get(key), "explicit env must win over the derived value for " + key)
+    for key in ctx.attr.absent_keys:
+        asserts.false(env, key in action_env, "{} must not leak into the action env".format(key))
+    return analysistest.end(env)
+
+pep517_native_whl_derived_env_test = analysistest.make(
+    _derived_env_test_impl,
+    attrs = {
+        "derived_keys": attr.string_list(doc = "Env keys that must be present and non-empty without an explicit `env` entry."),
+        "expected_env": attr.string_dict(doc = "Env entries that must hold exactly these (explicit) values."),
+        "absent_keys": attr.string_list(doc = "Env keys that must not appear (make-variable names are not env keys)."),
+    },
+)


### PR DESCRIPTION
`pep517_native_whl` reads the make-variables of the toolchains listed on it and sets the env keys `build_helper.py` consumes, so listing a toolchain is enough:

```starlark
uv.override_package(
    lock = "//:uv.lock",
    name = "jpype1",
    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
)
```

| make-variable | env key | source |
|---|---|---|
| `CARGO`, `RUSTC` | `CARGO`, `RUSTC` | rules_rust `current_rust_toolchain` |
| `RUST_HOST_SYSROOT` | `RULES_PY_RUST_HOST_SYSROOT` | exec-configured rust sysroot layer |
| `JAVA`, `JAVABASE` | `JAVA`, `JAVA_HOME` | Java runtime |
| `ANT_HOME`, `ANT_BIN_DIR` | `ANT_HOME`, `RULES_PY_ANT_BIN_DIR` | Ant layer |

The table mirrors the set `build_helper.py` already absolutizes. Explicit `env` entries win over derived values, and other make-variables still need an explicit `"FOO": "$(FOO)"`.

**Why.** Until now the only way to feed the helper's `RULES_PY_RUST_HOST_SYSROOT` / `RULES_PY_ANT_BIN_DIR` was for users to spell those internal names in `uv.override_package(env = ...)`, next to `"CARGO": "$(CARGO)"`-style boilerplate. The `RULES_PY_*` names go back to being a contract between the rule and the helper.

**Consumers.** `e2e/cases/uv-sdist-jdk-build`, `e2e/crossbuild/pycross-rust` and `e2e/crossbuild/pycross-jdk` drop their `env` dicts and keep only `toolchains`; the jpype1 BUILD snapshot loses the same four lines. Every table entry has one of these as its consumer.

**Tests.**
- `derived_env_test`: `JAVA`/`JAVA_HOME` derive from the Java runtime with no `env`; the make-variable name `JAVABASE` does not leak as an env key.
- `derived_env_explicit_wins_test`: an explicit `JAVA_HOME` overrides the derived value while `JAVA` stays derived.
- `explicit_env` end-to-end fixture (`python_env_test`): drops its `$(JAVA)`/`$(JAVABASE)` lines, so the in-tree PEP 517 backend now checks that the *derived* paths arrive absolute and existing.
- `pycross-rust` and `pycross-jdk` cross-build green locally with derived env only.

Docs: "Build-time toolchains" section in `docs/uv.md`; `toolchains` attr doc names the derived set.
