### PR TITLE
fix(py): keep freethreaded optional for direct python_transition callers

### DIFF
--- a/py/private/transitions.bzl
+++ b/py/private/transitions.bzl
@@ -55,8 +55,10 @@ def _freethreaded_available(version):
     return (int(parts[0]), int(parts[1])) >= (3, 13)
 
 def _python_transition_base(settings, attr, validate):
-    if attr.freethreaded:
-        freethreaded = attr.freethreaded == "true"
+    # Direct callers of the transition may declare no freethreaded attr.
+    mode = getattr(attr, "freethreaded", "")
+    if mode:
+        freethreaded = mode == "true"
     else:
         # The bool flag has no unset state, so inheriting also honors
         # rules_python's flag.

--- a/py/tests/reset-data-edges/BUILD.bazel
+++ b/py/tests/reset-data-edges/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//py:defs.bzl", "py_binary", "py_library", "py_venv")
-load(":tests.bzl", "probe", "reset_data_edges_test_suite", "root", "terminal")
+load(":tests.bzl", "probe", "reset_data_edges_test_suite", "root", "terminal", "versioned_terminal")
 
 package(default_testonly = True)
 
@@ -65,6 +65,14 @@ terminal(
     tags = ["manual"],
 )
 
+# A rule applying python_transition without declaring freethreaded at all.
+versioned_terminal(
+    name = "no_freethreaded_attr_terminal",
+    data = [":probe"],
+    python_version = "3.13",
+    tags = ["manual"],
+)
+
 py_venv(
     name = "second",
     srcs = ["main.py"],
@@ -85,6 +93,7 @@ root(
     deps = [
         ":first",
         ":inherit_terminal",
+        ":no_freethreaded_attr_terminal",
         ":parent_terminal",
         ":probe",
         ":second",

--- a/py/tests/reset-data-edges/tests.bzl
+++ b/py/tests/reset-data-edges/tests.bzl
@@ -82,22 +82,30 @@ def _terminal_impl(_ctx):
 # Minimal terminal for exercising nested incoming transitions. The public
 # rules below cover their real data attrs; this one isolates baseline
 # propagation without adding Python-provider constraints to the fixture graph.
-terminal = rule(
-    implementation = _terminal_impl,
-    attrs = {
-        "data": attr.label_list(
-            cfg = reset_python_flags_transition,
+def _terminal_rule(**attrs):
+    return rule(
+        implementation = _terminal_impl,
+        attrs = dict(
+            {
+                "data": attr.label_list(
+                    cfg = reset_python_flags_transition,
+                ),
+                "deps": attr.label_list(),
+                "dep_group": attr.string(default = ""),
+                "python_version": attr.string(),
+                "_allowlist_function_transition": attr.label(
+                    default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+                ),
+            },
+            **attrs
         ),
-        "deps": attr.label_list(),
-        "dep_group": attr.string(default = ""),
-        "freethreaded": attr.string(default = "", values = ["", "false", "true"]),
-        "python_version": attr.string(),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
-    },
-    cfg = python_transition,
-)
+        cfg = python_transition,
+    )
+
+terminal = _terminal_rule(freethreaded = attr.string(default = "", values = ["", "false", "true"]))
+
+# Direct transition callers may declare no freethreaded attr at all.
+versioned_terminal = _terminal_rule()
 
 def _root_impl(ctx):
     transitive = [dep[_ProbeFilesInfo].files for dep in ctx.attr.deps]
@@ -179,6 +187,7 @@ def _reset_data_edges_test_impl(ctx):
         ("parent_terminal", True, "yes"),
         ("nested_terminal", False, "no"),
         ("inherit_terminal", True, "yes"),
+        ("no_freethreaded_attr_terminal", True, "yes"),
     ]
     tracked = {name: True for name, _, _ in expected}
     modes = [


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
