### PR TITLE
fix(uv): recognize generic linux wheel platform tags (1.x backport of #996)

### DIFF
--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -383,6 +383,22 @@ uv.project(
 )
 # }}}
 
+# For cases/uv-bare-linux-wheels
+# Regression: grpcio ships bare linux_armv7l wheels that must survive lockfile parsing.
+# {{{
+uv.declare_hub(hub_name = "pypi-bare-linux-wheels")
+uv.project(
+    default_build_dependencies = [
+        "build",
+        "setuptools",
+    ],
+    hub_name = "pypi-bare-linux-wheels",
+    lock = "//cases/uv-bare-linux-wheels:uv.lock",
+    pyproject = "//cases/uv-bare-linux-wheels:pyproject.toml",
+)
+use_repo(uv, "pypi-bare-linux-wheels")
+# }}}
+
 # For cases/pytest-mock-530
 # Regression: pytest-mock plugin discovery with py_test and py_venv_test.
 # {{{

--- a/e2e/cases/uv-bare-linux-wheels/BUILD.bazel
+++ b/e2e/cases/uv-bare-linux-wheels/BUILD.bazel
@@ -1,0 +1,17 @@
+# Regression: bare linux_* wheel platform tags must survive lockfile parsing.
+# grpcio 1.80.0 ships cp3x-linux_armv7l wheels that exercise this.
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+genquery(
+    name = "grpcio_targets",
+    expression = "deps(@pypi-bare-linux-wheels//grpcio)",
+    scope = ["@pypi-bare-linux-wheels//grpcio"],
+)
+
+sh_test(
+    name = "test",
+    srcs = ["test_bare_linux_wheels.sh"],
+    data = [":grpcio_targets"],
+    target_compatible_with = ["@platforms//os:linux"],
+)

--- a/e2e/cases/uv-bare-linux-wheels/pyproject.toml
+++ b/e2e/cases/uv-bare-linux-wheels/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "uv-bare-linux-wheels"
+version = "0.0.0"
+requires-python = ">=3.11"
+# grpcio 1.80.0 ships cp3x-linux_armv7l wheels (bare linux_* platform tags).
+# `build`/`setuptools` satisfy the hub's default_build_dependencies, which
+# the uv extension expects every project lockfile to resolve.
+dependencies = [
+    "build",
+    "setuptools",
+    "grpcio==1.80.0",
+]

--- a/e2e/cases/uv-bare-linux-wheels/test_bare_linux_wheels.sh
+++ b/e2e/cases/uv-bare-linux-wheels/test_bare_linux_wheels.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGETS_FILE="${TEST_SRCDIR}/_main/cases/uv-bare-linux-wheels/grpcio_targets"
+TARGETS="$(cat "$TARGETS_FILE")"
+
+if ! grep -q 'constraints/platform:linux_armv7l' <<< "$TARGETS"; then
+    echo "FAIL: :linux_armv7l constraint missing from deps(@pypi-bare-linux-wheels//grpcio) — bare linux_* wheel tags were filtered out"
+    echo ""
+    echo "Platform constraints found:"
+    grep 'constraints/platform' <<< "$TARGETS" || echo "  (none)"
+    exit 1
+fi
+
+echo "PASS: :linux_armv7l referenced — grpcio's bare linux_* wheels survived lockfile parsing"

--- a/e2e/cases/uv-bare-linux-wheels/uv.lock
+++ b/e2e/cases/uv-bare-linux-wheels/uv.lock
@@ -1,0 +1,130 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uv-bare-linux-wheels"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "build" },
+    { name = "grpcio" },
+    { name = "setuptools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "build" },
+    { name = "grpcio", specifier = "==1.80.0" },
+    { name = "setuptools" },
+]

--- a/uv/private/constraints/platform/BUILD.bazel
+++ b/uv/private/constraints/platform/BUILD.bazel
@@ -90,13 +90,6 @@ generate(
     visibility = ["//visibility:public"],
 )
 
-# FIXME: Is this right?
-alias(
-    name = "linux_armv7l",
-    actual = "manylinux_2_17_armv7l",
-    visibility = ["//visibility:public"],
-)
-
 # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#manylinux
 alias(
     name = "manylinux1",

--- a/uv/private/constraints/platform/defs.bzl
+++ b/uv/private/constraints/platform/defs.bzl
@@ -42,6 +42,22 @@ LINUX_ARCHES = [
     "armv7l",
 ]
 
+# CPU architectures supported for bare linux_* wheel tags. These config_settings
+# carry no libc/version constraint, so they match musl and older-glibc systems
+# too.
+GENERIC_LINUX_ARCHES = [
+    "x86_64",
+    "i686",
+    "aarch64",
+    "ppc64",
+    "ppc64le",
+    "s390x",
+    "riscv64",
+    "armv6l",
+    "armv7l",
+    "armv8l",
+]
+
 # Supported Windows platform tags and their CPU constraints.
 WINDOWS_PLATFORMS = {
     "win32": "x86_64",
@@ -73,7 +89,6 @@ def supported_platform(platform_tag):
 
     - Android
     - iOS
-    - The legacy/undefined linux_* platforms
     - Architectures we don't generate config_setting targets for
 
     Args:
@@ -93,6 +108,10 @@ def supported_platform(platform_tag):
     if platform_tag.startswith("manylinux_") or platform_tag.startswith("musllinux_"):
         arch = _parse_platform_arch(platform_tag)
         return arch != None and arch in LINUX_ARCHES
+
+    if platform_tag.startswith("linux_"):
+        arch = platform_tag.removeprefix("linux_")
+        return arch in GENERIC_LINUX_ARCHES
 
     return platform_tag in WINDOWS_PLATFORMS
 

--- a/uv/private/constraints/platform/macro.bzl
+++ b/uv/private/constraints/platform/macro.bzl
@@ -2,7 +2,7 @@
 
 """
 
-load(":defs.bzl", "LINUX_ARCHES", "MACOS_ARCHES", "MACOS_ARCH_GROUPS", "WINDOWS_PLATFORMS", "platform_version_at_least")
+load(":defs.bzl", "GENERIC_LINUX_ARCHES", "LINUX_ARCHES", "MACOS_ARCHES", "MACOS_ARCH_GROUPS", "WINDOWS_PLATFORMS", "platform_version_at_least")
 
 ## These are defined but we're ignoring them for now.
 # android_21_arm64_v8a
@@ -18,7 +18,8 @@ load(":defs.bzl", "LINUX_ARCHES", "MACOS_ARCHES", "MACOS_ARCH_GROUPS", "WINDOWS_
 # ios_13_0_arm64_iphonesimulator
 # ios_13_0_x86_64_iphonesimulator
 
-## These seem wrong and/or are defined by Conda not packaging
+## We intentionally support generic linux_* tags because some upstream wheels,
+## notably PyTorch CPU wheels, still publish them.
 # linux_armv6l
 # linux_armv7l
 # linux_x86_64
@@ -34,7 +35,7 @@ platform_repo_name_mangling = {
         [["amd64", "x86_64", "x64"], "x86_64"],
         [["ppc", "ppc64"], "ppc"],
         [["ppc64le"], "ppc64le"],
-        [["arm", "armv7l"], "arm"],
+        [["arm", "armv6l", "armv7l", "armv8l"], "arm"],
         [["aarch64"], "aarch64"],
         [["s390x", "s390"], "s390x"],
         [["mips64el", "mips64"], "mips64"],
@@ -154,6 +155,19 @@ def generate_musllinux(visibility):
 
 # buildifier: disable=unnamed-macro
 # buildifier: disable=function-docstring
+def generate_linux(visibility):
+    for arch in GENERIC_LINUX_ARCHES:
+        native.config_setting(
+            name = "linux_{}".format(arch),
+            constraint_values = [
+                "@platforms//os:linux",
+                "@platforms//cpu:{}".format(platform_repo_name_mangling.get(arch, arch)),
+            ],
+            visibility = visibility,
+        )
+
+# buildifier: disable=unnamed-macro
+# buildifier: disable=function-docstring
 def generate_windows(visibility):
     for name, cpu in WINDOWS_PLATFORMS.items():
         native.config_setting(
@@ -174,4 +188,5 @@ def generate(visibility):
     generate_macos(visibility = visibility)
     generate_manylinux(visibility = visibility)
     generate_musllinux(visibility = visibility)
+    generate_linux(visibility = visibility)
     generate_windows(visibility = visibility)

--- a/uv/private/constraints/platform/test.bzl
+++ b/uv/private/constraints/platform/test.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":defs.bzl", "LINUX_ARCHES", "MACOS_ARCHES", "MACOS_ARCH_GROUPS", "WINDOWS_PLATFORMS", "supported_platform")
+load(":defs.bzl", "GENERIC_LINUX_ARCHES", "LINUX_ARCHES", "MACOS_ARCHES", "MACOS_ARCH_GROUPS", "WINDOWS_PLATFORMS", "supported_platform")
 
 # -- supported_platform: accepted tags -----------------------------------------
 
@@ -27,6 +27,14 @@ def _manylinux_arches_test_impl(ctx):
     return unittest.end(env)
 
 manylinux_arches_test = unittest.make(_manylinux_arches_test_impl)
+
+def _generic_linux_arches_test_impl(ctx):
+    env = unittest.begin(ctx)
+    for arch in GENERIC_LINUX_ARCHES:
+        asserts.true(env, supported_platform("linux_%s" % arch), "generic linux arch %s should be supported" % arch)
+    return unittest.end(env)
+
+generic_linux_arches_test = unittest.make(_generic_linux_arches_test_impl)
 
 def _musllinux_arches_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -60,6 +68,7 @@ def _reject_unsupported_arches_test_impl(ctx):
     # Unknown linux arch
     asserts.false(env, supported_platform("manylinux_2_17_sparc64"), "sparc64 is not a supported linux arch")
     asserts.false(env, supported_platform("musllinux_1_1_mips"), "mips is not a supported linux arch")
+    asserts.false(env, supported_platform("linux_sparc64"), "sparc64 is not a supported generic linux arch")
 
     # Unknown macOS arch
     asserts.false(env, supported_platform("macosx_11_0_mips"), "mips is not a supported macOS arch")
@@ -67,11 +76,19 @@ def _reject_unsupported_arches_test_impl(ctx):
     # Unsupported OS families
     asserts.false(env, supported_platform("android_21_arm64_v8a"), "android should not be supported")
     asserts.false(env, supported_platform("ios_13_0_arm64_iphoneos"), "ios should not be supported")
-    asserts.false(env, supported_platform("linux_x86_64"), "bare linux_ should not be supported")
 
     return unittest.end(env)
 
 reject_unsupported_arches_test = unittest.make(_reject_unsupported_arches_test_impl)
+
+def _bare_linux_tags_test_impl(ctx):
+    """Regression: bare linux_* wheel tags (e.g. PyTorch CPU) must be accepted."""
+    env = unittest.begin(ctx)
+    asserts.true(env, supported_platform("linux_x86_64"), "linux_x86_64 should be supported")
+    asserts.true(env, supported_platform("linux_aarch64"), "linux_aarch64 should be supported")
+    return unittest.end(env)
+
+bare_linux_tags_test = unittest.make(_bare_linux_tags_test_impl)
 
 def _reject_malformed_tags_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -103,6 +120,11 @@ def _real_world_tags_test_impl(ctx):
         "manylinux_2_17_i686",
         "manylinux_2_31_x86_64",
         "manylinux_2_27_aarch64",
+        "linux_x86_64",
+        "linux_aarch64",
+        "linux_armv7l",
+        "linux_armv6l",
+        "linux_armv8l",
         "musllinux_1_1_x86_64",
         "musllinux_1_2_aarch64",
         "win32",
@@ -114,8 +136,7 @@ def _real_world_tags_test_impl(ctx):
     # Rejected: tags seen in the wild that we intentionally do not support
     for tag in [
         "win_ia64",
-        "linux_armv7l",
-        "linux_armv6l",
+        "linux_sparc64",
         "android_21_arm64_v8a",
     ]:
         asserts.false(env, supported_platform(tag), "tag %s should be rejected" % tag)
@@ -132,9 +153,11 @@ def platform_suite():
         any_test,
         macos_arches_test,
         manylinux_arches_test,
+        generic_linux_arches_test,
         musllinux_arches_test,
         windows_platforms_test,
         reject_win_ia64_test,
+        bare_linux_tags_test,
         reject_unsupported_arches_test,
         reject_malformed_tags_test,
         real_world_tags_test,


### PR DESCRIPTION
Backport of #996 (2aff0bee) to the 1.x maintenance branch.

## Problem

1.x deliberately rejects bare-linux wheel platform tags (`linux_x86_64`, `linux_armv7l`, ...) in `supported_platform()`. Wheels published without `auditwheel repair` (internal registries, PyTorch CPU wheels) generate no select arm; if the package has no sdist it resolves to `@platforms//:incompatible` and the build breaks.

## Changes

- Code is a byte-identical port of #996 (zero drift between 1.x and the commit's parent on the touched files): `GENERIC_LINUX_ARCHES`, `linux_*` acceptance in `supported_platform()`, `generate_linux()` config_settings (os+cpu only, no libc/version constraint), `armv6l/armv8l → arm` mangling, and removal of the `linux_armv7l → manylinux_2_17_armv7l` FIXME alias.
- `constraints/platform/test.bzl`: rejection assert inverted; new `generic_linux_arches_test` and `bare_linux_tags_test`; `linux_sparc64` remains rejected.
- e2e `cases/uv-bare-linux-wheels` ported from #996 and adapted to the 1.x module wiring (dedicated hub, `default_build_dependencies` on `uv.project`). The uv_hub snapshot goldens updated by #996 do not exist on 1.x; equivalent coverage lives in the case's genquery+grep assertions.
- `select_key` needed no change: bare-linux ranks `(0, 0)`, below any manylinux/musllinux, so it only matches when no better wheel exists (same emergent behavior as main).

## Observable behavior

A bare-linux wheel now matches on musl hosts and glibc < 2.17 as well (config_setting carries no libc constraint), mirroring pip/uv (`packaging.tags` includes the host's bare tag). It acts strictly as a fallback and never shadows a compatible manylinux/musllinux wheel.

## Test plan

- Red without the code fix: `//cases/uv-bare-linux-wheels:test` fails — `linux_armv7l` constraint absent from `deps(@pypi-bare-linux-wheels//grpcio)`.
- Green with the fix: e2e passes; `bazel test //uv/...` 89/89; regressions `uv-platform-filter-844`, `uv-dep-hashes` (both), `uv-abi3-compat-853` all pass.